### PR TITLE
feat(ci): add Discord notifications for deploys and CLI releases

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -53,6 +53,7 @@ jobs:
           VERSION: ${{ steps.detect.outputs.version }}
           CHANGES: ${{ steps.changes.outputs.logs }}
         run: |
+          export CHANGES_TEXT
           CHANGES_TEXT=$(echo "$CHANGES" | python3 -c 'import sys,json; print(json.loads(sys.stdin.read()))')
           BODY=$(python3 -c "
           import json, os
@@ -78,9 +79,11 @@ jobs:
           MSG=$(git log -1 --format='%s' "${{ github.event.workflow_run.head_sha }}")
           AUTHOR=$(git log -1 --format='%an' "${{ github.event.workflow_run.head_sha }}")
           SHORT_SHA=$(echo "${{ github.event.workflow_run.head_sha }}" | cut -c1-7)
-          echo "msg=$(echo "$MSG" | head -c 200)" >> "$GITHUB_OUTPUT"
-          echo "author=$AUTHOR" >> "$GITHUB_OUTPUT"
-          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          {
+            echo "msg=$(echo "$MSG" | head -c 200)"
+            echo "author=$AUTHOR"
+            echo "short_sha=$SHORT_SHA"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Send push notification
         if: steps.detect.outputs.is_release == 'false'

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -1,0 +1,112 @@
+name: Discord Notify
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  notify-release:
+    name: Notify Discord on release
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push'
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Detect release commit
+        id: detect
+        run: |
+          MSG=$(git log -1 --format='%s' "${{ github.event.workflow_run.head_sha }}")
+          if [[ "$MSG" =~ ^release:\ v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+            echo "version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Collect changes since last release
+        if: steps.detect.outputs.is_release == 'true'
+        id: changes
+        run: |
+          PREV_TAG=$(git tag --sort=-creatordate | grep '^v' | head -1)
+          if [ -z "$PREV_TAG" ]; then
+            PREV_TAG=$(git tag --sort=-creatordate | grep '^cli/v' | head -1)
+          fi
+          if [ -n "$PREV_TAG" ]; then
+            LOGS=$(git log "$PREV_TAG"..HEAD~1 --format='• %s' --no-merges | head -15)
+          else
+            LOGS=$(git log -10 --format='• %s' --no-merges)
+          fi
+          # Escape for JSON
+          LOGS_ESCAPED=$(echo "$LOGS" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))')
+          echo "logs=$LOGS_ESCAPED" >> "$GITHUB_OUTPUT"
+
+      - name: Send release notification
+        if: steps.detect.outputs.is_release == 'true'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          VERSION: ${{ steps.detect.outputs.version }}
+          CHANGES: ${{ steps.changes.outputs.logs }}
+        run: |
+          CHANGES_TEXT=$(echo "$CHANGES" | python3 -c 'import sys,json; print(json.loads(sys.stdin.read()))')
+          BODY=$(python3 -c "
+          import json, os
+          version = os.environ['VERSION']
+          changes = os.environ.get('CHANGES_TEXT', 'No changelog available')
+          payload = {
+            'embeds': [{
+              'title': f'🚀 Alook v{version} Released',
+              'description': f'A new version of Alook has been deployed.\n\n**Changes:**\n{changes}',
+              'color': 3066993,
+              'footer': {'text': 'Alook CI/CD'},
+              'timestamp': '$(date -u +%Y-%m-%dT%H:%M:%SZ)'
+            }]
+          }
+          print(json.dumps(payload))
+          ")
+          curl -sf -H "Content-Type: application/json" -d "$BODY" "$DISCORD_WEBHOOK"
+
+      - name: Collect recent commits for non-release push
+        if: steps.detect.outputs.is_release == 'false'
+        id: commits
+        run: |
+          MSG=$(git log -1 --format='%s' "${{ github.event.workflow_run.head_sha }}")
+          AUTHOR=$(git log -1 --format='%an' "${{ github.event.workflow_run.head_sha }}")
+          SHORT_SHA=$(echo "${{ github.event.workflow_run.head_sha }}" | cut -c1-7)
+          echo "msg=$(echo "$MSG" | head -c 200)" >> "$GITHUB_OUTPUT"
+          echo "author=$AUTHOR" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Send push notification
+        if: steps.detect.outputs.is_release == 'false'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          MSG: ${{ steps.commits.outputs.msg }}
+          AUTHOR: ${{ steps.commits.outputs.author }}
+          SHORT_SHA: ${{ steps.commits.outputs.short_sha }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          BODY=$(python3 -c "
+          import json, os
+          msg = os.environ['MSG']
+          author = os.environ['AUTHOR']
+          sha = os.environ['SHORT_SHA']
+          full_sha = os.environ['SHA']
+          repo = '${{ github.repository }}'
+          payload = {
+            'embeds': [{
+              'title': '✅ Deploy to main',
+              'description': f'[\`{sha}\`](https://github.com/{repo}/commit/{full_sha}) {msg}\n\nby **{author}**',
+              'color': 5763719,
+              'footer': {'text': 'Alook CI/CD'},
+              'timestamp': '$(date -u +%Y-%m-%dT%H:%M:%SZ)'
+            }]
+          }
+          print(json.dumps(payload))
+          ")
+          curl -sf -H "Content-Type: application/json" -d "$BODY" "$DISCORD_WEBHOOK"

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -73,3 +73,25 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release create "${{ steps.version.outputs.tag }}" --generate-notes --title "CLI v${{ steps.version.outputs.version }}"
+
+      - name: Notify Discord
+        if: steps.check.outputs.skip == 'false'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          BODY=$(python3 -c "
+          import json, os
+          version = os.environ['VERSION']
+          payload = {
+            'embeds': [{
+              'title': f'📦 @alook/cli v{version} published to npm',
+              'description': 'A new CLI version is available.\n\n\`\`\`\nnpx @alook/cli@latest\n\`\`\`',
+              'color': 15105570,
+              'url': f'https://www.npmjs.com/package/@alook/cli/v/{version}',
+              'footer': {'text': 'npm registry'},
+            }]
+          }
+          print(json.dumps(payload))
+          ")
+          curl -sf -H "Content-Type: application/json" -d "$BODY" "$DISCORD_WEBHOOK"


### PR DESCRIPTION
# Why we need this PR?

Add automated Discord notifications so the community stays informed about releases and deployments.

## What changed

### New: `.github/workflows/discord-notify.yml`
- Triggered after CI workflow succeeds on `main` branch (via `workflow_run`)
- **Release commits** (`release: vX.Y.Z`): sends a green embed with version number and changelog (commits since last tag)
- **Regular pushes** (feat/fix/chore): sends a blue embed with commit hash, message, and author
- Uses Discord webhook via `DISCORD_WEBHOOK_URL` repository secret

### Modified: `.github/workflows/publish-cli.yml`
- Added a "Notify Discord" step after successful npm publish + GitHub release
- Sends an orange embed with version, npm link, and install command

## Setup required
Add repository secret `DISCORD_WEBHOOK_URL` with the Discord webhook URL.

## Checklist
- [x] Tests added/updated as needed (CI-only change, no application tests needed)
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] CI/CD