### PR TITLE
fix: pass raw ArrayBuffer to CF SendEmail to prevent double-encoding attachments

### DIFF
--- a/src/email-worker/src/index.test.ts
+++ b/src/email-worker/src/index.test.ts
@@ -453,14 +453,15 @@ describe("POST /send/agent", () => {
 
     expect(res.status).toBe(200)
 
-    // Verify SEND_EMAIL.send includes attachments with base64 content string
+    // Verify SEND_EMAIL.send includes attachments with raw ArrayBuffer content
     const sendArg = send.mock.calls[0][0]
     expect(sendArg.attachments).toHaveLength(1)
     expect(sendArg.attachments[0].filename).toBe("doc.txt")
     expect(sendArg.attachments[0].type).toBe("text/plain")
     expect(sendArg.attachments[0].disposition).toBe("attachment")
-    expect(typeof sendArg.attachments[0].content).toBe("string")
-    expect(sendArg.attachments[0].content).toBe(btoa("file content"))
+    expect(sendArg.attachments[0].content).toBeInstanceOf(ArrayBuffer)
+    const decoded = new TextDecoder().decode(sendArg.attachments[0].content)
+    expect(decoded).toBe("file content")
 
     // Verify R2 MIME archive contains attachment
     const storedMime = put.mock.calls[0][1] as string

--- a/src/email-worker/src/index.ts
+++ b/src/email-worker/src/index.ts
@@ -127,17 +127,18 @@ export default {
     const htmlBody = body.htmlBody ?? ""
     const attachmentKeys = body.attachmentKeys ?? []
 
-    // Fetch attachment content from R2 and convert to base64
-    const attachments: { disposition: "attachment"; filename: string; type: string; content: string }[] = []
+    // Fetch attachment content from R2
+    const attachments: { disposition: "attachment"; filename: string; type: string; raw: ArrayBuffer; base64: string }[] = []
     for (const att of attachmentKeys) {
       const obj = await env.EMAIL_BUCKET.get(att.key)
       if (!obj) continue
-      const buf = await obj.arrayBuffer()
+      const raw = await obj.arrayBuffer()
       attachments.push({
         disposition: "attachment" as const,
         filename: att.filename,
         type: att.contentType,
-        content: arrayBufferToBase64(buf),
+        raw,
+        base64: arrayBufferToBase64(raw),
       })
     }
 
@@ -174,7 +175,7 @@ export default {
             headers: threadingHeaders,
             attachments: attachments.map(a => ({
               filename: a.filename,
-              content: a.content,
+              content: a.base64,
               mimeType: a.type,
             })),
           }
@@ -192,7 +193,12 @@ export default {
         html: htmlBody,
       }
       if (attachments.length > 0) {
-        sendPayload.attachments = attachments
+        sendPayload.attachments = attachments.map(a => ({
+          disposition: a.disposition,
+          filename: a.filename,
+          type: a.type,
+          content: a.raw,
+        }))
       }
       await env.SEND_EMAIL.send(sendPayload as any)
     }
@@ -242,7 +248,7 @@ export default {
             `Content-Disposition: attachment; filename="${att.filename}"`,
             `Content-Transfer-Encoding: base64`,
             "",
-            att.content.match(/.{1,76}/g)?.join("\r\n") ?? att.content,
+            att.base64.match(/.{1,76}/g)?.join("\r\n") ?? att.base64,
           ].join("\r\n")
         )
       }


### PR DESCRIPTION
# Why we need this PR?

Email attachments sent via Cloudflare SEND_EMAIL binding arrive garbled/mojibake in email clients, while the web interface displays them correctly.

## What changed

- **Root cause**: `SEND_EMAIL.send()` accepts `string | ArrayBuffer | ArrayBufferView` for attachment content. When passed a base64 `string`, Cloudflare treats it as raw text and re-encodes it — causing double-encoding and garbled attachments.
- **Fix**: Pass raw `ArrayBuffer` to the CF SEND_EMAIL path instead of base64 string. WorkerMailer (custom SMTP) and R2 MIME archival continue using base64 as expected.
- Store both `raw` (ArrayBuffer) and `base64` (string) per attachment to serve each consumer correctly.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Email Worker (`@alook/email-worker`)