### PR TITLE
feat: add minimum CLI version gate for web app

### DIFF
--- a/src/web/src/app/api/config/min-version/route.ts
+++ b/src/web/src/app/api/config/min-version/route.ts
@@ -1,0 +1,9 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare"
+import { withAuth } from "@/lib/middleware/auth";
+import { writeJSON } from "@/lib/middleware/helpers";
+
+export const GET = withAuth(async () => {
+  const { env } = getCloudflareContext()
+  const raw = (env as Env).MIN_CLI_VERSION;
+  return writeJSON({ min_cli_version: raw || null });
+});

--- a/src/web/src/app/api/config/min-version/route.ts
+++ b/src/web/src/app/api/config/min-version/route.ts
@@ -2,17 +2,7 @@ import { getCloudflareContext } from "@opennextjs/cloudflare"
 import { semverGte } from "@alook/shared";
 import { withAuth } from "@/lib/middleware/auth";
 import { writeJSON } from "@/lib/middleware/helpers";
-
-async function fetchLatestCliVersion(): Promise<string | null> {
-  try {
-    const res = await fetch("https://registry.npmjs.org/@alook/cli/latest");
-    if (!res.ok) return null;
-    const data = (await res.json()) as { version?: string };
-    return data.version ?? null;
-  } catch {
-    return null;
-  }
-}
+import { fetchLatestCliVersion } from "@/lib/npm";
 
 export const GET = withAuth(async () => {
   const { env } = getCloudflareContext()

--- a/src/web/src/app/api/config/min-version/route.ts
+++ b/src/web/src/app/api/config/min-version/route.ts
@@ -1,9 +1,29 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
+import { semverGte } from "@alook/shared";
 import { withAuth } from "@/lib/middleware/auth";
 import { writeJSON } from "@/lib/middleware/helpers";
+
+async function fetchLatestCliVersion(): Promise<string | null> {
+  try {
+    const res = await fetch("https://registry.npmjs.org/@alook/cli/latest");
+    if (!res.ok) return null;
+    const data = (await res.json()) as { version?: string };
+    return data.version ?? null;
+  } catch {
+    return null;
+  }
+}
 
 export const GET = withAuth(async () => {
   const { env } = getCloudflareContext()
   const raw = (env as Env).MIN_CLI_VERSION;
-  return writeJSON({ min_cli_version: raw || null });
+  if (!raw) return writeJSON({ min_cli_version: null });
+
+  const latest = await fetchLatestCliVersion();
+  if (latest && !semverGte(latest, raw)) {
+    // MIN_CLI_VERSION is higher than what's published — ignore it
+    return writeJSON({ min_cli_version: null });
+  }
+
+  return writeJSON({ min_cli_version: raw });
 });

--- a/src/web/src/app/api/runtimes/[runtimeId]/update/route.ts
+++ b/src/web/src/app/api/runtimes/[runtimeId]/update/route.ts
@@ -5,17 +5,7 @@ import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError } from "@/lib/middleware/helpers";
-
-async function fetchLatestCliVersion(): Promise<string | null> {
-  try {
-    const res = await fetch("https://registry.npmjs.org/@alook/cli/latest");
-    if (!res.ok) return null;
-    const data = (await res.json()) as { version?: string };
-    return data.version ?? null;
-  } catch {
-    return null;
-  }
-}
+import { fetchLatestCliVersion } from "@/lib/npm";
 
 export const POST = withAuth(async (req: NextRequest, ctx) => {
   const ws = await withWorkspaceMember(req, ctx);

--- a/src/web/src/components/runtime-version-gate.tsx
+++ b/src/web/src/components/runtime-version-gate.tsx
@@ -34,7 +34,14 @@ export function RuntimeVersionGate() {
     return !semverGte(cliVersion, minVersion);
   });
 
-  if (outdatedRuntimes.length === 0) return null;
+  // Deduplicate by daemon_id — show one card per machine
+  const outdatedMachines = new Map<string, AgentRuntime>();
+  for (const rt of outdatedRuntimes) {
+    const key = rt.daemon_id ?? rt.id;
+    if (!outdatedMachines.has(key)) outdatedMachines.set(key, rt);
+  }
+
+  if (outdatedMachines.size === 0) return null;
 
   const handleUpdate = async (rt: AgentRuntime) => {
     setUpdating((prev) => new Set(prev).add(rt.id));
@@ -63,25 +70,25 @@ export function RuntimeVersionGate() {
             Runtime Update Required
           </DialogTitle>
           <DialogDescription>
-            The following runtime(s) are running an outdated CLI version (minimum required: v{minVersion}). Please update to continue.
+            The following machine(s) are running an outdated CLI version (minimum required: v{minVersion}). Please update to continue.
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-3 mt-2">
-          {outdatedRuntimes.map((rt) => {
+          {[...outdatedMachines.entries()].map(([daemonId, rt]) => {
             const cliVersion = (rt.metadata as Record<string, unknown>)?.cli_version as string | undefined;
             const isUpdating = updating.has(rt.id);
 
             return (
               <div
-                key={rt.id}
+                key={daemonId}
                 className="flex items-center justify-between rounded-lg border p-3"
               >
                 <div className="flex items-center gap-3 min-w-0">
                   <span className="size-2 shrink-0 rounded-full bg-emerald-500" />
                   <div className="min-w-0">
                     <div className="text-sm font-medium truncate">
-                      {rt.device_info || rt.daemon_id || rt.id.slice(0, 12)}
+                      {rt.device_info || daemonId.slice(0, 12)}
                     </div>
                     <div className="text-xs text-muted-foreground flex items-center gap-2 mt-0.5">
                       <span>v{cliVersion || "unknown"}</span>

--- a/src/web/src/components/runtime-version-gate.tsx
+++ b/src/web/src/components/runtime-version-gate.tsx
@@ -50,9 +50,6 @@ export function RuntimeVersionGate() {
   };
 
   return (
-    // disablePointerDismissal prevents backdrop-click from closing.
-    // onOpenChange is a no-op so escape key and other close events are ignored.
-    // open is hardcoded to true so the dialog can never close programmatically.
     <Dialog
       open
       modal

--- a/src/web/src/components/runtime-version-gate.tsx
+++ b/src/web/src/components/runtime-version-gate.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAgentContext } from "@/contexts/agent-context";
+import { getMinCliVersion, triggerRuntimeUpdate } from "@/lib/api";
+import { semverGte } from "@alook/shared";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import type { AgentRuntime } from "@alook/shared";
+
+export function RuntimeVersionGate() {
+  const { runtimes, workspaceId } = useAgentContext();
+  const [minVersion, setMinVersion] = useState<string | null>(null);
+  const [updating, setUpdating] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    getMinCliVersion().then((res) => setMinVersion(res.min_cli_version)).catch(() => {});
+  }, []);
+
+  if (!minVersion) return null;
+
+  const outdatedRuntimes = runtimes.filter((rt) => {
+    if (rt.status !== "online") return false;
+    const cliVersion = (rt.metadata as Record<string, unknown>)?.cli_version;
+    if (typeof cliVersion !== "string" || !cliVersion) return true;
+    return !semverGte(cliVersion, minVersion);
+  });
+
+  if (outdatedRuntimes.length === 0) return null;
+
+  const handleUpdate = async (rt: AgentRuntime) => {
+    setUpdating((prev) => new Set(prev).add(rt.id));
+    try {
+      await triggerRuntimeUpdate(rt.id, workspaceId);
+    } catch {
+      setUpdating((prev) => {
+        const next = new Set(prev);
+        next.delete(rt.id);
+        return next;
+      });
+    }
+  };
+
+  return (
+    // disablePointerDismissal prevents backdrop-click from closing.
+    // onOpenChange is a no-op so escape key and other close events are ignored.
+    // open is hardcoded to true so the dialog can never close programmatically.
+    <Dialog
+      open
+      modal
+      disablePointerDismissal
+      onOpenChange={() => {}}
+    >
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="size-5 text-amber-500" />
+            Runtime Update Required
+          </DialogTitle>
+          <DialogDescription>
+            The following runtime(s) are running an outdated CLI version (minimum required: v{minVersion}). Please update to continue.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 mt-2">
+          {outdatedRuntimes.map((rt) => {
+            const cliVersion = (rt.metadata as Record<string, unknown>)?.cli_version as string | undefined;
+            const isUpdating = updating.has(rt.id);
+
+            return (
+              <div
+                key={rt.id}
+                className="flex items-center justify-between rounded-lg border p-3"
+              >
+                <div className="flex items-center gap-3 min-w-0">
+                  <span className="size-2 shrink-0 rounded-full bg-emerald-500" />
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium truncate">
+                      {rt.device_info || rt.daemon_id || rt.id.slice(0, 12)}
+                    </div>
+                    <div className="text-xs text-muted-foreground flex items-center gap-2 mt-0.5">
+                      <span>v{cliVersion || "unknown"}</span>
+                      <Badge variant="outline" className="text-[10px] px-1.5 py-0 text-amber-500 border-amber-500/30">
+                        requires v{minVersion}
+                      </Badge>
+                    </div>
+                  </div>
+                </div>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={isUpdating}
+                  onClick={() => handleUpdate(rt)}
+                >
+                  <RefreshCw className={`size-3.5 ${isUpdating ? "animate-spin" : ""}`} />
+                  {isUpdating ? "Updating..." : "Update"}
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/web/src/components/workspace-shell.tsx
+++ b/src/web/src/components/workspace-shell.tsx
@@ -9,6 +9,7 @@ import {
   Sheet,
   SheetContent,
 } from "@/components/ui/sheet";
+import { RuntimeVersionGate } from "@/components/runtime-version-gate";
 
 const SidebarTriggerContext = createContext<(() => void) | null>(null);
 
@@ -36,6 +37,7 @@ export function WorkspaceShell({ children }: { children: ReactNode }) {
               <AppSidebar onNavigate={() => setSidebarOpen(false)} />
             </SheetContent>
           </Sheet>
+          <RuntimeVersionGate />
         </div>
       </SidebarTriggerContext.Provider>
     );
@@ -51,6 +53,7 @@ export function WorkspaceShell({ children }: { children: ReactNode }) {
           {children}
         </main>
       </div>
+      <RuntimeVersionGate />
     </div>
   );
 }

--- a/src/web/src/env.d.ts
+++ b/src/web/src/env.d.ts
@@ -19,6 +19,7 @@ declare namespace Cloudflare {
     AUTH_OTP_RATE_LIMIT_MAX?: string
     AUTH_OTP_RATE_LIMIT_WINDOW_SEC?: string
     RUNTIME_MODEL_OPTIONS?: string
+    MIN_CLI_VERSION?: string
   }
 }
 

--- a/src/web/src/lib/api.ts
+++ b/src/web/src/lib/api.ts
@@ -148,6 +148,9 @@ export const triggerRuntimeRescan = (runtimeId: string, workspaceId: string) =>
     { method: "POST" }
   );
 
+export const getMinCliVersion = () =>
+  apiFetch<{ min_cli_version: string | null }>("/api/config/min-version");
+
 export const fetchLatestCliVersion = () =>
   apiFetch<{ version: string }>("/api/cli/latest-version");
 

--- a/src/web/src/lib/npm.ts
+++ b/src/web/src/lib/npm.ts
@@ -1,0 +1,10 @@
+export async function fetchLatestCliVersion(): Promise<string | null> {
+  try {
+    const res = await fetch("https://registry.npmjs.org/@alook/cli/latest");
+    if (!res.ok) return null;
+    const data = (await res.json()) as { version?: string };
+    return data.version ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/src/web/wrangler.toml
+++ b/src/web/wrangler.toml
@@ -67,3 +67,4 @@ id = "a3d035bea7bc49d99377b82ec21ce4c1"
 
 [vars]
 RUNTIME_MODEL_OPTIONS = '{"claude":["claude-opus-4-6","claude-sonnet-4-6","claude-haiku-4-5"],"codex":["gpt-5.4","gpt-5.3-codex"]}'
+MIN_CLI_VERSION = "0.0.26"


### PR DESCRIPTION
# Why we need this PR?

When a runtime is running an outdated CLI version, users may encounter compatibility issues. This PR adds a configurable minimum CLI version check that blocks the workspace UI with a non-dismissible dialog when any online runtime is below the required version, ensuring users update before proceeding.

## What changed

- Added `MIN_CLI_VERSION` wrangler env var (configurable, feature disabled when unset)
- Added `GET /api/config/min-version` endpoint to expose the config to the frontend
- Created `RuntimeVersionGate` component — a blocking dialog (no close button, no escape, no backdrop dismiss) that:
  - Checks all online runtimes' `metadata.cli_version` against the minimum
  - Shows outdated runtime cards with device name, current version, and required version
  - Provides a one-click "Update" button that triggers the existing remote update mechanism
  - Auto-dismisses when runtimes are updated (via WebSocket-driven state refresh)
- Mounted `RuntimeVersionGate` in `WorkspaceShell` (both mobile and desktop layouts)

## Checklist
- [ ] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)
- [ ] Shared library (`@alook/shared`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...