### PR TITLE
fix: prevent Codex non-zero exit code from overriding completed turns

### DIFF
--- a/src/cli/daemon/agent/__tests__/codex.test.ts
+++ b/src/cli/daemon/agent/__tests__/codex.test.ts
@@ -856,6 +856,58 @@ describe("CodexBackend", () => {
     expect(messages).not.toContainEqual({ type: "text", content: "ignored" });
   });
 
+  it("turn completed successfully + non-zero exit code → status completed (not failed)", async () => {
+    const session = backend.execute("hello", { cwd: "/tmp" });
+    const mock = getMock();
+
+    await completeHandshake();
+    sendNotification("turn/completed", { turn: { id: "turn_1", status: "completed" } });
+    mock.proc.emit("close", 1);
+
+    const result = await session.result;
+    expect(result.status).toBe("completed");
+  });
+
+  it("non-zero exit code before turn completes → status failed", async () => {
+    const session = backend.execute("hello", { cwd: "/tmp" });
+    const mock = getMock();
+
+    await completeHandshake();
+    sendNotification("turn/started", { turn: { id: "turn_1" } });
+    // Process exits before turn/completed
+    mock.proc.emit("close", 1);
+
+    const result = await session.result;
+    expect(result.status).toBe("failed");
+  });
+
+  it("turn completed successfully + non-zero exit + turnError → status failed with turnError", async () => {
+    const session = backend.execute("hello", { cwd: "/tmp" });
+    const mock = getMock();
+
+    await completeHandshake();
+    sendNotification("error", { error: { message: "rate limit" }, willRetry: false });
+    sendNotification("turn/completed", { turn: { id: "turn_1", status: "completed" } });
+    mock.proc.emit("close", 1);
+
+    const result = await session.result;
+    expect(result.status).toBe("failed");
+    expect(result.error).toBe("rate limit");
+  });
+
+  it("strips ANSI escape codes from stderr", async () => {
+    const session = backend.execute("hello", { cwd: "/tmp" });
+    const mock = getMock();
+
+    await completeHandshake();
+    mock.stderr.push("\x1b[31mERROR\x1b[0m something broke\n");
+    mock.proc.emit("close", 1);
+
+    const result = await session.result;
+    expect(result.error).toBe("ERROR something broke\n");
+    expect(result.error).not.toContain("\x1b[");
+  });
+
   it("handles invalid JSON gracefully", async () => {
     const session = backend.execute("hello", { cwd: "/tmp" });
     const mock = getMock();

--- a/src/cli/daemon/agent/codex.ts
+++ b/src/cli/daemon/agent/codex.ts
@@ -78,6 +78,7 @@ export class CodexBackend implements AgentBackend {
     // Turn lifecycle state
     let turnStarted = false;
     let turnDoneTriggered = false;
+    let turnCompletedSuccessfully = false;
     let lastCompletedTurnId = "";
     let turnError = "";
 
@@ -210,6 +211,7 @@ export class CodexBackend implements AgentBackend {
 
           const status = (turn?.status as string) || (params.status as string) || "";
           if (status === "completed" || status === "finished") {
+            turnCompletedSuccessfully = true;
             triggerTurnDone(false);
           } else if (status === "cancelled" || status === "aborted" || status === "interrupted") {
             triggerTurnDone(true);
@@ -504,11 +506,11 @@ export class CodexBackend implements AgentBackend {
 
         if (timedOut) {
           resultStatus = "timeout";
-        } else if (code !== 0 && resultStatus === "completed") {
+        } else if (code !== 0 && resultStatus === "completed" && !turnCompletedSuccessfully) {
           resultStatus = "failed";
         }
 
-        const stderr = stderrChunks.join("");
+        const stderr = stderrChunks.join("").replace(/\x1b\[[0-9;]*m/g, "");
         if (stderr && !lastError) {
           lastError = stderr;
         }

--- a/src/cli/daemon/session-runner.test.ts
+++ b/src/cli/daemon/session-runner.test.ts
@@ -221,6 +221,24 @@ describe("session-runner runSession", () => {
     expect(mockClientInstance.completeTask).not.toHaveBeenCalled();
   });
 
+  it("uses 'agent exited unexpectedly' when result.error is empty on failure", async () => {
+    setupBackend([], {
+      status: "failed",
+      output: "",
+      error: "",
+      durationMs: 100,
+      sessionId: "sess-1",
+    });
+
+    await runSession(makeInput());
+
+    expect(mockClientInstance.failTask).toHaveBeenCalledWith(
+      "test_token",
+      "t1",
+      "agent exited unexpectedly",
+    );
+  });
+
   it("writes timeline init entry with session runner PID (process.pid)", async () => {
     setupBackend([], {
       status: "completed",

--- a/src/cli/daemon/session-runner.ts
+++ b/src/cli/daemon/session-runner.ts
@@ -362,7 +362,7 @@ export async function runSession(input: SessionRunnerInput): Promise<void> {
     updateEntry(timelineDir, task.id, (entry) => {
       entry.pid = null;
       entry.status = "failed";
-      entry.errmsg = result.error || "unknown error";
+      entry.errmsg = result.error || "agent exited unexpectedly";
     });
   }
 
@@ -381,7 +381,7 @@ export async function runSession(input: SessionRunnerInput): Promise<void> {
     const dur = (result.durationMs / 1000).toFixed(1);
     log.info(`completed (duration=${dur}s, messages=${seq}, tools=${toolCount})`);
   } else {
-    const errorMsg = result.error || "unknown error";
+    const errorMsg = result.error || "agent exited unexpectedly";
     await reportToServer(
       () => client.failTask(token, task.id, errorMsg),
       { taskId: task.id, type: "fail", payload: { error: errorMsg }, token, serverURL, createdAt: new Date().toISOString() },


### PR DESCRIPTION
# Why we need this PR?

When a Codex agent completes a turn successfully (agent responds correctly), but the Codex CLI process exits with a non-zero code due to background errors (e.g. TLS handshake failure on `wss://chatgpt.com`), the daemon incorrectly marks the task as `failed` with `"unknown error"`. This causes users to see error states even when their agent replied correctly.

Diagnosed from a real user case where every DM task was marked failed despite the agent responding normally.

## What changed

### `src/cli/daemon/agent/codex.ts`
- Added `turnCompletedSuccessfully` flag, set to `true` when `turn/completed` fires with status `completed`/`finished`
- In `proc.on("close")`: skip the `code !== 0 → failed` override when the turn completed successfully and there's no turn-level error
- Strip ANSI escape codes from stderr before storing as error message

### `src/cli/daemon/session-runner.ts`
- Changed empty-error fallback from `"unknown error"` to `"agent exited unexpectedly"` for better debuggability

### Tests (4 new cases)
- Turn completed + non-zero exit → `completed` (core fix)
- Turn not completed + non-zero exit → `failed` (existing behavior preserved)
- Turn completed + turnError + non-zero exit → `failed` with turnError (error takes precedence)
- ANSI codes stripped from stderr
- Empty error + failed → `"agent exited unexpectedly"`

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] CLI (`@alook/cli`)