### PR TITLE
feat: enable network access in Codex workspace-write sandbox

### DIFF
--- a/src/cli/daemon/agent/__tests__/codex.test.ts
+++ b/src/cli/daemon/agent/__tests__/codex.test.ts
@@ -115,6 +115,19 @@ describe("CodexBackend", () => {
     backend = new CodexBackend("/usr/bin/codex");
   });
 
+  it("spawns codex with network_access config flag", async () => {
+    const { spawn } = await import("child_process");
+    const session = backend.execute("hello", { cwd: "/tmp" });
+    const mock = getMock();
+
+    const spawnCall = (spawn as any).mock.calls[0];
+    expect(spawnCall[1]).toContain("--config");
+    expect(spawnCall[1]).toContain("sandbox_workspace_write.network_access=true");
+
+    mock.proc.emit("close", 0);
+    await session.result;
+  });
+
   it("sends structured initialize params", async () => {
     const session = backend.execute("hello", { cwd: "/tmp" });
     const mock = getMock();

--- a/src/cli/daemon/agent/codex.ts
+++ b/src/cli/daemon/agent/codex.ts
@@ -46,7 +46,7 @@ export class CodexBackend implements AgentBackend {
   constructor(private cliPath: string) {}
 
   execute(prompt: string, options: ExecOptions): AgentSession {
-    const proc = spawn(this.cliPath, ["app-server", "--listen", "stdio://"], {
+    const proc = spawn(this.cliPath, ["app-server", "--listen", "stdio://", "--config", "sandbox_workspace_write.network_access=true"], {
       cwd: options.cwd,
       stdio: ["pipe", "pipe", "pipe"],
       env: { ...process.env, ...options.env },


### PR DESCRIPTION
# Why we need this PR?

Codex agents running in Alook daemon use `workspace-write` sandbox mode, which blocks all outbound network access by default. This causes agent commands that need the network (e.g. `npx @alook/cli email send`) to fail with `getaddrinfo ENOTFOUND registry.npmjs.org`.

The Codex CLI supports enabling network access within `workspace-write` mode via `--config sandbox_workspace_write.network_access=true`, which allows outbound connections while keeping filesystem writes restricted to the workspace.

## What changed

### `src/cli/daemon/agent/codex.ts`
- Added `--config sandbox_workspace_write.network_access=true` to Codex CLI spawn args

### `src/cli/daemon/agent/__tests__/codex.test.ts`
- Added test verifying the config flag is present in spawn args

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] CLI (`@alook/cli`)