### PR TITLE
fix(email-worker): add missing exports to test mocks

### DIFF
--- a/src/email-worker/src/imap-poller-do.test.ts
+++ b/src/email-worker/src/imap-poller-do.test.ts
@@ -59,7 +59,8 @@ const mockGetEmailAccount = vi.fn()
 const mockUpdateEmailAccount = vi.fn()
 const mockIsWhitelisted = vi.fn().mockResolvedValue(true)
 
-vi.mock("@alook/shared", () => {
+vi.mock("@alook/shared", async () => {
+  const real = await vi.importActual<typeof import("@alook/shared")>("@alook/shared")
   const noopLogger = {
     debug: () => {},
     info: () => {},
@@ -70,6 +71,8 @@ vi.mock("@alook/shared", () => {
   return {
     createDb: () => ({}),
     createLogger: () => noopLogger,
+    parseIcs: real.parseIcs,
+    extractAttachmentMeta: real.extractAttachmentMeta,
     DEV_WEB_URL: "http://localhost:3000",
     queries: {
       emailAccount: {

--- a/src/email-worker/src/index.test.ts
+++ b/src/email-worker/src/index.test.ts
@@ -50,6 +50,8 @@ vi.mock("@alook/shared", async () => {
   }
   return {
     buildMimeMessage: real.buildMimeMessage,
+    extractAttachmentMeta: real.extractAttachmentMeta,
+    filterDownloadableAttachments: real.filterDownloadableAttachments,
     createDb: (d1: unknown) => mockCreateDb(d1),
     createLogger: () => noopLogger,
     parseEmailHandle: (address: string) => {


### PR DESCRIPTION
# Why we need this PR?

CI has been failing on all recent commits because email-worker tests are missing mock exports that were added to `@alook/shared`.

## What changed

Added `extractAttachmentMeta` and `parseIcs` to the `vi.mock("@alook/shared")` blocks in:
- `src/email-worker/src/index.test.ts`
- `src/email-worker/src/imap-poller-do.test.ts`

Both use `vi.importActual` to pass through the real implementation (these are pure utility functions that don't need mocking).

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Email Worker (`@alook/email-worker`)