### PR TITLE
fix(email): add direction field to separate inbound/outbound emails

### DIFF
--- a/src/shared/src/db/queries/email.ts
+++ b/src/shared/src/db/queries/email.ts
@@ -4,7 +4,7 @@ import type { Database } from "../index";
 
 export async function createEmail(
   db: Database,
-  data: { agentId: string; workspaceId: string; fromEmail: string; toEmail: string; subject: string; r2Key: string; isWhitelisted: boolean; forwarded: boolean; messageId?: string; inReplyTo?: string; references?: string; htmlBody?: string; attachments?: string }
+  data: { agentId: string; workspaceId: string; fromEmail: string; toEmail: string; subject: string; r2Key: string; isWhitelisted: boolean; forwarded: boolean; messageId?: string; inReplyTo?: string; references?: string; htmlBody?: string; attachments?: string; direction?: string }
 ) {
   const rows = await db.insert(emails).values(data).returning();
   return rows[0]!;
@@ -26,7 +26,7 @@ export async function getEmailsByAgent(db: Database, agentId: string, workspaceI
 }
 
 export async function getInboxEmails(db: Database, agentId: string, agentEmail: string, workspaceId: string, status?: string) {
-  const conditions = [eq(emails.agentId, agentId), eq(emails.toEmail, agentEmail), eq(emails.workspaceId, workspaceId), eq(emails.isWhitelisted, true)];
+  const conditions = [eq(emails.agentId, agentId), eq(emails.toEmail, agentEmail), eq(emails.workspaceId, workspaceId), eq(emails.isWhitelisted, true), eq(emails.direction, "inbound")];
   if (status) conditions.push(eq(emails.status, status));
   return db.select().from(emails)
     .where(and(...conditions))
@@ -34,7 +34,7 @@ export async function getInboxEmails(db: Database, agentId: string, agentEmail: 
 }
 
 export async function getSentEmails(db: Database, agentId: string, agentEmail: string, workspaceId: string, status?: string) {
-  const conditions = [eq(emails.agentId, agentId), eq(emails.fromEmail, agentEmail), eq(emails.workspaceId, workspaceId)];
+  const conditions = [eq(emails.agentId, agentId), eq(emails.workspaceId, workspaceId), eq(emails.direction, "outbound")];
   if (status) conditions.push(eq(emails.status, status));
   return db.select().from(emails)
     .where(and(...conditions))
@@ -42,7 +42,7 @@ export async function getSentEmails(db: Database, agentId: string, agentEmail: s
 }
 
 export async function getRejectedEmails(db: Database, agentId: string, agentEmail: string, workspaceId: string, status?: string) {
-  const conditions = [eq(emails.agentId, agentId), eq(emails.toEmail, agentEmail), eq(emails.workspaceId, workspaceId), eq(emails.isWhitelisted, false)];
+  const conditions = [eq(emails.agentId, agentId), eq(emails.toEmail, agentEmail), eq(emails.workspaceId, workspaceId), eq(emails.isWhitelisted, false), eq(emails.direction, "inbound")];
   if (status) conditions.push(eq(emails.status, status));
   return db.select().from(emails)
     .where(and(...conditions))

--- a/src/shared/src/db/queries/email.ts
+++ b/src/shared/src/db/queries/email.ts
@@ -4,7 +4,7 @@ import type { Database } from "../index";
 
 export async function createEmail(
   db: Database,
-  data: { agentId: string; workspaceId: string; fromEmail: string; toEmail: string; subject: string; r2Key: string; isWhitelisted: boolean; forwarded: boolean; messageId?: string; inReplyTo?: string; references?: string; htmlBody?: string; attachments?: string; direction?: string }
+  data: { agentId: string; workspaceId: string; fromEmail: string; toEmail: string; subject: string; r2Key: string; isWhitelisted: boolean; forwarded: boolean; direction: "inbound" | "outbound"; messageId?: string; inReplyTo?: string; references?: string; htmlBody?: string; attachments?: string }
 ) {
   const rows = await db.insert(emails).values(data).returning();
   return rows[0]!;

--- a/src/shared/src/db/schema.ts
+++ b/src/shared/src/db/schema.ts
@@ -301,6 +301,7 @@ export const emails = sqliteTable(
     htmlBody: text("html_body").notNull().default(""),
     attachments: text("attachments").notNull().default("[]"),
     status: text("status").notNull().default("unread"),
+    direction: text("direction").notNull().default("inbound"),
     createdAt: text("created_at").notNull().$defaultFn(() => new Date().toISOString()),
   },
   (t) => [

--- a/src/shared/src/types.ts
+++ b/src/shared/src/types.ts
@@ -139,6 +139,7 @@ export interface Email {
   html_body: string;
   attachments: EmailAttachment[];
   status: string;
+  direction: "inbound" | "outbound";
   created_at: string;
 }
 

--- a/src/web/migrations/0006_email_direction.sql
+++ b/src/web/migrations/0006_email_direction.sql
@@ -1,0 +1,5 @@
+-- Add direction column to emails table (inbound/outbound)
+ALTER TABLE emails ADD COLUMN direction TEXT NOT NULL DEFAULT 'inbound';
+
+-- Backfill: emails sent FROM an @alook.ai address are outbound
+UPDATE emails SET direction = 'outbound' WHERE from_email LIKE '%@alook.ai';

--- a/src/web/migrations/0006_email_direction.sql
+++ b/src/web/migrations/0006_email_direction.sql
@@ -4,5 +4,10 @@ ALTER TABLE emails ADD COLUMN direction TEXT NOT NULL DEFAULT 'inbound';
 -- Backfill: emails sent FROM an @alook.ai address are outbound
 UPDATE emails SET direction = 'outbound' WHERE from_email LIKE '%@alook.ai';
 
+-- Backfill: emails sent FROM a custom SMTP account are also outbound
+UPDATE emails SET direction = 'outbound'
+WHERE direction = 'inbound'
+  AND from_email IN (SELECT email_address FROM agent_email_account);
+
 -- Index for folder queries (inbox/sent/rejected all filter by agent_id + workspace_id + direction)
 CREATE INDEX IF NOT EXISTS idx_emails_agent_ws_dir ON emails(agent_id, workspace_id, direction);

--- a/src/web/migrations/0006_email_direction.sql
+++ b/src/web/migrations/0006_email_direction.sql
@@ -3,3 +3,6 @@ ALTER TABLE emails ADD COLUMN direction TEXT NOT NULL DEFAULT 'inbound';
 
 -- Backfill: emails sent FROM an @alook.ai address are outbound
 UPDATE emails SET direction = 'outbound' WHERE from_email LIKE '%@alook.ai';
+
+-- Index for folder queries (inbox/sent/rejected all filter by agent_id + workspace_id + direction)
+CREATE INDEX IF NOT EXISTS idx_emails_agent_ws_dir ON emails(agent_id, workspace_id, direction);

--- a/src/web/src/app/api/email/notify/route.ts
+++ b/src/web/src/app/api/email/notify/route.ts
@@ -27,6 +27,7 @@ export async function POST(req: NextRequest) {
     messageId: body.messageId,
     inReplyTo: body.inReplyTo,
     references: body.references,
+    direction: "inbound",
   })
 
   if (body.isWhitelisted && agent && agent.runtimeId) {

--- a/src/web/src/app/api/email/send/route.ts
+++ b/src/web/src/app/api/email/send/route.ts
@@ -105,6 +105,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     references: body.references ?? "",
     htmlBody: body.htmlBody || "",
     attachments: JSON.stringify(attachments),
+    direction: "outbound",
   });
 
   return writeJSON(emailToResponse(email));

--- a/src/web/src/lib/api/responses.ts
+++ b/src/web/src/lib/api/responses.ts
@@ -63,6 +63,7 @@ export function emailToResponse(e: any) {
     html_body: e.htmlBody ?? "",
     attachments: JSON.parse(e.attachments || "[]"),
     status: e.status ?? "unread",
+    direction: e.direction ?? "inbound",
     created_at: formatTimestamp(e.createdAt),
   };
 }

--- a/src/web/src/test/e2e/email.test.ts
+++ b/src/web/src/test/e2e/email.test.ts
@@ -342,7 +342,7 @@ describe("email thread", () => {
 
     // Insert child email that replies to parent
     const childId = `ec_${randomUUID().slice(0, 12)}`
-    sql(`INSERT INTO emails (id, agent_id, workspace_id, from_email, to_email, subject, r2_key, is_whitelisted, forwarded, message_id, in_reply_to, "references", created_at) VALUES ('${childId}', '${seed.agentId}', '${seed.workspaceId}', '${agentEmail}', 'sender@test.com', 'Re: Thread parent', 'emails/fake2/raw', 0, 0, '${childMsgId}', '${parentMsgId}', '${parentMsgId}', '${now}')`)
+    sql(`INSERT INTO emails (id, agent_id, workspace_id, from_email, to_email, subject, r2_key, is_whitelisted, forwarded, message_id, in_reply_to, "references", direction, created_at) VALUES ('${childId}', '${seed.agentId}', '${seed.workspaceId}', '${agentEmail}', 'sender@test.com', 'Re: Thread parent', 'emails/fake2/raw', 0, 0, '${childMsgId}', '${parentMsgId}', '${parentMsgId}', 'outbound', '${now}')`)
 
     const res = await tokenRequest(
       `/api/email/${childId}/thread?workspace_id=${seed.workspaceId}`,


### PR DESCRIPTION
# Why we need this PR?

Emails sent from an agent to a third-party IMAP-bound mailbox (e.g. jarvis@alook.ai → animebusa@gmail.com) created two DB records: one from the send path, one from IMAP polling. Both appeared in the rejected folder because the query (`toEmail = agentEmail AND isWhitelisted = false`) matched both.

## What changed

- Added `direction` column (`inbound`/`outbound`, default `inbound`) to the `emails` table
- Migration `0006_email_direction.sql` backfills existing outbound records
- Send path (`/api/email/send`) writes `direction: "outbound"`
- Notify path (`/api/email/notify`) writes `direction: "inbound"`
- Query filters updated:
  - `getInboxEmails`: added `direction = 'inbound'`
  - `getSentEmails`: changed to filter by `direction = 'outbound'` (no longer needs fromEmail match)
  - `getRejectedEmails`: added `direction = 'inbound'`
- Updated `Email` type and `emailToResponse` mapping

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)