### PR TITLE
fix: add tooltip hint for right-clickable elements

### DIFF
--- a/src/web/src/components/app-sidebar.tsx
+++ b/src/web/src/components/app-sidebar.tsx
@@ -55,41 +55,47 @@ export function AppSidebar({ onNavigate }: { onNavigate?: () => void } = {}) {
     const isActive = activeAgentId === agent.id;
     const isPinned = pins.has(agent.id);
     return (
-      <ContextMenu key={agent.id}>
-        <ContextMenuTrigger
-          render={
-            <button
-              type="button"
-              title={agent.name}
-              onClick={() => handleAgentClick(agent.id)}
-              className={cn(
-                "relative flex shrink-0 items-center justify-center size-10 rounded-xl text-sm font-medium transition-colors duration-200 cursor-pointer",
-                isActive
-                  ? "bg-primary text-primary-foreground shadow-sm"
-                  : "bg-secondary text-secondary-foreground hover:bg-accent"
-              )}
-            />
-          }
-        >
-          {agent.name.charAt(0).toUpperCase()}
-          {(taskCounts[agent.id] ?? 0) > 0 && (
-            <span className="absolute bottom-0 right-0 size-2 rounded-full bg-status-online animate-pulse ring-2 ring-background" />
-          )}
-        </ContextMenuTrigger>
-        <ContextMenuContent>
-          {isPinned ? (
-            <ContextMenuItem onClick={() => handleUnpinAgent(agent.id)}>
-              <PinOffIcon className="size-3.5 mr-1.5" />
-              Unpin
-            </ContextMenuItem>
-          ) : (
-            <ContextMenuItem onClick={() => handlePinAgent(agent.id)}>
-              <PinIcon className="size-3.5 mr-1.5" />
-              Pin to top
-            </ContextMenuItem>
-          )}
-        </ContextMenuContent>
-      </ContextMenu>
+      <Tooltip key={agent.id}>
+        <ContextMenu>
+          <TooltipTrigger
+            render={
+              <ContextMenuTrigger
+                render={
+                  <button
+                    type="button"
+                    onClick={() => handleAgentClick(agent.id)}
+                    className={cn(
+                      "relative flex shrink-0 items-center justify-center size-10 rounded-xl text-sm font-medium transition-colors duration-200 cursor-pointer",
+                      isActive
+                        ? "bg-primary text-primary-foreground shadow-sm"
+                        : "bg-secondary text-secondary-foreground hover:bg-accent"
+                    )}
+                  />
+                }
+              />
+            }
+          >
+            {agent.name.charAt(0).toUpperCase()}
+            {(taskCounts[agent.id] ?? 0) > 0 && (
+              <span className="absolute bottom-0 right-0 size-2 rounded-full bg-status-online animate-pulse ring-2 ring-background" />
+            )}
+          </TooltipTrigger>
+          <ContextMenuContent>
+            {isPinned ? (
+              <ContextMenuItem onClick={() => handleUnpinAgent(agent.id)}>
+                <PinOffIcon className="size-3.5 mr-1.5" />
+                Unpin
+              </ContextMenuItem>
+            ) : (
+              <ContextMenuItem onClick={() => handlePinAgent(agent.id)}>
+                <PinIcon className="size-3.5 mr-1.5" />
+                Pin to top
+              </ContextMenuItem>
+            )}
+          </ContextMenuContent>
+        </ContextMenu>
+        <TooltipContent side="right">{agent.name} (right-click for options)</TooltipContent>
+      </Tooltip>
     );
   };
 

--- a/src/web/src/components/channel-bar.tsx
+++ b/src/web/src/components/channel-bar.tsx
@@ -18,6 +18,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 
@@ -153,46 +154,53 @@ function ChannelPill({
   }
 
   return (
-    <Popover open={deleting} onOpenChange={(open) => { if (!open) onDeleteCancel(); }}>
-      <ContextMenu>
-        <ContextMenuTrigger className="inline-flex">
-          <PopoverTrigger
+    <Tooltip>
+      <Popover open={deleting} onOpenChange={(open) => { if (!open) onDeleteCancel(); }}>
+        <ContextMenu>
+          <TooltipTrigger
             render={
-              <button onClick={onSelect} className={pillClasses} />
+              <ContextMenuTrigger className="inline-flex" />
             }
           >
-            {name}
-          </PopoverTrigger>
-        </ContextMenuTrigger>
-        <ContextMenuContent>
-          <ContextMenuItem onClick={onRename}>
-            <Pencil className="size-3.5 mr-2" />
-            Rename
-          </ContextMenuItem>
-          <ContextMenuSeparator />
-          <ContextMenuItem
-            onClick={onDeleteRequest}
-            className="text-destructive focus:text-destructive"
-          >
-            <Trash2 className="size-3.5 mr-2" />
-            Delete
-          </ContextMenuItem>
-        </ContextMenuContent>
-      </ContextMenu>
-      <PopoverContent className="w-auto p-3" align="start">
-        <p className="text-sm mb-3">
-          Delete &ldquo;{name}&rdquo;? Its conversations will be removed.
-        </p>
-        <div className="flex gap-2 justify-end">
-          <Button variant="ghost" size="sm" onClick={onDeleteCancel}>
-            Cancel
-          </Button>
-          <Button variant="destructive" size="sm" onClick={onDeleteConfirm}>
-            Delete
-          </Button>
-        </div>
-      </PopoverContent>
-    </Popover>
+            <PopoverTrigger
+              render={
+                <button onClick={onSelect} className={pillClasses} />
+              }
+            >
+              {name}
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <ContextMenuContent>
+            <ContextMenuItem onClick={onRename}>
+              <Pencil className="size-3.5 mr-2" />
+              Rename
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+            <ContextMenuItem
+              onClick={onDeleteRequest}
+              className="text-destructive focus:text-destructive"
+            >
+              <Trash2 className="size-3.5 mr-2" />
+              Delete
+            </ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
+        <PopoverContent className="w-auto p-3" align="start">
+          <p className="text-sm mb-3">
+            Delete &ldquo;{name}&rdquo;? Its conversations will be removed.
+          </p>
+          <div className="flex gap-2 justify-end">
+            <Button variant="ghost" size="sm" onClick={onDeleteCancel}>
+              Cancel
+            </Button>
+            <Button variant="destructive" size="sm" onClick={onDeleteConfirm}>
+              Delete
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+      <TooltipContent side="bottom">Right-click for options</TooltipContent>
+    </Tooltip>
   );
 }
 


### PR DESCRIPTION
# Why we need this PR?

Context menu actions (pin/unpin agents, rename/delete channels) are not discoverable — users don't know they can right-click these elements.

## What changed

Added tooltip hints to all right-clickable elements:
- **Sidebar agent buttons**: hover shows `"{agent name} (right-click for options)"`
- **Channel pills** (non-default): hover shows `"Right-click for options"`

Uses the existing `Tooltip` component, nested with `ContextMenuTrigger` via the `render` prop pattern.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...