### PR TITLE
feat(web): add email setup guide page

### DIFF
--- a/src/web/src/app/(app)/w/[slug]/help/email-setup/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/help/email-setup/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState } from "react";
 import { MobileSidebarLogo } from "@/components/mobile-sidebar-logo";
-import { cn } from "@/lib/utils";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 
 const PROVIDERS = [
   {
+    id: "gmail",
     name: "Gmail",
     imap: { host: "imap.gmail.com", port: 993 },
     smtp: { host: "smtp.gmail.com", port: 587 },
@@ -19,6 +19,7 @@ const PROVIDERS = [
     note: "Gmail no longer supports regular passwords for third-party apps. You must use an App Password.",
   },
   {
+    id: "outlook",
     name: "Outlook",
     imap: { host: "outlook.office365.com", port: 993 },
     smtp: { host: "smtp.office365.com", port: 587 },
@@ -31,6 +32,7 @@ const PROVIDERS = [
     note: "If your organization uses Microsoft 365, your admin may need to enable App Passwords or IMAP access.",
   },
   {
+    id: "yahoo",
     name: "Yahoo",
     imap: { host: "imap.mail.yahoo.com", port: 993 },
     smtp: { host: "smtp.mail.yahoo.com", port: 587 },
@@ -43,6 +45,7 @@ const PROVIDERS = [
     note: null,
   },
   {
+    id: "icloud",
     name: "iCloud",
     imap: { host: "imap.mail.me.com", port: 993 },
     smtp: { host: "smtp.mail.me.com", port: 587 },
@@ -56,6 +59,7 @@ const PROVIDERS = [
     note: "Two-factor authentication must be enabled on your Apple ID.",
   },
   {
+    id: "qq",
     name: "QQ",
     imap: { host: "imap.qq.com", port: 993 },
     smtp: { host: "smtp.qq.com", port: 587 },
@@ -70,6 +74,7 @@ const PROVIDERS = [
     note: null,
   },
   {
+    id: "163",
     name: "163",
     imap: { host: "imap.163.com", port: 993 },
     smtp: { host: "smtp.163.com", port: 465 },
@@ -83,6 +88,7 @@ const PROVIDERS = [
     note: "SMTP uses port 465 with SSL instead of the typical 587.",
   },
   {
+    id: "feishu",
     name: "Feishu",
     imap: { host: "imap.feishu.cn", port: 993 },
     smtp: { host: "smtp.feishu.cn", port: 465 },
@@ -96,6 +102,7 @@ const PROVIDERS = [
     note: "SMTP uses port 465 with SSL. Your organization admin must enable IMAP access.",
   },
   {
+    id: "other",
     name: "Other",
     imap: null,
     smtp: null,
@@ -110,9 +117,6 @@ const PROVIDERS = [
 ];
 
 export default function EmailSetupHelpPage() {
-  const [active, setActive] = useState(0);
-  const provider = PROVIDERS[active]!;
-
   return (
     <>
       <div className="flex items-center justify-between border-b border-border/50 px-3 md:px-5 py-2.5 gap-3">
@@ -126,51 +130,45 @@ export default function EmailSetupHelpPage() {
       </div>
 
       <div className="flex-1 overflow-y-auto px-5 py-6">
-        <div className="mx-auto max-w-2xl space-y-6">
-          <div className="flex flex-wrap gap-1.5">
-            {PROVIDERS.map((p, i) => (
-              <button
-                key={p.name}
-                type="button"
-                onClick={() => setActive(i)}
-                className={cn(
-                  "px-3 py-1.5 rounded-md text-sm transition-colors",
-                  i === active
-                    ? "bg-primary text-primary-foreground font-medium"
-                    : "bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground"
-                )}
-              >
-                {p.name}
-              </button>
-            ))}
-          </div>
-
-          <div className="space-y-4">
-            {provider.imap && provider.smtp && (
-              <div className="grid grid-cols-2 gap-3 text-xs">
-                <div className="rounded-md border border-border/50 px-3 py-2 space-y-0.5">
-                  <span className="font-medium text-muted-foreground">IMAP</span>
-                  <div className="font-mono">{provider.imap.host}:{provider.imap.port}</div>
-                </div>
-                <div className="rounded-md border border-border/50 px-3 py-2 space-y-0.5">
-                  <span className="font-medium text-muted-foreground">SMTP</span>
-                  <div className="font-mono">{provider.smtp.host}:{provider.smtp.port}</div>
-                </div>
-              </div>
-            )}
-
-            <ol className="list-decimal list-inside space-y-2 text-sm text-muted-foreground">
-              {provider.steps.map((step, i) => (
-                <li key={i}>{step}</li>
+        <div className="mx-auto max-w-2xl">
+          <Tabs defaultValue="gmail">
+            <TabsList className="flex-wrap h-auto gap-1">
+              {PROVIDERS.map((p) => (
+                <TabsTrigger key={p.id} value={p.id}>
+                  {p.name}
+                </TabsTrigger>
               ))}
-            </ol>
+            </TabsList>
 
-            {provider.note && (
-              <p className="text-xs text-amber-600 dark:text-amber-400 rounded-md bg-amber-500/5 border border-amber-500/10 px-3 py-2">
-                {provider.note}
-              </p>
-            )}
-          </div>
+            {PROVIDERS.map((provider) => (
+              <TabsContent key={provider.id} value={provider.id} className="space-y-4 pt-4">
+                {provider.imap && provider.smtp && (
+                  <div className="grid grid-cols-2 gap-3 text-xs">
+                    <div className="rounded-md border border-border/50 px-3 py-2 space-y-0.5">
+                      <span className="font-medium text-muted-foreground">IMAP</span>
+                      <div className="font-mono">{provider.imap.host}:{provider.imap.port}</div>
+                    </div>
+                    <div className="rounded-md border border-border/50 px-3 py-2 space-y-0.5">
+                      <span className="font-medium text-muted-foreground">SMTP</span>
+                      <div className="font-mono">{provider.smtp.host}:{provider.smtp.port}</div>
+                    </div>
+                  </div>
+                )}
+
+                <ol className="list-decimal list-inside space-y-2 text-sm text-muted-foreground">
+                  {provider.steps.map((step, i) => (
+                    <li key={i}>{step}</li>
+                  ))}
+                </ol>
+
+                {provider.note && (
+                  <p className="text-xs text-amber-600 dark:text-amber-400 rounded-md bg-amber-500/5 border border-amber-500/10 px-3 py-2">
+                    {provider.note}
+                  </p>
+                )}
+              </TabsContent>
+            ))}
+          </Tabs>
         </div>
       </div>
     </>

--- a/src/web/src/app/(app)/w/[slug]/help/email-setup/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/help/email-setup/page.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { MobileSidebarLogo } from "@/components/mobile-sidebar-logo";
+
+const PROVIDERS = [
+  {
+    name: "Gmail",
+    imap: { host: "imap.gmail.com", port: 993 },
+    smtp: { host: "smtp.gmail.com", port: 587 },
+    steps: [
+      "Enable 2-Step Verification in your Google Account (Security > 2-Step Verification).",
+      "Go to https://myaccount.google.com/apppasswords and generate an App Password.",
+      'Enter a name (e.g. "Alook") and click Generate.',
+      "Copy the 16-character password — use this as both IMAP and SMTP password.",
+      "Username is your full Gmail address (e.g. you@gmail.com).",
+    ],
+    note: "Gmail no longer supports regular passwords for third-party apps. You must use an App Password.",
+  },
+  {
+    name: "Outlook / Microsoft 365",
+    imap: { host: "outlook.office365.com", port: 993 },
+    smtp: { host: "smtp.office365.com", port: 587 },
+    steps: [
+      "Sign in at https://account.microsoft.com/security.",
+      "Go to Security > Advanced Security Options > App Passwords.",
+      "Generate an App Password and use it as both IMAP and SMTP password.",
+      "Username is your full email address (e.g. you@outlook.com).",
+    ],
+    note: "If your organization uses Microsoft 365, your admin may need to enable App Passwords or IMAP access.",
+  },
+  {
+    name: "Yahoo Mail",
+    imap: { host: "imap.mail.yahoo.com", port: 993 },
+    smtp: { host: "smtp.mail.yahoo.com", port: 587 },
+    steps: [
+      "Go to https://login.yahoo.com/account/security.",
+      'Enable "Allow apps that use less secure sign in" or generate an App Password.',
+      "Use the App Password as both IMAP and SMTP password.",
+      "Username is your full Yahoo email address.",
+    ],
+    note: null,
+  },
+  {
+    name: "iCloud Mail",
+    imap: { host: "imap.mail.me.com", port: 993 },
+    smtp: { host: "smtp.mail.me.com", port: 587 },
+    steps: [
+      "Go to https://appleid.apple.com and sign in.",
+      "Navigate to Sign-In and Security > App-Specific Passwords.",
+      "Generate an App-Specific Password.",
+      "Use the generated password as both IMAP and SMTP password.",
+      "Username is your full iCloud email address (e.g. you@icloud.com).",
+    ],
+    note: "Two-factor authentication must be enabled on your Apple ID.",
+  },
+  {
+    name: "QQ Mail",
+    imap: { host: "imap.qq.com", port: 993 },
+    smtp: { host: "smtp.qq.com", port: 587 },
+    steps: [
+      "Log in to QQ Mail (mail.qq.com).",
+      "Go to Settings > Account > POP3/IMAP/SMTP/Exchange/CardDAV.",
+      "Enable IMAP/SMTP service — you may need to send an SMS to verify.",
+      "After verification, QQ Mail will display an authorization code.",
+      "Use the authorization code as both IMAP and SMTP password (not your QQ password).",
+      "Username is your full QQ email address (e.g. 123456789@qq.com).",
+    ],
+    note: null,
+  },
+  {
+    name: "163 Mail (NetEase)",
+    imap: { host: "imap.163.com", port: 993 },
+    smtp: { host: "smtp.163.com", port: 465 },
+    steps: [
+      "Log in to 163 Mail (mail.163.com).",
+      "Go to Settings > POP3/SMTP/IMAP.",
+      "Enable IMAP/SMTP service and set an authorization password.",
+      "Use the authorization password as both IMAP and SMTP password.",
+      "Username is your full 163 email address (e.g. you@163.com).",
+    ],
+    note: "SMTP uses port 465 with SSL instead of the typical 587.",
+  },
+  {
+    name: "Feishu (Lark) Mail",
+    imap: { host: "imap.feishu.cn", port: 993 },
+    smtp: { host: "smtp.feishu.cn", port: 465 },
+    steps: [
+      "Log in to Feishu Admin Console.",
+      "Go to Security > Application Password, or ask your admin to enable IMAP/SMTP.",
+      "Generate an application-specific password.",
+      "Use the application password as both IMAP and SMTP password.",
+      "Username is your full Feishu email address.",
+    ],
+    note: "SMTP uses port 465 with SSL. Your organization admin must enable IMAP access.",
+  },
+  {
+    name: "Other Providers",
+    imap: null,
+    smtp: null,
+    steps: [
+      "Check your email provider's help docs for IMAP/SMTP server settings.",
+      "IMAP is typically on port 993 (SSL/TLS), SMTP on port 587 (STARTTLS) or 465 (SSL).",
+      "If your provider supports App Passwords, generate one and use it instead of your account password.",
+      "Username is usually your full email address.",
+    ],
+    note: null,
+  },
+];
+
+export default function EmailSetupHelpPage() {
+  return (
+    <>
+      <div className="flex items-center justify-between border-b border-border/50 px-3 md:px-5 py-2.5 gap-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <MobileSidebarLogo />
+          <h1 className="text-sm font-medium">Email Setup Guide</h1>
+          <p className="text-xs text-muted-foreground hidden md:block">
+            How to get IMAP/SMTP credentials for your email provider
+          </p>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-5 py-6">
+        <div className="mx-auto max-w-2xl space-y-8">
+          {PROVIDERS.map((provider) => (
+            <section key={provider.name} className="space-y-3">
+              <h2 className="text-base font-semibold">{provider.name}</h2>
+
+              {provider.imap && provider.smtp && (
+                <div className="grid grid-cols-2 gap-3 text-xs">
+                  <div className="rounded-md border border-border/50 px-3 py-2 space-y-0.5">
+                    <span className="font-medium text-muted-foreground">IMAP</span>
+                    <div>{provider.imap.host}:{provider.imap.port}</div>
+                  </div>
+                  <div className="rounded-md border border-border/50 px-3 py-2 space-y-0.5">
+                    <span className="font-medium text-muted-foreground">SMTP</span>
+                    <div>{provider.smtp.host}:{provider.smtp.port}</div>
+                  </div>
+                </div>
+              )}
+
+              <ol className="list-decimal list-inside space-y-1 text-sm text-muted-foreground">
+                {provider.steps.map((step, i) => (
+                  <li key={i}>{step}</li>
+                ))}
+              </ol>
+
+              {provider.note && (
+                <p className="text-xs text-amber-600 dark:text-amber-400">
+                  {provider.note}
+                </p>
+              )}
+            </section>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/web/src/app/(app)/w/[slug]/help/email-setup/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/help/email-setup/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useState } from "react";
 import { MobileSidebarLogo } from "@/components/mobile-sidebar-logo";
+import { cn } from "@/lib/utils";
 
 const PROVIDERS = [
   {
@@ -17,7 +19,7 @@ const PROVIDERS = [
     note: "Gmail no longer supports regular passwords for third-party apps. You must use an App Password.",
   },
   {
-    name: "Outlook / Microsoft 365",
+    name: "Outlook",
     imap: { host: "outlook.office365.com", port: 993 },
     smtp: { host: "smtp.office365.com", port: 587 },
     steps: [
@@ -29,7 +31,7 @@ const PROVIDERS = [
     note: "If your organization uses Microsoft 365, your admin may need to enable App Passwords or IMAP access.",
   },
   {
-    name: "Yahoo Mail",
+    name: "Yahoo",
     imap: { host: "imap.mail.yahoo.com", port: 993 },
     smtp: { host: "smtp.mail.yahoo.com", port: 587 },
     steps: [
@@ -41,7 +43,7 @@ const PROVIDERS = [
     note: null,
   },
   {
-    name: "iCloud Mail",
+    name: "iCloud",
     imap: { host: "imap.mail.me.com", port: 993 },
     smtp: { host: "smtp.mail.me.com", port: 587 },
     steps: [
@@ -54,7 +56,7 @@ const PROVIDERS = [
     note: "Two-factor authentication must be enabled on your Apple ID.",
   },
   {
-    name: "QQ Mail",
+    name: "QQ",
     imap: { host: "imap.qq.com", port: 993 },
     smtp: { host: "smtp.qq.com", port: 587 },
     steps: [
@@ -68,7 +70,7 @@ const PROVIDERS = [
     note: null,
   },
   {
-    name: "163 Mail (NetEase)",
+    name: "163",
     imap: { host: "imap.163.com", port: 993 },
     smtp: { host: "smtp.163.com", port: 465 },
     steps: [
@@ -81,7 +83,7 @@ const PROVIDERS = [
     note: "SMTP uses port 465 with SSL instead of the typical 587.",
   },
   {
-    name: "Feishu (Lark) Mail",
+    name: "Feishu",
     imap: { host: "imap.feishu.cn", port: 993 },
     smtp: { host: "smtp.feishu.cn", port: 465 },
     steps: [
@@ -94,7 +96,7 @@ const PROVIDERS = [
     note: "SMTP uses port 465 with SSL. Your organization admin must enable IMAP access.",
   },
   {
-    name: "Other Providers",
+    name: "Other",
     imap: null,
     smtp: null,
     steps: [
@@ -108,6 +110,9 @@ const PROVIDERS = [
 ];
 
 export default function EmailSetupHelpPage() {
+  const [active, setActive] = useState(0);
+  const provider = PROVIDERS[active]!;
+
   return (
     <>
       <div className="flex items-center justify-between border-b border-border/50 px-3 md:px-5 py-2.5 gap-3">
@@ -121,37 +126,51 @@ export default function EmailSetupHelpPage() {
       </div>
 
       <div className="flex-1 overflow-y-auto px-5 py-6">
-        <div className="mx-auto max-w-2xl space-y-8">
-          {PROVIDERS.map((provider) => (
-            <section key={provider.name} className="space-y-3">
-              <h2 className="text-base font-semibold">{provider.name}</h2>
+        <div className="mx-auto max-w-2xl space-y-6">
+          <div className="flex flex-wrap gap-1.5">
+            {PROVIDERS.map((p, i) => (
+              <button
+                key={p.name}
+                type="button"
+                onClick={() => setActive(i)}
+                className={cn(
+                  "px-3 py-1.5 rounded-md text-sm transition-colors",
+                  i === active
+                    ? "bg-primary text-primary-foreground font-medium"
+                    : "bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground"
+                )}
+              >
+                {p.name}
+              </button>
+            ))}
+          </div>
 
-              {provider.imap && provider.smtp && (
-                <div className="grid grid-cols-2 gap-3 text-xs">
-                  <div className="rounded-md border border-border/50 px-3 py-2 space-y-0.5">
-                    <span className="font-medium text-muted-foreground">IMAP</span>
-                    <div>{provider.imap.host}:{provider.imap.port}</div>
-                  </div>
-                  <div className="rounded-md border border-border/50 px-3 py-2 space-y-0.5">
-                    <span className="font-medium text-muted-foreground">SMTP</span>
-                    <div>{provider.smtp.host}:{provider.smtp.port}</div>
-                  </div>
+          <div className="space-y-4">
+            {provider.imap && provider.smtp && (
+              <div className="grid grid-cols-2 gap-3 text-xs">
+                <div className="rounded-md border border-border/50 px-3 py-2 space-y-0.5">
+                  <span className="font-medium text-muted-foreground">IMAP</span>
+                  <div className="font-mono">{provider.imap.host}:{provider.imap.port}</div>
                 </div>
-              )}
+                <div className="rounded-md border border-border/50 px-3 py-2 space-y-0.5">
+                  <span className="font-medium text-muted-foreground">SMTP</span>
+                  <div className="font-mono">{provider.smtp.host}:{provider.smtp.port}</div>
+                </div>
+              </div>
+            )}
 
-              <ol className="list-decimal list-inside space-y-1 text-sm text-muted-foreground">
-                {provider.steps.map((step, i) => (
-                  <li key={i}>{step}</li>
-                ))}
-              </ol>
+            <ol className="list-decimal list-inside space-y-2 text-sm text-muted-foreground">
+              {provider.steps.map((step, i) => (
+                <li key={i}>{step}</li>
+              ))}
+            </ol>
 
-              {provider.note && (
-                <p className="text-xs text-amber-600 dark:text-amber-400">
-                  {provider.note}
-                </p>
-              )}
-            </section>
-          ))}
+            {provider.note && (
+              <p className="text-xs text-amber-600 dark:text-amber-400 rounded-md bg-amber-500/5 border border-amber-500/10 px-3 py-2">
+                {provider.note}
+              </p>
+            )}
+          </div>
         </div>
       </div>
     </>

--- a/src/web/src/components/custom-email-form.tsx
+++ b/src/web/src/components/custom-email-form.tsx
@@ -21,9 +21,10 @@ import {
 import type { AgentEmailAccount, CreateEmailAccountRequest } from "@alook/shared";
 import {
   Loader2, Mail, RefreshCw, Trash2, AlertCircle, CheckCircle2,
-  ChevronRight, XIcon,
+  ChevronRight, XIcon, CircleHelp,
 } from "lucide-react";
 import { toast } from "sonner";
+import { useWorkspace } from "@/contexts/workspace-context";
 
 const PRESETS: Record<string, { imapHost: string; imapPort: number; smtpHost: string; smtpPort: number }> = {
   Gmail: { imapHost: "imap.gmail.com", imapPort: 993, smtpHost: "smtp.gmail.com", smtpPort: 587 },
@@ -145,6 +146,7 @@ function EmailFieldsForm({ fields, applyPreset }: {
 }
 
 export function CustomEmailForm({ agentId, workspaceId, onDataChange, getDataRef }: Props) {
+  const { slug } = useWorkspace();
   const isCreateMode = !agentId;
   const [open, setOpen] = useState(false);
   const [accounts, setAccounts] = useState<AgentEmailAccount[]>([]);
@@ -280,7 +282,18 @@ export function CustomEmailForm({ agentId, workspaceId, onDataChange, getDataRef
         <SheetBody className="px-8 pt-10 pb-6">
           <div className="space-y-4">
             <div>
-              <h2 className="font-heading text-lg font-semibold">Custom Email</h2>
+              <div className="flex items-center gap-2">
+                <h2 className="font-heading text-lg font-semibold">Custom Email</h2>
+                <a
+                  href={`/w/${slug}/help/email-setup`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-muted-foreground hover:text-foreground transition-colors"
+                  title="How to get IMAP/SMTP credentials"
+                >
+                  <CircleHelp className="size-4" />
+                </a>
+              </div>
               <p className="text-sm text-muted-foreground mt-1">
                 Connect your own mailbox to send and receive email as your identity.
               </p>

--- a/src/web/src/components/ui/tabs.tsx
+++ b/src/web/src/components/ui/tabs.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: TabsPrimitive.Root.Props) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-horizontal:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: TabsPrimitive.List.Props & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
+        "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="tabs-content"
+      className={cn("flex-1 text-sm outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }


### PR DESCRIPTION
# Why we need this PR?

Users binding third-party email (Gmail, Outlook, etc.) need to know how to get IMAP/SMTP credentials and App Passwords. Currently there's no guidance in the product.

## What changed

- New page at `/w/[slug]/help/email-setup` with per-provider setup instructions:
  - **Gmail** — App Password via myaccount.google.com/apppasswords
  - **Outlook / Microsoft 365** — App Password via Microsoft Security
  - **Yahoo Mail** — App Password or less secure sign-in
  - **iCloud Mail** — App-Specific Password via Apple ID
  - **QQ Mail** — Authorization code via mail.qq.com settings
  - **163 Mail (NetEase)** — Authorization password, note: SMTP port 465
  - **Feishu (Lark)** — Application password, note: SMTP port 465
  - **Other Providers** — Generic IMAP/SMTP guidance
- Each provider shows IMAP/SMTP host:port settings and step-by-step instructions
- Added CircleHelp icon button in the Custom Email sheet header that opens the guide in a new tab

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)