### PR TITLE
fix(cli): clear stale update marker on daemon startup to prevent update hang

### DIFF
--- a/src/cli/daemon/daemon.test.ts
+++ b/src/cli/daemon/daemon.test.ts
@@ -1375,11 +1375,11 @@ describe("daemon restart via update", () => {
     expect(clearUpdateMarker).toHaveBeenCalled();
   });
 
-  it("does not clear update marker when versions differ", async () => {
+  it("clears stale update marker on startup when current version does not match marker", async () => {
     vi.clearAllMocks();
     mockProcessExit.mockImplementation((() => {}) as any);
 
-    vi.mocked(readUpdateMarker).mockReturnValue("0.0.9"); // differs from cliVersion 0.1.0
+    vi.mocked(readUpdateMarker).mockReturnValue("0.0.9"); // stale — differs from cliVersion 0.1.0
 
     vi.mocked(loadCLIConfigForProfile).mockReturnValue({
       server_url: "",
@@ -1390,7 +1390,7 @@ describe("daemon restart via update", () => {
 
     await startDaemon();
 
-    expect(clearUpdateMarker).not.toHaveBeenCalled();
+    expect(clearUpdateMarker).toHaveBeenCalled();
   });
 
 });

--- a/src/cli/daemon/daemon.ts
+++ b/src/cli/daemon/daemon.ts
@@ -225,9 +225,13 @@ export async function startDaemon(
   if (serverUrl) config.serverURL = serverUrl;
 
   const marker = readUpdateMarker(profile);
-  if (marker && marker === config.cliVersion) {
+  if (marker) {
     clearUpdateMarker(profile);
-    log.info(`Cleared update marker — now running v${config.cliVersion}`);
+    if (marker === config.cliVersion) {
+      log.info(`Cleared update marker — now running v${config.cliVersion}`);
+    } else {
+      log.info(`Cleared stale update marker (was v${marker}, running v${config.cliVersion}) — update will be retried`);
+    }
   }
 
   const cliConfig = loadCLIConfigForProfile(profile);


### PR DESCRIPTION
## Problem
When a CLI update installs successfully but the daemon restart fails (e.g. PATH mismatch), the update marker stays set at the target version. On next startup the old code only cleared the marker when it matched the running version, so the marker was never cleared → `handleCliUpdate` skipped silently → UI stuck on "Updating..." forever.

## Fix
Always clear the update marker on daemon startup. The marker is a within-session dedup guard; on a fresh restart it should always reset. The `pending_update.version !== config.cliVersion` check in `handleCliUpdate` already prevents redundant reinstalls.

## Checklist
- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [ ] PR targets the correct branch

## Impact Areas
- [x] CLI (`@alook/cli`)