### PR TITLE
feat: inline SVG avatar system (v2)

### DIFF
--- a/src/shared/src/api-types.ts
+++ b/src/shared/src/api-types.ts
@@ -93,6 +93,7 @@ export interface UpdateAgentRequest {
   max_concurrent_tasks?: number;
   email_handle?: string;
   visibility?: string;
+  avatar_url?: string | null;
 }
 
 export interface SendMessageRequest {

--- a/src/shared/src/db/queries/agent.ts
+++ b/src/shared/src/db/queries/agent.ts
@@ -115,6 +115,7 @@ export async function updateAgent(
     runtimeId?: string | null;
     runtimeConfig?: unknown;
     visibility?: string;
+    avatarUrl?: string | null;
   },
   ownerId?: string
 ) {

--- a/src/shared/src/schemas.ts
+++ b/src/shared/src/schemas.ts
@@ -353,6 +353,7 @@ export const CreateAgentRequestSchema = z.object({
   runtime_config: RuntimeConfigSchema,
   max_concurrent_tasks: z.number().int().optional(),
   email_handle: z.string().optional(),
+  avatar_url: z.string().max(2000).nullable().optional(),
 });
 export type CreateAgentRequest = z.infer<typeof CreateAgentRequestSchema>;
 
@@ -364,6 +365,7 @@ export const UpdateAgentRequestSchema = z
     runtime_id: z.string().min(1).optional(),
     runtime_config: RuntimeConfigSchema,
     visibility: z.enum(["public", "private"]).optional(),
+    avatar_url: z.string().max(2000).nullable().optional(),
   })
   .refine(
     (v) =>
@@ -372,7 +374,8 @@ export const UpdateAgentRequestSchema = z
       v.instructions !== undefined ||
       v.runtime_id !== undefined ||
       v.runtime_config !== undefined ||
-      v.visibility !== undefined,
+      v.visibility !== undefined ||
+      v.avatar_url !== undefined,
     { message: "at least one field is required" },
   );
 export type UpdateAgentRequest = z.infer<typeof UpdateAgentRequestSchema>;

--- a/src/web/src/app/(app)/w/[slug]/home/_components/agent-overview.tsx
+++ b/src/web/src/app/(app)/w/[slug]/home/_components/agent-overview.tsx
@@ -8,6 +8,7 @@ import { useWorkspace } from "@/contexts/workspace-context";
 import { MessageSquare, Mail, Plus } from "lucide-react";
 import type { Agent, AgentRuntime } from "@alook/shared";
 import type { WorkspaceOverview } from "@/lib/api";
+import { AvatarRenderer, parseAvatarUrl } from "@/components/avatar";
 
 interface AgentOverviewProps {
   agents: Agent[];
@@ -51,9 +52,17 @@ export function AgentOverview({ agents, runtimes, activeTaskCounts, overview }: 
                 onClick={() => router.push(`/w/${slug}/agents/${agent.id}`)}
                 className="flex w-full items-center gap-3 px-4 py-2.5 text-left hover:bg-accent/50 transition-colors cursor-pointer"
               >
-                <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-secondary text-secondary-foreground text-sm font-medium">
-                  {agent.name.charAt(0).toUpperCase()}
-                </div>
+                {(() => {
+                  const avatarConfig = parseAvatarUrl(agent.avatar_url);
+                  if (avatarConfig) {
+                    return <AvatarRenderer config={avatarConfig} size={32} className="shrink-0 rounded-lg" />;
+                  }
+                  return (
+                    <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-secondary text-secondary-foreground text-sm font-medium">
+                      {agent.name.charAt(0).toUpperCase()}
+                    </div>
+                  );
+                })()}
 
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">

--- a/src/web/src/app/api/agents/[id]/route.ts
+++ b/src/web/src/app/api/agents/[id]/route.ts
@@ -61,12 +61,13 @@ export const PATCH = withAuth(async (req, ctx) => {
     data.runtimeConfig = sanitized;
   }
   if (body.visibility !== undefined) data.visibility = body.visibility;
+  if (body.avatar_url !== undefined) data.avatarUrl = body.avatar_url;
 
   const existing = await queries.agent.getAgent(db, id, ws.workspaceId, ctx.userId);
   if (!existing) return writeError("agent not found", 404);
   if (existing.ownerId !== ctx.userId) return writeError("agent owner access required", 403);
 
-  const updated = await queries.agent.updateAgent(db, id, ws.workspaceId, data as { name?: string; description?: string; instructions?: string; runtimeId?: string; runtimeConfig?: unknown; visibility?: string }, ctx.userId);
+  const updated = await queries.agent.updateAgent(db, id, ws.workspaceId, data as { name?: string; description?: string; instructions?: string; runtimeId?: string; runtimeConfig?: unknown; visibility?: string; avatarUrl?: string | null }, ctx.userId);
   if (!updated) {
     return writeError("agent not found", 404);
   }

--- a/src/web/src/app/api/agents/route.ts
+++ b/src/web/src/app/api/agents/route.ts
@@ -76,6 +76,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     maxConcurrentTasks,
     ownerId: ctx.userId,
     emailHandle: emailHandle || null,
+    avatarUrl: body.avatar_url ?? null,
   });
 
   if (emailHandle && ctx.email) {

--- a/src/web/src/app/globals.css
+++ b/src/web/src/app/globals.css
@@ -709,6 +709,15 @@
   }
 }
 
+@keyframes shake {
+  0% { transform: rotate(0) scale(1); }
+  20% { transform: rotate(-6deg) scale(0.96); }
+  40% { transform: rotate(5deg) scale(1.04); }
+  60% { transform: rotate(-3deg) scale(0.98); }
+  80% { transform: rotate(2deg) scale(1.01); }
+  100% { transform: rotate(0) scale(1); }
+}
+
 @keyframes glow-border-spin {
   0% { --glow-angle: 0deg; }
   100% { --glow-angle: 360deg; }

--- a/src/web/src/components/agent-create-form.tsx
+++ b/src/web/src/components/agent-create-form.tsx
@@ -16,7 +16,7 @@ import {
 import { useWorkspace } from "@/contexts/workspace-context";
 import {
   type AvatarConfig,
-  AvatarGenerator,
+  AvatarPickerDialog,
   DEFAULT_CONFIG,
   serializeAvatarConfig,
 } from "@/components/avatar";
@@ -89,7 +89,7 @@ export function AgentCreateForm({
   return (
     <div className="flex-1 min-h-0 overflow-y-auto thin-scrollbar px-5 py-6">
       <form onSubmit={handleSubmit} className="mx-auto max-w-md space-y-4">
-        <AvatarGenerator
+        <AvatarPickerDialog
           config={avatarConfig}
           onChange={setAvatarConfig}
         />

--- a/src/web/src/components/agent-create-form.tsx
+++ b/src/web/src/components/agent-create-form.tsx
@@ -14,6 +14,12 @@ import {
   type CustomEmailData,
 } from "@/components/custom-email-form";
 import { useWorkspace } from "@/contexts/workspace-context";
+import {
+  type AvatarConfig,
+  AvatarGenerator,
+  DEFAULT_CONFIG,
+  serializeAvatarConfig,
+} from "@/components/avatar";
 
 interface AgentCreateFormProps {
   runtimes: Runtime[];
@@ -27,6 +33,7 @@ interface AgentCreateFormProps {
     email_handle?: string;
     runtime_config?: Record<string, unknown>;
     custom_email?: CustomEmailData;
+    avatar_url?: string | null;
   }) => Promise<boolean>;
   onCancel: () => void;
   saving: boolean;
@@ -52,6 +59,7 @@ export function AgentCreateForm({
     null
   );
   const [model, setModel] = useState("");
+  const [avatarConfig, setAvatarConfig] = useState<AvatarConfig>(DEFAULT_CONFIG);
 
   const selectedRuntime = runtimes.find((r) => r.id === runtimeId);
   const providerModels =
@@ -74,12 +82,17 @@ export function AgentCreateForm({
       runtime_config: model ? { model } : {},
       custom_email:
         customEmailGetDataRef.current?.() ?? customEmailData ?? undefined,
+      avatar_url: serializeAvatarConfig(avatarConfig),
     });
   };
 
   return (
     <div className="flex-1 min-h-0 overflow-y-auto thin-scrollbar px-5 py-6">
       <form onSubmit={handleSubmit} className="mx-auto max-w-md space-y-4">
+        <AvatarGenerator
+          config={avatarConfig}
+          onChange={setAvatarConfig}
+        />
         <GeneralFields
           name={name}
           setName={setName}

--- a/src/web/src/components/agent-edit-form.tsx
+++ b/src/web/src/components/agent-edit-form.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/components/agent-form-fields";
 import {
   type AvatarConfig,
-  AvatarGenerator,
+  AvatarPickerDialog,
   DEFAULT_CONFIG,
   parseAvatarUrl,
   serializeAvatarConfig,
@@ -249,7 +249,7 @@ export function AgentEditForm({
               >
                 {activeTab === "general" && (
                   <>
-                    <AvatarGenerator
+                    <AvatarPickerDialog
                       config={avatarConfig}
                       onChange={setAvatarConfig}
                     />

--- a/src/web/src/components/agent-edit-form.tsx
+++ b/src/web/src/components/agent-edit-form.tsx
@@ -18,6 +18,13 @@ import {
   AllowedSendersTab,
   AgentAccessTab,
 } from "@/components/agent-form-fields";
+import {
+  type AvatarConfig,
+  AvatarGenerator,
+  DEFAULT_CONFIG,
+  parseAvatarUrl,
+  serializeAvatarConfig,
+} from "@/components/avatar";
 
 const MAX_INSTRUCTION_LENGTH = 50_000;
 const DEBOUNCE_MS = 500;
@@ -57,6 +64,7 @@ interface AgentEditFormProps {
     description: string;
     runtime_id: string;
     runtime_config?: Record<string, unknown>;
+    avatar_url?: string | null;
   }) => Promise<boolean>;
   onCancel: () => void;
   saving: boolean;
@@ -77,6 +85,9 @@ export function AgentEditForm({
   const [name, setName] = useState(agent.name ?? "");
   const [description, setDescription] = useState(agent.description ?? "");
   const [runtimeId, setRuntimeId] = useState(agent.runtime_id ?? "");
+  const [avatarConfig, setAvatarConfig] = useState<AvatarConfig>(
+    () => parseAvatarUrl(agent.avatar_url) ?? DEFAULT_CONFIG
+  );
   const [model, setModel] = useState(() => {
     const rc = agent.runtime_config;
     return typeof rc?.model === "string" ? rc.model : "";
@@ -159,6 +170,7 @@ export function AgentEditForm({
       description,
       runtime_id: runtimeId,
       runtime_config: model ? { model } : {},
+      avatar_url: serializeAvatarConfig(avatarConfig),
     });
   };
 
@@ -237,6 +249,10 @@ export function AgentEditForm({
               >
                 {activeTab === "general" && (
                   <>
+                    <AvatarGenerator
+                      config={avatarConfig}
+                      onChange={setAvatarConfig}
+                    />
                     <GeneralFields
                       name={name}
                       setName={setName}

--- a/src/web/src/components/agent-preview-card.tsx
+++ b/src/web/src/components/agent-preview-card.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 import type { Agent } from "@alook/shared";
 import { Check, Copy } from "lucide-react";
 import { toast } from "sonner";
+import { AvatarRenderer, parseAvatarUrl } from "@/components/avatar";
 
 export function AgentPreviewCard({ agent }: { agent: Agent }) {
   const [copied, setCopied] = useState(false);
@@ -24,17 +25,17 @@ export function AgentPreviewCard({ agent }: { agent: Agent }) {
   return (
     <div className="flex flex-col gap-2.5 p-1">
       <div className="flex items-start gap-3">
-        {agent.avatar_url ? (
-          <img
-            src={agent.avatar_url}
-            alt={agent.name}
-            className="size-10 rounded-xl object-cover shrink-0"
-          />
-        ) : (
-          <div className="flex items-center justify-center size-10 rounded-xl bg-secondary text-secondary-foreground text-sm font-medium shrink-0">
-            {agent.name.charAt(0).toUpperCase()}
-          </div>
-        )}
+        {(() => {
+          const avatarConfig = parseAvatarUrl(agent.avatar_url);
+          if (avatarConfig) {
+            return <AvatarRenderer config={avatarConfig} size={40} className="shrink-0 rounded-xl" />;
+          }
+          return (
+            <div className="flex items-center justify-center size-10 rounded-xl bg-secondary text-secondary-foreground text-sm font-medium shrink-0">
+              {agent.name.charAt(0).toUpperCase()}
+            </div>
+          );
+        })()}
         <div className="min-w-0 flex-1">
           <p className="text-sm font-medium truncate">{agent.name}</p>
           {email && (

--- a/src/web/src/components/app-sidebar.tsx
+++ b/src/web/src/components/app-sidebar.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/context-menu";
 import { AgentPreviewCard } from "@/components/agent-preview-card";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { AvatarRenderer, parseAvatarUrl } from "@/components/avatar";
 
 function AgentSidebarButton({
   agent,
@@ -68,7 +69,13 @@ function AgentSidebarButton({
             />
           }
         >
-          {agent.name.charAt(0).toUpperCase()}
+          {(() => {
+            const avatarConfig = parseAvatarUrl(agent.avatar_url);
+            if (avatarConfig) {
+              return <AvatarRenderer config={avatarConfig} size={40} className="rounded-xl" />;
+            }
+            return agent.name.charAt(0).toUpperCase();
+          })()}
           {taskCount > 0 && (
             <span className="absolute bottom-0 right-0 size-2 rounded-full bg-status-online animate-pulse ring-2 ring-background" />
           )}

--- a/src/web/src/components/avatar/avatar-generator.tsx
+++ b/src/web/src/components/avatar/avatar-generator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import {
   type AvatarConfig,
   AvatarRenderer,
@@ -111,9 +111,11 @@ function Cycler<K extends string>({
 interface AvatarGeneratorProps {
   config: AvatarConfig;
   onChange: (config: AvatarConfig) => void;
+  /** "horizontal" puts preview left + controls right; default is vertical stack */
+  layout?: "vertical" | "horizontal";
 }
 
-export function AvatarGenerator({ config, onChange }: AvatarGeneratorProps) {
+export function AvatarGenerator({ config, onChange, layout = "vertical" }: AvatarGeneratorProps) {
   const [tab, setTab] = useState<"presets" | "custom">("presets");
 
   const setField = useCallback(
@@ -122,6 +124,31 @@ export function AvatarGenerator({ config, onChange }: AvatarGeneratorProps) {
     },
     [config, onChange]
   );
+
+  // Find matched preset name
+  const matchedPresetName = useMemo(() => {
+    const match = PRESETS.find(
+      (p) =>
+        p.config.shape === config.shape &&
+        p.config.eye === config.eye &&
+        p.config.nose === config.nose &&
+        p.config.bg === config.bg
+    );
+    return match?.name ?? null;
+  }, [config]);
+
+  // Spacebar shortcut for random in horizontal (dialog) mode
+  useEffect(() => {
+    if (layout !== "horizontal") return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.code === "Space" && e.target === document.body) {
+        e.preventDefault();
+        onChange(randomConfig());
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [layout, onChange]);
 
   const renderShapeThumb = (key: string) => (
     <svg viewBox="0 0 200 200" width="40" height="40">
@@ -139,15 +166,42 @@ export function AvatarGenerator({ config, onChange }: AvatarGeneratorProps) {
     </svg>
   );
 
-  return (
-    <div className="flex flex-col gap-4">
-      {/* Preview */}
-      <div className="flex justify-center">
-        <div className="rounded-2xl bg-background p-2 shadow-sm border border-border">
-          <AvatarRenderer config={config} size={160} />
-        </div>
-      </div>
+  const isHorizontal = layout === "horizontal";
 
+  const preview = (
+    <div className={cn(
+      "flex flex-col items-center gap-3 rounded-2xl bg-muted/30 p-4",
+      isHorizontal ? "w-[240px] shrink-0 justify-center" : ""
+    )}>
+      <div className="rounded-2xl">
+        <AvatarRenderer config={config} size={isHorizontal ? 200 : 160} />
+      </div>
+      <button
+        type="button"
+        onClick={() => onChange(randomConfig())}
+        className="inline-flex items-center gap-2 rounded-full bg-foreground px-4 py-1.5 text-sm font-medium text-background hover:bg-foreground/80 transition-colors"
+      >
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="2" y="2" width="20" height="20" rx="3" />
+          <circle cx="8" cy="8" r="1.5" fill="currentColor" />
+          <circle cx="16" cy="8" r="1.5" fill="currentColor" />
+          <circle cx="8" cy="16" r="1.5" fill="currentColor" />
+          <circle cx="16" cy="16" r="1.5" fill="currentColor" />
+          <circle cx="12" cy="12" r="1.5" fill="currentColor" />
+        </svg>
+        随机
+        {isHorizontal && (
+          <kbd className="ml-1 rounded bg-background/20 px-1.5 py-0.5 text-[10px] font-mono">空格</kbd>
+        )}
+      </button>
+    </div>
+  );
+
+  const controls = (
+    <div className={cn(
+      "flex flex-col gap-3 flex-1 min-w-0",
+      isHorizontal && "rounded-2xl bg-muted/30 p-4 h-[380px]"
+    )}>
       {/* Tabs */}
       <div className="flex border-b border-border">
         <button
@@ -160,7 +214,7 @@ export function AvatarGenerator({ config, onChange }: AvatarGeneratorProps) {
               : "border-transparent text-muted-foreground hover:text-foreground"
           )}
         >
-          预设
+          ★ 预设
         </button>
         <button
           type="button"
@@ -172,11 +226,12 @@ export function AvatarGenerator({ config, onChange }: AvatarGeneratorProps) {
               : "border-transparent text-muted-foreground hover:text-foreground"
           )}
         >
-          自定义
+          ⚙ 自定义
         </button>
       </div>
 
-      {/* Tab content */}
+      {/* Tab content — fixed height so dialog doesn't resize on tab switch */}
+      <div className={cn("flex-1 min-h-0", isHorizontal && "overflow-y-auto thin-scrollbar")}>
       {tab === "presets" && (
         <div className="grid grid-cols-4 gap-2">
           {PRESETS.map((p) => {
@@ -191,13 +246,13 @@ export function AvatarGenerator({ config, onChange }: AvatarGeneratorProps) {
                 type="button"
                 onClick={() => onChange(p.config)}
                 className={cn(
-                  "flex flex-col items-center gap-1 rounded-lg border p-1.5 transition-colors",
+                  "flex flex-col items-center gap-1 rounded-xl border p-2 transition-all",
                   isActive
-                    ? "border-primary bg-primary/5"
-                    : "border-border hover:border-primary/40"
+                    ? "border-primary border-2 bg-primary/5 shadow-sm"
+                    : "border-border bg-background hover:border-primary/40"
                 )}
               >
-                <AvatarRenderer config={p.config} size={48} />
+                <AvatarRenderer config={p.config} size={56} />
                 <span className="text-[10px] text-muted-foreground">
                   {p.name}
                 </span>
@@ -217,18 +272,18 @@ export function AvatarGenerator({ config, onChange }: AvatarGeneratorProps) {
             renderThumb={renderShapeThumb}
           />
           <Cycler
-            label="眼睛"
-            keys={EYE_KEYS}
-            value={config.eye}
-            onChange={(v) => setField("eye", v)}
-            renderThumb={renderEyeThumb}
-          />
-          <Cycler
             label="鼻子"
             keys={NOSE_KEYS}
             value={config.nose}
             onChange={(v) => setField("nose", v)}
             renderThumb={renderNoseThumb}
+          />
+          <Cycler
+            label="眼睛"
+            keys={EYE_KEYS}
+            value={config.eye}
+            onChange={(v) => setField("eye", v)}
+            renderThumb={renderEyeThumb}
           />
 
           {/* Background colors */}
@@ -256,15 +311,23 @@ export function AvatarGenerator({ config, onChange }: AvatarGeneratorProps) {
           </div>
         </div>
       )}
+      </div>
+    </div>
+  );
 
-      {/* Random button */}
-      <button
-        type="button"
-        onClick={() => onChange(randomConfig())}
-        className="w-full rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-      >
-        随机生成
-      </button>
+  if (isHorizontal) {
+    return (
+      <div className="flex gap-4">
+        {preview}
+        {controls}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {preview}
+      {controls}
     </div>
   );
 }

--- a/src/web/src/components/avatar/avatar-generator.tsx
+++ b/src/web/src/components/avatar/avatar-generator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useMemo } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import {
   type AvatarConfig,
   AvatarRenderer,
@@ -125,6 +125,23 @@ export function AvatarGenerator({ config, onChange, layout = "vertical" }: Avata
     [config, onChange]
   );
 
+  // Shake animation on config change
+  const [shaking, setShaking] = useState(false);
+  const prevConfigRef = useRef(config);
+  useEffect(() => {
+    if (
+      prevConfigRef.current.shape !== config.shape ||
+      prevConfigRef.current.eye !== config.eye ||
+      prevConfigRef.current.nose !== config.nose ||
+      prevConfigRef.current.bg !== config.bg
+    ) {
+      setShaking(true);
+      const timer = setTimeout(() => setShaking(false), 450);
+      prevConfigRef.current = config;
+      return () => clearTimeout(timer);
+    }
+  }, [config]);
+
   // Find matched preset name
   const matchedPresetName = useMemo(() => {
     const match = PRESETS.find(
@@ -171,10 +188,10 @@ export function AvatarGenerator({ config, onChange, layout = "vertical" }: Avata
   const preview = (
     <div className={cn(
       "flex flex-col items-center gap-3 rounded-2xl bg-muted/30 p-4",
-      isHorizontal ? "w-[240px] shrink-0 justify-center" : ""
+      isHorizontal ? "w-[280px] shrink-0 justify-center" : ""
     )}>
-      <div className="rounded-2xl">
-        <AvatarRenderer config={config} size={isHorizontal ? 200 : 160} />
+      <div className={cn("rounded-2xl", shaking && "animate-[shake_0.45s_cubic-bezier(.36,.07,.19,.97)]")}>
+        <AvatarRenderer config={config} size={isHorizontal ? 220 : 160} />
       </div>
       <button
         type="button"

--- a/src/web/src/components/avatar/avatar-generator.tsx
+++ b/src/web/src/components/avatar/avatar-generator.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import {
+  type AvatarConfig,
+  AvatarRenderer,
+  Shapes,
+  Eyes,
+  Noses,
+  BG_COLORS,
+  SHAPE_KEYS,
+  EYE_KEYS,
+  NOSE_KEYS,
+  PRESETS,
+  randomConfig,
+} from "./avatar-parts";
+import { cn } from "@/lib/utils";
+
+// ─────────────────────────────────────────────────────────────
+// CYCLER — left/right carousel for picking a part
+// ─────────────────────────────────────────────────────────────
+function Cycler<K extends string>({
+  label,
+  keys,
+  value,
+  onChange,
+  renderThumb,
+}: {
+  label: string;
+  keys: K[];
+  value: K;
+  onChange: (v: K) => void;
+  renderThumb: (key: K) => React.ReactNode;
+}) {
+  const idx = keys.indexOf(value);
+  const go = (delta: number) =>
+    onChange(keys[(idx + delta + keys.length) % keys.length]!);
+
+  const prev = keys[(idx - 1 + keys.length) % keys.length]!;
+  const next = keys[(idx + 1) % keys.length]!;
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-12 text-xs font-medium text-muted-foreground shrink-0">
+        {label}
+      </span>
+      <button
+        type="button"
+        onClick={() => go(-1)}
+        className="flex items-center justify-center size-7 rounded-md hover:bg-accent transition-colors"
+      >
+        <svg viewBox="0 0 24 24" width="16" height="16">
+          <path
+            d="M15 5 L8 12 L15 19"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+      <div className="flex items-center gap-1 flex-1 justify-center">
+        <button
+          type="button"
+          onClick={() => go(-1)}
+          className="opacity-30 hover:opacity-60 transition-opacity"
+          tabIndex={-1}
+        >
+          {renderThumb(prev)}
+        </button>
+        <button
+          type="button"
+          onClick={() => go(1)}
+          className="border-2 border-primary rounded-lg p-0.5"
+        >
+          {renderThumb(value)}
+        </button>
+        <button
+          type="button"
+          onClick={() => go(1)}
+          className="opacity-30 hover:opacity-60 transition-opacity"
+          tabIndex={-1}
+        >
+          {renderThumb(next)}
+        </button>
+      </div>
+      <button
+        type="button"
+        onClick={() => go(1)}
+        className="flex items-center justify-center size-7 rounded-md hover:bg-accent transition-colors"
+      >
+        <svg viewBox="0 0 24 24" width="16" height="16">
+          <path
+            d="M9 5 L16 12 L9 19"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// AVATAR GENERATOR
+// ─────────────────────────────────────────────────────────────
+interface AvatarGeneratorProps {
+  config: AvatarConfig;
+  onChange: (config: AvatarConfig) => void;
+}
+
+export function AvatarGenerator({ config, onChange }: AvatarGeneratorProps) {
+  const [tab, setTab] = useState<"presets" | "custom">("presets");
+
+  const setField = useCallback(
+    <K extends keyof AvatarConfig>(key: K, value: AvatarConfig[K]) => {
+      onChange({ ...config, [key]: value });
+    },
+    [config, onChange]
+  );
+
+  const renderShapeThumb = (key: string) => (
+    <svg viewBox="0 0 200 200" width="40" height="40">
+      {Shapes[key]?.render()}
+    </svg>
+  );
+  const renderNoseThumb = (key: string) => (
+    <svg viewBox="-14 -10 28 20" width="36" height="24">
+      {Noses[key]?.render()}
+    </svg>
+  );
+  const renderEyeThumb = (key: string) => (
+    <svg viewBox="-18 -8 36 16" width="44" height="22">
+      {Eyes[key]?.render(8)}
+    </svg>
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Preview */}
+      <div className="flex justify-center">
+        <div className="rounded-2xl bg-background p-2 shadow-sm border border-border">
+          <AvatarRenderer config={config} size={160} />
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex border-b border-border">
+        <button
+          type="button"
+          onClick={() => setTab("presets")}
+          className={cn(
+            "flex-1 pb-2 text-sm font-medium text-center transition-colors border-b-2",
+            tab === "presets"
+              ? "border-primary text-foreground"
+              : "border-transparent text-muted-foreground hover:text-foreground"
+          )}
+        >
+          预设
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab("custom")}
+          className={cn(
+            "flex-1 pb-2 text-sm font-medium text-center transition-colors border-b-2",
+            tab === "custom"
+              ? "border-primary text-foreground"
+              : "border-transparent text-muted-foreground hover:text-foreground"
+          )}
+        >
+          自定义
+        </button>
+      </div>
+
+      {/* Tab content */}
+      {tab === "presets" && (
+        <div className="grid grid-cols-4 gap-2">
+          {PRESETS.map((p) => {
+            const isActive =
+              p.config.shape === config.shape &&
+              p.config.eye === config.eye &&
+              p.config.nose === config.nose &&
+              p.config.bg === config.bg;
+            return (
+              <button
+                key={p.name}
+                type="button"
+                onClick={() => onChange(p.config)}
+                className={cn(
+                  "flex flex-col items-center gap-1 rounded-lg border p-1.5 transition-colors",
+                  isActive
+                    ? "border-primary bg-primary/5"
+                    : "border-border hover:border-primary/40"
+                )}
+              >
+                <AvatarRenderer config={p.config} size={48} />
+                <span className="text-[10px] text-muted-foreground">
+                  {p.name}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {tab === "custom" && (
+        <div className="flex flex-col gap-4">
+          <Cycler
+            label="轮廓"
+            keys={SHAPE_KEYS}
+            value={config.shape}
+            onChange={(v) => setField("shape", v)}
+            renderThumb={renderShapeThumb}
+          />
+          <Cycler
+            label="眼睛"
+            keys={EYE_KEYS}
+            value={config.eye}
+            onChange={(v) => setField("eye", v)}
+            renderThumb={renderEyeThumb}
+          />
+          <Cycler
+            label="鼻子"
+            keys={NOSE_KEYS}
+            value={config.nose}
+            onChange={(v) => setField("nose", v)}
+            renderThumb={renderNoseThumb}
+          />
+
+          {/* Background colors */}
+          <div>
+            <div className="mb-2 text-xs font-medium text-muted-foreground">
+              背景色
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {BG_COLORS.map((c, i) => (
+                <button
+                  key={c.value}
+                  type="button"
+                  onClick={() => setField("bg", i)}
+                  title={c.name}
+                  className={cn(
+                    "size-7 rounded-full transition-shadow",
+                    config.bg === i
+                      ? "ring-2 ring-primary ring-offset-2"
+                      : "ring-1 ring-border"
+                  )}
+                  style={{ backgroundColor: c.value }}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Random button */}
+      <button
+        type="button"
+        onClick={() => onChange(randomConfig())}
+        className="w-full rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+      >
+        随机生成
+      </button>
+    </div>
+  );
+}

--- a/src/web/src/components/avatar/avatar-parts.tsx
+++ b/src/web/src/components/avatar/avatar-parts.tsx
@@ -1,0 +1,340 @@
+// Avatar parts library — inline SVG components for modular avatar generation.
+// Ported from Jacky's Notion-style avatar generator prototype.
+// All shapes are pure SVG paths — no external PNG files needed.
+
+import type { ReactNode } from "react";
+
+// ─────────────────────────────────────────────────────────────
+// STROKE / FILL CONSTANTS
+// ─────────────────────────────────────────────────────────────
+const STROKE = "#1F1F1F";
+const FILL = "#FFFFFF";
+const SW_OUT = 8;
+const SW_INNER = 5;
+const SW_FACE = 5;
+
+const sp = (w = SW_OUT) =>
+  ({ fill: FILL, stroke: STROKE, strokeWidth: w, strokeLinejoin: "round" as const, strokeLinecap: "round" as const });
+const lp = (w = SW_INNER) =>
+  ({ fill: "none", stroke: STROKE, strokeWidth: w, strokeLinejoin: "round" as const, strokeLinecap: "round" as const });
+const lpf = (w = SW_FACE) =>
+  ({ fill: "none", stroke: STROKE, strokeWidth: w, strokeLinejoin: "round" as const, strokeLinecap: "round" as const });
+const fp = { fill: STROKE };
+
+// ─────────────────────────────────────────────────────────────
+// PALETTES
+// ─────────────────────────────────────────────────────────────
+export interface ColorOption {
+  name: string;
+  value: string;
+}
+
+export const BG_COLORS: ColorOption[] = [
+  { name: "紫", value: "#9B7FE8" },
+  { name: "青", value: "#2BAA9C" },
+  { name: "橙", value: "#F39A4F" },
+  { name: "蓝", value: "#3D7EE8" },
+  { name: "粉", value: "#F8B4C4" },
+  { name: "黄", value: "#F4C141" },
+  { name: "绿", value: "#7FCB6F" },
+  { name: "米", value: "#D6CCB8" },
+  { name: "红", value: "#EE5E48" },
+  { name: "湖蓝", value: "#3FA8C0" },
+  { name: "雾灰", value: "#C9D1D9" },
+  { name: "深紫", value: "#6A4DCC" },
+];
+
+// ─────────────────────────────────────────────────────────────
+// SHAPES (outlines)
+// ─────────────────────────────────────────────────────────────
+export interface ShapeDef {
+  name: string;
+  face: { cx: number; cy: number; w: number };
+  render: () => ReactNode;
+}
+
+export const Shapes: Record<string, ShapeDef> = {
+  circle: {
+    name: "圆形",
+    face: { cx: 100, cy: 105, w: 80 },
+    render: () => <circle cx="100" cy="100" r="70" {...sp()} />,
+  },
+  rounded: {
+    name: "方形",
+    face: { cx: 100, cy: 105, w: 90 },
+    render: () => <rect x="30" y="30" width="140" height="140" rx="20" {...sp()} />,
+  },
+  hexagon: {
+    name: "六边形",
+    face: { cx: 100, cy: 105, w: 86 },
+    render: () => <path d="M100 28 L162 64 L162 136 L100 172 L38 136 L38 64 Z" {...sp()} />,
+  },
+  task: {
+    name: "任务",
+    face: { cx: 92, cy: 92, w: 70 },
+    render: () => (
+      <g>
+        <rect x="34" y="34" width="132" height="132" rx="14" {...sp()} />
+        <path d="M70 110 L102 138 L168 64" {...lp(SW_OUT)} />
+      </g>
+    ),
+  },
+  book: {
+    name: "笔记",
+    face: { cx: 100, cy: 105, w: 90 },
+    render: () => (
+      <g>
+        <path d="M30 60 C 60 50, 85 56, 100 70 C 115 56, 140 50, 170 60 L 170 158 C 140 148, 115 154, 100 168 C 85 154, 60 148, 30 158 Z" {...sp()} />
+        <path d="M100 70 L100 84" {...lp(SW_INNER)} />
+        <path d="M100 154 L100 168" {...lp(SW_INNER)} />
+      </g>
+    ),
+  },
+  mail: {
+    name: "邮件",
+    face: { cx: 100, cy: 118, w: 80 },
+    render: () => (
+      <g>
+        <rect x="30" y="56" width="140" height="100" rx="12" {...sp()} />
+        <path d="M36 64 L100 108 L164 64" {...lp(SW_INNER)} />
+      </g>
+    ),
+  },
+  calendar: {
+    name: "日历",
+    face: { cx: 100, cy: 122, w: 80 },
+    render: () => (
+      <g>
+        <rect x="30" y="48" width="140" height="124" rx="12" {...sp()} />
+        <path d="M30 80 L170 80" {...lp(SW_INNER)} />
+        <path d="M62 36 L62 60" {...lp(SW_INNER)} />
+        <path d="M138 36 L138 60" {...lp(SW_INNER)} />
+      </g>
+    ),
+  },
+  bulb: {
+    name: "想法",
+    face: { cx: 100, cy: 100, w: 70 },
+    render: () => (
+      <g>
+        <path d="M100 26 C 62 26, 36 52, 36 86 C 36 110, 52 126, 68 138 L 68 148 A 6 6 0 0 0 74 154 L 126 154 A 6 6 0 0 0 132 148 L 132 138 C 148 126, 164 110, 164 86 C 164 52, 138 26, 100 26 Z" {...sp()} />
+        <path d="M76 162 L124 162" {...lp(SW_INNER)} />
+        <path d="M82 172 L118 172" {...lp(SW_INNER)} />
+      </g>
+    ),
+  },
+  folder: {
+    name: "文件夹",
+    face: { cx: 100, cy: 118, w: 90 },
+    render: () => (
+      <path d="M30 64 A 10 10 0 0 1 40 54 L 84 54 L 96 66 L 160 66 A 10 10 0 0 1 170 76 L 170 158 A 10 10 0 0 1 160 168 L 40 168 A 10 10 0 0 1 30 158 Z" {...sp()} />
+    ),
+  },
+  mountain: {
+    name: "目标",
+    face: { cx: 100, cy: 130, w: 70 },
+    render: () => (
+      <g>
+        <path d="M28 168 L100 56 L172 168 Z" {...sp()} />
+        <path d="M100 56 L100 28" {...lpf(SW_INNER)} />
+        <path d="M100 30 L122 38 L100 46" {...sp(SW_INNER)} />
+      </g>
+    ),
+  },
+};
+
+export const SHAPE_KEYS = Object.keys(Shapes);
+
+// ─────────────────────────────────────────────────────────────
+// NOSES
+// ─────────────────────────────────────────────────────────────
+export interface NoseDef {
+  name: string;
+  render: () => ReactNode;
+}
+
+export const Noses: Record<string, NoseDef> = {
+  dot:   { name: "点",     render: () => <circle cx="0" cy="0" r="3.2" {...fp} /> },
+  dash:  { name: "横",     render: () => <line x1="-8" y1="0" x2="8" y2="0" {...lpf(SW_FACE)} /> },
+  hookL: { name: "L 形",   render: () => <path d="M-4 -6 L-4 5 L7 5" {...lpf(SW_FACE)} /> },
+  smile: { name: "微笑",   render: () => <path d="M-8 -3 Q0 7 8 -3" {...lpf(SW_FACE)} /> },
+  caret: { name: "尖角",   render: () => <path d="M-8 5 L0 -5 L8 5" {...lpf(SW_FACE)} /> },
+  arrow: { name: "小箭头", render: () => <path d="M-8 -3 L0 4 L8 -3" {...lpf(SW_FACE)} /> },
+  oh:    { name: "o",      render: () => <circle cx="0" cy="0" r="4" {...lpf(SW_FACE - 1)} /> },
+};
+
+export const NOSE_KEYS = Object.keys(Noses);
+
+// ─────────────────────────────────────────────────────────────
+// EYES
+// ─────────────────────────────────────────────────────────────
+export interface EyeDef {
+  name: string;
+  render: (dx: number) => ReactNode;
+}
+
+const eye = (l: ReactNode, r: ReactNode = l) => (dx: number) => (
+  <g>
+    <g transform={`translate(${-dx}, 0)`}>{l}</g>
+    <g transform={`translate(${dx}, 0)`}>{r}</g>
+  </g>
+);
+
+export const Eyes: Record<string, EyeDef> = {
+  dots: { name: "点点", render: eye(<circle cx="0" cy="0" r="4.5" {...fp} />) },
+  big: {
+    name: "大眼睛",
+    render: eye(
+      <g>
+        <circle cx="0" cy="0" r="7" {...sp(SW_FACE - 1)} />
+        <circle cx="2" cy="-2" r="2" {...fp} />
+      </g>
+    ),
+  },
+  rings:  { name: "圆圈", render: eye(<circle cx="0" cy="0" r="5" {...lpf(SW_FACE - 1)} />) },
+  arches: { name: "弯弯", render: eye(<path d="M-7 3 Q0 -7 7 3" {...lpf(SW_FACE)} />) },
+  lines:  { name: "横线", render: eye(<line x1="-7" y1="0" x2="7" y2="0" {...lpf(SW_FACE)} />) },
+  happy:  { name: "笑眼", render: eye(<path d="M-7 3 L0 -5 L7 3" {...lpf(SW_FACE)} />) },
+  sleepy: { name: "困困", render: eye(<path d="M-7 -2 Q0 6 7 -2" {...lpf(SW_FACE)} />) },
+  shy: {
+    name: "半月",
+    render: eye(<path d="M-6 -3 A6 6 0 0 1 6 -3 L6 1 A6 6 0 0 1 -6 1 Z" {...fp} />),
+  },
+  wink: {
+    name: "俏皮",
+    render: (dx: number) => (
+      <g>
+        <g transform={`translate(${-dx}, 0)`}><circle cx="0" cy="0" r="4.5" {...fp} /></g>
+        <g transform={`translate(${dx}, 0)`}><path d="M-7 1 Q0 -6 7 1" {...lpf(SW_FACE)} /></g>
+      </g>
+    ),
+  },
+};
+
+export const EYE_KEYS = Object.keys(Eyes);
+
+// ─────────────────────────────────────────────────────────────
+// AVATAR CONFIG
+// ─────────────────────────────────────────────────────────────
+export interface AvatarConfig {
+  shape: string;
+  eye: string;
+  nose: string;
+  bg: number;
+}
+
+export const DEFAULT_CONFIG: AvatarConfig = {
+  shape: "book",
+  eye: "happy",
+  nose: "dash",
+  bg: 1,
+};
+
+// ─────────────────────────────────────────────────────────────
+// PRESETS
+// ─────────────────────────────────────────────────────────────
+export interface Preset {
+  name: string;
+  config: AvatarConfig;
+}
+
+export const PRESETS: Preset[] = [
+  { name: "任务",  config: { shape: "task",     nose: "dot",   eye: "dots",   bg: 0 } },
+  { name: "笔记",  config: { shape: "book",     nose: "dash",  eye: "happy",  bg: 1 } },
+  { name: "邮件",  config: { shape: "mail",     nose: "smile", eye: "dots",   bg: 3 } },
+  { name: "日程",  config: { shape: "calendar", nose: "dot",   eye: "dots",   bg: 4 } },
+  { name: "想法",  config: { shape: "bulb",     nose: "oh",    eye: "rings",  bg: 5 } },
+  { name: "项目",  config: { shape: "folder",   nose: "dash",  eye: "lines",  bg: 7 } },
+  { name: "目标",  config: { shape: "mountain", nose: "caret", eye: "arches", bg: 8 } },
+  { name: "梦想",  config: { shape: "circle",   nose: "smile", eye: "shy",    bg: 11 } },
+  { name: "收纳",  config: { shape: "rounded",  nose: "dot",   eye: "sleepy", bg: 6 } },
+  { name: "探索",  config: { shape: "hexagon",  nose: "hookL", eye: "wink",   bg: 9 } },
+  { name: "专注",  config: { shape: "task",     nose: "caret", eye: "lines",  bg: 2 } },
+  { name: "收藏",  config: { shape: "book",     nose: "oh",    eye: "rings",  bg: 10 } },
+];
+
+// ─────────────────────────────────────────────────────────────
+// RANDOM CONFIG
+// ─────────────────────────────────────────────────────────────
+function pick<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)]!;
+}
+
+export function randomConfig(): AvatarConfig {
+  return {
+    shape: pick(SHAPE_KEYS),
+    eye: pick(EYE_KEYS),
+    nose: pick(NOSE_KEYS),
+    bg: Math.floor(Math.random() * BG_COLORS.length),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────
+// AVATAR RENDERER
+// ─────────────────────────────────────────────────────────────
+interface AvatarRendererProps {
+  config: AvatarConfig;
+  size?: number;
+  className?: string;
+}
+
+export function AvatarRenderer({ config, size = 200, className }: AvatarRendererProps) {
+  const sh = Shapes[config.shape] ?? Shapes.book!;
+  const ey = Eyes[config.eye];
+  const no = Noses[config.nose];
+  const bgColor = BG_COLORS[config.bg]?.value ?? BG_COLORS[0]!.value;
+
+  const { cx, cy, w } = sh.face;
+  const eyeDx = Math.max(11, w * 0.22);
+  const eyeY = cy - Math.max(10, w * 0.14);
+
+  return (
+    <svg
+      viewBox="0 0 200 200"
+      width={size}
+      height={size}
+      className={className}
+      style={{ display: "block" }}
+    >
+      <rect x="0" y="0" width="200" height="200" rx="56" fill={bgColor} />
+      {sh.render()}
+      {ey && <g transform={`translate(${cx}, ${eyeY})`}>{ey.render(eyeDx)}</g>}
+      {no && <g transform={`translate(${cx}, ${cy + 5})`}>{no.render()}</g>}
+    </svg>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// SERIALIZE / DESERIALIZE
+// ─────────────────────────────────────────────────────────────
+const AVATAR_PREFIX = "avatar:";
+
+export function serializeAvatarConfig(config: AvatarConfig): string {
+  return AVATAR_PREFIX + JSON.stringify(config);
+}
+
+function isValidAvatarConfig(obj: unknown): obj is AvatarConfig {
+  if (typeof obj !== "object" || obj === null) return false;
+  const rec = obj as Record<string, unknown>;
+  return (
+    typeof rec.shape === "string" &&
+    typeof rec.eye === "string" &&
+    typeof rec.nose === "string" &&
+    typeof rec.bg === "number"
+  );
+}
+
+export function parseAvatarUrl(avatarUrl: string | null | undefined): AvatarConfig | null {
+  if (!avatarUrl || !avatarUrl.startsWith(AVATAR_PREFIX)) return null;
+  try {
+    const parsed = JSON.parse(avatarUrl.slice(AVATAR_PREFIX.length));
+    if (isValidAvatarConfig(parsed)) return parsed;
+    // Fallback for old format (had "outline"/"eyes"/"bgColor" fields)
+    if (typeof parsed === "object" && parsed !== null && "outline" in parsed) {
+      return DEFAULT_CONFIG;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/web/src/components/avatar/avatar-picker-dialog.tsx
+++ b/src/web/src/components/avatar/avatar-picker-dialog.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { type AvatarConfig, AvatarRenderer } from "./avatar-parts";
+import { AvatarGenerator } from "./avatar-generator";
+
+interface AvatarPickerDialogProps {
+  config: AvatarConfig;
+  onChange: (config: AvatarConfig) => void;
+}
+
+export function AvatarPickerDialog({ config, onChange }: AvatarPickerDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState<AvatarConfig>(config);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (nextOpen) setDraft(config);
+        setOpen(nextOpen);
+      }}
+    >
+      <div className="flex justify-center">
+        <DialogTrigger
+          render={
+            <button
+              type="button"
+              className="rounded-2xl bg-background p-1.5 shadow-sm border border-border hover:border-primary/40 transition-colors cursor-pointer"
+            />
+          }
+        >
+          <AvatarRenderer config={config} size={80} />
+        </DialogTrigger>
+      </div>
+
+      <DialogContent className="sm:max-w-[720px]">
+        <DialogHeader>
+          <DialogTitle>选择头像</DialogTitle>
+        </DialogHeader>
+        <AvatarGenerator
+          config={draft}
+          layout="horizontal"
+          onChange={(next) => {
+            setDraft(next);
+            onChange(next);
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/web/src/components/avatar/index.ts
+++ b/src/web/src/components/avatar/index.ts
@@ -8,3 +8,4 @@ export {
 } from "./avatar-parts";
 
 export { AvatarGenerator } from "./avatar-generator";
+export { AvatarPickerDialog } from "./avatar-picker-dialog";

--- a/src/web/src/components/avatar/index.ts
+++ b/src/web/src/components/avatar/index.ts
@@ -1,0 +1,10 @@
+export {
+  type AvatarConfig,
+  AvatarRenderer,
+  DEFAULT_CONFIG,
+  serializeAvatarConfig,
+  parseAvatarUrl,
+  randomConfig,
+} from "./avatar-parts";
+
+export { AvatarGenerator } from "./avatar-generator";

--- a/src/web/src/lib/api/responses.ts
+++ b/src/web/src/lib/api/responses.ts
@@ -11,7 +11,7 @@ export function userToResponse(u: any) {
     id: u.id,
     name: u.name,
     email: u.email,
-    avatar_url: u.avatarUrl || null,
+    avatar_url: u.avatarUrl ?? null,
     created_at: formatTimestamp(u.createdAt),
     updated_at: formatTimestamp(u.updatedAt),
   };
@@ -42,7 +42,7 @@ export function agentToResponse(a: any) {
     status: a.status,
     max_concurrent_tasks: a.maxConcurrentTasks,
     email_handle: a.emailHandle || null,
-    avatar_url: a.avatarUrl || null,
+    avatar_url: a.avatarUrl ?? null,
     visibility: a.visibility ?? "private",
     owner_id: a.ownerId ?? null,
     created_at: formatTimestamp(a.createdAt),


### PR DESCRIPTION
## Summary
- Replace PNG-based avatar with pure inline SVG system — 10 shapes, 9 eyes, 7 noses, 12 background colors, 12 presets
- Add `AvatarPickerDialog`: click avatar preview to open a dialog with horizontal layout (preview left, controls right)
- Render SVG avatars across sidebar, preview card, and home overview
- Store as `avatar:{"shape":"book","eye":"happy","nose":"dash","bg":1}` in existing `avatar_url` field with backward compatibility
- Shake animation on avatar change, spacebar shortcut for random generation

## Screenshots

### Presets tab
<img width="730" height="450" alt="image" src="https://github.com/user-attachments/assets/e812dd8c-b7a6-43f4-bcb6-95ae854682ce" />


### Custom tab
<img width="733" height="458" alt="image" src="https://github.com/user-attachments/assets/04dd2bfb-3a23-491f-b81a-ade4262c33e2" />


## Test plan
- [ ] Create a new agent → verify avatar picker dialog appears on click, selection persists after save
- [ ] Edit an existing agent → verify avatar loads from saved config, changes save correctly
- [ ] Check sidebar, preview card hover, and home overview all render the SVG avatar
- [ ] Verify agents without avatar_url still show first-letter fallback
- [ ] Confirm shake animation plays when switching avatars
- [ ] Confirm spacebar shortcut randomizes avatar in dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)