### PR TITLE
feat: add runtime rescan and redesign machine card

### DIFF
--- a/src/cli/daemon/client.test.ts
+++ b/src/cli/daemon/client.test.ts
@@ -37,6 +37,16 @@ describe("PollResponseSchema validation", () => {
     expect(parsed.tasks[0].agent?.name).toBe("bot");
   });
 
+  it("parses response with pending_rescan", () => {
+    const parsed = PollResponseSchema.parse({ tasks: [], pending_rescan: true });
+    expect(parsed.pending_rescan).toBe(true);
+  });
+
+  it("parses response without pending_rescan (optional)", () => {
+    const parsed = PollResponseSchema.parse({ tasks: [] });
+    expect(parsed.pending_rescan).toBeUndefined();
+  });
+
   it("parses empty tasks array", () => {
     const parsed = PollResponseSchema.parse({ tasks: [] });
     expect(parsed.tasks).toEqual([]);
@@ -197,6 +207,31 @@ describe("DaemonClient.poll() with mocked fetch", () => {
     const result = await client.poll("tok", "d1", 1);
     expect(result.tasks).toEqual([]);
     expect(result.evicted).toBe(false);
+  });
+
+  it("returns pending_rescan when present in response", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ tasks: [], pending_rescan: true }),
+    });
+
+    const client = new DaemonClient("http://localhost:8080");
+    const result = await client.poll("tok", "d1", 1);
+    expect(result.tasks).toEqual([]);
+    expect(result.pending_rescan).toBe(true);
+  });
+
+  it("returns undefined pending_rescan when absent", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ tasks: [] }),
+    });
+
+    const client = new DaemonClient("http://localhost:8080");
+    const result = await client.poll("tok", "d1", 1);
+    expect(result.pending_rescan).toBeUndefined();
   });
 
   it("returns evicted: true when server signals eviction", async () => {

--- a/src/cli/daemon/client.ts
+++ b/src/cli/daemon/client.ts
@@ -80,7 +80,7 @@ export class DaemonClient {
     daemonId: string,
     maxTasks: number,
     cliVersion?: string,
-  ): Promise<{ tasks: TaskApi[]; evicted: boolean; pending_update?: { version: string } }> {
+  ): Promise<{ tasks: TaskApi[]; evicted: boolean; pending_update?: { version: string }; pending_rescan?: boolean }> {
     const raw = await this.request<unknown>(
       "POST",
       "/api/daemon/tasks/poll",
@@ -92,6 +92,7 @@ export class DaemonClient {
       tasks: resp.tasks,
       evicted: resp.evicted ?? false,
       pending_update: resp.pending_update,
+      pending_rescan: resp.pending_rescan,
     };
   }
 

--- a/src/cli/daemon/daemon.test.ts
+++ b/src/cli/daemon/daemon.test.ts
@@ -1395,6 +1395,76 @@ describe("daemon restart via update", () => {
 
 });
 
+describe("daemon rescan via poll", () => {
+  beforeEach(async () => {
+    signalHandlers.clear();
+    intervalTimers.length = 0;
+    clearedTimers.length = 0;
+    spawnedChildren.length = 0;
+    nextPid = 50000;
+    vi.clearAllMocks();
+    mockProcessExit.mockImplementation((() => {}) as any);
+    mockOpenSync.mockReturnValue(99);
+
+    const { createHealthServer } = await import("./health.js");
+    vi.mocked(createHealthServer).mockReturnValue({
+      setRuntimeCount: vi.fn(),
+      server: { close: vi.fn((cb?: () => void) => { if (cb) cb(); }) },
+    } as any);
+
+    mockClientInstance.register.mockResolvedValue({ runtimes: [{ id: "rt1" }] });
+    mockClientInstance.deregister.mockResolvedValue(undefined as any);
+  });
+
+  afterEach(() => {
+    for (const t of intervalTimers) realClearInterval(t);
+  });
+
+  it("calls requestRestart when pending_rescan is true in poll response", async () => {
+    vi.mocked(loadCLIConfigForProfile).mockReturnValue({
+      server_url: "",
+      watched_workspaces: [{ id: "ws1", name: "Test WS", token: "al_test_token" }],
+    });
+
+    mockClientInstance.poll.mockResolvedValue({
+      tasks: [],
+      evicted: false,
+      pending_rescan: true,
+    });
+
+    await startDaemon();
+    await new Promise((r) => setTimeout(r, 200));
+
+    // requestRestart triggers shutdown + spawn of new daemon
+    const spawnCalls = vi.mocked(spawn).mock.calls;
+    const restartCall = spawnCalls.find(
+      (call) => call[0] === process.execPath && (call[1] as string[]).includes("--foreground"),
+    );
+    expect(restartCall).toBeDefined();
+  });
+
+  it("does not restart when pending_rescan is absent", async () => {
+    vi.mocked(loadCLIConfigForProfile).mockReturnValue({
+      server_url: "",
+      watched_workspaces: [{ id: "ws1", name: "Test WS", token: "al_test_token" }],
+    });
+
+    mockClientInstance.poll.mockResolvedValue({
+      tasks: [],
+      evicted: false,
+    });
+
+    await startDaemon();
+    await new Promise((r) => setTimeout(r, 200));
+
+    const spawnCalls = vi.mocked(spawn).mock.calls;
+    const restartCall = spawnCalls.find(
+      (call) => call[0] === process.execPath && (call[1] as string[]).includes("--foreground"),
+    );
+    expect(restartCall).toBeUndefined();
+  });
+});
+
 describe("daemon restart spawn", () => {
   beforeEach(async () => {
     signalHandlers.clear();

--- a/src/cli/daemon/daemon.test.ts
+++ b/src/cli/daemon/daemon.test.ts
@@ -2,18 +2,17 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { EventEmitter } from "events";
 
 // Mock all external dependencies before importing
-/* eslint-disable @typescript-eslint/no-explicit-any */
 const mockClientInstance = {
-  register: vi.fn<any, [any]>(async () => ({
+  register: vi.fn(async () => ({
     runtimes: [{ id: "rt1" }],
   })),
-  deregister: vi.fn<any, [any]>(async () => {}),
-  poll: vi.fn<any, [any]>(async () => ({ tasks: [] as any[], evicted: false })),
-  startTask: vi.fn<any, [any]>(async () => ({})),
-  completeTask: vi.fn<any, [any]>(async () => ({})),
-  failTask: vi.fn<any, [any]>(async () => ({})),
-  supersedeTask: vi.fn<any, [any]>(async () => ({})),
-  reportMessages: vi.fn<any, [any]>(async () => ({})),
+  deregister: vi.fn(async () => {}),
+  poll: vi.fn(async () => ({ tasks: [], evicted: false })),
+  startTask: vi.fn(async () => ({})),
+  completeTask: vi.fn(async () => ({})),
+  failTask: vi.fn(async () => ({})),
+  supersedeTask: vi.fn(async () => ({})),
+  reportMessages: vi.fn(async () => ({})),
 };
 vi.mock("./client.js", () => {
   function MockDaemonClient() { return mockClientInstance; }
@@ -77,18 +76,18 @@ vi.mock("./update-handler.js", () => ({
   clearUpdateMarker: vi.fn(),
 }));
 
-const mockFindRunningPidByTaskId = vi.fn<any, any>();
-const mockFindRunningEntryByContextKey = vi.fn<any, any>(() => null);
+const mockFindRunningPidByTaskId = vi.fn();
+const mockFindRunningEntryByContextKey = vi.fn(() => null);
 vi.mock("./execenv/timeline.js", () => ({
   findRunningPidByTaskId: (...args: any[]) => mockFindRunningPidByTaskId(...args),
   findRunningEntryByContextKey: (...args: any[]) => mockFindRunningEntryByContextKey(...args),
 }));
 
-const mockWriteKillIntent = vi.fn<any, any>();
-const mockClearKillIntent = vi.fn<any, any>();
-const mockAcquireSteeringLock = vi.fn<any, any>(() => true);
-const mockReleaseSteeringLock = vi.fn<any, any>();
-const mockCleanupStaleIntents = vi.fn<any, any>();
+const mockWriteKillIntent = vi.fn();
+const mockClearKillIntent = vi.fn();
+const mockAcquireSteeringLock = vi.fn(() => true);
+const mockReleaseSteeringLock = vi.fn();
+const mockCleanupStaleIntents = vi.fn();
 vi.mock("./execenv/steering.js", () => ({
   writeKillIntent: (...args: any[]) => mockWriteKillIntent(...args),
   clearKillIntent: (...args: any[]) => mockClearKillIntent(...args),
@@ -106,8 +105,8 @@ interface MockChild extends EventEmitter {
 const spawnedChildren: MockChild[] = [];
 let nextPid = 50000;
 
-vi.mock("child_process", async () => {
-  const { EventEmitter } = await import("events");
+vi.mock("child_process", () => {
+  const { EventEmitter } = require("events");
 
   return {
     execSync: vi.fn(),
@@ -121,13 +120,13 @@ vi.mock("child_process", async () => {
   };
 });
 
-const mockOpenSync = vi.fn<any, any>(() => 42);
-const mockCloseSync = vi.fn<any, any>();
-const mockRenameSync = vi.fn<any, any>();
-const mockMkdirSync = vi.fn<any, any>();
-const mockReaddirSync = vi.fn<any, any>(() => [] as string[]);
-const mockStatSync = vi.fn<any, any>(() => ({ mtimeMs: 0 }));
-const mockUnlinkSync = vi.fn<any, any>();
+const mockOpenSync = vi.fn(() => 42);
+const mockCloseSync = vi.fn();
+const mockRenameSync = vi.fn();
+const mockMkdirSync = vi.fn();
+const mockReaddirSync = vi.fn(() => [] as string[]);
+const mockStatSync = vi.fn(() => ({ mtimeMs: 0 }));
+const mockUnlinkSync = vi.fn();
 
 vi.mock("fs", () => ({
   existsSync: vi.fn((p: string) => p.endsWith("session-runner.js")),
@@ -140,10 +139,10 @@ vi.mock("fs", () => ({
   unlinkSync: (...args: any[]) => mockUnlinkSync(...args),
 }));
 
-const mockReaddir = vi.fn<any, any>(async () => [] as string[]);
-const mockReadFile = vi.fn<any, any>(async () => "");
-const mockUnlink = vi.fn<any, any>(async () => undefined);
-const mockFsStat = vi.fn<any, any>(async () => ({ mtimeMs: Date.now() }));
+const mockReaddir = vi.fn(async () => [] as string[]);
+const mockReadFile = vi.fn(async () => "");
+const mockUnlink = vi.fn(async () => undefined);
+const mockFsStat = vi.fn(async () => ({ mtimeMs: Date.now() }));
 vi.mock("fs/promises", () => ({
   readdir: (...args: any[]) => mockReaddir(...args),
   readFile: (...args: any[]) => mockReadFile(...args),

--- a/src/cli/daemon/daemon.test.ts
+++ b/src/cli/daemon/daemon.test.ts
@@ -2,17 +2,18 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { EventEmitter } from "events";
 
 // Mock all external dependencies before importing
+/* eslint-disable @typescript-eslint/no-explicit-any */
 const mockClientInstance = {
-  register: vi.fn(async () => ({
+  register: vi.fn<any, [any]>(async () => ({
     runtimes: [{ id: "rt1" }],
   })),
-  deregister: vi.fn(async () => {}),
-  poll: vi.fn(async () => ({ tasks: [], evicted: false })),
-  startTask: vi.fn(async () => ({})),
-  completeTask: vi.fn(async () => ({})),
-  failTask: vi.fn(async () => ({})),
-  supersedeTask: vi.fn(async () => ({})),
-  reportMessages: vi.fn(async () => ({})),
+  deregister: vi.fn<any, [any]>(async () => {}),
+  poll: vi.fn<any, [any]>(async () => ({ tasks: [] as any[], evicted: false })),
+  startTask: vi.fn<any, [any]>(async () => ({})),
+  completeTask: vi.fn<any, [any]>(async () => ({})),
+  failTask: vi.fn<any, [any]>(async () => ({})),
+  supersedeTask: vi.fn<any, [any]>(async () => ({})),
+  reportMessages: vi.fn<any, [any]>(async () => ({})),
 };
 vi.mock("./client.js", () => {
   function MockDaemonClient() { return mockClientInstance; }
@@ -76,18 +77,18 @@ vi.mock("./update-handler.js", () => ({
   clearUpdateMarker: vi.fn(),
 }));
 
-const mockFindRunningPidByTaskId = vi.fn();
-const mockFindRunningEntryByContextKey = vi.fn(() => null);
+const mockFindRunningPidByTaskId = vi.fn<any, any>();
+const mockFindRunningEntryByContextKey = vi.fn<any, any>(() => null);
 vi.mock("./execenv/timeline.js", () => ({
   findRunningPidByTaskId: (...args: any[]) => mockFindRunningPidByTaskId(...args),
   findRunningEntryByContextKey: (...args: any[]) => mockFindRunningEntryByContextKey(...args),
 }));
 
-const mockWriteKillIntent = vi.fn();
-const mockClearKillIntent = vi.fn();
-const mockAcquireSteeringLock = vi.fn(() => true);
-const mockReleaseSteeringLock = vi.fn();
-const mockCleanupStaleIntents = vi.fn();
+const mockWriteKillIntent = vi.fn<any, any>();
+const mockClearKillIntent = vi.fn<any, any>();
+const mockAcquireSteeringLock = vi.fn<any, any>(() => true);
+const mockReleaseSteeringLock = vi.fn<any, any>();
+const mockCleanupStaleIntents = vi.fn<any, any>();
 vi.mock("./execenv/steering.js", () => ({
   writeKillIntent: (...args: any[]) => mockWriteKillIntent(...args),
   clearKillIntent: (...args: any[]) => mockClearKillIntent(...args),
@@ -105,8 +106,8 @@ interface MockChild extends EventEmitter {
 const spawnedChildren: MockChild[] = [];
 let nextPid = 50000;
 
-vi.mock("child_process", () => {
-  const { EventEmitter } = require("events");
+vi.mock("child_process", async () => {
+  const { EventEmitter } = await import("events");
 
   return {
     execSync: vi.fn(),
@@ -120,13 +121,13 @@ vi.mock("child_process", () => {
   };
 });
 
-const mockOpenSync = vi.fn(() => 42);
-const mockCloseSync = vi.fn();
-const mockRenameSync = vi.fn();
-const mockMkdirSync = vi.fn();
-const mockReaddirSync = vi.fn(() => [] as string[]);
-const mockStatSync = vi.fn(() => ({ mtimeMs: 0 }));
-const mockUnlinkSync = vi.fn();
+const mockOpenSync = vi.fn<any, any>(() => 42);
+const mockCloseSync = vi.fn<any, any>();
+const mockRenameSync = vi.fn<any, any>();
+const mockMkdirSync = vi.fn<any, any>();
+const mockReaddirSync = vi.fn<any, any>(() => [] as string[]);
+const mockStatSync = vi.fn<any, any>(() => ({ mtimeMs: 0 }));
+const mockUnlinkSync = vi.fn<any, any>();
 
 vi.mock("fs", () => ({
   existsSync: vi.fn((p: string) => p.endsWith("session-runner.js")),
@@ -139,10 +140,10 @@ vi.mock("fs", () => ({
   unlinkSync: (...args: any[]) => mockUnlinkSync(...args),
 }));
 
-const mockReaddir = vi.fn(async () => [] as string[]);
-const mockReadFile = vi.fn(async () => "");
-const mockUnlink = vi.fn(async () => undefined);
-const mockFsStat = vi.fn(async () => ({ mtimeMs: Date.now() }));
+const mockReaddir = vi.fn<any, any>(async () => [] as string[]);
+const mockReadFile = vi.fn<any, any>(async () => "");
+const mockUnlink = vi.fn<any, any>(async () => undefined);
+const mockFsStat = vi.fn<any, any>(async () => ({ mtimeMs: Date.now() }));
 vi.mock("fs/promises", () => ({
   readdir: (...args: any[]) => mockReaddir(...args),
   readFile: (...args: any[]) => mockReadFile(...args),

--- a/src/cli/daemon/daemon.ts
+++ b/src/cli/daemon/daemon.ts
@@ -395,7 +395,7 @@ export async function startDaemon(
       }
 
       try {
-        const { tasks: apiTasks, evicted, pending_update } = await client.poll(
+        const { tasks: apiTasks, evicted, pending_update, pending_rescan } = await client.poll(
           ws.token,
           config.daemonId,
           remaining,
@@ -409,6 +409,11 @@ export async function startDaemon(
 
         if (pending_update && !isUpdating() && pending_update.version !== config.cliVersion) {
           handleCliUpdate(pending_update.version, () => requestRestart(), profile);
+        }
+
+        if (pending_rescan) {
+          log.info("Rescan requested — restarting daemon to re-detect runtimes");
+          requestRestart();
         }
 
         for (const apiTask of apiTasks) {

--- a/src/cli/package.json
+++ b/src/cli/package.json
@@ -41,7 +41,7 @@
     "build": "bun build src/index.ts --outdir dist --target node --format esm --external citty --external commander --external postal-mime && bun build daemon/session-runner.ts --outdir dist --target node --format esm --external citty --external commander --external postal-mime && node scripts/prepare-dist.mjs",
     "prepack": "pnpm run build",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit -p tsconfig.build.json"
   },
   "dependencies": {
     "citty": "^0.2.2",

--- a/src/cli/tsconfig.build.json
+++ b/src/cli/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"]
+  },
+  "include": ["src", "commands", "daemon", "lib"],
+  "exclude": ["**/__tests__", "**/*.test.ts"]
+}

--- a/src/cli/tsconfig.json
+++ b/src/cli/tsconfig.json
@@ -5,8 +5,7 @@
     "moduleResolution": "bundler",
     "strict": true,
     "skipLibCheck": true,
-    "types": ["bun"]
+    "types": ["bun", "vitest/globals"]
   },
-  "include": ["src", "commands", "daemon", "lib"],
-  "exclude": ["**/__tests__", "**/*.test.ts"]
+  "include": ["src", "commands", "daemon", "lib", "**/*.test.ts", "**/__tests__/**/*.ts"]
 }

--- a/src/shared/src/db/queries/machine.ts
+++ b/src/shared/src/db/queries/machine.ts
@@ -121,3 +121,31 @@ export async function clearPendingUpdateVersion(
     .set({ pendingUpdateVersion: null, updatedAt: now })
     .where(eq(machine.daemonId, daemonId));
 }
+
+export async function setPendingRescan(
+  db: Database,
+  daemonId: string,
+  workspaceId: string,
+) {
+  const now = new Date().toISOString();
+  await db
+    .update(machine)
+    .set({ pendingRescan: true, updatedAt: now })
+    .where(
+      and(eq(machine.daemonId, daemonId), eq(machine.workspaceId, workspaceId)),
+    );
+}
+
+export async function clearPendingRescan(
+  db: Database,
+  daemonId: string,
+  workspaceId: string,
+) {
+  const now = new Date().toISOString();
+  await db
+    .update(machine)
+    .set({ pendingRescan: false, updatedAt: now })
+    .where(
+      and(eq(machine.daemonId, daemonId), eq(machine.workspaceId, workspaceId)),
+    );
+}

--- a/src/shared/src/db/schema.ts
+++ b/src/shared/src/db/schema.ts
@@ -170,6 +170,7 @@ export const machine = sqliteTable(
     lastSeenAt: text("last_seen_at"),
     createdAt: text("created_at").notNull().$defaultFn(() => new Date().toISOString()),
     pendingUpdateVersion: text("pending_update_version"),
+    pendingRescan: integer("pending_rescan", { mode: "boolean" }).default(false),
     updatedAt: text("updated_at").notNull().$defaultFn(() => new Date().toISOString()),
   },
   (t) => [primaryKey({ columns: [t.workspaceId, t.daemonId] })]

--- a/src/shared/src/schemas.ts
+++ b/src/shared/src/schemas.ts
@@ -104,6 +104,7 @@ export const PollResponseSchema = z.object({
   tasks: z.array(TaskApiSchema),
   evicted: z.boolean().optional(),
   pending_update: z.object({ version: z.string() }).optional(),
+  pending_rescan: z.boolean().optional(),
 });
 export type PollResponse = z.infer<typeof PollResponseSchema>;
 

--- a/src/shared/src/types.ts
+++ b/src/shared/src/types.ts
@@ -48,6 +48,7 @@ export interface AgentRuntime {
   device_info: string;
   metadata: Record<string, unknown>;
   pending_update_version?: string | null;
+  pending_rescan?: boolean;
   last_seen_at: string | null;
   created_at: string;
   updated_at: string;

--- a/src/web/migrations/0011_machine_pending_rescan.sql
+++ b/src/web/migrations/0011_machine_pending_rescan.sql
@@ -1,0 +1,1 @@
+ALTER TABLE machine ADD COLUMN pending_rescan integer DEFAULT 0;

--- a/src/web/src/app/(app)/w/[slug]/runtimes/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/runtimes/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useMemo, useRef, useEffect, useCallback } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { useAgentContext } from "@/contexts/agent-context";
 import { Button } from "@/components/ui/button";
@@ -9,7 +9,6 @@ import {
   Card,
   CardHeader,
   CardTitle,
-  CardAction,
   CardContent,
 } from "@/components/ui/card";
 import {
@@ -29,8 +28,8 @@ import type { AgentRuntime as Runtime } from "@alook/shared";
 import { semverGte } from "@alook/shared";
 import { CLI_CMD } from "@/lib/utils";
 import { ProviderLogo } from "@/components/provider-logo";
-import { triggerRuntimeUpdate, fetchLatestCliVersion } from "@/lib/api";
-import { Loader2 } from "lucide-react";
+import { triggerRuntimeUpdate, triggerRuntimeRescan, fetchLatestCliVersion } from "@/lib/api";
+import { Loader2, RefreshCw } from "lucide-react";
 
 function ConnectMachineSteps({
   generatedToken,
@@ -140,12 +139,13 @@ export default function RuntimesPage() {
   const router = useRouter();
   const pathname = usePathname();
 
-  const [sheetOpen, setSheetOpen] = useState(false);
+  const [sheetOpen, setSheetOpen] = useState(() => searchParams.has("connect"));
   const [generatedToken, setGeneratedToken] = useState("");
   const [generatingToken, setGeneratingToken] = useState(false);
 
   const [latestCliVersion, setLatestCliVersion] = useState<string | null>(null);
   const [updatingDaemons, setUpdatingDaemons] = useState<Set<string>>(new Set());
+  const [rescanningDaemons, setRescanningDaemons] = useState<Set<string>>(new Set());
 
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [confirmTitle, setConfirmTitle] = useState("");
@@ -159,10 +159,9 @@ export default function RuntimesPage() {
       .catch(() => {});
   }, []);
 
-  // Auto-open "New machine" sheet when navigated with ?connect
+  // Clean up ?connect query param after initial open
   useEffect(() => {
     if (searchParams.has("connect")) {
-      setSheetOpen(true);
       router.replace(pathname, { scroll: false });
     }
   }, [searchParams, router, pathname]);
@@ -226,25 +225,50 @@ export default function RuntimesPage() {
     }
   };
 
-  // Clear updatingDaemons when runtimes reload shows update completed
-  useEffect(() => {
-    if (updatingDaemons.size === 0) return;
-    const stillUpdating = new Set<string>();
+  const handleRescan = async (runtimeId: string, daemonId: string) => {
+    setRescanningDaemons((prev) => new Set(prev).add(daemonId));
+    try {
+      await triggerRuntimeRescan(runtimeId, workspaceId);
+      toast.success("Rescan triggered — daemon will restart to detect runtimes");
+    } catch {
+      toast.error("Failed to trigger rescan");
+      setRescanningDaemons((prev) => {
+        const next = new Set(prev);
+        next.delete(daemonId);
+        return next;
+      });
+    }
+  };
+
+  // Derive effective optimistic sets: filter out entries whose server-side flag has cleared
+  const effectiveUpdatingDaemons = useMemo(() => {
+    if (updatingDaemons.size === 0) return updatingDaemons;
+    const still = new Set<string>();
     for (const rt of runtimes) {
       const key = rt.daemon_id || rt.id;
       if (updatingDaemons.has(key) && rt.pending_update_version) {
-        stillUpdating.add(key);
+        still.add(key);
       }
     }
-    if (stillUpdating.size < updatingDaemons.size) {
-      setUpdatingDaemons(stillUpdating);
+    return still;
+  }, [runtimes, updatingDaemons]);
+
+  const effectiveRescanningDaemons = useMemo(() => {
+    if (rescanningDaemons.size === 0) return rescanningDaemons;
+    const still = new Set<string>();
+    for (const rt of runtimes) {
+      const key = rt.daemon_id || rt.id;
+      if (rescanningDaemons.has(key) && rt.pending_rescan) {
+        still.add(key);
+      }
     }
-  }, [runtimes]); // eslint-disable-line react-hooks/exhaustive-deps
+    return still;
+  }, [runtimes, rescanningDaemons]);
 
   // Group runtimes by machine
   const machines = new Map<
     string,
-    { deviceInfo: string; name: string; status: string; lastSeenAt: string | null; pendingUpdateVersion: string | null; cliVersion: string | null; runtimes: Runtime[] }
+    { deviceInfo: string; name: string; status: string; lastSeenAt: string | null; pendingUpdateVersion: string | null; pendingRescan: boolean; cliVersion: string | null; runtimes: Runtime[] }
   >();
   for (const rt of runtimes) {
     const key = rt.daemon_id || rt.id;
@@ -256,6 +280,7 @@ export default function RuntimesPage() {
         status: rt.status,
         lastSeenAt: rt.last_seen_at,
         pendingUpdateVersion: rt.pending_update_version ?? null,
+        pendingRescan: !!rt.pending_rescan,
         cliVersion: (meta?.cli_version as string) ?? null,
         runtimes: [],
       });
@@ -372,61 +397,84 @@ export default function RuntimesPage() {
                         {machine.status}
                       </Badge>
                     </div>
-                    <CardAction>
-                      {(() => {
-                        const isUpdating = !!machine.pendingUpdateVersion || updatingDaemons.has(daemonId);
-                        const needsUpdate = latestCliVersion && machine.cliVersion && !semverGte(machine.cliVersion, latestCliVersion);
-                        if (isUpdating) {
-                          return (
-                            <Button variant="ghost" size="sm" disabled className="text-xs h-6 px-2">
-                              <Loader2 className="size-3 animate-spin mr-1" />
-                              Updating...
-                            </Button>
-                          );
-                        }
-                        if (needsUpdate) {
-                          return (
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              className="text-xs h-6 px-2"
-                              onClick={() => handleUpdate(machine.runtimes[0].id, daemonId)}
-                            >
-                              Update
-                            </Button>
-                          );
-                        }
-                        return null;
-                      })()}
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="text-xs text-muted-foreground h-6 px-2 hover:text-destructive opacity-0 group-hover:opacity-100 transition-opacity"
-                        onClick={() => {
-                          openConfirm(
-                            "Remove machine",
-                            `This will remove "${displayName}" and all its runtimes. Agents using these runtimes will be unlinked.`,
-                            async () => {
-                              await handleDeleteMachine(daemonId);
-                            }
-                          );
-                        }}
-                      >
-                        Remove
-                      </Button>
-                    </CardAction>
+                    {machine.cliVersion && (
+                      <span className="text-xs text-muted-foreground/60 shrink-0">v{machine.cliVersion}</span>
+                    )}
                   </CardHeader>
                   <CardContent>
                     <div className="space-y-2.5">
-                      <div className="flex items-center gap-2 text-xs text-muted-foreground tabular-nums">
-                        <span>
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs text-muted-foreground tabular-nums">
                           {machine.lastSeenAt ? new Date(
                             machine.lastSeenAt
                           ).toLocaleString() : "Never seen"}
                         </span>
-                        {machine.cliVersion && (
-                          <span className="text-muted-foreground/60">v{machine.cliVersion}</span>
-                        )}
+                        <div className="flex items-center gap-1">
+                          {(() => {
+                            const isUpdating = !!machine.pendingUpdateVersion || effectiveUpdatingDaemons.has(daemonId);
+                            const needsUpdate = latestCliVersion && machine.cliVersion && !semverGte(machine.cliVersion, latestCliVersion);
+                            if (isUpdating) {
+                              return (
+                                <Button variant="ghost" size="sm" disabled className="text-xs h-6 px-2">
+                                  <Loader2 className="size-3 animate-spin mr-1" />
+                                  Updating...
+                                </Button>
+                              );
+                            }
+                            if (needsUpdate) {
+                              return (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  className="text-xs h-6 px-2"
+                                  onClick={() => handleUpdate(machine.runtimes[0].id, daemonId)}
+                                >
+                                  Update
+                                </Button>
+                              );
+                            }
+                            return null;
+                          })()}
+                          {(() => {
+                            const isRescanning = machine.pendingRescan || effectiveRescanningDaemons.has(daemonId);
+                            if (machine.status !== "online") return null;
+                            if (isRescanning) {
+                              return (
+                                <Button variant="ghost" size="sm" disabled className="text-xs h-6 px-2">
+                                  <RefreshCw className="size-3 animate-spin mr-1" />
+                                  Rescanning...
+                                </Button>
+                              );
+                            }
+                            return (
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                className="text-xs h-6 px-2"
+                                onClick={() => handleRescan(machine.runtimes[0].id, daemonId)}
+                              >
+                                <RefreshCw className="size-3 mr-1" />
+                                Rescan
+                              </Button>
+                            );
+                          })()}
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-xs text-muted-foreground h-6 px-2 hover:text-destructive opacity-0 group-hover:opacity-100 transition-opacity"
+                            onClick={() => {
+                              openConfirm(
+                                "Remove machine",
+                                `This will remove "${displayName}" and all its runtimes. Agents using these runtimes will be unlinked.`,
+                                async () => {
+                                  await handleDeleteMachine(daemonId);
+                                }
+                              );
+                            }}
+                          >
+                            Remove
+                          </Button>
+                        </div>
                       </div>
                       <div className="flex flex-wrap gap-1.5">
                         {machine.runtimes.map((runtime) => (
@@ -458,7 +506,7 @@ export default function RuntimesPage() {
                             }}
                             title="Click to copy"
                           >
-                            <span className="absolute inset-0 -translate-x-full animate-[shimmer_2.5s_infinite] bg-gradient-to-r from-transparent via-[var(--shimmer-peak)] to-transparent" />
+                            <span className="absolute inset-0 -translate-x-full animate-[shimmer_2.5s_infinite] bg-linear-to-r from-transparent via-(--shimmer-peak) to-transparent" />
                             <span className="relative">{CLI_CMD} daemon start</span>
                           </div>
                         </div>

--- a/src/web/src/app/api/daemon/tasks/poll/route.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.ts
@@ -146,5 +146,16 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     }
   }
 
-  return writeJSON({ tasks, ...(pendingUpdate && { pending_update: pendingUpdate }) });
+  // 6. Pending rescan check
+  let pendingRescan: boolean | undefined;
+  if (machineRow?.pendingRescan) {
+    pendingRescan = true;
+    await queries.machine.clearPendingRescan(db, body.daemon_id, ctx.workspaceId);
+  }
+
+  return writeJSON({
+    tasks,
+    ...(pendingUpdate && { pending_update: pendingUpdate }),
+    ...(pendingRescan && { pending_rescan: pendingRescan }),
+  });
 });

--- a/src/web/src/app/api/runtimes/[runtimeId]/rescan/route.test.ts
+++ b/src/web/src/app/api/runtimes/[runtimeId]/rescan/route.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetAgentRuntimeForWorkspace = vi.fn();
+const mockSetPendingRescan = vi.fn();
+const mockGetMemberByUserAndWorkspace = vi.fn();
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
+}));
+
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
+vi.mock("@alook/shared", () => ({
+  createDb: vi.fn(() => ({})),
+  queries: {
+    runtime: {
+      getAgentRuntimeForWorkspace: (...args: any[]) =>
+        mockGetAgentRuntimeForWorkspace(...args),
+    },
+    machine: {
+      setPendingRescan: (...args: any[]) =>
+        mockSetPendingRescan(...args),
+    },
+    member: {
+      getMemberByUserAndWorkspace: (...args: any[]) =>
+        mockGetMemberByUserAndWorkspace(...args),
+    },
+  },
+}));
+
+vi.mock("@/lib/middleware/auth", () => ({
+  withAuth: vi.fn((handler: any) => async (req: any, ctx?: any) => {
+    const params = ctx?.params instanceof Promise ? await ctx.params : ctx?.params;
+    return handler(req, { userId: "u1", email: "u@t.com", params });
+  }),
+}));
+
+vi.mock("@/lib/middleware/workspace", () => ({
+  withWorkspaceMember: vi.fn(async (req: any) => {
+    const wsId = req.nextUrl.searchParams.get("workspace_id");
+    if (!wsId) {
+      const { NextResponse } = await import("next/server");
+      return NextResponse.json({ error: "workspace_id is required" }, { status: 400 });
+    }
+    const member = await mockGetMemberByUserAndWorkspace({}, "u1", wsId);
+    if (!member) {
+      const { NextResponse } = await import("next/server");
+      return NextResponse.json({ error: "workspace not found" }, { status: 404 });
+    }
+    return { workspaceId: wsId };
+  }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  log: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from "./route";
+
+function makeReq(runtimeId: string, workspaceId: string) {
+  const url = `http://localhost/api/runtimes/${runtimeId}/rescan?workspace_id=${workspaceId}`;
+  return new NextRequest(url, { method: "POST" });
+}
+
+describe("POST /api/runtimes/[runtimeId]/rescan", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetMemberByUserAndWorkspace.mockResolvedValue({ id: "m1" });
+  });
+
+  it("returns 200 with pending_rescan: true", async () => {
+    mockGetAgentRuntimeForWorkspace.mockResolvedValue({
+      id: "rt1",
+      daemonId: "d1",
+    });
+    mockSetPendingRescan.mockResolvedValue(undefined);
+
+    const res = await POST(makeReq("rt1", "w1"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.pending_rescan).toBe(true);
+    expect(mockSetPendingRescan).toHaveBeenCalledWith({}, "d1", "w1");
+  });
+
+  it("returns 404 for non-existent runtime", async () => {
+    mockGetAgentRuntimeForWorkspace.mockResolvedValue(null);
+
+    const res = await POST(makeReq("nonexistent", "w1"));
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toContain("not found");
+  });
+
+  it("returns 404 for runtime in another workspace", async () => {
+    mockGetMemberByUserAndWorkspace.mockResolvedValue(null);
+
+    const res = await POST(makeReq("rt1", "w-other"));
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toContain("workspace not found");
+  });
+
+  it("returns 400 when runtime id is missing from URL", async () => {
+    mockGetAgentRuntimeForWorkspace.mockResolvedValue(null);
+    const url = `http://localhost/api/runtimes//rescan?workspace_id=w1`;
+    const req = new NextRequest(url, { method: "POST" });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain("runtime id required");
+  });
+});

--- a/src/web/src/app/api/runtimes/[runtimeId]/rescan/route.ts
+++ b/src/web/src/app/api/runtimes/[runtimeId]/rescan/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { queries } from "@alook/shared";
+import { getDb } from "@/lib/db"
+import { withAuth } from "@/lib/middleware/auth";
+import { withWorkspaceMember } from "@/lib/middleware/workspace";
+import { writeJSON, writeError } from "@/lib/middleware/helpers";
+
+export const POST = withAuth(async (req: NextRequest, ctx) => {
+  const ws = await withWorkspaceMember(req, ctx);
+  if (ws instanceof Response) return ws;
+
+  const { env } = getCloudflareContext();
+  const db = getDb((env as Env).DB);
+
+  const runtimeId = req.nextUrl.pathname.split("/runtimes/")[1]?.split("/")[0];
+  if (!runtimeId) return writeError("runtime id required", 400);
+
+  const runtime = await queries.runtime.getAgentRuntimeForWorkspace(
+    db,
+    runtimeId,
+    ws.workspaceId,
+  );
+  if (!runtime) return writeError("runtime not found", 404);
+
+  await queries.machine.setPendingRescan(db, runtime.daemonId, ws.workspaceId);
+
+  return writeJSON({ pending_rescan: true });
+});

--- a/src/web/src/lib/api.ts
+++ b/src/web/src/lib/api.ts
@@ -140,6 +140,12 @@ export const triggerRuntimeUpdate = (runtimeId: string, workspaceId: string) =>
     { method: "POST" }
   );
 
+export const triggerRuntimeRescan = (runtimeId: string, workspaceId: string) =>
+  apiFetch<{ pending_rescan: boolean }>(
+    `/api/runtimes/${runtimeId}/rescan${wsQuery(workspaceId)}`,
+    { method: "POST" }
+  );
+
 export const fetchLatestCliVersion = () =>
   apiFetch<{ version: string }>("/api/cli/latest-version");
 

--- a/src/web/src/lib/api/responses.test.ts
+++ b/src/web/src/lib/api/responses.test.ts
@@ -381,7 +381,7 @@ describe("AgentRuntimeResponse shape", () => {
     });
     expect(Object.keys(res).sort()).toEqual([
       "created_at", "daemon_id", "device_info", "id", "last_seen_at",
-      "metadata", "name", "pending_update_version", "provider", "runtime_mode", "status",
+      "metadata", "name", "pending_rescan", "pending_update_version", "provider", "runtime_mode", "status",
       "updated_at", "workspace_id",
     ]);
   });

--- a/src/web/src/lib/api/responses.ts
+++ b/src/web/src/lib/api/responses.ts
@@ -173,6 +173,7 @@ export function runtimeToResponse(rt: any) {
     device_info: rt.deviceInfo,
     metadata,
     pending_update_version: rt.pendingUpdateVersion ?? null,
+    pending_rescan: !!rt.pendingRescan,
     last_seen_at: formatTimestampNullable(machineLastSeenAt),
     created_at: formatTimestamp(rt.createdAt),
     updated_at: formatTimestamp(rt.updatedAt),


### PR DESCRIPTION
# Why we need this PR?

Users who install a new runtime (e.g. Codex, OpenCode) after initial registration have no way to make the daemon detect it without re-running `alook register`. This PR adds a "Rescan" button on the runtimes page and redesigns the machine card layout.

## What changed

### Runtime Rescan Feature
- **DB**: Added `pending_rescan` boolean column to `machine` table (migration 0011)
- **Queries**: `setPendingRescan()` / `clearPendingRescan()` in machine queries
- **API**: `POST /api/runtimes/[runtimeId]/rescan` sets the flag
- **Poll**: Daemon poll response includes `pending_rescan: true` (auto-cleared after delivery)
- **Daemon**: Calls `requestRestart()` when `pending_rescan` is received — new daemon process re-scans runtimes and re-registers with server
- **Frontend**: `triggerRuntimeRescan()` API call, Rescan button with spinner state

### Machine Card Redesign
- **Row 1**: Machine name + status badge + CLI version
- **Row 2**: Last seen time + action buttons (Update | Rescan | Remove)
- **Row 3**: Runtime provider badges (unchanged)

### Fixes
- Fixed 3 ESLint `set-state-in-effect` warnings using `useMemo` for derived state
- Fixed Tailwind v4 canonical class names (`bg-linear-to-r`, `via-(--shimmer-peak)`)

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [x] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...