### PR TITLE
fix(daemon): use stdin ignore for opencode to prevent hang

### DIFF
--- a/src/cli/daemon/agent/__tests__/opencode.test.ts
+++ b/src/cli/daemon/agent/__tests__/opencode.test.ts
@@ -7,24 +7,16 @@ let currentMockProc: ReturnType<typeof createMockProc> | null = null;
 let lastSpawnArgs: { cmd: string; args: string[]; opts: Record<string, unknown> } | null = null;
 
 function createMockProc() {
-  const stdinWrites: string[] = [];
   const stdout = new Readable({ read() {} });
   const stderr = new Readable({ read() {} });
-  const stdinEnd = vi.fn();
   const proc = Object.assign(new EventEmitter(), {
     stdout,
     stderr,
-    stdin: {
-      write: (data: string) => {
-        stdinWrites.push(data);
-        return true;
-      },
-      end: stdinEnd,
-    },
+    stdin: null,
     kill: vi.fn(),
     pid: 12345,
   });
-  return { proc, stdout, stderr, stdinWrites, stdinEnd };
+  return { proc, stdout, stderr };
 }
 
 vi.mock("child_process", () => ({
@@ -196,6 +188,15 @@ describe("OpenCodeBackend", () => {
     expect(messages).toContainEqual({ type: "log", content: "not json", level: "debug" });
   });
 
+  it("spawns with stdin ignored to prevent opencode from blocking on pipe", () => {
+    backend.execute("hello", { cwd: "/tmp" });
+    expect(lastSpawnArgs).toBeTruthy();
+    const stdio = lastSpawnArgs!.opts.stdio as string[];
+    expect(stdio[0]).toBe("ignore");
+    expect(stdio[1]).toBe("pipe");
+    expect(stdio[2]).toBe("pipe");
+  });
+
   it("OPENCODE_PERMISSION env var is set on subprocess", () => {
     backend.execute("hello", { cwd: "/tmp" });
     expect(lastSpawnArgs).toBeTruthy();
@@ -280,14 +281,13 @@ describe("OpenCodeBackend", () => {
 
   // --- Turn completion: process lifecycle ---
 
-  it("done event closes stdin and kills the process", async () => {
+  it("done event kills the process", async () => {
     const session = backend.execute("hello", { cwd: "/tmp" });
     const mock = getMock();
 
     mock.stdout.push(JSON.stringify({ type: "done", output: "all done" }) + "\n");
     await tick();
 
-    expect(mock.stdinEnd).toHaveBeenCalled();
     expect(mock.proc.kill).toHaveBeenCalledWith("SIGTERM");
 
     mock.proc.emit("close", 0);
@@ -296,14 +296,13 @@ describe("OpenCodeBackend", () => {
     expect(result.output).toBe("all done");
   });
 
-  it("complete event closes stdin and kills the process", async () => {
+  it("complete event kills the process", async () => {
     const session = backend.execute("hello", { cwd: "/tmp" });
     const mock = getMock();
 
     mock.stdout.push(JSON.stringify({ type: "complete", output: "finished" }) + "\n");
     await tick();
 
-    expect(mock.stdinEnd).toHaveBeenCalled();
     expect(mock.proc.kill).toHaveBeenCalledWith("SIGTERM");
 
     mock.proc.emit("close", 0);
@@ -311,14 +310,13 @@ describe("OpenCodeBackend", () => {
     expect(result.status).toBe("completed");
   });
 
-  it("error event closes stdin and kills the process", async () => {
+  it("error event kills the process", async () => {
     const session = backend.execute("hello", { cwd: "/tmp" });
     const mock = getMock();
 
     mock.stdout.push(JSON.stringify({ type: "error", message: "fatal error" }) + "\n");
     await tick();
 
-    expect(mock.stdinEnd).toHaveBeenCalled();
     expect(mock.proc.kill).toHaveBeenCalledWith("SIGTERM");
 
     mock.proc.emit("close", 1);
@@ -335,7 +333,6 @@ describe("OpenCodeBackend", () => {
     mock.stdout.push(JSON.stringify({ type: "done", output: "done anyway" }) + "\n");
     await tick();
 
-    expect(mock.stdinEnd).toHaveBeenCalledTimes(1);
     expect(mock.proc.kill).toHaveBeenCalledTimes(1);
 
     mock.proc.emit("close", 1);
@@ -354,7 +351,7 @@ describe("OpenCodeBackend", () => {
     mock.stdout.push(JSON.stringify({ type: "done", output: "Found the bug", session_id: "sess_123" }) + "\n");
     await tick();
 
-    expect(mock.stdinEnd).toHaveBeenCalled();
+    expect(mock.proc.kill).toHaveBeenCalledWith("SIGTERM");
     mock.proc.emit("close", 0);
 
     const result = await session.result;

--- a/src/cli/daemon/agent/opencode.ts
+++ b/src/cli/daemon/agent/opencode.ts
@@ -23,7 +23,7 @@ export class OpenCodeBackend implements AgentBackend {
 
     const proc = spawn(this.cliPath, args, {
       cwd: options.cwd,
-      stdio: ["pipe", "pipe", "pipe"],
+      stdio: ["ignore", "pipe", "pipe"],
       env: { ...process.env, ...options.env, OPENCODE_PERMISSION: '{"*":"allow"}' },
     });
 

--- a/src/cli/daemon/agent/opencode.ts
+++ b/src/cli/daemon/agent/opencode.ts
@@ -50,7 +50,6 @@ export class OpenCodeBackend implements AgentBackend {
     const turnDone = () => {
       if (turnDoneTriggered) return;
       turnDoneTriggered = true;
-      try { proc.stdin?.end(); } catch { /* already closed */ }
       try { proc.kill("SIGTERM"); } catch { /* already dead */ }
     };
 


### PR DESCRIPTION
# Why we need this PR?

opencode-based agents hang indefinitely on every task dispatch. The process starts but never produces any output, blocking until the agent timeout kills it.

## What changed

**Root cause:** opencode is built on Bun runtime. When spawned with `stdin: "pipe"`, it detects the pipe and blocks waiting for input that never arrives (the session-runner never writes to stdin nor closes it).

**Fix:** Changed `stdio[0]` from `"pipe"` to `"ignore"` in `OpenCodeBackend.execute()`. This connects stdin to `/dev/null`, so opencode immediately knows there's no input and proceeds normally.

Also removed the now-dead `proc.stdin?.end()` call which TypeScript correctly flags as unreachable when stdin is `null`.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] CLI (`@alook/cli`)