### PR TITLE
feat(cli): add Windows compatibility support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,13 @@ jobs:
       - run: pnpm typecheck
 
   test:
-    name: Tests
-    runs-on: ubuntu-latest
+    name: Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6

--- a/src/cli/commands/daemon.test.ts
+++ b/src/cli/commands/daemon.test.ts
@@ -192,7 +192,9 @@ describe("daemon stop", () => {
     const { out, err } = await promise;
 
     expect(killSpy).toHaveBeenCalledWith(888, "SIGTERM");
-    expect(killSpy).toHaveBeenCalledWith(888, "SIGKILL");
+    if (process.platform !== "win32") {
+      expect(killSpy).toHaveBeenCalledWith(888, "SIGKILL");
+    }
     expect(removePidFileIfMatchesMock).toHaveBeenCalledWith(888, undefined);
     expect(err.join("\n")).toContain("force killing");
     expect(out.join("\n")).toContain("Daemon stopped.");

--- a/src/cli/commands/daemon.test.ts
+++ b/src/cli/commands/daemon.test.ts
@@ -194,7 +194,7 @@ describe("daemon stop", () => {
     expect(killSpy).toHaveBeenCalledWith(888, "SIGTERM");
     expect(killSpy).toHaveBeenCalledWith(888, "SIGKILL");
     expect(removePidFileIfMatchesMock).toHaveBeenCalledWith(888, undefined);
-    expect(err.join("\n")).toContain("SIGKILL");
+    expect(err.join("\n")).toContain("force killing");
     expect(out.join("\n")).toContain("Daemon stopped.");
 
     delete process.env.ALOOK_SHUTDOWN_TIMEOUT_MS;

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -9,6 +9,8 @@ import {
   readDaemonPid,
   removePidFileIfMatches,
 } from "../daemon/pidfile.js";
+import { resolveLoginShellEnv } from "../lib/shell-env.js";
+import { isWindows } from "../lib/platform.js";
 
 const PID_POLL_INTERVAL_MS = 200;
 const PID_POLL_TIMEOUT_MS = 2000;
@@ -55,6 +57,7 @@ async function startInBackground(
   const child = spawn(process.execPath, buildChildArgs(profile, serverUrl), {
     detached: true,
     stdio: ["ignore", logFd, logFd],
+    env: resolveLoginShellEnv(),
   });
   child.unref();
   closeSync(logFd);
@@ -119,12 +122,14 @@ async function stopCommand(profile: string | undefined): Promise<void> {
   }
 
   console.warn(
-    `Daemon did not exit within ${shutdownMs}ms — sending SIGKILL.`,
+    `Daemon did not exit within ${shutdownMs}ms — force killing.`,
   );
-  try {
-    process.kill(pid, "SIGKILL");
-  } catch {
-    // already dead
+  if (!isWindows) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // already dead
+    }
   }
   removePidFileIfMatches(pid, profile);
   console.log("Daemon stopped.");

--- a/src/cli/commands/email.ts
+++ b/src/cli/commands/email.ts
@@ -6,6 +6,7 @@ import { APIClient } from "../lib/client.js";
 import { loadCLIConfigForProfile } from "../lib/config.js";
 import { printJSON, printTable } from "../lib/output.js";
 import { cmdPrefix } from "../lib/env.js";
+import { tempDir } from "../lib/platform.js";
 
 interface EmailResponse {
   id: string;
@@ -27,7 +28,7 @@ interface EmailResponse {
 
 const VALID_STATUSES = ["unread", "read", "archived", "sent"];
 const VALID_FOLDERS = ["inbox", "sent", "untrust"];
-const EMAIL_BASE = "/tmp/alook-emails";
+const EMAIL_BASE = tempDir("alook-emails");
 
 const MIME_BY_EXT: Record<string, string> = {
   ".pdf": "application/pdf",

--- a/src/cli/daemon/daemon.test.ts
+++ b/src/cli/daemon/daemon.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { EventEmitter } from "events";
+import path from "path";
 
 // Mock all external dependencies before importing
 const mockClientInstance = {
@@ -34,13 +35,13 @@ vi.mock("./config.js", () => ({
     maxConcurrentTasks: 20,
     daemonId: "d1",
     deviceName: "test-host",
-    workspacesRoot: "/tmp/ws",
+    workspacesRoot: path.join("/tmp", "ws"),
     cliVersion: "0.1.0",
   })),
-  sessionRunnerLogDir: vi.fn(() => "/tmp/alook/daemon/session-runners"),
-  daemonLogFilePath: vi.fn(() => "/tmp/alook/daemon/logs/2026-01-01.log"),
+  sessionRunnerLogDir: vi.fn(() => path.join("/tmp", "alook", "daemon", "session-runners")),
+  daemonLogFilePath: vi.fn(() => path.join("/tmp", "alook", "daemon", "logs", "2026-01-01.log")),
   lastUpdateMarkerPath: vi.fn((profile?: string) =>
-    profile ? `/tmp/alook/last_update_${profile}` : "/tmp/alook/last_update",
+    profile ? path.join("/tmp", "alook", `last_update_${profile}`) : path.join("/tmp", "alook", "last_update"),
   ),
 }));
 
@@ -927,11 +928,11 @@ describe("spawnSessionRunner", () => {
     spawnSessionRunner(makeSpawnInput() as any);
 
     expect(mockMkdirSync).toHaveBeenCalledWith(
-      "/tmp/alook/daemon/session-runners",
+      path.join("/tmp", "alook", "daemon", "session-runners"),
       { recursive: true },
     );
     expect(mockOpenSync).toHaveBeenCalledWith(
-      "/tmp/alook/daemon/session-runners/t1.log",
+      path.join("/tmp", "alook", "daemon", "session-runners", "t1.log"),
       "a",
     );
 
@@ -951,7 +952,7 @@ describe("spawnSessionRunner", () => {
     const call = vi.mocked(spawn).mock.calls[0];
     const encoded = call[1]![1] as string;
     const decoded = JSON.parse(Buffer.from(encoded, "base64").toString("utf-8"));
-    expect(decoded.logFilePath).toBe("/tmp/alook/daemon/session-runners/t1.log");
+    expect(decoded.logFilePath).toBe(path.join("/tmp", "alook", "daemon", "session-runners", "t1.log"));
   });
 
   it("spawns with stdio ignore when openSync fails (disk full)", () => {
@@ -1006,7 +1007,7 @@ describe("pruneSessionRunnerLogs", () => {
     // Files 0-4 are the oldest (lowest mtime), they should be deleted
     for (let i = 0; i < 5; i++) {
       expect(mockUnlinkSync).toHaveBeenCalledWith(
-        `/tmp/alook/daemon/session-runners/${i}.log`,
+        path.join("/tmp", "alook", "daemon", "session-runners", `${i}.log`),
       );
     }
   });
@@ -1531,7 +1532,7 @@ describe("daemon restart spawn", () => {
       { recursive: true, mode: 0o700 },
     );
     expect(mockOpenSync).toHaveBeenCalledWith(
-      "/tmp/alook/daemon/logs/2026-01-01.log",
+      path.join("/tmp", "alook", "daemon", "logs", "2026-01-01.log"),
       "a",
       0o600,
     );
@@ -1763,7 +1764,7 @@ describe("reconcilePendingCompletions", () => {
     await reconcilePendingCompletions("/tmp/ws");
 
     expect(mockClientInstance.completeTask).toHaveBeenCalledWith("tok_123", "t1", { output: "Done!" });
-    expect(mockUnlink).toHaveBeenCalledWith("/tmp/ws/.pending_completions/t1.json");
+    expect(mockUnlink).toHaveBeenCalledWith(path.join("/tmp", "ws", ".pending_completions", "t1.json"));
   });
 
   it("delivers 'fail' marker and deletes file", async () => {
@@ -1783,7 +1784,7 @@ describe("reconcilePendingCompletions", () => {
 
     await reconcilePendingCompletions("/tmp/ws");
 
-    expect(mockUnlink).toHaveBeenCalledWith("/tmp/ws/.pending_completions/t1.json");
+    expect(mockUnlink).toHaveBeenCalledWith(path.join("/tmp", "ws", ".pending_completions", "t1.json"));
   });
 
   it("retains marker on network error", async () => {
@@ -1814,7 +1815,7 @@ describe("reconcilePendingCompletions", () => {
     await reconcilePendingCompletions("/tmp/ws");
 
     expect(mockClientInstance.completeTask).not.toHaveBeenCalled();
-    expect(mockUnlink).toHaveBeenCalledWith("/tmp/ws/.pending_completions/t1.json");
+    expect(mockUnlink).toHaveBeenCalledWith(path.join("/tmp", "ws", ".pending_completions", "t1.json"));
   });
 
   it("deletes malformed JSON marker files and continues processing", async () => {
@@ -1824,7 +1825,7 @@ describe("reconcilePendingCompletions", () => {
 
     await reconcilePendingCompletions("/tmp/ws");
 
-    expect(mockUnlink).toHaveBeenCalledWith("/tmp/ws/.pending_completions/bad.json");
+    expect(mockUnlink).toHaveBeenCalledWith(path.join("/tmp", "ws", ".pending_completions", "bad.json"));
     expect(mockClientInstance.completeTask).toHaveBeenCalledTimes(1);
   });
 
@@ -1835,7 +1836,7 @@ describe("reconcilePendingCompletions", () => {
     await reconcilePendingCompletions("/tmp/ws");
 
     expect(mockClientInstance.completeTask).not.toHaveBeenCalled();
-    expect(mockUnlink).toHaveBeenCalledWith("/tmp/ws/.pending_completions/t1.json");
+    expect(mockUnlink).toHaveBeenCalledWith(path.join("/tmp", "ws", ".pending_completions", "t1.json"));
   });
 
   it("skips structurally invalid marker files and deletes them", async () => {
@@ -1877,9 +1878,9 @@ describe("reconcilePendingCompletions", () => {
 
     expect(mockClientInstance.completeTask).toHaveBeenCalledTimes(3);
     // t1 and t3 delivered → deleted, t2 failed → retained
-    expect(mockUnlink).toHaveBeenCalledWith("/tmp/ws/.pending_completions/t1.json");
-    expect(mockUnlink).not.toHaveBeenCalledWith("/tmp/ws/.pending_completions/t2.json");
-    expect(mockUnlink).toHaveBeenCalledWith("/tmp/ws/.pending_completions/t3.json");
+    expect(mockUnlink).toHaveBeenCalledWith(path.join("/tmp", "ws", ".pending_completions", "t1.json"));
+    expect(mockUnlink).not.toHaveBeenCalledWith(path.join("/tmp", "ws", ".pending_completions", "t2.json"));
+    expect(mockUnlink).toHaveBeenCalledWith(path.join("/tmp", "ws", ".pending_completions", "t3.json"));
   });
 
   it("ignores .tmp files (not processed as markers)", async () => {
@@ -1898,7 +1899,7 @@ describe("reconcilePendingCompletions", () => {
 
     await reconcilePendingCompletions("/tmp/ws");
 
-    expect(mockUnlink).toHaveBeenCalledWith("/tmp/ws/.pending_completions/t1.tmp");
+    expect(mockUnlink).toHaveBeenCalledWith(path.join("/tmp", "ws", ".pending_completions", "t1.tmp"));
   });
 
   it("keeps recent .tmp files", async () => {

--- a/src/cli/daemon/daemon.test.ts
+++ b/src/cli/daemon/daemon.test.ts
@@ -295,7 +295,7 @@ describe("daemon session runner dispatch", () => {
     expect(input.model).toBe("opus");
     expect(input.serverURL).toBe("http://localhost:8080");
     expect(input.token).toBe("al_test_token");
-    expect(input.workspacesRoot).toBe("/tmp/ws");
+    expect(input.workspacesRoot).toBe(path.join("/tmp", "ws"));
     expect(input.agentTimeout).toBe(7200000);
     expect(input.messageInactivityTimeout).toBe(300000);
   });
@@ -996,7 +996,7 @@ describe("pruneSessionRunnerLogs", () => {
     const files = Array.from({ length: 505 }, (_, i) => `${i}.log`);
     mockReaddirSync.mockReturnValue(files);
     mockStatSync.mockImplementation((p: string) => {
-      const name = p.split("/").pop()!;
+      const name = path.basename(p);
       const idx = parseInt(name);
       return { mtimeMs: idx * 1000 };
     });

--- a/src/cli/daemon/daemon.ts
+++ b/src/cli/daemon/daemon.ts
@@ -19,6 +19,7 @@ import {
 } from "./execenv/steering.js";
 import { TASK_TYPES } from "@alook/shared";
 import { readDirectoryTree, readFileContent, validatePath } from "./workspace-files.js";
+import { resolveLoginShellEnv } from "../lib/shell-env.js";
 import { existsSync, mkdirSync, openSync, closeSync, readdirSync, statSync, unlinkSync } from "fs";
 import { readdir, readFile, unlink, stat as fsStat } from "fs/promises";
 import { execSync, spawn, type ChildProcess } from "child_process";
@@ -523,6 +524,7 @@ export async function startDaemon(
         const child = spawn(process.execPath, args, {
           detached: true,
           stdio: logFd != null ? ["ignore", logFd, logFd] : ["ignore", "ignore", "ignore"],
+          env: resolveLoginShellEnv(),
         });
         child.unref();
         if (logFd != null) closeSync(logFd);

--- a/src/cli/daemon/execenv/context.test.ts
+++ b/src/cli/daemon/execenv/context.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { buildInstructionContent } from "./context.js";
+import { tempDir } from "../../lib/platform.js";
 import type { Task } from "../types.js";
 
 function makeTask(overrides: Partial<Task> = {}): Task {
@@ -27,7 +28,7 @@ describe("buildInstructionContent email tool injection", () => {
 
     expect(content).toContain("npx @alook/cli email pull --agent_id agent-123 --status unread");
     expect(content).toContain("npx @alook/cli email set --agent_id agent-123 --email_id <EMAIL_ID> --status read");
-    expect(content).toContain("/tmp/alook-emails/ws1/agent-123/");
+    expect(content).toContain(`${tempDir("alook-emails")}/ws1/agent-123/`);
     expect(content).toContain("metadata.json");
     expect(content).toContain("'myagent@alook.ai' (default, Alook platform address)");
   });

--- a/src/cli/daemon/execenv/context.ts
+++ b/src/cli/daemon/execenv/context.ts
@@ -1,5 +1,6 @@
 import { createHash } from "crypto";
 import { toAlookAddress } from "@alook/shared";
+import { tempDir } from "../../lib/platform.js";
 import {
   writeFileSync,
   readFileSync,
@@ -102,14 +103,14 @@ Your alook agent id is '${task.agentId}'. remember this, most of alook cli will 
 
 ### Emails
 ---
-Run 'npx @alook/cli email pull --agent_id ${task.agentId} --status unread' to download unread emails from inbox to '/tmp/alook-emails/${task.workspaceId}/${task.agentId}/'.
+Run 'npx @alook/cli email pull --agent_id ${task.agentId} --status unread' to download unread emails from inbox to '${tempDir("alook-emails")}/${task.workspaceId}/${task.agentId}/'.
 ---
 To download sent emails, add '--folder sent': 'npx @alook/cli email pull --agent_id ${task.agentId} --folder sent'
 Valid folders: inbox (default), sent, untrust.
 To limit the number of emails downloaded, add '--limit <N>' (e.g. '--limit 20'). Use '--offset <N>' to skip emails for pagination.
 Example: 'npx @alook/cli email pull --agent_id ${task.agentId} --status unread --limit 20 --offset 0'
 ---
-Each email is saved to '/tmp/alook-emails/${task.workspaceId}/${task.agentId}/<emailId>/' with:
+Each email is saved to '${tempDir("alook-emails")}/${task.workspaceId}/${task.agentId}/<emailId>/' with:
 - 'metadata.json' — sender, recipient, subject, date, status, message_id, in_reply_to, references
 - 'body.txt' — plain text body
 - 'body.html' — HTML body (if available)

--- a/src/cli/daemon/meeting-runner.ts
+++ b/src/cli/daemon/meeting-runner.ts
@@ -14,6 +14,8 @@ import {
   formatTranscript,
 } from "@alook/shared/browser"
 import type { TranscriptEntry } from "@alook/shared/browser"
+import { join } from "path"
+import { tempDir } from "../lib/platform.js"
 
 const SCRAPE_INTERVAL_MS = 3_000
 const DEFAULT_BOT_NAME = "Alook Meeting Bot"
@@ -152,7 +154,7 @@ async function tryJoinAndRecord(input: MeetingRunnerInput, chromePath: string): 
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     if (msg.includes("Blocked from joining")) {
-      const screenshotPath = `/tmp/meeting-${input.meetingId}-blocked.png`
+      const screenshotPath = join(tempDir("alook-meetings"), `meeting-${input.meetingId}-blocked.png`)
       await page.screenshot({ path: screenshotPath }).catch(() => {})
       log(`Blocked — screenshot: ${screenshotPath}`)
       return { status: "blocked", transcript, error: msg }

--- a/src/cli/daemon/session-runner.test.ts
+++ b/src/cli/daemon/session-runner.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import path from "path";
 
 // --- Mocks ---
 
@@ -1196,21 +1197,21 @@ describe("writeMarkerFile", () => {
   it("writes marker with correct JSON structure", async () => {
     await writeMarkerFile("/tmp/ws", marker);
 
-    expect(mockMkdir).toHaveBeenCalledWith("/tmp/ws/.pending_completions", { recursive: true, mode: 0o700 });
+    expect(mockMkdir).toHaveBeenCalledWith(path.join("/tmp", "ws", ".pending_completions"), { recursive: true, mode: 0o700 });
     expect(mockWriteFile).toHaveBeenCalledWith(
-      "/tmp/ws/.pending_completions/t1.tmp",
+      path.join("/tmp", "ws", ".pending_completions", "t1.tmp"),
       JSON.stringify(marker),
       { mode: 0o600 },
     );
     expect(mockRename).toHaveBeenCalledWith(
-      "/tmp/ws/.pending_completions/t1.tmp",
-      "/tmp/ws/.pending_completions/t1.json",
+      path.join("/tmp", "ws", ".pending_completions", "t1.tmp"),
+      path.join("/tmp", "ws", ".pending_completions", "t1.json"),
     );
   });
 
   it("creates .pending_completions/ directory if missing", async () => {
     await writeMarkerFile("/tmp/ws", marker);
-    expect(mockMkdir).toHaveBeenCalledWith("/tmp/ws/.pending_completions", { recursive: true, mode: 0o700 });
+    expect(mockMkdir).toHaveBeenCalledWith(path.join("/tmp", "ws", ".pending_completions"), { recursive: true, mode: 0o700 });
   });
 
   it("works when directory already exists", async () => {

--- a/src/cli/daemon/session-runner.ts
+++ b/src/cli/daemon/session-runner.ts
@@ -20,9 +20,10 @@ import {
 import { readKillIntent, clearKillIntent } from "./execenv/steering.js";
 import { buildPrompt } from "./prompt.js";
 import { log } from "../lib/logger.js";
+import { tempDir } from "../lib/platform.js";
 import type { SessionRunnerInput, Attachment } from "./types.js";
 
-const ATTACHMENTS_BASE = "/tmp/alook-attachments";
+const ATTACHMENTS_BASE = tempDir("alook-attachments");
 
 // --- Marker file support for resilient server reporting ---
 

--- a/src/cli/daemon/workspace-files.ts
+++ b/src/cli/daemon/workspace-files.ts
@@ -1,5 +1,5 @@
 import { readdir, stat, readFile } from "fs/promises";
-import { join, resolve, extname, relative } from "path";
+import { join, resolve, extname, relative, sep } from "path";
 import type { WorkspaceFileEntry } from "@alook/shared";
 
 const SKIP_DIRS = new Set([".git", "node_modules", ".next", ".wrangler", "__pycache__", ".venv"]);
@@ -73,6 +73,6 @@ export async function readFileContent(
 
 export function validatePath(agentWorkdir: string, requestedPath: string): string | null {
   const resolved = resolve(agentWorkdir, requestedPath);
-  if (resolved !== agentWorkdir && !resolved.startsWith(agentWorkdir + "/")) return null;
+  if (resolved !== agentWorkdir && !resolved.startsWith(agentWorkdir + sep)) return null;
   return resolved;
 }

--- a/src/cli/lib/platform.test.ts
+++ b/src/cli/lib/platform.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { tmpdir } from "os";
+import { join, sep } from "path";
+import { tempDir, isPathContained, isWindows } from "./platform.js";
+
+describe("platform", () => {
+  describe("tempDir", () => {
+    it("returns os tmpdir joined with subdir", () => {
+      expect(tempDir("alook-test")).toBe(join(tmpdir(), "alook-test"));
+    });
+  });
+
+  describe("isPathContained", () => {
+    it("returns true for exact match", () => {
+      expect(isPathContained("/a/b", "/a/b")).toBe(true);
+    });
+
+    it("returns true for child path", () => {
+      expect(isPathContained(`/a/b`, `/a/b${sep}c`)).toBe(true);
+    });
+
+    it("returns false for sibling with shared prefix", () => {
+      expect(isPathContained("/a/b", "/a/bc")).toBe(false);
+    });
+
+    it("returns false for parent path", () => {
+      expect(isPathContained("/a/b/c", "/a/b")).toBe(false);
+    });
+  });
+
+  describe("isWindows", () => {
+    it("reflects current platform", () => {
+      expect(isWindows).toBe(process.platform === "win32");
+    });
+  });
+});

--- a/src/cli/lib/platform.ts
+++ b/src/cli/lib/platform.ts
@@ -1,0 +1,12 @@
+import { tmpdir } from "os";
+import { join, sep } from "path";
+
+export const isWindows = process.platform === "win32";
+
+export function tempDir(subdir: string): string {
+  return join(tmpdir(), subdir);
+}
+
+export function isPathContained(parent: string, child: string): boolean {
+  return child === parent || child.startsWith(parent + sep);
+}

--- a/src/cli/lib/shell-env.ts
+++ b/src/cli/lib/shell-env.ts
@@ -1,0 +1,28 @@
+import { execSync } from "child_process";
+import { isWindows } from "./platform.js";
+
+export function resolveLoginShellEnv(): NodeJS.ProcessEnv {
+  if (isWindows) {
+    return { ...process.env };
+  }
+
+  const shell = process.env.SHELL || "/bin/zsh";
+  try {
+    const output = execSync(`${shell} -lc 'env'`, {
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const env: NodeJS.ProcessEnv = {};
+    for (const line of output.split("\n")) {
+      const idx = line.indexOf("=");
+      if (idx > 0) {
+        env[line.slice(0, idx)] = line.slice(idx + 1);
+      }
+    }
+    if (env.PATH) return env;
+  } catch {
+    // fall through
+  }
+  return { ...process.env };
+}


### PR DESCRIPTION
# Why we need this PR?
> The CLI daemon and related commands use Unix-specific patterns (hardcoded /tmp/ paths, shell-specific env resolution, path separator assumptions) that prevent it from running on Windows. CI also had no Windows coverage.

## What changed
- **New `src/cli/lib/platform.ts`** — cross-platform utilities: `tempDir()` (uses `os.tmpdir()`), `isPathContained()` (uses `path.sep`), `isWindows` constant
- **New `src/cli/lib/shell-env.ts`** — resolves login shell env on Unix, returns `process.env` directly on Windows (no login shell concept)
- **Fixed hardcoded `/tmp/` paths** in session-runner, email command, and meeting-runner → use `tempDir()`
- **Fixed path separator** in `workspace-files.ts` validation → use `path.sep` instead of hardcoded `/`
- **Guarded SIGKILL** in daemon stop command — on Windows, SIGTERM already calls TerminateProcess()
- **Added `resolveLoginShellEnv()`** to daemon spawn for proper rescan support (inherits fresh PATH)
- **CI: added Windows matrix** to the test job (`ubuntu-latest` + `windows-latest`)

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [x] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [ ] Other: ...