### PR TITLE
feat: SEO enhancements — manifest, preconnect, FAQ schema, a11y fix

### DIFF
--- a/src/web/public/manifest.json
+++ b/src/web/public/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "Alook — Always-on AI Agents",
+  "short_name": "Alook",
+  "description": "Your AI agents, always on. Give them an email, let them work for you around the clock.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#f5f0e8",
+  "theme_color": "#3d3428",
+  "icons": [
+    {
+      "src": "/alook.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/src/web/src/app/layout.tsx
+++ b/src/web/src/app/layout.tsx
@@ -113,26 +113,43 @@ export default function RootLayout({
     >
       <head>
         <ThemeScript />
+        <link rel="manifest" href="/manifest.json" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
       </head>
       <body className="min-h-full flex flex-col">
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify({
-              "@context": "https://schema.org",
-              "@type": "WebApplication",
-              name: "Alook",
-              url: SITE_URL,
-              description:
-                "Your AI agents, always on. Give them an email, let them work for you around the clock.",
-              applicationCategory: "DeveloperApplication",
-              operatingSystem: "All",
-              offers: {
-                "@type": "Offer",
-                price: "0",
-                priceCurrency: "USD",
+            __html: JSON.stringify([
+              {
+                "@context": "https://schema.org",
+                "@type": "WebApplication",
+                name: "Alook",
+                url: SITE_URL,
+                description:
+                  "Your AI agents, always on. Give them an email, let them work for you around the clock.",
+                applicationCategory: "DeveloperApplication",
+                operatingSystem: "All",
+                offers: {
+                  "@type": "Offer",
+                  price: "0",
+                  priceCurrency: "USD",
+                },
               },
-            }),
+              {
+                "@context": "https://schema.org",
+                "@type": "Organization",
+                name: "Alook",
+                url: SITE_URL,
+                logo: `${SITE_URL}/alook.svg`,
+                contactPoint: {
+                  "@type": "ContactPoint",
+                  email: "support@alook.ai",
+                  contactType: "customer support",
+                },
+              },
+            ]),
           }}
         />
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>

--- a/src/web/src/app/not-found.tsx
+++ b/src/web/src/app/not-found.tsx
@@ -1,7 +1,12 @@
-"use client";
-
+import type { Metadata } from "next";
 import Link from "next/link";
 import { TypewriterVisual } from "@/components/typewriter-visual";
+
+export const metadata: Metadata = {
+  title: "Page Not Found",
+  description: "The page you're looking for doesn't exist or has been moved.",
+  robots: { index: false, follow: true },
+};
 
 export default function NotFound() {
   return (

--- a/src/web/src/app/page.tsx
+++ b/src/web/src/app/page.tsx
@@ -10,8 +10,47 @@ export const metadata: Metadata = {
   alternates: { canonical: "https://alook.ai" },
 };
 
+const faqJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "What is Alook?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Alook is a platform that gives your AI agents an email address and keeps them always on. They can receive tasks via email, process them autonomously, and respond — around the clock.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "How do I communicate with my AI agent?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Each agent gets its own @alook.ai email address. You can send instructions via email, and the agent will process them and reply. You can also interact through the Alook dashboard.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Is Alook free to use?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes, Alook offers a free tier to get started with always-on AI agents.",
+      },
+    },
+  ],
+};
+
 export default async function Page() {
   const session = await getSession();
   if (session) return <WorkspaceRedirect />;
-  return <HomePage isLoggedIn={false} />;
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+      />
+      <HomePage isLoggedIn={false} />
+    </>
+  );
 }

--- a/src/web/src/components/typewriter-visual.tsx
+++ b/src/web/src/components/typewriter-visual.tsx
@@ -497,6 +497,7 @@ export function TypewriterVisual({
 
                       <div
                         className="tw-email-body"
+                        aria-hidden
                         style={{
                           fontFamily: "var(--font-crt)",
                           color: "oklch(0.45 0.01 55)",


### PR DESCRIPTION
# Why we need this PR?

Follow-up to #28 — extends SEO infrastructure with PWA support, performance hints, richer structured data, and an accessibility fix.

## What changed

- **404 page** (`not-found.tsx`): Added metadata (title, description, noindex), removed unnecessary "use client" directive
- **PWA manifest** (`public/manifest.json`): Web app manifest with Alook branding, `standalone` display mode, warm theme colors
- **Preconnect hints** (`layout.tsx`): Added `<link rel="preconnect">` for `fonts.googleapis.com` and `fonts.gstatic.com` to speed up font loading
- **Structured data** (`layout.tsx`): Added Organization schema (name, logo, contact point) alongside existing WebApplication schema
- **FAQ schema** (`page.tsx`): Added FAQPage JSON-LD on landing page with common questions about Alook
- **Accessibility** (`typewriter-visual.tsx`): Fixed "Elements use prohibited ARIA attributes" by adding `aria-hidden` to the animated email body (decorative content)

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)