### PR TITLE
feat: add global instruction for workspace members

### DIFF
--- a/src/shared/src/db/queries/member.ts
+++ b/src/shared/src/db/queries/member.ts
@@ -18,6 +18,20 @@ export async function listMembers(db: Database, workspaceId: string) {
   return db.select().from(member).where(eq(member.workspaceId, workspaceId));
 }
 
+export async function updateMemberGlobalInstruction(
+  db: Database,
+  userId: string,
+  workspaceId: string,
+  globalInstruction: string
+) {
+  const rows = await db
+    .update(member)
+    .set({ globalInstruction })
+    .where(and(eq(member.userId, userId), eq(member.workspaceId, workspaceId)))
+    .returning();
+  return rows[0] ?? null;
+}
+
 export async function createMember(
   db: Database,
   data: { workspaceId: string; userId: string; role: string }

--- a/src/shared/src/db/schema.ts
+++ b/src/shared/src/db/schema.ts
@@ -88,6 +88,7 @@ export const member = sqliteTable(
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
     role: text("role").notNull().default("member"),
+    globalInstruction: text("global_instruction").notNull().default(""),
     createdAt: text("created_at").notNull().$defaultFn(() => new Date().toISOString()),
   },
   (t) => [unique("member_workspace_user").on(t.workspaceId, t.userId)]

--- a/src/shared/src/index.ts
+++ b/src/shared/src/index.ts
@@ -108,6 +108,7 @@ export {
   SendEmailRequestSchema,
   UpdateEmailStatusRequestSchema,
   EmailNotifyRequestSchema,
+  UpdateMemberRequestSchema,
   CreateWorkspaceRequestSchema,
   CreateEmailAccountSchema,
   UpdateEmailAccountSchema,
@@ -137,6 +138,7 @@ export type {
   CalendarEventApi,
   AddWhitelistRequest,
   CreateEmailAccountRequest,
+  UpdateMemberRequest,
   UpdateEmailAccountRequest,
   TestEmailConnectionRequest,
 } from "./schemas";

--- a/src/shared/src/schemas.ts
+++ b/src/shared/src/schemas.ts
@@ -470,6 +470,15 @@ export const TestEmailConnectionSchema = z.object({
 export type TestEmailConnectionRequest = z.infer<typeof TestEmailConnectionSchema>;
 
 // ---------------------------------------------------------------------------
+// Member request schemas
+// ---------------------------------------------------------------------------
+
+export const UpdateMemberRequestSchema = z.object({
+  global_instruction: z.string().max(50000),
+});
+export type UpdateMemberRequest = z.infer<typeof UpdateMemberRequestSchema>;
+
+// ---------------------------------------------------------------------------
 // Workspace request schemas
 // ---------------------------------------------------------------------------
 

--- a/src/shared/src/schemas.ts
+++ b/src/shared/src/schemas.ts
@@ -474,7 +474,7 @@ export type TestEmailConnectionRequest = z.infer<typeof TestEmailConnectionSchem
 // ---------------------------------------------------------------------------
 
 export const UpdateMemberRequestSchema = z.object({
-  global_instruction: z.string().max(50000),
+  global_instruction: z.string().max(50000).trim(),
 });
 export type UpdateMemberRequest = z.infer<typeof UpdateMemberRequestSchema>;
 

--- a/src/shared/test/schemas/member.test.ts
+++ b/src/shared/test/schemas/member.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { UpdateMemberRequestSchema } from "../../src/schemas";
+
+describe("UpdateMemberRequestSchema", () => {
+  it("accepts valid global_instruction", () => {
+    const result = UpdateMemberRequestSchema.parse({ global_instruction: "speak chinese" });
+    expect(result.global_instruction).toBe("speak chinese");
+  });
+
+  it("accepts empty string", () => {
+    const result = UpdateMemberRequestSchema.parse({ global_instruction: "" });
+    expect(result.global_instruction).toBe("");
+  });
+
+  it("rejects missing global_instruction", () => {
+    expect(() => UpdateMemberRequestSchema.parse({})).toThrow();
+  });
+
+  it("rejects strings over 50000 chars", () => {
+    expect(() =>
+      UpdateMemberRequestSchema.parse({ global_instruction: "x".repeat(50001) })
+    ).toThrow();
+  });
+
+  it("accepts strings at 50000 chars", () => {
+    const result = UpdateMemberRequestSchema.parse({ global_instruction: "x".repeat(50000) });
+    expect(result.global_instruction).toHaveLength(50000);
+  });
+});

--- a/src/shared/test/schemas/member.test.ts
+++ b/src/shared/test/schemas/member.test.ts
@@ -26,4 +26,14 @@ describe("UpdateMemberRequestSchema", () => {
     const result = UpdateMemberRequestSchema.parse({ global_instruction: "x".repeat(50000) });
     expect(result.global_instruction).toHaveLength(50000);
   });
+
+  it("trims leading and trailing whitespace", () => {
+    const result = UpdateMemberRequestSchema.parse({ global_instruction: "  hello world  " });
+    expect(result.global_instruction).toBe("hello world");
+  });
+
+  it("normalizes whitespace-only string to empty", () => {
+    const result = UpdateMemberRequestSchema.parse({ global_instruction: "   " });
+    expect(result.global_instruction).toBe("");
+  });
 });

--- a/src/web/migrations/0005_member_global_instruction.sql
+++ b/src/web/migrations/0005_member_global_instruction.sql
@@ -1,0 +1,1 @@
+ALTER TABLE member ADD COLUMN global_instruction TEXT NOT NULL DEFAULT '';

--- a/src/web/src/app/(app)/w/[slug]/settings/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useWorkspace } from "@/contexts/workspace-context";
 import { getMemberMe, updateMemberMe } from "@/lib/api";
@@ -50,6 +50,31 @@ export default function SettingsPage() {
   };
 
   const isDirty = value !== savedValue;
+  const isDirtyRef = useRef(isDirty);
+  isDirtyRef.current = isDirty;
+  const handleSaveRef = useRef(handleSave);
+  handleSaveRef.current = handleSave;
+
+  // Warn on unsaved changes when navigating away
+  useEffect(() => {
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (isDirtyRef.current) e.preventDefault();
+    };
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, []);
+
+  // Cmd+S / Ctrl+S to save
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "s") {
+        e.preventDefault();
+        if (isDirtyRef.current) handleSaveRef.current();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
 
   return (
     <>

--- a/src/web/src/app/(app)/w/[slug]/settings/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/settings/page.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { useWorkspace } from "@/contexts/workspace-context";
+import { getMemberMe, updateMemberMe } from "@/lib/api";
+import { MobileSidebarLogo } from "@/components/mobile-sidebar-logo";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const MAX_LENGTH = 50_000;
+
+export default function SettingsPage() {
+  const { workspaceId } = useWorkspace();
+  const [value, setValue] = useState("");
+  const [savedValue, setSavedValue] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const fetchInstruction = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await getMemberMe(workspaceId);
+      setValue(data.global_instruction);
+      setSavedValue(data.global_instruction);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to load settings");
+    } finally {
+      setLoading(false);
+    }
+  }, [workspaceId]);
+
+  useEffect(() => {
+    fetchInstruction();
+  }, [fetchInstruction]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const data = await updateMemberMe(workspaceId, value);
+      setSavedValue(data.global_instruction);
+      toast.success("Settings saved");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to save settings");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const isDirty = value !== savedValue;
+
+  return (
+    <>
+      <div className="flex items-center justify-between border-b border-border/50 px-3 md:px-5 py-2.5 gap-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <MobileSidebarLogo />
+          <h1 className="text-sm font-medium">Settings</h1>
+          <p className="text-xs text-muted-foreground hidden md:block">
+            Instructions shared across all your agents
+          </p>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-5 py-5">
+        {loading ? (
+          <div className="mx-auto max-w-md space-y-4">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-40 w-full" />
+          </div>
+        ) : (
+          <div className="mx-auto max-w-md space-y-4">
+            <Label htmlFor="global-instruction">Global Instruction</Label>
+            <Textarea
+              id="global-instruction"
+              rows={10}
+              className="min-h-16"
+              placeholder="Write instructions that every agent you own will follow..."
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              maxLength={MAX_LENGTH}
+            />
+            <div className="flex items-center justify-between">
+              <p className="text-xs text-muted-foreground/70">
+                This markdown instruction is prepended to every agent&apos;s individual instruction.
+              </p>
+              <span className="text-xs text-muted-foreground tabular-nums shrink-0 ml-4">
+                {value.length.toLocaleString()} / {MAX_LENGTH.toLocaleString()}
+              </span>
+            </div>
+            <div className="flex items-center gap-2 pt-2">
+              <Button
+                size="sm"
+                onClick={handleSave}
+                disabled={!isDirty || saving}
+              >
+                {saving ? "Saving…" : "Save"}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/web/src/app/api/daemon/tasks/poll/route.test.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.test.ts
@@ -6,6 +6,7 @@ const mockUpsertMachine = vi.fn();
 const mockGetMachineByDaemon = vi.fn();
 const mockClearPendingUpdateVersion = vi.fn();
 const mockGetAgent = vi.fn();
+const mockGetMemberByUserAndWorkspace = vi.fn();
 const mockClaimTasksForRuntimes = vi.fn();
 const mockSweepStaleState = vi.fn();
 const mockBroadcastToUser = vi.fn();
@@ -30,6 +31,9 @@ vi.mock("@alook/shared", async () => {
       },
       agent: {
         getAgent: (...args: unknown[]) => mockGetAgent(...args),
+      },
+      member: {
+        getMemberByUserAndWorkspace: (...args: unknown[]) => mockGetMemberByUserAndWorkspace(...args),
       },
       emailAccount: {
         getEmailAccountsByAgent: vi.fn().mockResolvedValue([]),
@@ -340,5 +344,102 @@ describe("POST /api/daemon/tasks/poll", () => {
     expect(res.status).toBe(200);
     expect(body.tasks).toEqual([]);
     expect(body.pending_update).toBeUndefined();
+  });
+
+  it("concatenates global + per-agent instructions when owner has global instruction", async () => {
+    mockUpsertMachine.mockResolvedValue({});
+    mockGetRuntimeIdsByDaemon.mockResolvedValue(["r1"]);
+    mockSweepStaleState.mockResolvedValue(undefined);
+    mockBroadcastToUser.mockResolvedValue(undefined);
+    mockClaimTasksForRuntimes.mockResolvedValue([
+      { id: "t1", agentId: "a1", runtimeId: "r1", workspaceId: "w1", prompt: "hi", status: "dispatched" },
+    ]);
+    mockGetAgent.mockResolvedValue({
+      id: "a1",
+      ownerId: "owner1",
+      instructions: "you are a planner",
+      name: "Bot",
+      runtimeConfig: {},
+    });
+    mockGetMemberByUserAndWorkspace.mockResolvedValue({
+      globalInstruction: "speak chinese",
+    });
+
+    const res = await POST(postReq({ daemon_id: "d1" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.tasks[0].agent.instructions).toBe("speak chinese\n\nyou are a planner");
+    expect(mockGetMemberByUserAndWorkspace).toHaveBeenCalledWith({}, "owner1", "w1");
+  });
+
+  it("returns only agent instructions when global instruction is empty", async () => {
+    mockUpsertMachine.mockResolvedValue({});
+    mockGetRuntimeIdsByDaemon.mockResolvedValue(["r1"]);
+    mockSweepStaleState.mockResolvedValue(undefined);
+    mockBroadcastToUser.mockResolvedValue(undefined);
+    mockClaimTasksForRuntimes.mockResolvedValue([
+      { id: "t1", agentId: "a1", runtimeId: "r1", workspaceId: "w1", prompt: "hi", status: "dispatched" },
+    ]);
+    mockGetAgent.mockResolvedValue({
+      id: "a1",
+      ownerId: "owner1",
+      instructions: "you are a planner",
+      name: "Bot",
+      runtimeConfig: {},
+    });
+    mockGetMemberByUserAndWorkspace.mockResolvedValue({
+      globalInstruction: "",
+    });
+
+    const res = await POST(postReq({ daemon_id: "d1" }));
+    const body = await res.json();
+
+    expect(body.tasks[0].agent.instructions).toBe("you are a planner");
+  });
+
+  it("falls back to agent instructions when agent has no ownerId", async () => {
+    mockUpsertMachine.mockResolvedValue({});
+    mockGetRuntimeIdsByDaemon.mockResolvedValue(["r1"]);
+    mockSweepStaleState.mockResolvedValue(undefined);
+    mockBroadcastToUser.mockResolvedValue(undefined);
+    mockClaimTasksForRuntimes.mockResolvedValue([
+      { id: "t1", agentId: "a1", runtimeId: "r1", workspaceId: "w1", prompt: "hi", status: "dispatched" },
+    ]);
+    mockGetAgent.mockResolvedValue({
+      id: "a1",
+      ownerId: null,
+      instructions: "just agent",
+      name: "Bot",
+      runtimeConfig: {},
+    });
+
+    const res = await POST(postReq({ daemon_id: "d1" }));
+    const body = await res.json();
+
+    expect(body.tasks[0].agent.instructions).toBe("just agent");
+    expect(mockGetMemberByUserAndWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("caches member lookups by ownerId across multiple tasks", async () => {
+    mockUpsertMachine.mockResolvedValue({});
+    mockGetRuntimeIdsByDaemon.mockResolvedValue(["r1"]);
+    mockSweepStaleState.mockResolvedValue(undefined);
+    mockBroadcastToUser.mockResolvedValue(undefined);
+    mockClaimTasksForRuntimes.mockResolvedValue([
+      { id: "t1", agentId: "a1", runtimeId: "r1", workspaceId: "w1", prompt: "hi", status: "dispatched" },
+      { id: "t2", agentId: "a2", runtimeId: "r1", workspaceId: "w1", prompt: "yo", status: "dispatched" },
+    ]);
+    mockGetAgent
+      .mockResolvedValueOnce({ id: "a1", ownerId: "owner1", instructions: "inst1", name: "Bot1", runtimeConfig: {} })
+      .mockResolvedValueOnce({ id: "a2", ownerId: "owner1", instructions: "inst2", name: "Bot2", runtimeConfig: {} });
+    mockGetMemberByUserAndWorkspace.mockResolvedValue({ globalInstruction: "global" });
+
+    const res = await POST(postReq({ daemon_id: "d1" }));
+    const body = await res.json();
+
+    expect(body.tasks[0].agent.instructions).toBe("global\n\ninst1");
+    expect(body.tasks[1].agent.instructions).toBe("global\n\ninst2");
+    expect(mockGetMemberByUserAndWorkspace).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/web/src/app/api/daemon/tasks/poll/route.test.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.test.ts
@@ -442,4 +442,29 @@ describe("POST /api/daemon/tasks/poll", () => {
     expect(body.tasks[1].agent.instructions).toBe("global\n\ninst2");
     expect(mockGetMemberByUserAndWorkspace).toHaveBeenCalledTimes(1);
   });
+
+  it("returns only global instruction when agent instructions are empty", async () => {
+    mockUpsertMachine.mockResolvedValue({});
+    mockGetRuntimeIdsByDaemon.mockResolvedValue(["r1"]);
+    mockSweepStaleState.mockResolvedValue(undefined);
+    mockBroadcastToUser.mockResolvedValue(undefined);
+    mockClaimTasksForRuntimes.mockResolvedValue([
+      { id: "t1", agentId: "a1", runtimeId: "r1", workspaceId: "w1", prompt: "hi", status: "dispatched" },
+    ]);
+    mockGetAgent.mockResolvedValue({
+      id: "a1",
+      ownerId: "owner1",
+      instructions: "",
+      name: "Bot",
+      runtimeConfig: {},
+    });
+    mockGetMemberByUserAndWorkspace.mockResolvedValue({
+      globalInstruction: "global only",
+    });
+
+    const res = await POST(postReq({ daemon_id: "d1" }));
+    const body = await res.json();
+
+    expect(body.tasks[0].agent.instructions).toBe("global only");
+  });
 });

--- a/src/web/src/app/api/daemon/tasks/poll/route.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.ts
@@ -75,6 +75,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
   );
 
   const tasks = [];
+  // Per-request cache: avoids duplicate DB reads when multiple agents share the same owner
   const memberCache = new Map<string, { globalInstruction: string } | null>();
   for (const task of claimed) {
     const agent = await queries.agent.getAgent(db, task.agentId, task.workspaceId);

--- a/src/web/src/app/api/daemon/tasks/poll/route.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.ts
@@ -75,6 +75,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
   );
 
   const tasks = [];
+  const memberCache = new Map<string, { globalInstruction: string } | null>();
   for (const task of claimed) {
     const agent = await queries.agent.getAgent(db, task.agentId, task.workspaceId);
     let emailAddresses: string[] = [];
@@ -85,11 +86,28 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
         emailAddresses.push(acc.emailAddress);
       }
     }
+
+    let instructions = agent?.instructions ?? "";
+    if (agent?.ownerId) {
+      if (!memberCache.has(agent.ownerId)) {
+        const m = await queries.member.getMemberByUserAndWorkspace(
+          db,
+          agent.ownerId,
+          task.workspaceId,
+        );
+        memberCache.set(agent.ownerId, m ? { globalInstruction: m.globalInstruction } : null);
+      }
+      const cached = memberCache.get(agent.ownerId);
+      if (cached?.globalInstruction) {
+        instructions = [cached.globalInstruction, instructions].filter(Boolean).join("\n\n");
+      }
+    }
+
     tasks.push({
       ...taskToResponse(task),
       agent: agent
         ? {
-            instructions: agent.instructions,
+            instructions,
             name: agent.name,
             runtime_config: agent.runtimeConfig || {},
             email_handle: agent.emailHandle || null,

--- a/src/web/src/app/api/members/me/route.test.ts
+++ b/src/web/src/app/api/members/me/route.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetMemberByUserAndWorkspace = vi.fn();
+const mockUpdateMemberGlobalInstruction = vi.fn();
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(async () => ({ env: { DB: {} } })),
+}));
+
+vi.mock("@alook/shared", async () => {
+  const real = await vi.importActual<typeof import("@alook/shared")>("@alook/shared");
+  return {
+    ...real,
+    createDb: vi.fn(() => ({})),
+    queries: {
+      member: {
+        getMemberByUserAndWorkspace: (...args: unknown[]) => mockGetMemberByUserAndWorkspace(...args),
+        updateMemberGlobalInstruction: (...args: unknown[]) => mockUpdateMemberGlobalInstruction(...args),
+      },
+    },
+  };
+});
+
+vi.mock("@/lib/middleware/auth", () => ({
+  withAuth: vi.fn((handler: any) => async (req: any, ctx?: any) => {
+    const params = ctx?.params instanceof Promise ? await ctx.params : ctx?.params;
+    return handler(req, { userId: "u1", email: "u@t.com", workspaceId: "w1", params });
+  }),
+}));
+
+vi.mock("@/lib/middleware/helpers", async () =>
+  await vi.importActual<typeof import("@/lib/middleware/helpers")>("@/lib/middleware/helpers")
+);
+
+vi.mock("@/lib/middleware/workspace", async () => {
+  const real = await vi.importActual<typeof import("@/lib/middleware/workspace")>("@/lib/middleware/workspace");
+  return {
+    ...real,
+    withWorkspaceMember: vi.fn(async (req: any) => {
+      const workspaceId =
+        new URL(req.url).searchParams.get("workspace_id") ||
+        req.headers.get("X-Workspace-ID");
+      if (!workspaceId) {
+        const { NextResponse } = await import("next/server");
+        return NextResponse.json({ error: "workspace_id is required" }, { status: 400 });
+      }
+      return { workspaceId };
+    }),
+  };
+});
+
+import { GET, PATCH } from "./route";
+
+function getReq(workspaceId?: string) {
+  const url = workspaceId
+    ? `http://localhost/api/members/me?workspace_id=${workspaceId}`
+    : "http://localhost/api/members/me";
+  return new NextRequest(url, { method: "GET" });
+}
+
+function patchReq(body: unknown, workspaceId = "w1") {
+  return new NextRequest(`http://localhost/api/members/me?workspace_id=${workspaceId}`, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("GET /api/members/me", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns global_instruction for the current user", async () => {
+    mockGetMemberByUserAndWorkspace.mockResolvedValue({
+      globalInstruction: "always speak chinese",
+    });
+
+    const res = await GET(getReq("w1"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.global_instruction).toBe("always speak chinese");
+  });
+
+  it("returns 400 when workspace_id is missing", async () => {
+    const res = await GET(getReq());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when member not found", async () => {
+    mockGetMemberByUserAndWorkspace.mockResolvedValue(null);
+
+    const res = await GET(getReq("w1"));
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("PATCH /api/members/me", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("saves and returns updated global instruction", async () => {
+    mockUpdateMemberGlobalInstruction.mockResolvedValue({
+      globalInstruction: "new instruction",
+    });
+
+    const res = await PATCH(patchReq({ global_instruction: "new instruction" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.global_instruction).toBe("new instruction");
+    expect(mockUpdateMemberGlobalInstruction).toHaveBeenCalledWith({}, "u1", "w1", "new instruction");
+  });
+
+  it("returns 400 for invalid body", async () => {
+    const res = await PATCH(patchReq({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when member not found", async () => {
+    mockUpdateMemberGlobalInstruction.mockResolvedValue(null);
+
+    const res = await PATCH(patchReq({ global_instruction: "something" }));
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/web/src/app/api/members/me/route.ts
+++ b/src/web/src/app/api/members/me/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { createDb, queries, UpdateMemberRequestSchema } from "@alook/shared";
+import { withAuth } from "@/lib/middleware/auth";
+import { withWorkspaceMember } from "@/lib/middleware/workspace";
+import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
+
+export const GET = withAuth(async (req: NextRequest, ctx) => {
+  const ws = await withWorkspaceMember(req, ctx);
+  if (ws instanceof Response) return ws;
+
+  const { env } = await getCloudflareContext({ async: true });
+  const db = createDb((env as Env).DB);
+
+  const member = await queries.member.getMemberByUserAndWorkspace(
+    db,
+    ctx.userId,
+    ws.workspaceId
+  );
+  if (!member) return writeError("member not found", 404);
+
+  return writeJSON({ global_instruction: member.globalInstruction });
+});
+
+export const PATCH = withAuth(async (req: NextRequest, ctx) => {
+  const ws = await withWorkspaceMember(req, ctx);
+  if (ws instanceof Response) return ws;
+
+  const [body, err] = await parseBody(req, UpdateMemberRequestSchema);
+  if (err) return err;
+
+  const { env } = await getCloudflareContext({ async: true });
+  const db = createDb((env as Env).DB);
+
+  const updated = await queries.member.updateMemberGlobalInstruction(
+    db,
+    ctx.userId,
+    ws.workspaceId,
+    body.global_instruction
+  );
+  if (!updated) return writeError("member not found", 404);
+
+  return writeJSON({ global_instruction: updated.globalInstruction });
+});

--- a/src/web/src/components/app-sidebar.tsx
+++ b/src/web/src/components/app-sidebar.tsx
@@ -5,7 +5,7 @@ import { useAgentContext } from "@/contexts/agent-context";
 import { useWorkspace } from "@/contexts/workspace-context";
 import { Logo } from "@/components/logo";
 import { cn } from "@/lib/utils";
-import { Monitor, SunMoon, Plus, LayoutGrid, CalendarDays } from "lucide-react";
+import { Monitor, SunMoon, Plus, LayoutGrid, CalendarDays, Settings } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useTheme } from "next-themes";
 import { NavUser } from "@/components/nav-user";
@@ -23,6 +23,7 @@ export function AppSidebar({ onNavigate }: { onNavigate?: () => void } = {}) {
   const prefix = `/w/${slug}`;
   const isRuntimes = pathname === `${prefix}/runtimes`;
   const isCalendar = pathname === `${prefix}/calendar`;
+  const isSettings = pathname === `${prefix}/settings`;
   const isCreateAgent = pathname === `${prefix}/agents/new`;
 
   // Detect active agent from ?agent= param or /w/[slug]/agents/[id] route
@@ -122,6 +123,19 @@ export function AppSidebar({ onNavigate }: { onNavigate?: () => void } = {}) {
           )}
         >
           <CalendarDays className="size-4" />
+        </button>
+
+        <button
+          type="button"
+          title="Settings"
+          onClick={() => { router.push(`${prefix}/settings`); onNavigate?.(); }}
+          className={cn(
+            "flex items-center justify-center size-10 rounded-xl transition-colors duration-200 cursor-pointer",
+            "text-muted-foreground hover:text-foreground hover:bg-accent",
+            isSettings && "bg-accent text-foreground"
+          )}
+        >
+          <Settings className="size-4" />
         </button>
 
         <button

--- a/src/web/src/lib/api.ts
+++ b/src/web/src/lib/api.ts
@@ -491,6 +491,16 @@ export const syncEmailAccount = (agentId: string, accountId: string, workspaceId
     method: "POST",
   });
 
+// Members
+export const getMemberMe = (workspaceId: string) =>
+  apiFetch<{ global_instruction: string }>(`/api/members/me${wsQuery(workspaceId)}`);
+
+export const updateMemberMe = (workspaceId: string, globalInstruction: string) =>
+  apiFetch<{ global_instruction: string }>(`/api/members/me${wsQuery(workspaceId)}`, {
+    method: "PATCH",
+    body: JSON.stringify({ global_instruction: globalInstruction }),
+  });
+
 // Artifacts
 export const listArtifacts = (conversationId: string, workspaceId: string) =>
   apiFetch<Artifact[]>(`/api/artifacts${wsQuery(workspaceId, { conversation_id: conversationId })}`);


### PR DESCRIPTION
# Why we need this PR?

Allow each workspace member to set a **global instruction** that automatically applies to all agents they own. This provides a single place to define cross-agent behaviors like language preferences, company context, or security policies.

## What changed

### Database & Shared Layer
- Added `global_instruction` TEXT column to `member` table (schema + D1 migration)
- Added `updateMemberGlobalInstruction()` query function
- Added `UpdateMemberRequestSchema` Zod validator (max 50,000 chars)

### API
- **GET `/api/members/me`** — returns the current member's global instruction
- **PATCH `/api/members/me`** — updates the global instruction
- **Task poll route** — concatenates `member.globalInstruction + agent.instructions` with per-owner caching

### Web UI
- Added **Settings** icon button to workspace sidebar (between Calendar and Theme toggle)
- Created **`/w/[slug]/settings`** page with textarea, character counter, and save button

### Tests
- 4 new poll route tests (concatenation, empty handling, no-ownerId fallback, cache dedup)
- 6 new members/me route tests (GET, PATCH, validation, error cases)
- 5 new schema validation tests

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...