### PR TITLE
feat: prioritize related agents in mention popup

### DIFF
--- a/src/web/src/components/agent-chat/agent-chat-view.tsx
+++ b/src/web/src/components/agent-chat/agent-chat-view.tsx
@@ -325,7 +325,7 @@ export function AgentChatView() {
   const params = useParams();
   const searchParams = useSearchParams();
   const { workspaceId } = useWorkspace();
-  const { agents, activeTaskCounts, subscribeWs } = useAgentContext();
+  const { agents, agentLinks, activeTaskCounts, subscribeWs } = useAgentContext();
   const { refresh: refreshInboxCount } = useInboxCount();
   const { activeChannel, loading: channelLoading } = useChannel();
   const agentId = params.id as string;
@@ -402,6 +402,8 @@ export function AgentChatView() {
     caretIndex,
     textareaRef,
     agents: otherAgents,
+    agentLinks,
+    currentAgentId: agentId,
     onInputChange: setInput,
   });
 
@@ -1517,7 +1519,8 @@ export function AgentChatView() {
             )}
             <MentionPopup
               isOpen={mentionPopup.isOpen}
-              agents={mentionPopup.filteredAgents}
+              relatedAgents={mentionPopup.relatedAgents}
+              otherAgents={mentionPopup.otherAgents}
               selectedIndex={mentionPopup.selectedIndex}
               onSelect={mentionPopup.selectAgent}
               anchorPos={mentionPopup.anchorPos}

--- a/src/web/src/components/agent-chat/mention-popup.tsx
+++ b/src/web/src/components/agent-chat/mention-popup.tsx
@@ -4,22 +4,59 @@ import { cn } from "@/lib/utils"
 
 interface MentionPopupProps {
   isOpen: boolean
-  agents: Agent[]
+  relatedAgents: Agent[]
+  otherAgents: Agent[]
   selectedIndex: number
   onSelect: (agent: Agent) => void
   anchorPos: { top: number; left: number }
 }
 
-export function MentionPopup({ isOpen, agents, selectedIndex, onSelect, anchorPos }: MentionPopupProps) {
+function AgentRow({
+  agent,
+  isSelected,
+  onSelect,
+}: {
+  agent: Agent
+  isSelected: boolean
+  onSelect: (agent: Agent) => void
+}) {
+  return (
+    <button
+      type="button"
+      data-mention-item
+      className={cn(
+        "flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm transition-colors",
+        isSelected ? "bg-accent text-accent-foreground" : "hover:bg-accent/50",
+      )}
+      onMouseDown={(e) => {
+        e.preventDefault()
+        onSelect(agent)
+      }}
+    >
+      <span className="truncate font-medium">{agent.name}</span>
+      {agent.email_handle && (
+        <span className="truncate text-xs text-muted-foreground">
+          {agent.email_handle}@alook.ai
+        </span>
+      )}
+    </button>
+  )
+}
+
+export function MentionPopup({ isOpen, relatedAgents, otherAgents, selectedIndex, onSelect, anchorPos }: MentionPopupProps) {
   const listRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     if (!listRef.current) return
-    const selected = listRef.current.children[selectedIndex] as HTMLElement | undefined
+    const items = listRef.current.querySelectorAll("[data-mention-item]")
+    const selected = items[selectedIndex] as HTMLElement | undefined
     selected?.scrollIntoView({ block: "nearest" })
   }, [selectedIndex])
 
-  if (!isOpen || agents.length === 0) return null
+  const totalCount = relatedAgents.length + otherAgents.length
+  if (!isOpen || totalCount === 0) return null
+
+  const showDivider = relatedAgents.length > 0 && otherAgents.length > 0
 
   return (
     <div
@@ -31,26 +68,24 @@ export function MentionPopup({ isOpen, agents, selectedIndex, onSelect, anchorPo
       }}
     >
       <div ref={listRef} className="max-h-50 overflow-y-auto py-1 thin-scrollbar">
-        {agents.map((agent, i) => (
-          <button
+        {relatedAgents.map((agent, i) => (
+          <AgentRow
             key={agent.id}
-            type="button"
-            className={cn(
-              "flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm transition-colors",
-              i === selectedIndex ? "bg-accent text-accent-foreground" : "hover:bg-accent/50",
-            )}
-            onMouseDown={(e) => {
-              e.preventDefault()
-              onSelect(agent)
-            }}
-          >
-            <span className="truncate font-medium">{agent.name}</span>
-            {agent.email_handle && (
-              <span className="truncate text-xs text-muted-foreground">
-                {agent.email_handle}@alook.ai
-              </span>
-            )}
-          </button>
+            agent={agent}
+            isSelected={i === selectedIndex}
+            onSelect={onSelect}
+          />
+        ))}
+        {showDivider && (
+          <div className="mx-3 my-1 border-t border-border" />
+        )}
+        {otherAgents.map((agent, i) => (
+          <AgentRow
+            key={agent.id}
+            agent={agent}
+            isSelected={relatedAgents.length + i === selectedIndex}
+            onSelect={onSelect}
+          />
         ))}
       </div>
     </div>

--- a/src/web/src/contexts/agent-context.tsx
+++ b/src/web/src/contexts/agent-context.tsx
@@ -20,6 +20,7 @@ import {
   listAgentActiveTaskCounts,
   listWorkspaceActiveTasks,
   listAgentPins,
+  listAgentLinks,
   pinAgent as pinAgentApi,
   unpinAgent as unpinAgentApi,
   reorderAgentPins,
@@ -30,6 +31,7 @@ import type { AgentRuntime as Runtime } from "@alook/shared";
 import { toast } from "sonner";
 import type {
   Agent,
+  AgentLink,
   CreateAgentRequest,
   UpdateAgentRequest,
   WsMessage,
@@ -42,6 +44,7 @@ type WsSubscriber = (msg: WsMessage) => void;
 interface AgentContextValue {
   workspaceId: string;
   agents: Agent[];
+  agentLinks: AgentLink[];
   runtimes: Runtime[];
   loading: boolean;
   activeTaskCounts: Record<string, number>;
@@ -83,6 +86,7 @@ export function AgentProvider({
   const [activeTaskCounts, setActiveTaskCounts] = useState<Record<string, number>>({});
   const [activeTaskDetails, setActiveTaskDetails] = useState<WorkspaceActiveTask[]>([]);
   const hasActiveTasksRef = useRef(false);
+  const [agentLinks, setAgentLinks] = useState<AgentLink[]>([]);
   const [pins, setPins] = useState<Map<string, { created_at: string; position: number }>>(new Map());
   const [unpinnedOrder, setUnpinnedOrder] = useState<Map<string, number>>(new Map());
   const loadedRef = useRef(false);
@@ -142,13 +146,15 @@ export function AgentProvider({
 
   const reload = useCallback(async () => {
     try {
-      const [a, r, pinsData] = await Promise.all([
+      const [a, r, pinsData, links] = await Promise.all([
         listAgents(workspaceId),
         listRuntimes(workspaceId),
         listAgentPins(workspaceId),
+        listAgentLinks(workspaceId),
       ]);
       setAgents(a);
       setRuntimes(r);
+      setAgentLinks(links);
       setPins(new Map(pinsData.pins.map((pin) => [pin.agent_id, { created_at: pin.created_at, position: pin.position }])));
       setUnpinnedOrder(new Map(pinsData.sidebar_order.map((o) => [o.agent_id, o.position])));
     } catch (err) {
@@ -349,6 +355,7 @@ export function AgentProvider({
       value={{
         workspaceId,
         agents,
+        agentLinks,
         runtimes,
         loading,
         activeTaskCounts,

--- a/src/web/src/hooks/use-mention-popup.ts
+++ b/src/web/src/hooks/use-mention-popup.ts
@@ -1,12 +1,14 @@
 import { useState, useCallback, useMemo, useRef, useEffect } from "react"
-import type { Agent } from "@alook/shared"
+import type { Agent, AgentLink } from "@alook/shared"
 
 export interface MentionPopupState {
   isOpen: boolean
   query: string
   selectedIndex: number
   anchorPos: { top: number; left: number }
-  filteredAgents: Agent[]
+  relatedAgents: Agent[]
+  otherAgents: Agent[]
+  allAgents: Agent[]
   handleMentionKeyDown: (e: React.KeyboardEvent) => boolean
   selectAgent: (agent: Agent) => void
 }
@@ -16,6 +18,8 @@ interface UseMentionPopupParams {
   caretIndex: number | null
   textareaRef: React.RefObject<HTMLTextAreaElement | null>
   agents: Agent[]
+  agentLinks: AgentLink[]
+  currentAgentId: string
   onInputChange: (value: string) => void
 }
 
@@ -80,6 +84,8 @@ export function useMentionPopup({
   caretIndex,
   textareaRef,
   agents,
+  agentLinks,
+  currentAgentId,
   onInputChange,
 }: UseMentionPopupParams): MentionPopupState {
   const [isOpen, setIsOpen] = useState(false)
@@ -88,23 +94,51 @@ export function useMentionPopup({
   const [anchorPos, setAnchorPos] = useState({ top: 0, left: 0 })
   const triggerStartRef = useRef<number | null>(null)
 
-  const filteredAgents = useMemo(() => {
-    if (!isOpen) return []
-    if (!query) return agents.slice(0, 20)
-    const q = query.toLowerCase()
-    const startsWith: Agent[] = []
-    const includes: Agent[] = []
-    for (const a of agents) {
-      const name = a.name.toLowerCase()
-      if (name.startsWith(q)) startsWith.push(a)
-      else if (name.includes(q)) includes.push(a)
+  const relatedAgentIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const link of agentLinks) {
+      if (link.source_agent_id === currentAgentId) ids.add(link.target_agent_id)
+      if (link.target_agent_id === currentAgentId) ids.add(link.source_agent_id)
     }
-    return [...startsWith, ...includes]
-  }, [isOpen, query, agents])
+    return ids
+  }, [agentLinks, currentAgentId])
+
+  const { relatedAgents, otherAgents, allAgents } = useMemo(() => {
+    if (!isOpen) return { relatedAgents: [], otherAgents: [], allAgents: [] }
+
+    const filterByQuery = (list: Agent[]) => {
+      if (!query) return list.slice(0, 20)
+      const q = query.toLowerCase()
+      const startsWith: Agent[] = []
+      const includes: Agent[] = []
+      for (const a of list) {
+        const name = a.name.toLowerCase()
+        if (name.startsWith(q)) startsWith.push(a)
+        else if (name.includes(q)) includes.push(a)
+      }
+      return [...startsWith, ...includes]
+    }
+
+    const related: Agent[] = []
+    const other: Agent[] = []
+    for (const a of agents) {
+      if (relatedAgentIds.has(a.id)) related.push(a)
+      else other.push(a)
+    }
+
+    const filteredRelated = filterByQuery(related)
+    const filteredOther = filterByQuery(other)
+
+    return {
+      relatedAgents: filteredRelated,
+      otherAgents: filteredOther,
+      allAgents: [...filteredRelated, ...filteredOther],
+    }
+  }, [isOpen, query, agents, relatedAgentIds])
 
   useEffect(() => {
     setSelectedIndex(0)
-  }, [filteredAgents.length, query])
+  }, [allAgents.length, query])
 
   useEffect(() => {
     if (caretIndex === null) {
@@ -148,22 +182,22 @@ export function useMentionPopup({
   }, [input, caretIndex, textareaRef, onInputChange])
 
   const handleMentionKeyDown = useCallback((e: React.KeyboardEvent): boolean => {
-    if (!isOpen || filteredAgents.length === 0) return false
+    if (!isOpen || allAgents.length === 0) return false
     if (e.nativeEvent.isComposing) return false
 
     if (e.key === "ArrowDown") {
       e.preventDefault()
-      setSelectedIndex(i => (i + 1) % filteredAgents.length)
+      setSelectedIndex(i => (i + 1) % allAgents.length)
       return true
     }
     if (e.key === "ArrowUp") {
       e.preventDefault()
-      setSelectedIndex(i => (i - 1 + filteredAgents.length) % filteredAgents.length)
+      setSelectedIndex(i => (i - 1 + allAgents.length) % allAgents.length)
       return true
     }
     if (e.key === "Enter") {
       e.preventDefault()
-      selectAgent(filteredAgents[selectedIndex])
+      selectAgent(allAgents[selectedIndex])
       return true
     }
     if (e.key === "Escape") {
@@ -172,14 +206,16 @@ export function useMentionPopup({
       return true
     }
     return false
-  }, [isOpen, filteredAgents, selectedIndex, selectAgent])
+  }, [isOpen, allAgents, selectedIndex, selectAgent])
 
   return {
     isOpen,
     query,
     selectedIndex,
     anchorPos,
-    filteredAgents,
+    relatedAgents,
+    otherAgents,
+    allAgents,
     handleMentionKeyDown,
     selectAgent,
   }


### PR DESCRIPTION
## Summary
- Agents with relationships (agent-links) to the current agent now appear at the top of the @ mention popup
- A divider separates related agents from unrelated agents
- Agent-link data added to AgentContext for shared access across components

## Changes
- **`agent-context.tsx`** — added `agentLinks` to context, fetched in parallel with existing data
- **`use-mention-popup.ts`** — split agents into `relatedAgents` + `otherAgents` based on agent-links; search filtering works independently within each group
- **`mention-popup.tsx`** — renders two groups with a `border-border` divider; divider only shown when both groups are non-empty
- **`agent-chat-view.tsx`** — wired up `agentLinks` and `currentAgentId` to the mention popup

## Edge cases handled
- No divider when all agents are in one group
- Falls back to original sort when agent-links haven't loaded yet
- Keyboard navigation (Arrow keys) seamlessly crosses the divider

## Test plan
- [x] Open agent chat, type `@` — related agents should appear above the divider
- [x] Type a search query — filtering should work within each group independently
- [x] Verify keyboard navigation crosses the divider without skipping
- [x] Test with an agent that has no relationships — no divider should appear
- [x] Test with agent-links still loading — should show original flat list

🤖 Generated with [Claude Code](https://claude.com/claude-code)