### PR TITLE
fix(daemon): support opencode v1.14+ event format

### DIFF
--- a/src/cli/daemon/agent/__tests__/opencode.test.ts
+++ b/src/cli/daemon/agent/__tests__/opencode.test.ts
@@ -365,4 +365,105 @@ describe("OpenCodeBackend", () => {
     expect(messages).toContainEqual(expect.objectContaining({ type: "tool-use", tool: "read_file", callId: "c1" }));
     expect(messages).toContainEqual(expect.objectContaining({ type: "tool-result", callId: "c1", output: "buggy code" }));
   });
+
+  // --- v1.14+ format tests ---
+
+  it("v1.14+: emits text from part.text field", async () => {
+    const session = backend.execute("hello", { cwd: "/tmp" });
+    const mock = getMock();
+
+    mock.stdout.push(JSON.stringify({
+      type: "text",
+      timestamp: 1777626241755,
+      sessionID: "ses_abc123",
+      part: { id: "prt_1", messageID: "msg_1", sessionID: "ses_abc123", type: "text", text: "Hello from v1.14!" },
+    }) + "\n");
+    await tick();
+    mock.proc.emit("close", 0);
+
+    const messages = await collectMessages(session.messages);
+    expect(messages).toContainEqual({ type: "text", content: "Hello from v1.14!" });
+
+    const result = await session.result;
+    expect(result.output).toBe("Hello from v1.14!");
+    expect(result.sessionId).toBe("ses_abc123");
+  });
+
+  it("v1.14+: step_finish with reason=stop calls turnDone", async () => {
+    const session = backend.execute("hello", { cwd: "/tmp" });
+    const mock = getMock();
+
+    mock.stdout.push(JSON.stringify({
+      type: "step_start",
+      sessionID: "ses_abc",
+      part: { type: "step-start" },
+    }) + "\n");
+    mock.stdout.push(JSON.stringify({
+      type: "text",
+      sessionID: "ses_abc",
+      part: { type: "text", text: "Done!" },
+    }) + "\n");
+    mock.stdout.push(JSON.stringify({
+      type: "step_finish",
+      sessionID: "ses_abc",
+      part: { type: "step-finish", reason: "stop", tokens: { total: 100 } },
+    }) + "\n");
+    await tick();
+
+    expect(mock.proc.kill).toHaveBeenCalledWith("SIGTERM");
+    mock.proc.emit("close", 0);
+
+    const result = await session.result;
+    expect(result.status).toBe("completed");
+    expect(result.output).toBe("Done!");
+  });
+
+  it("v1.14+: extracts sessionID from event-level field", async () => {
+    const session = backend.execute("hello", { cwd: "/tmp" });
+    const mock = getMock();
+
+    mock.stdout.push(JSON.stringify({
+      type: "step_start",
+      sessionID: "ses_from_event",
+      part: { type: "step-start" },
+    }) + "\n");
+    await tick();
+    mock.proc.emit("close", 0);
+
+    const result = await session.result;
+    expect(result.sessionId).toBe("ses_from_event");
+  });
+
+  it("v1.14+: full flow with new format", async () => {
+    const session = backend.execute("你是谁", { cwd: "/tmp" });
+    const mock = getMock();
+
+    mock.stdout.push(JSON.stringify({
+      type: "step_start",
+      sessionID: "ses_new",
+      part: { id: "prt_1", messageID: "msg_1", sessionID: "ses_new", type: "step-start" },
+    }) + "\n");
+    mock.stdout.push(JSON.stringify({
+      type: "text",
+      sessionID: "ses_new",
+      part: { id: "prt_2", messageID: "msg_1", sessionID: "ses_new", type: "text", text: "我是トニー大木" },
+    }) + "\n");
+    mock.stdout.push(JSON.stringify({
+      type: "step_finish",
+      sessionID: "ses_new",
+      part: { id: "prt_3", reason: "stop", messageID: "msg_1", sessionID: "ses_new", type: "step-finish", tokens: { total: 20145, input: 6, output: 34 }, cost: 0.12 },
+    }) + "\n");
+    await tick();
+
+    expect(mock.proc.kill).toHaveBeenCalledWith("SIGTERM");
+    mock.proc.emit("close", 0);
+
+    const result = await session.result;
+    expect(result.status).toBe("completed");
+    expect(result.output).toBe("我是トニー大木");
+    expect(result.sessionId).toBe("ses_new");
+
+    const messages = await collectMessages(session.messages);
+    expect(messages).toContainEqual({ type: "text", content: "我是トニー大木" });
+  });
 });

--- a/src/cli/daemon/agent/opencode.ts
+++ b/src/cli/daemon/agent/opencode.ts
@@ -87,6 +87,14 @@ export class OpenCodeBackend implements AgentBackend {
         }
 
         const eventType = event.type as string | undefined;
+        const part = event.part as Record<string, unknown> | undefined;
+
+        // Extract sessionID from any event (v1.14+ format)
+        const eventSessionId = (event.sessionID as string) || (event.session_id as string);
+        if (eventSessionId && !lastSessionId) {
+          lastSessionId = eventSessionId;
+          resolveSessionId(eventSessionId);
+        }
 
         switch (eventType) {
           case "session": {
@@ -108,8 +116,18 @@ export class OpenCodeBackend implements AgentBackend {
             break;
           }
 
+          // v1.14+ format: { type: "text", part: { text: "..." } }
+          case "text": {
+            const text = (part?.text as string) || (event.content as string) || "";
+            if (text) {
+              lastOutput = text;
+              pushMessage({ type: "text", content: text });
+            }
+            break;
+          }
+
           case "thinking": {
-            const content = event.content as string | undefined;
+            const content = (part?.thinking as string) || (event.content as string) || "";
             pushMessage({ type: "thinking", content });
             break;
           }
@@ -117,9 +135,9 @@ export class OpenCodeBackend implements AgentBackend {
           case "tool_call": {
             pushMessage({
               type: "tool-use",
-              tool: (event.name as string) || "",
-              callId: event.call_id as string,
-              input: event.input as Record<string, unknown>,
+              tool: (event.name as string) || (part?.name as string) || "",
+              callId: (event.call_id as string) || (part?.id as string) || "",
+              input: (event.input as Record<string, unknown>) || (part?.input as Record<string, unknown>),
             });
             break;
           }
@@ -127,17 +145,30 @@ export class OpenCodeBackend implements AgentBackend {
           case "tool_result": {
             pushMessage({
               type: "tool-result",
-              callId: event.call_id as string,
-              output: event.output as string,
+              callId: (event.call_id as string) || (part?.id as string) || "",
+              output: (event.output as string) || (part?.output as string) || "",
             });
             break;
           }
 
           case "error": {
-            const content = (event.message as string) || (event.content as string) || "";
+            const content = (event.message as string) || (event.content as string) || (part?.error as string) || "";
             lastError = content;
             pushMessage({ type: "error", content });
             turnDone();
+            break;
+          }
+
+          // v1.14+ signals
+          case "step_start": {
+            break;
+          }
+
+          case "step_finish": {
+            const reason = part?.reason as string | undefined;
+            if (reason === "stop" || reason === "end_turn") {
+              turnDone();
+            }
             break;
           }
 


### PR DESCRIPTION
# Why we need this PR?
> opencode v1.14 changed its `--format json` event output, causing the トニー大木 agent to appear unresponsive (agent_responses always empty).

## What changed
- Added handling for opencode v1.14+ event types (`text`, `step_start`, `step_finish`) in the OpenCodeBackend event parser
- `type: "text"` events now extract content from `part.text`
- `type: "step_finish"` with `reason: "stop"` triggers turn completion
- Session ID is now extracted from event-level `sessionID` field
- Backward compatible with older opencode event format
- Added 4 new test cases covering the v1.14+ format

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] CLI (`@alook/cli`)