### PR TITLE
feat(web): add upcoming events float panel on home canvas

### DIFF
--- a/src/web/src/app/(app)/w/[slug]/home/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/home/page.tsx
@@ -44,6 +44,7 @@ import { AgentNode, type AgentNodeData } from "@/components/canvas/agent-node";
 import { LinkEdge } from "@/components/canvas/link-edge";
 import { LinkSidecar } from "@/components/canvas/link-sidecar";
 import { ActiveTasksFloat } from "@/components/canvas/active-tasks-float";
+import { UpcomingEventsFloat } from "@/components/canvas/upcoming-events-float";
 import { getAutoLayout } from "@/components/canvas/auto-layout";
 
 const nodeTypes = { agent: AgentNode };
@@ -415,7 +416,10 @@ function AgentCanvas() {
         onDelete={handleSidecarDelete}
       />
 
-      <ActiveTasksFloat />
+      <div className="absolute bottom-4 right-4 z-10 flex flex-wrap justify-end items-end gap-2">
+        <ActiveTasksFloat />
+        <UpcomingEventsFloat />
+      </div>
 
       {/* Create agent button */}
       <button

--- a/src/web/src/components/canvas/active-tasks-float.tsx
+++ b/src/web/src/components/canvas/active-tasks-float.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
-import { X, Minus } from "lucide-react";
+import { X } from "lucide-react";
 import { useAgentContext } from "@/contexts/agent-context";
 import { useWorkspace } from "@/contexts/workspace-context";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -63,8 +63,7 @@ export function ActiveTasksFloat() {
   const { activeTaskDetails } = useAgentContext();
   const { slug } = useWorkspace();
   const isMobile = useIsMobile();
-  const [minimized, setMinimized] = useState(false);
-  const [dismissed, setDismissed] = useState(false);
+  const [expanded, setExpanded] = useState(false);
   const prevTaskIdsRef = useRef<Set<string>>(new Set());
 
   const tasks = activeTaskDetails;
@@ -77,20 +76,20 @@ export function ActiveTasksFloat() {
     }
     const currentIds = new Set(tasks.map((t) => t.id));
     const hasNewTask = tasks.some((t) => !prevTaskIdsRef.current.has(t.id));
-    if (hasNewTask && dismissed) {
-      setDismissed(false);
+    if (hasNewTask && !expanded) {
+      setExpanded(true);
     }
     prevTaskIdsRef.current = currentIds;
-  }, [tasks, taskCount, dismissed]);
+  }, [tasks, taskCount, expanded]);
 
   if (isMobile || taskCount === 0) return null;
 
-  if (dismissed) {
+  if (!expanded) {
     return (
       <button
         type="button"
-        onClick={() => setDismissed(false)}
-        className="absolute bottom-4 right-4 z-10 flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-background/90 backdrop-blur-sm ring-1 ring-foreground/8 shadow-sm text-xs font-medium text-muted-foreground hover:text-foreground transition-colors animate-[fade-up_300ms_ease-out_both]"
+        onClick={() => setExpanded(true)}
+        className="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-background/90 backdrop-blur-sm ring-1 ring-foreground/8 shadow-sm text-xs font-medium text-muted-foreground hover:text-foreground transition-colors animate-[fade-up_300ms_ease-out_both]"
       >
         <span className="size-1.5 rounded-full bg-primary animate-pulse" />
         {taskCount} active
@@ -102,7 +101,7 @@ export function ActiveTasksFloat() {
     <div
       role="region"
       aria-label="Active tasks"
-      className="absolute bottom-4 right-4 z-10 w-80 rounded-lg ring-1 ring-foreground/8 shadow-sm bg-background/90 backdrop-blur-sm animate-[fade-up_300ms_ease-out_both]"
+      className="w-80 rounded-lg ring-1 ring-foreground/8 shadow-sm bg-background/90 backdrop-blur-sm animate-[fade-up_300ms_ease-out_both]"
     >
       <div className="flex items-center justify-between px-3 py-2 border-b border-border/50">
         <div className="flex items-center gap-2 text-sm font-medium" aria-live="polite">
@@ -111,41 +110,29 @@ export function ActiveTasksFloat() {
             {taskCount} task{taskCount !== 1 ? "s" : ""} active
           </span>
         </div>
-        <div className="flex items-center gap-0.5">
-          <button
-            type="button"
-            aria-label={minimized ? "Expand tasks" : "Minimize tasks"}
-            className="size-6 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-            onClick={() => setMinimized((v) => !v)}
-          >
-            <Minus className="size-3.5" />
-          </button>
-          <button
-            type="button"
-            aria-label="Close tasks panel"
-            className="size-6 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-            onClick={() => setDismissed(true)}
-          >
-            <X className="size-3.5" />
-          </button>
-        </div>
+        <button
+          type="button"
+          aria-label="Collapse tasks panel"
+          className="size-6 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+          onClick={() => setExpanded(false)}
+        >
+          <X className="size-3.5" />
+        </button>
       </div>
 
-      {!minimized && (
-        <div className="max-h-75 overflow-y-auto thin-scrollbar py-1">
-          {tasks.slice(0, 8).map((task) => (
-            <TaskRow key={task.id} task={task} slug={slug} />
-          ))}
-          {taskCount > 8 && (
-            <Link
-              href={`/w/${slug}/threads?status=active`}
-              className="block text-xs text-muted-foreground hover:text-foreground text-center py-1.5 transition-colors"
-            >
-              View all {taskCount} tasks
-            </Link>
-          )}
-        </div>
-      )}
+      <div className="max-h-75 overflow-y-auto thin-scrollbar py-1">
+        {tasks.slice(0, 8).map((task) => (
+          <TaskRow key={task.id} task={task} slug={slug} />
+        ))}
+        {taskCount > 8 && (
+          <Link
+            href={`/w/${slug}/threads?status=active`}
+            className="block text-xs text-muted-foreground hover:text-foreground text-center py-1.5 transition-colors"
+          >
+            View all {taskCount} tasks
+          </Link>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/web/src/components/canvas/upcoming-events-float.tsx
+++ b/src/web/src/components/canvas/upcoming-events-float.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { CalendarDays, X } from "lucide-react";
+import { useAgentContext } from "@/contexts/agent-context";
+import { useWorkspace } from "@/contexts/workspace-context";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { AvatarRenderer, parseAvatarUrl } from "@/components/avatar";
+import { listCalendarEvents } from "@/lib/api";
+import type { CalendarEvent } from "@alook/shared";
+
+function AgentAvatar({ name, avatarUrl, size = 20 }: { name?: string; avatarUrl?: string | null; size?: number }) {
+  const config = parseAvatarUrl(avatarUrl);
+  if (config) return <AvatarRenderer config={config} size={size} className="rounded-full shrink-0" />;
+  return (
+    <span
+      className="flex items-center justify-center rounded-full bg-secondary text-[7px] font-medium shrink-0"
+      style={{ width: size, height: size }}
+    >
+      {(name ?? "?").charAt(0).toUpperCase()}
+    </span>
+  );
+}
+
+interface AgentEventSummary {
+  agentId: string;
+  agentName: string;
+  avatarUrl: string | null;
+  count: number;
+}
+
+export function UpcomingEventsFloat() {
+  const { agents } = useAgentContext();
+  const { slug, workspaceId } = useWorkspace();
+  const isMobile = useIsMobile();
+  const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const [expanded, setExpanded] = useState(false);
+
+  const agentMap = new Map(agents.map((a) => [a.id, a]));
+
+  const fetchEvents = useCallback(async () => {
+    if (!workspaceId) return;
+    const now = new Date();
+    const todayEnd = new Date(now);
+    todayEnd.setHours(23, 59, 59, 999);
+    try {
+      const data = await listCalendarEvents(workspaceId, {
+        from: now.toISOString(),
+        to: todayEnd.toISOString(),
+      });
+      const upcoming = data.filter((e) => new Date(e.occurrence_at) >= now);
+      setEvents(upcoming);
+    } catch {
+      // silently ignore
+    }
+  }, [workspaceId]);
+
+  useEffect(() => {
+    fetchEvents();
+    const interval = setInterval(fetchEvents, 60_000);
+    return () => clearInterval(interval);
+  }, [fetchEvents]);
+
+  const count = events.reduce((sum, e) => sum + (e.collapsed_count ?? 1), 0);
+
+  if (isMobile || count === 0) return null;
+
+  // Group events by agent
+  const agentSummaries: AgentEventSummary[] = [];
+  const countByAgent = new Map<string, number>();
+  for (const e of events) {
+    countByAgent.set(e.agent_id, (countByAgent.get(e.agent_id) ?? 0) + (e.collapsed_count ?? 1));
+  }
+  for (const [agentId, eventCount] of countByAgent) {
+    const agent = agentMap.get(agentId);
+    agentSummaries.push({
+      agentId,
+      agentName: agent?.name ?? "Unknown",
+      avatarUrl: agent?.avatar_url ?? null,
+      count: eventCount,
+    });
+  }
+  agentSummaries.sort((a, b) => b.count - a.count);
+
+  if (!expanded) {
+    return (
+      <button
+        type="button"
+        onClick={() => setExpanded(true)}
+        className="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-background/90 backdrop-blur-sm ring-1 ring-foreground/8 shadow-sm text-xs font-medium text-muted-foreground hover:text-foreground transition-colors animate-[fade-up_300ms_ease-out_both]"
+      >
+        <CalendarDays className="size-3" />
+        {count} upcoming
+      </button>
+    );
+  }
+
+  return (
+    <div
+      role="region"
+      aria-label="Upcoming events"
+      className="w-72 rounded-lg ring-1 ring-foreground/8 shadow-sm bg-background/90 backdrop-blur-sm animate-[fade-up_300ms_ease-out_both]"
+    >
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border/50">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <CalendarDays className="size-3.5 text-muted-foreground" />
+          <span>{count} events today</span>
+        </div>
+        <button
+          type="button"
+          aria-label="Collapse events panel"
+          className="size-6 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+          onClick={() => setExpanded(false)}
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+
+      <div className="max-h-52 overflow-y-auto thin-scrollbar py-1">
+        {agentSummaries.map((summary) => (
+          <Link
+            key={summary.agentId}
+            href={`/w/${slug}/calendar`}
+            className="flex items-center gap-2.5 px-3 py-2 hover:bg-accent/50 transition-colors cursor-pointer rounded-md"
+          >
+            <AgentAvatar name={summary.agentName} avatarUrl={summary.avatarUrl} size={22} />
+            <span className="flex-1 text-sm truncate">{summary.agentName}</span>
+            <span className="text-xs text-muted-foreground shrink-0">
+              {summary.count} event{summary.count !== 1 ? "s" : ""}
+            </span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# Why we need this PR?

Add a floating panel on the home canvas that shows today's remaining calendar events, giving users quick visibility into their schedule without navigating away.

## What changed

- **New component**: `upcoming-events-float.tsx` — fetches today's remaining events via `listCalendarEvents`, groups by agent, shows event count per agent. Handles collapsed high-frequency recurring events correctly.
- **Refactored `active-tasks-float.tsx`**: Simplified from 3 states (expanded/minimized/dismissed) to 2 states (badge/tab). Positioning moved to parent container.
- **Updated home page**: Both float panels wrapped in a flex container at bottom-right. Badges sit side-by-side; expanded tabs stack vertically.

## Checklist
- [ ] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)