### PR TITLE
feat: isolate email download path by workspace and agent

### DIFF
--- a/src/cli/commands/email.ts
+++ b/src/cli/commands/email.ts
@@ -26,7 +26,7 @@ interface EmailResponse {
 }
 
 const VALID_STATUSES = ["unread", "read", "archived"];
-const EMAIL_DIR = "/tmp/alook-emails";
+const EMAIL_BASE = "/tmp/alook-emails";
 
 const MIME_BY_EXT: Record<string, string> = {
   ".pdf": "application/pdf",
@@ -101,7 +101,7 @@ export function emailCommand(): Command {
 
   cmd
     .command("pull")
-    .description("Download and parse emails to /tmp/alook-emails/")
+    .description("Download and parse emails to /tmp/alook-emails/{workspaceId}/{agentId}/")
     .requiredOption("--agent_id <id>", "Agent ID")
     .option("--status <status>", "Filter by status (unread, read, archived)")
     .option("--workspace <id>", "Workspace ID")
@@ -116,6 +116,8 @@ export function emailCommand(): Command {
         );
         process.exit(1);
       }
+
+      const emailDir_base = join(EMAIL_BASE, workspaceId, opts.agent_id);
 
       try {
         let query = `/api/email?agentId=${opts.agent_id}`;
@@ -133,12 +135,12 @@ export function emailCommand(): Command {
           return;
         }
 
-        mkdirSync(EMAIL_DIR, { recursive: true });
+        mkdirSync(emailDir_base, { recursive: true });
 
         const downloadedPaths: string[] = [];
 
         for (const email of emails) {
-          const emailDir = join(EMAIL_DIR, email.id);
+          const emailDir = join(emailDir_base, email.id);
           mkdirSync(emailDir, { recursive: true });
 
           // Write metadata
@@ -215,7 +217,7 @@ export function emailCommand(): Command {
         }
 
         console.log(
-          `Downloaded ${emails.length} email${emails.length === 1 ? "" : "s"} to ${EMAIL_DIR}/`,
+          `Downloaded ${emails.length} email${emails.length === 1 ? "" : "s"} to ${emailDir_base}/`,
         );
         for (const p of downloadedPaths) {
           console.log(`  ${p}`);

--- a/src/cli/daemon/execenv/context.test.ts
+++ b/src/cli/daemon/execenv/context.test.ts
@@ -25,9 +25,9 @@ describe("buildInstructionContent email tool injection", () => {
     });
     const content = buildInstructionContent(task);
 
-    expect(content).toContain("npx @alook/cli email pull --agent_id agent-123 --status unread");
-    expect(content).toContain("npx @alook/cli email set --agent_id agent-123 --email_id <EMAIL_ID> --status read");
-    expect(content).toContain("/tmp/alook-emails/");
+    expect(content).toContain("npx @alook/cli email pull --agent_id agent-123 --workspace ws1 --status unread");
+    expect(content).toContain("npx @alook/cli email set --agent_id agent-123 --workspace ws1 --email_id <EMAIL_ID> --status read");
+    expect(content).toContain("/tmp/alook-emails/ws1/agent-123/");
     expect(content).toContain("metadata.json");
     expect(content).toContain("'myagent@alook.ai' (default, Alook platform address)");
   });

--- a/src/cli/daemon/execenv/context.ts
+++ b/src/cli/daemon/execenv/context.ts
@@ -91,15 +91,15 @@ ${task.agent?.userEmail ? `Your owner's email address is '${task.agent.userEmail
 
 ### Emails
 ---
-Run 'npx @alook/cli email pull --agent_id ${task.agentId} --status unread' to download unread emails to '/tmp/alook-emails/'.
-Each email is saved to '/tmp/alook-emails/<emailId>/' with:
+Run 'npx @alook/cli email pull --agent_id ${task.agentId} --workspace ${task.workspaceId} --status unread' to download unread emails to '/tmp/alook-emails/${task.workspaceId}/${task.agentId}/'.
+Each email is saved to '/tmp/alook-emails/${task.workspaceId}/${task.agentId}/<emailId>/' with:
 - 'metadata.json' — sender, recipient, subject, date, status, message_id, in_reply_to, references
 - 'body.txt' — plain text body
 - 'body.html' — HTML body (if available)
 - 'attachments/' — extracted attachment files (if any)
 ---
 Before starting to process an email, mark it as read:
-- Run 'npx @alook/cli email set --agent_id ${task.agentId} --email_id <EMAIL_ID> --status read'
+- Run 'npx @alook/cli email set --agent_id ${task.agentId} --workspace ${task.workspaceId} --email_id <EMAIL_ID> --status read'
 ---
 
 #### Sending a new email

--- a/src/cli/daemon/execenv/context.ts
+++ b/src/cli/daemon/execenv/context.ts
@@ -104,17 +104,17 @@ Before starting to process an email, mark it as read:
 
 #### Sending a new email
 Write the HTML body to a file first, then send it. The body is forwarded as-is (HTML).
-- Run 'npx @alook/cli email send --agent_id ${task.agentId} --to <ADDRESS> --subject "<SUBJECT>" --body-file <PATH_TO_HTML>'
+- Run 'npx @alook/cli email send --agent_id ${task.agentId} --workspace ${task.workspaceId} --to <ADDRESS> --subject "<SUBJECT>" --body-file <PATH_TO_HTML>'
 - To send from a specific mailbox, add '--from <YOUR_EMAIL_ADDRESS>'. Without '--from', the default Alook address is used.
 - Attach files with '--attachment <PATH>' — repeat the flag for multiple attachments. Each file is uploaded before sending.
-- Example: 'npx @alook/cli email send --agent_id ${task.agentId} --to foo@bar.com --subject "Weekly report" --body-file /tmp/body.html --from alice@company.com --attachment /tmp/report.pdf'
+- Example: 'npx @alook/cli email send --agent_id ${task.agentId} --workspace ${task.workspaceId} --to foo@bar.com --subject "Weekly report" --body-file /tmp/body.html --from alice@company.com --attachment /tmp/report.pdf'
 
 #### Replying to an email
 To reply to an email, add '--in-reply-to <EMAIL_ID>' to the send command. This sets the correct email threading headers so the recipient's email client groups the reply into the same conversation thread.
 - Use 'Re: <original subject>' as the subject.
 - Quote the original email body in your reply (wrap it in a blockquote).
 - The <EMAIL_ID> is the Alook email id from metadata.json (not the message_id header).
-- Example: 'npx @alook/cli email send --agent_id ${task.agentId} --to sender@example.com --subject "Re: Bug report" --body-file /tmp/reply.html --in-reply-to <EMAIL_ID>'
+- Example: 'npx @alook/cli email send --agent_id ${task.agentId} --workspace ${task.workspaceId} --to sender@example.com --subject "Re: Bug report" --body-file /tmp/reply.html --in-reply-to <EMAIL_ID>'
 ---
 `;
   }


### PR DESCRIPTION
# Why we need this PR?

Email pull currently downloads all emails to a shared `/tmp/alook-emails/` directory regardless of workspace or agent. This means multiple agents across different workspaces write to the same folder, which breaks isolation and can cause conflicts. This PR aligns the email download path with the existing `{workspaceId}/{agentId}` isolation pattern used by workdir.

## What changed

- **`src/cli/commands/email.ts`**: Changed `EMAIL_DIR` from a hardcoded global path to a dynamic path constructed as `/tmp/alook-emails/{workspaceId}/{agentId}/`. The `workspaceId` is resolved from `--workspace` flag or config lookup (already existed).
- **`src/cli/daemon/execenv/context.ts`**: Updated the CLAUDE.md agent instruction template so all email CLI commands (`pull`, `set`, `send`) include `--workspace` and reference the new isolated path.
- **`src/cli/daemon/execenv/context.test.ts`**: Updated assertions to match the new path format and command flags.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] CLI (`@alook/cli`)
- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...