### PR TITLE
chore: migrate pnpm v10 → v11 configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "alook",
   "private": true,
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.1.2",
   "scripts": {
     "build": "turbo run build",
     "test": "turbo run test",
@@ -42,15 +42,5 @@
     "typescript": "^6.0.3",
     "vitest": "^4.1.5",
     "wrangler": "^4.90.0"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "msw",
-      "sharp",
-      "simple-git-hooks",
-      "unrs-resolver",
-      "workerd"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,11 @@ packages:
   - "src/email-worker"
   - "src/ws-do"
   - "src/app"
+
+allowBuilds:
+  esbuild: true
+  msw: true
+  sharp: true
+  simple-git-hooks: true
+  unrs-resolver: true
+  workerd: true


### PR DESCRIPTION
# Why we need this PR?

pnpm v11 deprecated `onlyBuiltDependencies` in `package.json#pnpm` and replaced it with `allowBuilds` in `pnpm-workspace.yaml`. This PR migrates the configuration to the v11 format.

Ref: https://pnpm.io/migration

## What changed

- **`package.json`**: Removed `pnpm.onlyBuiltDependencies` array, bumped `packageManager` to `pnpm@11.1.2`
- **`pnpm-workspace.yaml`**: Added `allowBuilds` map with all 6 build-allowed packages (`esbuild`, `msw`, `sharp`, `simple-git-hooks`, `unrs-resolver`, `workerd`)

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] CI/CD
- [x] Other: build toolchain (pnpm configuration)