### PR TITLE
feat(web): support paste-to-attach images and files in chat input

### DIFF
--- a/src/web/src/components/agent-chat/agent-chat-view.tsx
+++ b/src/web/src/components/agent-chat/agent-chat-view.tsx
@@ -837,6 +837,37 @@ export function AgentChatView() {
     }
   }, []);
 
+  const handlePaste = useCallback((e: React.ClipboardEvent) => {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+
+    const files: File[] = [];
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (item.kind === "file") {
+        const file = item.getAsFile();
+        if (file) files.push(file);
+      }
+    }
+
+    if (files.length === 0) return;
+
+    // Prevent default only when we have files to handle
+    e.preventDefault();
+
+    const valid: File[] = [];
+    for (const file of files) {
+      if (file.size > MAX_FILE_SIZE) {
+        toast.error(`"${file.name}" exceeds 10 MB limit`);
+      } else {
+        valid.push(file);
+      }
+    }
+    if (valid.length > 0) {
+      setPendingFiles((prev) => [...prev, ...valid]);
+    }
+  }, []);
+
   const handleStop = async () => {
     if (!conversation || cancelling) return;
     setCancelling(true);
@@ -1291,6 +1322,7 @@ export function AgentChatView() {
                 value={input}
                 onChange={(e) => { setInput(e.target.value); setCaretIndex(e.target.selectionStart); }}
                 onKeyDown={handleKeyDown}
+                onPaste={handlePaste}
                 onKeyUp={(e) => setCaretIndex((e.target as HTMLTextAreaElement).selectionStart)}
                 onClick={(e) => setCaretIndex((e.target as HTMLTextAreaElement).selectionStart)}
                 onSelect={(e) => setCaretIndex((e.target as HTMLTextAreaElement).selectionStart)}


### PR DESCRIPTION
## Summary
- The agent chat textarea had no `onPaste` handler, so pasting screenshots or copied files via Cmd+V was silently ignored
- Added `handlePaste` callback that extracts files from `clipboardData` and pushes them into the existing `pendingFiles` queue, reusing the same size validation logic as drag-and-drop
- Plain text paste is unaffected — `preventDefault` is only called when clipboard contains files

## Changes
- `agent-chat-view.tsx`: added `handlePaste` callback + bound `onPaste` on textarea

## Test plan
- [x] Cmd+V paste a screenshot — image appears in pending file pills
- [x] Paste a file exceeding 10MB — toast error shown
- [x] Paste plain text — text pastes normally, no interference
- [x] Drag-and-drop still works
- [x] Click-to-select file button still works
- [x] Paste multiple files (e.g. copied from Finder) — all added to pending queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)