### PR TITLE
feat(web): wrap D1 access with Sessions API for read replication

### DIFF
--- a/src/web/src/app/(app)/w/[slug]/layout.tsx
+++ b/src/web/src/app/(app)/w/[slug]/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation"
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { getSession } from "@/lib/session"
 import { WorkspaceProvider } from "@/contexts/workspace-context"
 import { AgentProvider } from "@/contexts/agent-context"
@@ -18,7 +19,7 @@ export default async function WorkspaceLayout({
 
   const { slug } = await params
   const { env } = await getCloudflareContext({ async: true })
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const ws = await queries.workspace.getWorkspaceBySlug(db, slug)
   if (!ws) redirect("/workspaces")

--- a/src/web/src/app/(app)/workspaces/page.tsx
+++ b/src/web/src/app/(app)/workspaces/page.tsx
@@ -1,7 +1,8 @@
 import { redirect } from "next/navigation"
 import { isRedirectError } from "next/dist/client/components/redirect-error"
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { requireSession } from "@/lib/session"
 import { WorkspaceListClient } from "./client"
 
@@ -26,7 +27,7 @@ export default async function WorkspacesPage({
 }) {
   const session = await requireSession()
   const { env } = await getCloudflareContext({ async: true })
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   let workspaces = await queries.workspace.listWorkspaces(db, session.user.id)
 

--- a/src/web/src/app/api/agents/[id]/conversation/route.test.ts
+++ b/src/web/src/app/api/agents/[id]/conversation/route.test.ts
@@ -7,6 +7,8 @@ vi.mock("@opennextjs/cloudflare", () => ({
 const mockGetAgent = vi.fn();
 const mockGetOrCreateAgentConversation = vi.fn();
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
   queries: {

--- a/src/web/src/app/api/agents/[id]/conversation/route.ts
+++ b/src/web/src/app/api/agents/[id]/conversation/route.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError } from "@/lib/middleware/helpers";
@@ -10,7 +11,7 @@ export const POST = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const id = ctx.params?.id;
   if (!id) {

--- a/src/web/src/app/api/agents/[id]/conversations/route.test.ts
+++ b/src/web/src/app/api/agents/[id]/conversations/route.test.ts
@@ -7,6 +7,8 @@ vi.mock("@opennextjs/cloudflare", () => ({
 const mockGetAgent = vi.fn();
 const mockListConversationsByAgent = vi.fn();
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
   queries: {

--- a/src/web/src/app/api/agents/[id]/conversations/route.ts
+++ b/src/web/src/app/api/agents/[id]/conversations/route.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError } from "@/lib/middleware/helpers";
@@ -10,7 +11,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const id = ctx.params?.id;
   if (!id) {

--- a/src/web/src/app/api/agents/[id]/email-accounts/[accountId]/route.ts
+++ b/src/web/src/app/api/agents/[id]/email-accounts/[accountId]/route.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries, UpdateEmailAccountSchema, DEV_EMAIL_WORKER_URL } from "@alook/shared"
+import { queries, UpdateEmailAccountSchema, DEV_EMAIL_WORKER_URL } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { encrypt } from "@alook/shared/crypto"
 import { withAuth } from "@/lib/middleware/auth"
 import { withWorkspaceMember } from "@/lib/middleware/workspace"
@@ -41,7 +42,7 @@ export const PATCH = withAuth(async (req, ctx) => {
 
   const { env } = getCloudflareContext()
   const cfEnv = env as Env
-  const db = createDb(cfEnv.DB)
+  const db = getDb(cfEnv.DB)
 
   const agentId = ctx.params?.id
   const accountId = ctx.params?.accountId
@@ -89,7 +90,7 @@ export const DELETE = withAuth(async (req, ctx) => {
 
   const { env } = getCloudflareContext()
   const cfEnv = env as Env
-  const db = createDb(cfEnv.DB)
+  const db = getDb(cfEnv.DB)
 
   const agentId = ctx.params?.id
   const accountId = ctx.params?.accountId

--- a/src/web/src/app/api/agents/[id]/email-accounts/[accountId]/sync/route.ts
+++ b/src/web/src/app/api/agents/[id]/email-accounts/[accountId]/sync/route.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries, DEV_EMAIL_WORKER_URL } from "@alook/shared"
+import { queries, DEV_EMAIL_WORKER_URL } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth"
 import { withWorkspaceMember } from "@/lib/middleware/workspace"
 import { writeJSON, writeError } from "@/lib/middleware/helpers"
@@ -10,7 +11,7 @@ export const POST = withAuth(async (req, ctx) => {
 
   const { env } = getCloudflareContext()
   const cfEnv = env as Env
-  const db = createDb(cfEnv.DB)
+  const db = getDb(cfEnv.DB)
 
   const agentId = ctx.params?.id
   const accountId = ctx.params?.accountId

--- a/src/web/src/app/api/agents/[id]/email-accounts/[accountId]/test/route.ts
+++ b/src/web/src/app/api/agents/[id]/email-accounts/[accountId]/test/route.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries, DEV_EMAIL_WORKER_URL } from "@alook/shared"
+import { queries, DEV_EMAIL_WORKER_URL } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth"
 import { withWorkspaceMember } from "@/lib/middleware/workspace"
 import { writeJSON, writeError } from "@/lib/middleware/helpers"
@@ -10,7 +11,7 @@ export const POST = withAuth(async (req, ctx) => {
 
   const { env } = getCloudflareContext()
   const cfEnv = env as Env
-  const db = createDb(cfEnv.DB)
+  const db = getDb(cfEnv.DB)
 
   const agentId = ctx.params?.id
   const accountId = ctx.params?.accountId

--- a/src/web/src/app/api/agents/[id]/email-accounts/route.ts
+++ b/src/web/src/app/api/agents/[id]/email-accounts/route.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries, CreateEmailAccountSchema, DEV_EMAIL_WORKER_URL } from "@alook/shared"
+import { queries, CreateEmailAccountSchema, DEV_EMAIL_WORKER_URL } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { encrypt } from "@alook/shared/crypto"
 import { withAuth } from "@/lib/middleware/auth"
 import { withWorkspaceMember } from "@/lib/middleware/workspace"
@@ -32,7 +33,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const agentId = ctx.params?.id
   if (!agentId) return writeError("agent id is required", 400)
@@ -50,7 +51,7 @@ export const POST = withAuth(async (req, ctx) => {
 
   const { env } = getCloudflareContext()
   const cfEnv = env as Env
-  const db = createDb(cfEnv.DB)
+  const db = getDb(cfEnv.DB)
 
   const agentId = ctx.params?.id
   if (!agentId) return writeError("agent id is required", 400)

--- a/src/web/src/app/api/agents/[id]/route.test.ts
+++ b/src/web/src/app/api/agents/[id]/route.test.ts
@@ -9,6 +9,8 @@ const mockDeleteAgent = vi.fn();
 const mockUpdateAgent = vi.fn();
 const mockGetAgentRuntimeForWorkspace = vi.fn();
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", async () => {
   const actual = await vi.importActual("@alook/shared");
   return {

--- a/src/web/src/app/api/agents/[id]/route.ts
+++ b/src/web/src/app/api/agents/[id]/route.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries, UpdateAgentRequestSchema } from "@alook/shared"
+import { queries, UpdateAgentRequestSchema } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
@@ -10,7 +11,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const id = ctx.params?.id;
   if (!id) {
@@ -30,7 +31,7 @@ export const PATCH = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const id = ctx.params?.id;
   if (!id) {
@@ -73,7 +74,7 @@ export const DELETE = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const id = ctx.params?.id;
   if (!id) {

--- a/src/web/src/app/api/agents/[id]/whitelist/[whitelistId]/route.test.ts
+++ b/src/web/src/app/api/agents/[id]/whitelist/[whitelistId]/route.test.ts
@@ -6,6 +6,8 @@ vi.mock("@opennextjs/cloudflare", () => ({
 
 const mockRemoveWhitelist = vi.fn();
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
   queries: {

--- a/src/web/src/app/api/agents/[id]/whitelist/[whitelistId]/route.ts
+++ b/src/web/src/app/api/agents/[id]/whitelist/[whitelistId]/route.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth"
 import { withWorkspaceMember } from "@/lib/middleware/workspace"
 import { writeError } from "@/lib/middleware/helpers"
@@ -9,7 +10,7 @@ export const DELETE = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const agentId = ctx.params?.id;
   const whitelistId = ctx.params?.whitelistId;

--- a/src/web/src/app/api/agents/[id]/whitelist/route.test.ts
+++ b/src/web/src/app/api/agents/[id]/whitelist/route.test.ts
@@ -10,6 +10,8 @@ const mockAddWhitelist = vi.fn();
 const mockCreateConversation = vi.fn();
 const mockEnqueueTask = vi.fn();
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
   TASK_TYPES: { USER_DM_MESSAGE: "user_dm_message", EMAIL_NOTIFICATION: "email_notification", CALENDAR_EVENT: "calendar_event" },

--- a/src/web/src/app/api/agents/[id]/whitelist/route.ts
+++ b/src/web/src/app/api/agents/[id]/whitelist/route.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries, AddWhitelistRequestSchema, TASK_TYPES } from "@alook/shared"
+import { queries, AddWhitelistRequestSchema, TASK_TYPES } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth"
 import { withWorkspaceMember } from "@/lib/middleware/workspace"
 import { writeJSON, writeError, parseBody, formatTimestamp } from "@/lib/middleware/helpers"
@@ -10,7 +11,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const agentId = ctx.params?.id;
   if (!agentId) return writeError("agent id is required", 400);
@@ -33,7 +34,7 @@ export const POST = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const agentId = ctx.params?.id;
   if (!agentId) return writeError("agent id is required", 400);

--- a/src/web/src/app/api/agents/route.test.ts
+++ b/src/web/src/app/api/agents/route.test.ts
@@ -9,6 +9,8 @@ const mockCreateAgent = vi.fn();
 const mockGetAgent = vi.fn();
 const mockGetAgentRuntimeForWorkspace = vi.fn();
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", async () => {
   const actual = await vi.importActual("@alook/shared");
   return {

--- a/src/web/src/app/api/agents/route.ts
+++ b/src/web/src/app/api/agents/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries, isValidHandle, isOnline, CreateAgentRequestSchema } from "@alook/shared"
+import { queries, isValidHandle, isOnline, CreateAgentRequestSchema } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
@@ -13,7 +14,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   // Sweep stale state: catches stuck tasks even when all daemons are dead
   await sweepStaleState(db, ws.workspaceId);
@@ -27,7 +28,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const [body, valErr] = await parseBody(req, CreateAgentRequestSchema);
   if (valErr) return valErr;

--- a/src/web/src/app/api/artifacts/[id]/content/route.ts
+++ b/src/web/src/app/api/artifacts/[id]/content/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { createDb, queries } from "@alook/shared";
+import { queries } from "@alook/shared";
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeError } from "@/lib/middleware/helpers";
@@ -11,7 +12,7 @@ export const GET = withAuth(async (req: NextRequest, ctx) => {
 
   const id = ctx.params?.id as string;
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
   const bucket = (env as Env).EMAIL_BUCKET;
 
   const row = await queries.artifact.getArtifact(db, id, ws.workspaceId);

--- a/src/web/src/app/api/artifacts/[id]/route.ts
+++ b/src/web/src/app/api/artifacts/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { createDb, queries } from "@alook/shared";
+import { queries } from "@alook/shared";
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError } from "@/lib/middleware/helpers";
@@ -11,7 +12,7 @@ export const GET = withAuth(async (req: NextRequest, ctx) => {
 
   const id = ctx.params?.id as string;
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const row = await queries.artifact.getArtifact(db, id, ws.workspaceId);
   if (!row) {

--- a/src/web/src/app/api/artifacts/route.ts
+++ b/src/web/src/app/api/artifacts/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { createDb, queries } from "@alook/shared";
+import { queries } from "@alook/shared";
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError } from "@/lib/middleware/helpers";
@@ -15,7 +16,7 @@ export const GET = withAuth(async (req: NextRequest, ctx) => {
   }
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const rows = await queries.artifact.listArtifactsByConversation(
     db,

--- a/src/web/src/app/api/artifacts/upload/route.ts
+++ b/src/web/src/app/api/artifacts/upload/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { createDb, queries } from "@alook/shared";
+import { queries } from "@alook/shared";
+import { getDb } from "@/lib/db"
 import { nanoid } from "nanoid";
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
@@ -19,7 +20,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
 
   const { env } = getCloudflareContext();
   const bucket = (env as Env).EMAIL_BUCKET;
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   let formData: FormData;
   try {

--- a/src/web/src/app/api/calendar/[id]/route.test.ts
+++ b/src/web/src/app/api/calendar/[id]/route.test.ts
@@ -11,6 +11,8 @@ vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
 }));
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", async () => {
   const actual = await vi.importActual<typeof import("@alook/shared")>("@alook/shared");
   return {

--- a/src/web/src/app/api/calendar/[id]/route.ts
+++ b/src/web/src/app/api/calendar/[id]/route.ts
@@ -1,12 +1,12 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import {
-  createDb,
   queries,
   UpdateCalendarEventRequestSchema,
   DeleteCalendarEventRequestSchema,
   isEmptyHtml,
   computeNextScheduledAt,
 } from "@alook/shared";
+import { getDb } from "@/lib/db";
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
@@ -18,7 +18,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const id = ctx.params?.id;
   if (!id) return writeError("calendar event id is required", 400);
@@ -37,7 +37,7 @@ export const PATCH = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const id = ctx.params?.id;
   if (!id) return writeError("calendar event id is required", 400);
@@ -166,7 +166,7 @@ export const DELETE = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const id = ctx.params?.id;
   if (!id) return writeError("calendar event id is required", 400);

--- a/src/web/src/app/api/calendar/route.test.ts
+++ b/src/web/src/app/api/calendar/route.test.ts
@@ -9,6 +9,8 @@ vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
 }));
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", async () => {
   const actual = await vi.importActual<typeof import("@alook/shared")>("@alook/shared");
   return {

--- a/src/web/src/app/api/calendar/route.ts
+++ b/src/web/src/app/api/calendar/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import {
-  createDb,
   queries,
   CreateCalendarEventRequestSchema,
   expandOccurrences,
   isEmptyHtml,
 } from "@alook/shared";
+import { getDb } from "@/lib/db";
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
@@ -18,7 +18,7 @@ export const GET = withAuth(async (req: NextRequest, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const agentId = req.nextUrl.searchParams.get("agentId") ?? undefined;
   const from = req.nextUrl.searchParams.get("from") ?? undefined;
@@ -70,7 +70,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const [body, err] = await parseBody(req, CreateCalendarEventRequestSchema);
   if (err) return err;

--- a/src/web/src/app/api/conversations/[id]/active-task/route.test.ts
+++ b/src/web/src/app/api/conversations/[id]/active-task/route.test.ts
@@ -8,6 +8,8 @@ const mockTaskToResponse = vi.fn((t: any) => ({ id: t.id, status: t.status }));
 vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
 }));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
   queries: {

--- a/src/web/src/app/api/conversations/[id]/active-task/route.ts
+++ b/src/web/src/app/api/conversations/[id]/active-task/route.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError } from "@/lib/middleware/helpers";
@@ -10,7 +11,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const id = ctx.params?.id;
   if (!id) {

--- a/src/web/src/app/api/conversations/[id]/buffered-messages/[messageId]/route.ts
+++ b/src/web/src/app/api/conversations/[id]/buffered-messages/[messageId]/route.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { createDb, queries } from "@alook/shared";
+import { queries } from "@alook/shared";
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeError } from "@/lib/middleware/helpers";
@@ -10,7 +11,7 @@ export const DELETE = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const conversationId = ctx.params?.id;
   const messageId = ctx.params?.messageId;

--- a/src/web/src/app/api/conversations/[id]/buffered-messages/route.ts
+++ b/src/web/src/app/api/conversations/[id]/buffered-messages/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import {
-  createDb,
   queries,
   CreateBufferedMessageRequestSchema,
 } from "@alook/shared";
+import { getDb } from "@/lib/db";
 import { nanoid } from "nanoid";
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
@@ -25,7 +25,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const id = ctx.params?.id;
   if (!id) return writeError("conversation id is required", 400);
@@ -42,7 +42,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
   const bucket = (env as Env).EMAIL_BUCKET;
 
   const id = ctx.params?.id;
@@ -139,7 +139,7 @@ export const DELETE = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const id = ctx.params?.id;
   if (!id) return writeError("conversation id is required", 400);

--- a/src/web/src/app/api/conversations/[id]/messages/route.test.ts
+++ b/src/web/src/app/api/conversations/[id]/messages/route.test.ts
@@ -12,6 +12,8 @@ const mockTaskToResponse = vi.fn((t: any) => ({ id: t.id, status: t.status }));
 vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
 }));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", async () => {
   const actual = await vi.importActual("@alook/shared");
   const noop = () => {};

--- a/src/web/src/app/api/conversations/[id]/messages/route.ts
+++ b/src/web/src/app/api/conversations/[id]/messages/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries, TASK_TYPES, buildContextKey, CreateMessageRequestSchema } from "@alook/shared"
+import { queries, TASK_TYPES, buildContextKey, CreateMessageRequestSchema } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { nanoid } from "nanoid";
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
@@ -31,7 +32,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const id = ctx.params?.id;
   if (!id) {
@@ -58,7 +59,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
   const bucket = (env as Env).EMAIL_BUCKET;
 
   const id = ctx.params?.id;

--- a/src/web/src/app/api/conversations/[id]/route.test.ts
+++ b/src/web/src/app/api/conversations/[id]/route.test.ts
@@ -9,6 +9,8 @@ const mockConversationToResponse = vi.fn((c: any) => ({ id: c.id, title: c.title
 vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
 }));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
   queries: {

--- a/src/web/src/app/api/conversations/[id]/route.ts
+++ b/src/web/src/app/api/conversations/[id]/route.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError } from "@/lib/middleware/helpers";
@@ -10,7 +11,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const id = ctx.params?.id;
   if (!id) {
@@ -30,7 +31,7 @@ export const DELETE = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const id = ctx.params?.id;
   if (!id) {

--- a/src/web/src/app/api/conversations/route.test.ts
+++ b/src/web/src/app/api/conversations/route.test.ts
@@ -8,6 +8,8 @@ const mockConversationToResponse = vi.fn((c: any) => ({ id: c.id, title: c.title
 vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
 }));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", async () => {
   const actual = await vi.importActual("@alook/shared");
   return {

--- a/src/web/src/app/api/conversations/route.ts
+++ b/src/web/src/app/api/conversations/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries, CreateConversationRequestSchema } from "@alook/shared"
+import { queries, CreateConversationRequestSchema } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, parseBody } from "@/lib/middleware/helpers";
@@ -11,7 +12,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const conversations = await queries.conversation.listConversations(
     db,
@@ -26,7 +27,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const [body, valErr] = await parseBody(req, CreateConversationRequestSchema);
   if (valErr) return valErr;

--- a/src/web/src/app/api/daemon/deregister/route.test.ts
+++ b/src/web/src/app/api/daemon/deregister/route.test.ts
@@ -44,6 +44,7 @@ describe("POST /api/daemon/deregister", () => {
 
     vi.doMock("@opennextjs/cloudflare", () => mocks["@opennextjs/cloudflare"]);
     vi.doMock("@alook/shared", mocks["@alook/shared"]);
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
     vi.doMock("@/lib/broadcast", () => mocks["@/lib/broadcast"]);
     vi.doMock("@/lib/middleware/auth", () => ({
       withAuth: vi.fn((handler: any) => async (req: any, ctx?: any) => {

--- a/src/web/src/app/api/daemon/deregister/route.ts
+++ b/src/web/src/app/api/daemon/deregister/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
 import { DeregisterRequestSchema } from "@alook/shared";
@@ -8,7 +9,7 @@ import { broadcastToUser } from "@/lib/broadcast";
 
 export const POST = withAuth(async (req: NextRequest, ctx) => {
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const [body, err] = await parseBody(req, DeregisterRequestSchema);
   if (err) return err;

--- a/src/web/src/app/api/daemon/register/route.test.ts
+++ b/src/web/src/app/api/daemon/register/route.test.ts
@@ -54,6 +54,7 @@ describe("POST /api/daemon/register", () => {
 
     vi.doMock("@opennextjs/cloudflare", () => mocks["@opennextjs/cloudflare"]);
     vi.doMock("@alook/shared", mocks["@alook/shared"]);
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
     vi.doMock("@/lib/broadcast", () => mocks["@/lib/broadcast"]);
     vi.doMock("@/lib/api/responses", () => mocks["@/lib/api/responses"]);
     vi.doMock("@/lib/middleware/auth", () => ({

--- a/src/web/src/app/api/daemon/register/route.ts
+++ b/src/web/src/app/api/daemon/register/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { writeJSON, parseBody } from "@/lib/middleware/helpers";
 import { runtimeToResponse } from "@/lib/api/responses";
@@ -9,7 +10,7 @@ import { broadcastToUser } from "@/lib/broadcast";
 
 export const POST = withAuth(async (req: NextRequest, ctx) => {
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const [body, err] = await parseBody(req, RegisterDaemonRequestSchema);
   if (err) return err;

--- a/src/web/src/app/api/daemon/routes.test.ts
+++ b/src/web/src/app/api/daemon/routes.test.ts
@@ -34,6 +34,7 @@ function baseMocks() {
 function applyBase() {
   const m = baseMocks();
   vi.doMock("@opennextjs/cloudflare", m["@opennextjs/cloudflare"]);
+  vi.doMock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
   vi.doMock("@/lib/middleware/auth", m["@/lib/middleware/auth"]);
   vi.doMock("@/lib/middleware/helpers", m["@/lib/middleware/helpers"]);
   vi.doMock("@/lib/logger", m["@/lib/logger"]);

--- a/src/web/src/app/api/daemon/tasks/[taskId]/complete/route.ts
+++ b/src/web/src/app/api/daemon/tasks/[taskId]/complete/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
 import { taskToResponse } from "@/lib/api/responses";
@@ -10,7 +10,7 @@ import { broadcastToUser } from "@/lib/broadcast";
 
 export const POST = withAuth(async (req: NextRequest, ctx) => {
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const taskId = ctx.params?.taskId;
   if (!taskId) {

--- a/src/web/src/app/api/daemon/tasks/[taskId]/fail/route.ts
+++ b/src/web/src/app/api/daemon/tasks/[taskId]/fail/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
 import { taskToResponse } from "@/lib/api/responses";
@@ -10,7 +10,7 @@ import { broadcastToUser } from "@/lib/broadcast";
 
 export const POST = withAuth(async (req: NextRequest, ctx) => {
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const taskId = ctx.params?.taskId;
   if (!taskId) {

--- a/src/web/src/app/api/daemon/tasks/[taskId]/messages/route.ts
+++ b/src/web/src/app/api/daemon/tasks/[taskId]/messages/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import type { TaskMessage } from "@alook/shared"
 import { withAuth } from "@/lib/middleware/auth";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
@@ -11,7 +12,7 @@ import { log } from "@/lib/logger";
 
 export const GET = withAuth(async (_req, ctx) => {
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const taskId = ctx.params?.taskId;
   if (!taskId) {
@@ -24,7 +25,7 @@ export const GET = withAuth(async (_req, ctx) => {
 
 export const POST = withAuth(async (req: NextRequest, ctx) => {
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const taskId = ctx.params?.taskId;
   if (!taskId) {

--- a/src/web/src/app/api/daemon/tasks/[taskId]/start/route.test.ts
+++ b/src/web/src/app/api/daemon/tasks/[taskId]/start/route.test.ts
@@ -7,6 +7,8 @@ const mockTaskToResponse = vi.fn();
 vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
 }));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
 }));

--- a/src/web/src/app/api/daemon/tasks/[taskId]/start/route.ts
+++ b/src/web/src/app/api/daemon/tasks/[taskId]/start/route.ts
@@ -1,5 +1,5 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { writeJSON, writeError } from "@/lib/middleware/helpers";
 import { taskToResponse } from "@/lib/api/responses";
@@ -7,7 +7,7 @@ import { TaskService } from "@/lib/services/task";
 
 export const POST = withAuth(async (_req, ctx) => {
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const taskId = ctx.params?.taskId;
   if (!taskId) {

--- a/src/web/src/app/api/daemon/tasks/[taskId]/status/route.test.ts
+++ b/src/web/src/app/api/daemon/tasks/[taskId]/status/route.test.ts
@@ -6,6 +6,8 @@ const mockGetTaskStatus = vi.fn();
 vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
 }));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
   queries: {

--- a/src/web/src/app/api/daemon/tasks/[taskId]/status/route.ts
+++ b/src/web/src/app/api/daemon/tasks/[taskId]/status/route.ts
@@ -1,11 +1,12 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { writeJSON, writeError } from "@/lib/middleware/helpers";
 
 export const GET = withAuth(async (_req, ctx) => {
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   if (!ctx.workspaceId) {
     return writeError("Forbidden: machine token required", 403);

--- a/src/web/src/app/api/daemon/tasks/poll/route.test.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.test.ts
@@ -15,6 +15,8 @@ vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
 }));
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", async () => {
   const real = await vi.importActual<typeof import("@alook/shared")>("@alook/shared");
   return {

--- a/src/web/src/app/api/daemon/tasks/poll/route.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { createDb, queries, PollRequestSchema, semverGte } from "@alook/shared";
+import { queries, PollRequestSchema, semverGte } from "@alook/shared";
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
 import { taskToResponse } from "@/lib/api/responses";
@@ -12,7 +13,7 @@ import { log } from "@/lib/logger";
 
 export const POST = withAuth(async (req: NextRequest, ctx) => {
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const [body, err] = await parseBody(req, PollRequestSchema);
   if (err) return err;

--- a/src/web/src/app/api/email/[id]/body/route.test.ts
+++ b/src/web/src/app/api/email/[id]/body/route.test.ts
@@ -11,6 +11,8 @@ vi.mock("@opennextjs/cloudflare", () => ({
 
 const mockGetEmailById = vi.fn();
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
   queries: {

--- a/src/web/src/app/api/email/[id]/body/route.ts
+++ b/src/web/src/app/api/email/[id]/body/route.ts
@@ -1,6 +1,7 @@
 import PostalMime from "postal-mime";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { createDb, queries } from "@alook/shared";
+import { queries } from "@alook/shared";
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeError } from "@/lib/middleware/helpers";
@@ -10,7 +11,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const id = ctx.params?.id;
   if (!id) return writeError("email id is required", 400);

--- a/src/web/src/app/api/email/[id]/raw/route.test.ts
+++ b/src/web/src/app/api/email/[id]/raw/route.test.ts
@@ -15,6 +15,8 @@ vi.mock("@opennextjs/cloudflare", () => ({
   })),
 }));
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
   queries: {

--- a/src/web/src/app/api/email/[id]/raw/route.ts
+++ b/src/web/src/app/api/email/[id]/raw/route.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { createDb, queries } from "@alook/shared";
+import { queries } from "@alook/shared";
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeError } from "@/lib/middleware/helpers";
@@ -9,7 +10,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const id = ctx.params?.id;
   if (!id) return writeError("email id is required", 400);

--- a/src/web/src/app/api/email/[id]/route.test.ts
+++ b/src/web/src/app/api/email/[id]/route.test.ts
@@ -11,6 +11,8 @@ vi.mock("@opennextjs/cloudflare", () => ({
   })),
 }));
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", async () => {
   const actual = await vi.importActual("@alook/shared");
   return {

--- a/src/web/src/app/api/email/[id]/route.ts
+++ b/src/web/src/app/api/email/[id]/route.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { createDb, queries, UpdateEmailStatusRequestSchema } from "@alook/shared";
+import { queries, UpdateEmailStatusRequestSchema } from "@alook/shared";
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
@@ -10,7 +11,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const id = ctx.params?.id;
   if (!id) return writeError("email id is required", 400);
@@ -26,7 +27,7 @@ export const DELETE = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const id = ctx.params?.id;
   if (!id) return writeError("email id is required", 400);
@@ -44,7 +45,7 @@ export const PATCH = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const id = ctx.params?.id;
   if (!id) return writeError("email id is required", 400);

--- a/src/web/src/app/api/email/[id]/thread/route.ts
+++ b/src/web/src/app/api/email/[id]/thread/route.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { createDb, queries } from "@alook/shared";
+import { queries } from "@alook/shared";
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError } from "@/lib/middleware/helpers";
@@ -10,7 +11,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const id = ctx.params?.id;
   if (!id) return writeError("email id is required", 400);

--- a/src/web/src/app/api/email/notify/route.ts
+++ b/src/web/src/app/api/email/notify/route.ts
@@ -1,13 +1,14 @@
 import { NextRequest } from "next/server"
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries, TASK_TYPES, buildContextKey, extractThreadId, EmailNotifyRequestSchema } from "@alook/shared"
+import { queries, TASK_TYPES, buildContextKey, extractThreadId, EmailNotifyRequestSchema } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { writeJSON, parseBody } from "@/lib/middleware/helpers"
 import { TaskService } from "@/lib/services/task"
 import { broadcastToUser } from "@/lib/broadcast"
 
 export async function POST(req: NextRequest) {
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const [body, valErr] = await parseBody(req, EmailNotifyRequestSchema);
   if (valErr) return valErr;

--- a/src/web/src/app/api/email/route.test.ts
+++ b/src/web/src/app/api/email/route.test.ts
@@ -10,6 +10,8 @@ vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
 }));
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
   queries: {

--- a/src/web/src/app/api/email/route.ts
+++ b/src/web/src/app/api/email/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { createDb, queries } from "@alook/shared";
+import { queries } from "@alook/shared";
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError } from "@/lib/middleware/helpers";
@@ -13,7 +14,7 @@ export const GET = withAuth(async (req: NextRequest, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const agentId = req.nextUrl.searchParams.get("agentId");
   if (!agentId) return writeError("agentId is required", 400);

--- a/src/web/src/app/api/email/send/route.test.ts
+++ b/src/web/src/app/api/email/send/route.test.ts
@@ -14,6 +14,8 @@ vi.mock("@opennextjs/cloudflare", () => ({
   })),
 }));
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", async () => {
   const actual = await vi.importActual("@alook/shared");
   return {

--- a/src/web/src/app/api/email/send/route.ts
+++ b/src/web/src/app/api/email/send/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { createDb, queries, DEV_EMAIL_WORKER_URL, SendEmailRequestSchema } from "@alook/shared";
+import { queries, DEV_EMAIL_WORKER_URL, SendEmailRequestSchema } from "@alook/shared";
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
@@ -12,7 +13,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
 
   const { env } = getCloudflareContext();
   const cfEnv = env as Env;
-  const db = createDb(cfEnv.DB);
+  const db = getDb(cfEnv.DB);
 
   const [body, valErr] = await parseBody(req, SendEmailRequestSchema);
   if (valErr) return valErr;

--- a/src/web/src/app/api/machine-tokens/[id]/route.test.ts
+++ b/src/web/src/app/api/machine-tokens/[id]/route.test.ts
@@ -7,6 +7,8 @@ vi.mock("@opennextjs/cloudflare", () => ({
 
 const mockDeleteMachineToken = vi.fn();
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
   queries: {

--- a/src/web/src/app/api/machine-tokens/[id]/route.ts
+++ b/src/web/src/app/api/machine-tokens/[id]/route.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeError } from "@/lib/middleware/helpers";
@@ -9,7 +10,7 @@ export const DELETE = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const id = ctx.params?.id;
   if (!id) {

--- a/src/web/src/app/api/machine-tokens/activate/route.ts
+++ b/src/web/src/app/api/machine-tokens/activate/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { createDb, queries, ActivateTokenRequestSchema, createLogger } from "@alook/shared";
+import { queries, ActivateTokenRequestSchema, createLogger } from "@alook/shared";
+import { getDb } from "@/lib/db"
 import { writeJSON } from "@/lib/middleware/helpers";
 import { runtimeToResponse } from "@/lib/api/responses";
 import { broadcastToUser } from "@/lib/broadcast";
@@ -23,7 +24,7 @@ export async function POST(req: NextRequest) {
   const { token, hostname, runtimes } = parsed.data;
 
   const { env } = await getCloudflareContext({ async: true });
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const mt = await queries.machineToken.getMachineTokenByToken(db, token);
   if (!mt) {

--- a/src/web/src/app/api/machine-tokens/route.test.ts
+++ b/src/web/src/app/api/machine-tokens/route.test.ts
@@ -27,6 +27,8 @@ vi.mock("@/lib/middleware/helpers", () => ({
 vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
 }));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
   queries: {

--- a/src/web/src/app/api/machine-tokens/route.ts
+++ b/src/web/src/app/api/machine-tokens/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { generateMachineToken } from "@/lib/token";
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
@@ -12,7 +13,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const tokens = await queries.machineToken.listMachineTokens(db, ctx.userId, ws.workspaceId);
   return writeJSON(tokens.map(machineTokenToResponse));
@@ -23,7 +24,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   // Reuse existing pending token for this workspace
   const pending = await queries.machineToken.getPendingMachineToken(db, ctx.userId, ws.workspaceId);

--- a/src/web/src/app/api/me/route.test.ts
+++ b/src/web/src/app/api/me/route.test.ts
@@ -7,6 +7,8 @@ vi.mock("@opennextjs/cloudflare", () => ({
 
 const mockGetUser = vi.fn();
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
   queries: {

--- a/src/web/src/app/api/me/route.ts
+++ b/src/web/src/app/api/me/route.ts
@@ -1,12 +1,13 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { writeJSON, writeError } from "@/lib/middleware/helpers";
 import { userToResponse } from "@/lib/api/responses";
 
 export const GET = withAuth(async (_req, ctx) => {
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const user = await queries.user.getUser(db, ctx.userId);
   if (!user) {

--- a/src/web/src/app/api/members/me/route.test.ts
+++ b/src/web/src/app/api/members/me/route.test.ts
@@ -8,6 +8,8 @@ vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(async () => ({ env: { DB: {} } })),
 }));
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", async () => {
   const real = await vi.importActual<typeof import("@alook/shared")>("@alook/shared");
   return {

--- a/src/web/src/app/api/members/me/route.ts
+++ b/src/web/src/app/api/members/me/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { createDb, queries, UpdateMemberRequestSchema } from "@alook/shared";
+import { queries, UpdateMemberRequestSchema } from "@alook/shared";
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
@@ -10,7 +11,7 @@ export const GET = withAuth(async (req: NextRequest, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = await getCloudflareContext({ async: true });
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const member = await queries.member.getMemberByUserAndWorkspace(
     db,
@@ -30,7 +31,7 @@ export const PATCH = withAuth(async (req: NextRequest, ctx) => {
   if (err) return err;
 
   const { env } = await getCloudflareContext({ async: true });
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const updated = await queries.member.updateMemberGlobalInstruction(
     db,

--- a/src/web/src/app/api/runtimes/[runtimeId]/update/route.test.ts
+++ b/src/web/src/app/api/runtimes/[runtimeId]/update/route.test.ts
@@ -10,6 +10,8 @@ vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
 }));
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
   queries: {

--- a/src/web/src/app/api/runtimes/[runtimeId]/update/route.ts
+++ b/src/web/src/app/api/runtimes/[runtimeId]/update/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { createDb, queries } from "@alook/shared";
+import { queries } from "@alook/shared";
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError } from "@/lib/middleware/helpers";
@@ -21,7 +22,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const runtimeId = req.nextUrl.pathname.split("/runtimes/")[1]?.split("/")[0];
   if (!runtimeId) return writeError("runtime id required", 400);
@@ -46,7 +47,7 @@ export const DELETE = withAuth(async (req: NextRequest, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = createDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const runtimeId = req.nextUrl.pathname.split("/runtimes/")[1]?.split("/")[0];
   if (!runtimeId) return writeError("runtime id required", 400);

--- a/src/web/src/app/api/runtimes/machine/route.test.ts
+++ b/src/web/src/app/api/runtimes/machine/route.test.ts
@@ -8,6 +8,8 @@ const mockGetMemberByUserAndWorkspace = vi.fn();
 vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
 }));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
   queries: {

--- a/src/web/src/app/api/runtimes/machine/route.ts
+++ b/src/web/src/app/api/runtimes/machine/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON } from "@/lib/middleware/helpers";
@@ -12,7 +13,7 @@ export const DELETE = withAuth(async (req: NextRequest, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const daemonId = req.nextUrl.searchParams.get("daemon_id");
   if (!daemonId) {

--- a/src/web/src/app/api/runtimes/route.test.ts
+++ b/src/web/src/app/api/runtimes/route.test.ts
@@ -8,6 +8,8 @@ vi.mock("@opennextjs/cloudflare", () => ({
 const mockListAgentRuntimes = vi.fn();
 const mockSweepStaleState = vi.fn();
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
   queries: {

--- a/src/web/src/app/api/runtimes/route.ts
+++ b/src/web/src/app/api/runtimes/route.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON } from "@/lib/middleware/helpers";
@@ -11,7 +12,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   // Sweep stale state: mark offline runtimes, fail stuck tasks, reconcile agents
   await sweepStaleState(db, ws.workspaceId);

--- a/src/web/src/app/api/tasks/[id]/messages/route.test.ts
+++ b/src/web/src/app/api/tasks/[id]/messages/route.test.ts
@@ -27,6 +27,8 @@ vi.mock("@/lib/middleware/helpers", () => ({
 vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
 }));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
   queries: {

--- a/src/web/src/app/api/tasks/[id]/messages/route.ts
+++ b/src/web/src/app/api/tasks/[id]/messages/route.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError } from "@/lib/middleware/helpers";
@@ -10,7 +11,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const id = ctx.params?.id;
   if (!id) {

--- a/src/web/src/app/api/tasks/[id]/route.test.ts
+++ b/src/web/src/app/api/tasks/[id]/route.test.ts
@@ -25,6 +25,8 @@ vi.mock("@/lib/middleware/helpers", () => ({
 vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
 }));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
   queries: {

--- a/src/web/src/app/api/tasks/[id]/route.ts
+++ b/src/web/src/app/api/tasks/[id]/route.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError } from "@/lib/middleware/helpers";
@@ -10,7 +11,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const id = ctx.params?.id;
   if (!id) {

--- a/src/web/src/app/api/workspaces/[id]/route.test.ts
+++ b/src/web/src/app/api/workspaces/[id]/route.test.ts
@@ -7,6 +7,8 @@ vi.mock("@opennextjs/cloudflare", () => ({
 
 const mockGetWorkspace = vi.fn();
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
   queries: {

--- a/src/web/src/app/api/workspaces/[id]/route.ts
+++ b/src/web/src/app/api/workspaces/[id]/route.ts
@@ -1,12 +1,13 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { writeJSON, writeError } from "@/lib/middleware/helpers";
 import { workspaceToResponse } from "@/lib/api/responses";
 
 export const GET = withAuth(async (_req, ctx) => {
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const id = ctx.params?.id;
   if (!id) {

--- a/src/web/src/app/api/workspaces/route.test.ts
+++ b/src/web/src/app/api/workspaces/route.test.ts
@@ -9,6 +9,8 @@ const mockListWorkspaces = vi.fn();
 const mockCreateWorkspace = vi.fn();
 const mockCreateMember = vi.fn();
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", async () => {
   const actual = await vi.importActual("@alook/shared");
   return {

--- a/src/web/src/app/api/workspaces/route.ts
+++ b/src/web/src/app/api/workspaces/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries, isUniqueConstraintError, CreateWorkspaceRequestSchema } from "@alook/shared"
+import { queries, isUniqueConstraintError, CreateWorkspaceRequestSchema } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { nanoid } from "nanoid"
 import { withAuth } from "@/lib/middleware/auth";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
@@ -8,7 +9,7 @@ import { workspaceToResponse } from "@/lib/api/responses";
 
 export const GET = withAuth(async (_req, ctx) => {
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const workspaces = await queries.workspace.listWorkspaces(db, ctx.userId);
   return writeJSON(workspaces.map(workspaceToResponse));
@@ -16,7 +17,7 @@ export const GET = withAuth(async (_req, ctx) => {
 
 export const POST = withAuth(async (req: NextRequest, ctx) => {
   const { env } = getCloudflareContext()
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const [body, valErr] = await parseBody(req, CreateWorkspaceRequestSchema);
   if (valErr) return valErr;

--- a/src/web/src/lib/api-auth.ts
+++ b/src/web/src/lib/api-auth.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 
 export async function withToken(request: Request) {
   const authHeader = request.headers.get("Authorization")
@@ -11,7 +12,7 @@ export async function withToken(request: Request) {
     return { error: new Response("Invalid token format", { status: 401 }), machineToken: null }
   }
   const { env } = await getCloudflareContext({ async: true })
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
   const mt = await queries.machineToken.getMachineTokenByToken(db, raw)
   if (!mt) {
     return { error: new Response("Token not found", { status: 401 }), machineToken: null }

--- a/src/web/src/lib/auth.test.ts
+++ b/src/web/src/lib/auth.test.ts
@@ -8,6 +8,8 @@ vi.mock("better-auth/plugins", () => ({
   emailOTP: vi.fn((cfg: unknown) => ({ __plugin: "emailOTP", cfg })),
 }))
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn() }),
   DEV_EMAIL_WORKER_URL: "http://localhost:0",

--- a/src/web/src/lib/db.ts
+++ b/src/web/src/lib/db.ts
@@ -1,0 +1,8 @@
+import { createDb, type Database } from "@alook/shared"
+
+export function getDb(d1: D1Database): Database {
+  const session = d1.withSession("first-primary")
+  // D1DatabaseSession has prepare() + batch() which is all Drizzle uses at runtime.
+  // Native Drizzle support tracked at https://github.com/drizzle-team/drizzle-orm/issues/4522
+  return createDb(session as unknown as Parameters<typeof createDb>[0])
+}

--- a/src/web/src/lib/dual-auth.ts
+++ b/src/web/src/lib/dual-auth.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { createAuth } from "@/lib/auth"
 
 export async function requireAuth(request: Request) {
@@ -10,7 +11,7 @@ export async function requireAuth(request: Request) {
   if (authHeader?.startsWith("Bearer ")) {
     const raw = authHeader.slice(7)
     if (raw.startsWith("al_")) {
-      const db = createDb(cloudflareEnv.DB)
+      const db = getDb(cloudflareEnv.DB)
       const mt = await queries.machineToken.getMachineTokenByToken(db, raw)
       if (mt) {
         queries.machineToken.updateMachineTokenLastUsed(db, mt.id).catch(() => {})

--- a/src/web/src/lib/middleware/auth.test.ts
+++ b/src/web/src/lib/middleware/auth.test.ts
@@ -5,6 +5,8 @@ vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(async () => ({ env: { DB: {} } })),
 }));
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
   queries: {

--- a/src/web/src/lib/middleware/auth.ts
+++ b/src/web/src/lib/middleware/auth.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import { createAuth } from "@/lib/auth"
 
 export interface AuthContext {
@@ -33,7 +34,7 @@ export function withAuth(handler: AuthenticatedHandler) {
       const raw = authHeader.slice(7)
       if (raw.startsWith("al_")) {
         try {
-          const db = createDb(cloudflareEnv.DB)
+          const db = getDb(cloudflareEnv.DB)
           const mt = await queries.machineToken.getMachineTokenByToken(db, raw)
           if (!mt) {
             return NextResponse.json({ error: "invalid token" }, { status: 401 })

--- a/src/web/src/lib/middleware/workspace.test.ts
+++ b/src/web/src/lib/middleware/workspace.test.ts
@@ -5,6 +5,8 @@ vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(async () => ({ env: { DB: {} } })),
 }));
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
   queries: {

--- a/src/web/src/lib/middleware/workspace.ts
+++ b/src/web/src/lib/middleware/workspace.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { createDb, queries } from "@alook/shared"
+import { queries } from "@alook/shared"
+import { getDb } from "@/lib/db"
 import type { AuthContext } from "./auth"
 
 export interface WorkspaceContext extends AuthContext {
@@ -31,7 +32,7 @@ export async function withWorkspaceMember(
   }
 
   const { env } = await getCloudflareContext({ async: true })
-  const db = createDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const membership = await queries.member.getMemberByUserAndWorkspace(
     db,

--- a/src/web/src/lib/services/calendar.test.ts
+++ b/src/web/src/lib/services/calendar.test.ts
@@ -17,6 +17,8 @@ const mockGetAgent = vi.fn();
 const mockCreateConv = vi.fn();
 const mockCreateTask = vi.fn();
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", async () => {
   const actual = await vi.importActual<typeof import("@alook/shared")>("@alook/shared");
   return {

--- a/src/web/src/lib/services/sweep.test.ts
+++ b/src/web/src/lib/services/sweep.test.ts
@@ -8,6 +8,8 @@ const mockGetConversation = vi.fn();
 const mockGetAgent = vi.fn();
 const mockCreateTask = vi.fn();
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   queries: {
     task: {

--- a/src/web/src/lib/services/task.test.ts
+++ b/src/web/src/lib/services/task.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
 vi.mock("@alook/shared", () => ({
   TASK_TYPES: {
     USER_DM_MESSAGE: "user_dm_message",


### PR DESCRIPTION
# Why we need this PR?

D1 read replication has been enabled. Without the Sessions API, all queries still route to the primary — replication benefits are wasted. With Sessions API (`withSession("first-primary")`), read queries can be served by nearby replicas with sequential consistency, reducing latency for geographically distant users.

## What changed

- **New `getDb()` helper** (`src/web/src/lib/db.ts`): wraps `env.DB.withSession("first-primary")` before passing to Drizzle's `createDb()`. First query per request hits the primary; subsequent reads use sequentially-consistent replicas.
- **All route handlers & middleware** (~55 files): switched from `createDb((env as Env).DB)` to `getDb((env as Env).DB)`.
- **All route tests** (~41 files): added `vi.mock("@/lib/db")` for the new module.
- **Better Auth** left unchanged — cookie cache already handles read-after-write consistency for auth sessions.
- **Shared package** unchanged — `createDb` still available for non-session use (tests, tooling).

### Type assertion note
`D1Database.withSession()` returns `D1DatabaseSession`, which is a different type from `D1Database`. Drizzle only uses `prepare()` + `batch()` at runtime (both present on `D1DatabaseSession`), but its types require `D1Database`. A `as unknown as` assertion bridges the gap. Tracked upstream: [drizzle-orm#4522](https://github.com/drizzle-team/drizzle-orm/issues/4522).

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)