### PR TITLE
feat(web): markdown editor for settings + breathing arrow on chat steps

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       '@tiptap/extension-underline':
         specifier: ^3.22.4
         version: 3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))
+      '@tiptap/markdown':
+        specifier: ^3.22.4
+        version: 3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)
       '@tiptap/react':
         specifier: ^3.22.4
         version: 3.22.4(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -2231,6 +2234,12 @@ packages:
 
   '@tiptap/extensions@3.22.4':
     resolution: {integrity: sha512-fOe8VptJvLPs32bNdUYo8SRyljwqKNQVXWW056VoXIc5en/59OdJlJQVeHI0jRRciH3MtrqODi/gfJR0VHNZ8A==}
+    peerDependencies:
+      '@tiptap/core': 3.22.4
+      '@tiptap/pm': 3.22.4
+
+  '@tiptap/markdown@3.22.4':
+    resolution: {integrity: sha512-gcoLOq5TBntw13QdeWMy7yc2X+b9yTplcFb5kpMQNgNoxlu0+jlX4LiBR+E6lOV+m+AtkprHHltTYyKG23bdOw==}
     peerDependencies:
       '@tiptap/core': 3.22.4
       '@tiptap/pm': 3.22.4
@@ -8345,6 +8354,12 @@ snapshots:
       '@tiptap/core': 3.22.4(@tiptap/pm@3.22.4)
       '@tiptap/pm': 3.22.4
 
+  '@tiptap/markdown@3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)':
+    dependencies:
+      '@tiptap/core': 3.22.4(@tiptap/pm@3.22.4)
+      '@tiptap/pm': 3.22.4
+      marked: 17.0.6
+
   '@tiptap/pm@3.22.4':
     dependencies:
       prosemirror-changeset: 2.4.1
@@ -9773,8 +9788,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.4
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -9796,7 +9811,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -9807,22 +9822,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9833,7 +9848,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -29,6 +29,7 @@
 		"@tiptap/extension-text-align": "^3.22.4",
 		"@tiptap/extension-text-style": "^3.22.4",
 		"@tiptap/extension-underline": "^3.22.4",
+		"@tiptap/markdown": "^3.22.4",
 		"@tiptap/react": "^3.22.4",
 		"@tiptap/starter-kit": "^3.22.4",
 		"better-auth": "^1.6.5",

--- a/src/web/src/app/(app)/w/[slug]/settings/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/settings/page.tsx
@@ -7,7 +7,7 @@ import { getMemberMe, updateMemberMe } from "@/lib/api";
 import { MobileSidebarLogo } from "@/components/mobile-sidebar-logo";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
+import { MarkdownEditor } from "@/components/ui/markdown-editor";
 import { Skeleton } from "@/components/ui/skeleton";
 
 const MAX_LENGTH = 50_000;
@@ -97,14 +97,12 @@ export default function SettingsPage() {
         ) : (
           <div className="mx-auto max-w-md space-y-4">
             <Label htmlFor="global-instruction">Global Instruction</Label>
-            <Textarea
-              id="global-instruction"
-              rows={10}
-              className="min-h-16"
-              placeholder="Write instructions that every agent you own will follow..."
+            <MarkdownEditor
               value={value}
-              onChange={(e) => setValue(e.target.value)}
-              maxLength={MAX_LENGTH}
+              onChange={setValue}
+              placeholder="Write instructions that every agent you own will follow..."
+              minHeight="240px"
+              contentType="markdown"
             />
             <div className="flex items-center justify-between">
               <p className="text-xs text-muted-foreground/70">

--- a/src/web/src/components/task-stream.tsx
+++ b/src/web/src/components/task-stream.tsx
@@ -321,10 +321,7 @@ export function TaskStream({
               "[&::-webkit-details-marker]:hidden [&::marker]:hidden"
             )}
           >
-            <ChevronRight className="size-3 shrink-0 text-muted-foreground/60 transition-transform duration-150 group-open/stream:rotate-90" />
-            {isRunning && (
-              <span className="size-1.5 rounded-full bg-primary animate-pulse shrink-0" />
-            )}
+            <ChevronRight className={cn("size-3 shrink-0 text-muted-foreground/60 transition-transform duration-150 group-open/stream:rotate-90", isRunning && "animate-pulse text-primary")} />
             <span><AnimatedNumber value={toolItems.length} /> {toolItems.length === 1 ? "step" : "steps"}</span>
           </summary>
           <div

--- a/src/web/src/components/ui/markdown-editor.tsx
+++ b/src/web/src/components/ui/markdown-editor.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
+import { Markdown } from "@tiptap/markdown";
 import { cn } from "@/lib/utils";
 import { isEmptyHtml } from "@alook/shared";
 
@@ -11,13 +12,15 @@ export { isEmptyHtml };
 
 export interface MarkdownEditorProps {
   value: string;
-  onChange: (html: string) => void;
+  onChange: (value: string) => void;
   placeholder?: string;
   className?: string;
   minHeight?: number | string;
   autoFocus?: boolean;
   /** `default` is framed (border + focus ring); `seamless` blends with the parent. */
   variant?: "default" | "seamless";
+  /** `html` (default) — value/onChange use HTML. `markdown` — value/onChange use Markdown text. */
+  contentType?: "html" | "markdown";
 }
 
 function normalize(html: string | null | undefined): string {
@@ -33,7 +36,10 @@ export function MarkdownEditor({
   minHeight = "9rem",
   autoFocus,
   variant = "default",
+  contentType = "html",
 }: MarkdownEditorProps) {
+  const isMd = contentType === "markdown";
+
   const minHeightStyle =
     typeof minHeight === "number" ? `${minHeight}px` : minHeight;
 
@@ -45,9 +51,11 @@ export function MarkdownEditor({
   const editor = useEditor({
     immediatelyRender: false,
     content: value || undefined,
+    ...(isMd ? { contentType: "markdown" } : {}),
     extensions: [
       StarterKit,
       Placeholder.configure({ placeholder: placeholder ?? "" }),
+      ...(isMd ? [Markdown] : []),
     ],
     editorProps: {
       attributes: {
@@ -57,17 +65,23 @@ export function MarkdownEditor({
     },
     autofocus: autoFocus ? "end" : false,
     onUpdate: ({ editor }) => {
-      onChange(editor.getHTML());
+      onChange(isMd ? editor.getMarkdown() : editor.getHTML());
     },
   });
 
   useEffect(() => {
     if (!editor) return;
-    const incoming = normalize(value);
-    const current = normalize(editor.getHTML());
-    if (incoming === current) return;
-    editor.commands.setContent(value || "", { emitUpdate: false });
-    // Only react to value changes, not editor identity.
+    if (isMd) {
+      const incoming = (value || "").trim();
+      const current = (editor.getMarkdown() || "").trim();
+      if (incoming === current) return;
+      editor.commands.setContent(value || "", { emitUpdate: false, contentType: "markdown" });
+    } else {
+      const incoming = normalize(value);
+      const current = normalize(editor.getHTML());
+      if (incoming === current) return;
+      editor.commands.setContent(value || "", { emitUpdate: false });
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value, editor]);
 


### PR DESCRIPTION
# Why we need this PR?

Two small UX improvements:
1. The Settings global instruction field is a plain textarea, but the content is markdown — a rich editor gives better authoring experience and matches the email compose pattern.
2. In the chat view, running steps show both a left arrow and a breathing dot, which is redundant.

## What changed

- **`src/web/src/components/ui/markdown-editor.tsx`**: Added `contentType` prop (`"html"` | `"markdown"`). In markdown mode, uses `@tiptap/markdown` extension so `value`/`onChange` work with plain markdown text. Existing HTML mode is unchanged.
- **`src/web/src/app/(app)/w/[slug]/settings/page.tsx`**: Replaced `<Textarea>` with `<MarkdownEditor contentType="markdown">` for the global instruction field.
- **`src/web/src/components/task-stream.tsx`**: Removed the breathing dot on the top-level steps summary. The `ChevronRight` arrow now pulses with `animate-pulse` and turns primary color when running.
- **`src/web/package.json`**: Added `@tiptap/markdown` dependency.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)
- [ ] Shared library (`@alook/shared`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...