### PR TITLE
fix: chat steps loading state and meeting timeline recording

### DIFF
--- a/src/cli/daemon/daemon.ts
+++ b/src/cli/daemon/daemon.ts
@@ -453,6 +453,8 @@ export async function startDaemon(
         // Spawn meeting bots from merged poll response
         if (meetings) {
           for (const m of meetings) {
+            const agentBaseDir = join(config.workspacesRoot, m.workspace_id, m.agent_id, "workdir");
+            const timelineDir = join(agentBaseDir, ".context_timeline");
             spawnMeetingRunner({
               meetingId: m.id,
               meetingUrl: m.meeting_url,
@@ -461,6 +463,9 @@ export async function startDaemon(
               callbackUrl: config.serverURL,
               authToken: ws.token,
               agentName: m.agent_name,
+              agentId: m.agent_id,
+              timelineDir,
+              title: m.title,
             });
           }
         }
@@ -635,6 +640,9 @@ export function spawnMeetingRunner(input: {
   callbackUrl: string;
   authToken: string;
   agentName?: string;
+  agentId?: string;
+  timelineDir?: string;
+  title?: string;
 }): ChildProcess {
   const logDir = sessionRunnerLogDir();
   mkdirSync(logDir, { recursive: true });

--- a/src/cli/daemon/meeting-runner.ts
+++ b/src/cli/daemon/meeting-runner.ts
@@ -15,8 +15,10 @@ import {
 } from "@alook/shared/browser"
 import type { TranscriptEntry } from "@alook/shared/browser"
 import { join } from "path"
+import { mkdirSync } from "fs"
 import { tempDir } from "../lib/platform.js"
 import { createLogger } from "../lib/logger.js"
+import { createTimelineEntry, initEntry, updateEntry } from "./execenv/timeline.js"
 
 const log = createLogger({ module: "meeting-runner" })
 
@@ -33,6 +35,9 @@ export interface MeetingRunnerInput {
   callbackUrl: string
   authToken: string
   agentName?: string
+  agentId?: string
+  timelineDir?: string
+  title?: string
 }
 
 async function callbackWeb(
@@ -166,8 +171,43 @@ async function tryJoinAndRecord(input: MeetingRunnerInput, chromePath: string): 
   }
 }
 
+function writeTimeline(
+  input: MeetingRunnerInput,
+  status: "running" | "completed" | "failed",
+  responses?: string[],
+  errmsg?: string,
+): void {
+  if (!input.timelineDir) return
+  try {
+    mkdirSync(input.timelineDir, { recursive: true })
+    const taskId = `meeting-${input.meetingId}`
+    if (status === "running") {
+      const meetingLabel = input.title || input.meetingUrl
+      const entry = createTimelineEntry(
+        taskId,
+        `Meeting: ${meetingLabel} (participants: ${input.participants.join(", ")})`,
+        "meeting",
+        undefined,
+        process.pid,
+      )
+      initEntry(input.timelineDir, entry)
+    } else {
+      updateEntry(input.timelineDir, taskId, (entry) => {
+        entry.status = status
+        entry.pid = null
+        if (responses) entry.agent_responses = responses
+        if (errmsg) entry.errmsg = errmsg
+      })
+    }
+  } catch (err) {
+    log.debug(`timeline write failed: ${err instanceof Error ? err.message : err}`)
+  }
+}
+
 async function run(input: MeetingRunnerInput): Promise<void> {
   log.info(`starting meeting: url=${input.meetingUrl}`, { meeting: input.meetingId, workspace: input.workspaceId })
+
+  writeTimeline(input, "running")
 
   let chromePath: string
   try {
@@ -176,6 +216,7 @@ async function run(input: MeetingRunnerInput): Promise<void> {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     log.error(`chrome setup failed: ${msg}`, { meeting: input.meetingId })
+    writeTimeline(input, "failed", undefined, `Chrome setup failed: ${msg}`)
     await callbackWeb(input, "failed", undefined, `Chrome setup failed: ${msg}`)
     process.exit(1)
   }
@@ -192,6 +233,13 @@ async function run(input: MeetingRunnerInput): Promise<void> {
     if (result.status === "completed") {
       const transcriptText = formatTranscript(result.transcript)
       log.info(`completed: ${result.transcript.length} transcript entries`, { meeting: input.meetingId })
+
+      const transcriptR2Key = `meetings/${input.meetingId}/transcript`
+      writeTimeline(input, "completed", [
+        `Meeting completed. ${result.transcript.length} transcript entries captured.`,
+        `Transcript stored at: ${transcriptR2Key}`,
+      ])
+
       await callbackWeb(input, "completed", transcriptText)
       return
     }
@@ -200,6 +248,7 @@ async function run(input: MeetingRunnerInput): Promise<void> {
       const elapsed = Date.now() - startTime
       if (elapsed >= MAX_RETRY_DURATION_MS) {
         log.warn(`giving up after ${Math.round(elapsed / 60_000)}min of retries`, { meeting: input.meetingId })
+        writeTimeline(input, "failed", undefined, result.error)
         await callbackWeb(input, "failed", undefined, result.error)
         return
       }
@@ -210,6 +259,7 @@ async function run(input: MeetingRunnerInput): Promise<void> {
     }
 
     // Other errors — don't retry
+    writeTimeline(input, "failed", undefined, result.error)
     await callbackWeb(input, "failed", undefined, result.error)
     return
   }

--- a/src/shared/src/schemas.ts
+++ b/src/shared/src/schemas.ts
@@ -135,7 +135,9 @@ export const PollMeetingItemSchema = z.object({
   meeting_url: z.string(),
   participants: z.array(z.string()),
   workspace_id: z.string(),
+  agent_id: z.string(),
   agent_name: z.string(),
+  title: z.string().optional(),
 });
 export type PollMeetingItem = z.infer<typeof PollMeetingItemSchema>;
 

--- a/src/web/src/app/api/daemon/tasks/poll/route.test.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.test.ts
@@ -711,7 +711,7 @@ describe("POST /api/daemon/tasks/poll", () => {
     mockBroadcastToUser.mockResolvedValue(undefined);
     mockClaimTasksForRuntimes.mockResolvedValue([]);
     mockListScheduledMeetings.mockResolvedValue([
-      { id: "ms1", agentId: "a1", workspaceId: "w1", meetingUrl: "https://meet.google.com/abc", participants: ["alice@test.com"], status: "scheduled", agentName: "Jarvis" },
+      { id: "ms1", agentId: "a1", workspaceId: "w1", meetingUrl: "https://meet.google.com/abc", participants: ["alice@test.com"], status: "scheduled", agentName: "Jarvis", title: "Standup" },
     ]);
     mockClaimMeetingSessions.mockResolvedValue([{
       id: "ms1", agentId: "a1", workspaceId: "w1", meetingUrl: "https://meet.google.com/abc", participants: ["alice@test.com"], status: "joining",
@@ -727,7 +727,9 @@ describe("POST /api/daemon/tasks/poll", () => {
       meeting_url: "https://meet.google.com/abc",
       participants: ["alice@test.com"],
       workspace_id: "w1",
+      agent_id: "a1",
       agent_name: "Jarvis",
+      title: "Standup",
     });
   });
 

--- a/src/web/src/app/api/daemon/tasks/poll/route.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.ts
@@ -261,14 +261,19 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
         now,
       );
       if (claimedRows.length > 0) {
-        const agentNameMap = new Map(scheduled.map((m) => [m.id, m.agentName || ""]));
-        meetings = claimedRows.map((row) => ({
-          id: row.id,
-          meeting_url: row.meetingUrl,
-          participants: row.participants as string[],
-          workspace_id: row.workspaceId,
-          agent_name: agentNameMap.get(row.id) || "",
-        }));
+        const scheduledMap = new Map(scheduled.map((m) => [m.id, m]));
+        meetings = claimedRows.map((row) => {
+          const sched = scheduledMap.get(row.id);
+          return {
+            id: row.id,
+            meeting_url: row.meetingUrl,
+            participants: row.participants as string[],
+            workspace_id: row.workspaceId,
+            agent_id: row.agentId,
+            agent_name: sched?.agentName || "",
+            title: sched?.title || undefined,
+          };
+        });
       }
     }
   } catch (e) {

--- a/src/web/src/app/api/meeting/callback/route.test.ts
+++ b/src/web/src/app/api/meeting/callback/route.test.ts
@@ -113,9 +113,11 @@ describe("POST /api/meeting/callback", () => {
     const mimeContent = mimeCall![1] as string;
     expect(mimeContent).toContain("From: no-reply@alook.ai");
     expect(mimeContent).toContain("To: jarvis@alook.ai");
-    expect(mimeContent).toContain("Subject: Meeting transcript: Weekly");
+    expect(mimeContent).toContain("Subject: Meeting completed: Weekly");
     expect(mimeContent).toContain("MIME-Version: 1.0");
     expect(mimeContent).toContain("Content-Type: text/plain; charset=utf-8");
+    expect(mimeContent).toContain("Meeting \"Weekly\" has ended.");
+    expect(mimeContent).toContain("Please summarize this meeting");
     expect(mimeContent).toContain("[00:01] Alice: Hello");
 
     // Should call email notify with correct r2Key
@@ -126,7 +128,7 @@ describe("POST /api/meeting/callback", () => {
     expect(notifyBody.r2Key).toBe("emails/test-nanoid-123/raw");
     expect(notifyBody.from).toBe("no-reply@alook.ai");
     expect(notifyBody.to).toBe("jarvis@alook.ai");
-    expect(notifyBody.subject).toBe("Meeting transcript: Weekly");
+    expect(notifyBody.subject).toContain("Meeting completed: Weekly");
     expect(notifyBody.isWhitelisted).toBe(true);
     expect(notifyBody.messageId).toBe("<meeting-ms1@alook.ai>");
   });

--- a/src/web/src/app/api/meeting/callback/route.ts
+++ b/src/web/src/app/api/meeting/callback/route.ts
@@ -73,14 +73,26 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
       if (!existing) {
         const fromAddr = "no-reply@alook.ai"
         const toAddr = `${agent.emailHandle}@alook.ai`
-        const subject = `Meeting transcript: ${meeting.title || "Untitled"}`
+        const meetingTitle = meeting.title || "Untitled"
+        const subject = `Meeting completed: ${meetingTitle} — please summarize`
+
+        const emailBody = [
+          `Meeting "${meetingTitle}" has ended. The transcript is below.`,
+          `Transcript R2 key: ${transcriptR2Key}`,
+          "",
+          "Please summarize this meeting and send the summary to the owner.",
+          "",
+          "--- Transcript ---",
+          "",
+          body.transcript,
+        ].join("\n")
 
         const rawMime = buildMimeMessage({
           from: fromAddr,
           to: toAddr,
           subject,
           messageId,
-          body: body.transcript,
+          body: emailBody,
           bodyType: "text/plain",
         })
 

--- a/src/web/src/components/task-stream.tsx
+++ b/src/web/src/components/task-stream.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import type { TaskMessage } from "@alook/shared";
 import type { TaskApi as Task } from "@alook/shared";
 import {
+  Check,
   ChevronRight,
   Brain,
   AlertCircle,
@@ -105,7 +106,7 @@ function groupMessages(messages: TaskMessage[]): StreamItem[] {
 
 /* ── ToolCallBlock ── */
 
-function ToolCallBlock({ item, isRunning }: { item: ToolCallGroup; isRunning: boolean }) {
+function ToolCallBlock({ item, isRunning, isLast }: { item: ToolCallGroup; isRunning: boolean; isLast: boolean }) {
   const inputStr = useMemo(() => {
     if (!item.input) return null;
     try {
@@ -126,8 +127,11 @@ function ToolCallBlock({ item, isRunning }: { item: ToolCallGroup; isRunning: bo
         <span className="font-medium text-foreground/80">
           {formatToolName(item.tool)}
         </span>
-        {isRunning && (
+        {isRunning && isLast && (
           <span className="ml-auto size-1.5 rounded-full bg-primary/60 animate-pulse" />
+        )}
+        {isRunning && !isLast && (
+          <Check className="ml-auto size-3 text-emerald-500" />
         )}
       </div>
     );
@@ -147,8 +151,11 @@ function ToolCallBlock({ item, isRunning }: { item: ToolCallGroup; isRunning: bo
         <span className="font-medium text-foreground/80">
           {formatToolName(item.tool)}
         </span>
-        {isRunning && (
+        {isRunning && isLast && (
           <span className="ml-auto size-1.5 rounded-full bg-primary/60 animate-pulse" />
+        )}
+        {isRunning && !isLast && (
+          <Check className="ml-auto size-3 text-emerald-500" />
         )}
       </summary>
 
@@ -382,10 +389,10 @@ export function TaskStream({
                 <span>Loading steps...</span>
               </div>
             )}
-            {toolItems.map((item) => {
+            {toolItems.map((item, idx) => {
               switch (item.kind) {
                 case "tool-call":
-                  return <ToolCallBlock key={item.id} item={item} isRunning={isRunning} />;
+                  return <ToolCallBlock key={item.id} item={item} isRunning={isRunning} isLast={idx === toolItems.length - 1} />;
                 case "thinking":
                   return <ThinkingBlock key={item.id} item={item as ThinkingItem} />;
                 case "status":


### PR DESCRIPTION
# Why we need this PR?

Addresses two user-reported issues:
1. Chat step indicators showing loading animation on all items instead of only the active one
2. Meeting transcript completion not recorded in agent timeline

## What changed

### 1. Chat steps loading indicator (task-stream.tsx)
- Only the **last** tool call item shows the pulse animation (in-progress)
- All preceding items show a green checkmark (completed)
- Added `isLast` prop to `ToolCallBlock` component

### 2. Meeting timeline recording (meeting-runner.ts, daemon.ts, schemas.ts, poll route)
- Added `agent_id` and `title` to `PollMeetingItem` schema
- Daemon now passes `timelineDir` to meeting runner
- Meeting runner writes timeline entries: "running" on start, "completed"/"failed" on finish
- Completed entries include transcript entry count and R2 storage key

### 3. Meeting completion email (callback route)
- Email subject changed from `Meeting transcript: ...` to `Meeting completed: ... — please summarize`
- Email body now includes summarization prompt and transcript R2 key reference

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [x] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...