### PR TITLE
fix(web): use dvh instead of vh for mobile viewport

### DIFF
--- a/src/web/src/app/(app)/workspaces/client.tsx
+++ b/src/web/src/app/(app)/workspaces/client.tsx
@@ -65,7 +65,7 @@ export function WorkspaceListClient({
   }
 
   return (
-    <div className="relative flex min-h-screen flex-col items-center justify-center p-6">
+    <div className="relative flex min-h-dvh flex-col items-center justify-center p-6">
       <GradientBackground />
 
       <div className="w-full max-w-md space-y-8">

--- a/src/web/src/components/workspace-shell.tsx
+++ b/src/web/src/components/workspace-shell.tsx
@@ -22,7 +22,7 @@ export function WorkspaceShell({ children }: { children: ReactNode }) {
   if (isMobile) {
     return (
       <SidebarTriggerContext.Provider value={() => setSidebarOpen(true)}>
-        <div className="flex flex-col h-screen overflow-hidden relative">
+        <div className="flex flex-col h-dvh overflow-hidden relative">
           <GradientBackground />
           <div className="flex-1 min-h-0 px-2 pb-2 pt-2">
             <main className="h-full rounded-xl bg-card/80 backdrop-blur-xl shadow-lg ring-1 ring-border/40 overflow-hidden flex flex-col">
@@ -40,7 +40,7 @@ export function WorkspaceShell({ children }: { children: ReactNode }) {
   }
 
   return (
-    <div className="flex h-screen overflow-hidden relative">
+    <div className="flex h-dvh overflow-hidden relative">
       <GradientBackground />
       <AppSidebar />
       <div className="flex-1 min-w-0 p-2 pl-0">


### PR DESCRIPTION
# Why we need this PR?

On mobile browsers, `100vh` equals the maximum viewport height (with address bar collapsed). When the address bar is visible, the actual visible area is smaller than `100vh`, causing blank areas at the top and bottom of the workspace shell.

## What changed

- Replaced `h-screen` (`100vh`) with `h-dvh` (`100dvh`) in `workspace-shell.tsx` for both mobile and desktop layouts
- `dvh` (dynamic viewport height) adjusts in real-time as the browser chrome (address bar / bottom bar) appears and disappears

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)