### PR TITLE
feat(web): support paste-to-attach images and files in chat input

### DIFF
--- a/src/web/src/components/agent-chat/agent-chat-view.tsx
+++ b/src/web/src/components/agent-chat/agent-chat-view.tsx
@@ -837,6 +837,37 @@ export function AgentChatView() {
     }
   }, []);
 
+  const handlePaste = useCallback((e: React.ClipboardEvent) => {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+
+    const files: File[] = [];
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (item.kind === "file") {
+        const file = item.getAsFile();
+        if (file) files.push(file);
+      }
+    }
+
+    if (files.length === 0) return;
+
+    // Prevent default only when we have files to handle
+    e.preventDefault();
+
+    const valid: File[] = [];
+    for (const file of files) {
+      if (file.size > MAX_FILE_SIZE) {
+        toast.error(`"${file.name}" exceeds 10 MB limit`);
+      } else {
+        valid.push(file);
+      }
+    }
+    if (valid.length > 0) {
+      setPendingFiles((prev) => [...prev, ...valid]);
+    }
+  }, []);
+
   const handleStop = async () => {
     if (!conversation || cancelling) return;
     setCancelling(true);
@@ -1291,6 +1322,7 @@ export function AgentChatView() {
                 value={input}
                 onChange={(e) => { setInput(e.target.value); setCaretIndex(e.target.selectionStart); }}
                 onKeyDown={handleKeyDown}
+                onPaste={handlePaste}
                 onKeyUp={(e) => setCaretIndex((e.target as HTMLTextAreaElement).selectionStart)}
                 onClick={(e) => setCaretIndex((e.target as HTMLTextAreaElement).selectionStart)}
                 onSelect={(e) => setCaretIndex((e.target as HTMLTextAreaElement).selectionStart)}


### PR DESCRIPTION
## Summary
- Agent 聊天输入框的 textarea 之前没有 `onPaste` handler，粘贴截图或文件会被忽略
- 新增 `handlePaste`，从 `clipboardData` 提取文件，复用现有的 `pendingFiles` 队列和大小校验逻辑（与拖拽一致）
- 纯文本粘贴不受影响（只在剪贴板含文件时 `preventDefault`）

## Changes
- `agent-chat-view.tsx`: 新增 `handlePaste` callback + textarea 绑定 `onPaste`

## Test plan
- [ ] 在输入框中 Cmd+V 粘贴截图，确认图片出现在 pending file pills 中
- [ ] 粘贴超过 10MB 的文件，确认 toast 报错
- [ ] 粘贴普通文本，确认文本正常粘贴不受影响
- [ ] 拖拽文件仍然正常工作
- [ ] 点击按钮选文件仍然正常工作
- [ ] 粘贴多个文件（如从 Finder 复制多个），确认全部添加

🤖 Generated with [Claude Code](https://claude.com/claude-code)