### PR TITLE
refactor: replace native title with Tooltip and unify Button usage

### DIFF
--- a/src/web/src/app/(app)/w/[slug]/agents/[id]/activity/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/agents/[id]/activity/page.tsx
@@ -6,6 +6,8 @@ import Link from "next/link";
 import { useWorkspace } from "@/contexts/workspace-context";
 import { listAgentActivity, retryTask, type ActivityTask } from "@/lib/api";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import {
   Select,
   SelectTrigger,
@@ -135,12 +137,12 @@ function ActivityRow({ task, slug, agentId, workspaceId, onRetry }: { task: Acti
         <span className="text-sm text-foreground truncate flex-1 min-w-0">
           {task.prompt}
         </span>
-        <span
-          className="text-xs text-muted-foreground shrink-0 ml-2"
-          title={new Date(task.created_at).toLocaleString()}
-        >
-          {relativeTime(task.created_at)}
-        </span>
+        <Tooltip>
+          <TooltipTrigger render={<span className="text-xs text-muted-foreground shrink-0 ml-2" />}>
+            {relativeTime(task.created_at)}
+          </TooltipTrigger>
+          <TooltipContent>{new Date(task.created_at).toLocaleString()}</TooltipContent>
+        </Tooltip>
       </div>
       <div className="flex items-center gap-1.5 mt-1 ml-5.5">
         <StatusDot status={task.status} />
@@ -162,17 +164,20 @@ function ActivityRow({ task, slug, agentId, workspaceId, onRetry }: { task: Acti
           </>
         )}
         {task.status === "failed" && (
-          <button
-            type="button"
-            onClick={handleRetry}
-            disabled={retrying}
-            className="ml-auto shrink-0 text-muted-foreground hover:text-foreground transition-colors cursor-pointer disabled:opacity-50"
-            title="Retry task"
-          >
-            {retrying
-              ? <Loader2 className="size-3 animate-spin" />
-              : <RotateCw className="size-3" />}
-          </button>
+          <Tooltip>
+            <TooltipTrigger render={<Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={handleRetry}
+              disabled={retrying}
+              className="ml-auto text-muted-foreground"
+            />}>
+              {retrying
+                ? <Loader2 className="size-3 animate-spin" />
+                : <RotateCw className="size-3" />}
+            </TooltipTrigger>
+            <TooltipContent>Retry task</TooltipContent>
+          </Tooltip>
         )}
       </div>
     </Link>

--- a/src/web/src/app/(app)/w/[slug]/agents/[id]/email/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/agents/[id]/email/page.tsx
@@ -9,6 +9,7 @@ import type { Email, EmailAttachment, AgentEmailAccount } from "@alook/shared";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { EmailCompose } from "@/components/email-compose";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -263,19 +264,21 @@ export default function AgentEmailPage() {
       {mailboxes.length > 0 ? (
         <div className="px-3 pt-3 pb-1 relative">
           {mailboxes.length === 1 ? (
-            <button
-              type="button"
-              onClick={handleCopyAddress}
-              className="group flex items-center gap-1.5 text-left cursor-pointer w-full"
-              title="Click to copy"
-            >
-              <span className="text-xs text-muted-foreground truncate">{activeAddress}</span>
-              {copied ? (
-                <Check className="size-2.5 text-green-500 shrink-0" />
-              ) : (
-                <Copy className="size-2.5 text-muted-foreground/0 group-hover:text-muted-foreground/60 shrink-0 transition-colors" />
-              )}
-            </button>
+            <Tooltip>
+              <TooltipTrigger render={<button
+                type="button"
+                onClick={handleCopyAddress}
+                className="group flex items-center gap-1.5 text-left cursor-pointer w-full"
+              />}>
+                <span className="text-xs text-muted-foreground truncate">{activeAddress}</span>
+                {copied ? (
+                  <Check className="size-2.5 text-green-500 shrink-0" />
+                ) : (
+                  <Copy className="size-2.5 text-muted-foreground/0 group-hover:text-muted-foreground/60 shrink-0 transition-colors" />
+                )}
+              </TooltipTrigger>
+              <TooltipContent>Click to copy</TooltipContent>
+            </Tooltip>
           ) : (
             <>
               <div className="flex items-center gap-1 w-full">
@@ -287,18 +290,20 @@ export default function AgentEmailPage() {
                   <span className="text-xs text-muted-foreground truncate">{activeAddress}</span>
                   <ChevronDown className="size-2.5 text-muted-foreground shrink-0" />
                 </button>
-                <button
-                  type="button"
-                  onClick={handleCopyAddress}
-                  className="shrink-0 p-0.5"
-                  title="Copy address"
-                >
-                  {copied ? (
-                    <Check className="size-2.5 text-green-500" />
-                  ) : (
-                    <Copy className="size-2.5 text-muted-foreground/40 hover:text-muted-foreground/80 transition-colors" />
-                  )}
-                </button>
+                <Tooltip>
+                  <TooltipTrigger render={<button
+                    type="button"
+                    onClick={handleCopyAddress}
+                    className="shrink-0 p-0.5"
+                  />}>
+                    {copied ? (
+                      <Check className="size-2.5 text-green-500" />
+                    ) : (
+                      <Copy className="size-2.5 text-muted-foreground/40 hover:text-muted-foreground/80 transition-colors" />
+                    )}
+                  </TooltipTrigger>
+                  <TooltipContent>Copy address</TooltipContent>
+                </Tooltip>
               </div>
               {mailboxOpen && (
                 <div className="absolute left-2 right-2 top-full mt-0.5 z-10 rounded-lg border border-border bg-popover shadow-md py-1">
@@ -330,16 +335,18 @@ export default function AgentEmailPage() {
         </div>
       )}
       <div className="p-2">
-        <Button
-          size="sm"
-          className="w-full justify-start text-xs h-8 gap-1.5"
-          onClick={() => { setComposeInitial({}); setComposing(true); setSelectedId(null); }}
-          disabled={mailboxes.length === 0}
-          title={mailboxes.length === 0 ? "Configure an email in agent settings to send emails" : "Compose new email"}
-        >
-          <Plus className="size-3.5" />
-          New Email
-        </Button>
+        <Tooltip>
+          <TooltipTrigger render={<Button
+            size="sm"
+            className="w-full justify-start text-xs h-8 gap-1.5"
+            onClick={() => { setComposeInitial({}); setComposing(true); setSelectedId(null); }}
+            disabled={mailboxes.length === 0}
+          />}>
+            <Plus className="size-3.5" />
+            New Email
+          </TooltipTrigger>
+          <TooltipContent>{mailboxes.length === 0 ? "Configure an email in agent settings to send emails" : "Compose new email"}</TooltipContent>
+        </Tooltip>
       </div>
       <nav className="flex flex-col gap-0.5 px-2">
         <button
@@ -484,37 +491,43 @@ export default function AgentEmailPage() {
           {/* Detail toolbar */}
           <div className="flex items-center gap-0.5 border-b border-border/40 px-4 py-1.5">
             {folder !== "sent" && (
-              <Button
+              <Tooltip>
+                <TooltipTrigger render={<Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-7 text-muted-foreground/60 hover:text-foreground"
+                  onClick={() => handleReply(selected)}
+                />}>
+                  <Reply className="size-3.5" />
+                </TooltipTrigger>
+                <TooltipContent>Reply</TooltipContent>
+              </Tooltip>
+            )}
+            <Tooltip>
+              <TooltipTrigger render={<Button
                 variant="ghost"
                 size="icon"
                 className="size-7 text-muted-foreground/60 hover:text-foreground"
-                title="Reply"
-                onClick={() => handleReply(selected)}
-              >
-                <Reply className="size-3.5" />
-              </Button>
-            )}
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-7 text-muted-foreground/60 hover:text-foreground"
-              title="Forward"
-              onClick={() => handleForward(selected)}
-            >
-              <Forward className="size-3.5" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-7 text-muted-foreground/60 hover:text-destructive"
-              title="Delete"
-              onClick={() => {
-                setDeleteTarget(selected.id);
-                setDeleteConfirmOpen(true);
-              }}
-            >
-              <Trash2 className="size-3.5" />
-            </Button>
+                onClick={() => handleForward(selected)}
+              />}>
+                <Forward className="size-3.5" />
+              </TooltipTrigger>
+              <TooltipContent>Forward</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger render={<Button
+                variant="ghost"
+                size="icon"
+                className="size-7 text-muted-foreground/60 hover:text-destructive"
+                onClick={() => {
+                  setDeleteTarget(selected.id);
+                  setDeleteConfirmOpen(true);
+                }}
+              />}>
+                <Trash2 className="size-3.5" />
+              </TooltipTrigger>
+              <TooltipContent>Delete</TooltipContent>
+            </Tooltip>
           </div>
 
           {/* Thread parents */}
@@ -685,18 +698,20 @@ export default function AgentEmailPage() {
                 <span className="text-xs text-muted-foreground truncate">{activeAddress}</span>
                 <ChevronDown className="size-2.5 text-muted-foreground shrink-0" />
               </button>
-              <button
-                type="button"
-                onClick={handleCopyAddress}
-                className="shrink-0 p-0.5"
-                title="Copy address"
-              >
-                {copied ? (
-                  <Check className="size-2.5 text-green-500" />
-                ) : (
-                  <Copy className="size-2.5 text-muted-foreground/40 hover:text-muted-foreground/80 transition-colors" />
-                )}
-              </button>
+              <Tooltip>
+                <TooltipTrigger render={<button
+                  type="button"
+                  onClick={handleCopyAddress}
+                  className="shrink-0 p-0.5"
+                />}>
+                  {copied ? (
+                    <Check className="size-2.5 text-green-500" />
+                  ) : (
+                    <Copy className="size-2.5 text-muted-foreground/40 hover:text-muted-foreground/80 transition-colors" />
+                  )}
+                </TooltipTrigger>
+                <TooltipContent>Copy address</TooltipContent>
+              </Tooltip>
             </div>
             {mailboxOpen && (
               <div className="absolute left-2 right-2 top-full mt-0.5 z-10 rounded-lg border border-border bg-popover shadow-md py-1">

--- a/src/web/src/app/(app)/w/[slug]/agents/[id]/files/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/agents/[id]/files/page.tsx
@@ -6,6 +6,7 @@ import { useAgentContext } from "@/contexts/agent-context";
 import { useWorkspace } from "@/contexts/workspace-context";
 import { requestWorkspaceBrowse } from "@/lib/api";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { ResizablePanels } from "@/components/ui/resizable-panels";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -239,13 +240,15 @@ export default function AgentFilesPage() {
 
   const pathBar = (
     <div className="flex items-center gap-1.5 px-4 py-2 border-b border-border/50 text-xs text-muted-foreground shrink-0 min-w-0">
-      <button
-        onClick={handleCopyPath}
-        className="hover:text-foreground transition-colors shrink-0"
-        title="Copy full path"
-      >
-        <Copy className="size-3" />
-      </button>
+      <Tooltip>
+        <TooltipTrigger render={<button
+          onClick={handleCopyPath}
+          className="hover:text-foreground transition-colors shrink-0"
+        />}>
+          <Copy className="size-3" />
+        </TooltipTrigger>
+        <TooltipContent>Copy full path</TooltipContent>
+      </Tooltip>
       <span className="truncate opacity-60">{rootLabel}</span>
     </div>
   );

--- a/src/web/src/app/(app)/w/[slug]/agents/[id]/layout.tsx
+++ b/src/web/src/app/(app)/w/[slug]/agents/[id]/layout.tsx
@@ -19,6 +19,7 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { fetchModelOptions } from "@/lib/api";
 
 export default function AgentDetailLayout({ children }: { children: ReactNode }) {
@@ -72,15 +73,18 @@ export default function AgentDetailLayout({ children }: { children: ReactNode })
             <Skeleton className="size-2 rounded-full shrink-0" />
           )}
           {agent ? (
-            <Link
-              href={`/w/${slug}/agents/${agentId}`}
-              onClick={() => setEditing(false)}
-              className="text-sm font-medium truncate hover:text-foreground/80 transition-colors"
-            >
-              <span title={agent.description || "No description"}>
+            <Tooltip>
+              <TooltipTrigger render={
+                <Link
+                  href={`/w/${slug}/agents/${agentId}`}
+                  onClick={() => setEditing(false)}
+                  className="text-sm font-medium truncate hover:text-foreground/80 transition-colors"
+                />
+              }>
                 {agent.name}
-              </span>
-            </Link>
+              </TooltipTrigger>
+              <TooltipContent>{agent.description || "No description"}</TooltipContent>
+            </Tooltip>
           ) : (
             <Skeleton className="h-3.5 w-24" />
           )}

--- a/src/web/src/app/(app)/w/[slug]/agents/new/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/agents/new/page.tsx
@@ -8,6 +8,8 @@ import { AgentCreateForm } from "@/components/agent-create-form";
 import { fetchModelOptions, createEmailAccount } from "@/lib/api";
 import { toast } from "sonner";
 import { CircleHelp } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
 
 export default function CreateAgentPage() {
@@ -36,14 +38,21 @@ export default function CreateAgentPage() {
     <>
       <div className="flex items-center gap-2 border-b border-border/50 px-3 md:px-5 py-2.5">
         <h1 className="text-sm font-medium">Create Agent</h1>
-        <button
-          type="button"
-          title="Show guided tour"
-          onClick={() => startTourRef.current?.()}
-          className="text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <CircleHelp className="size-3.5" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={() => startTourRef.current?.()}
+                className="text-muted-foreground"
+              />
+            }
+          >
+            <CircleHelp className="size-3.5" />
+          </TooltipTrigger>
+          <TooltipContent>Show guided tour</TooltipContent>
+        </Tooltip>
       </div>
 
       <AgentCreateForm

--- a/src/web/src/app/(app)/w/[slug]/flags/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/flags/page.tsx
@@ -6,9 +6,11 @@ import { listFlaggedItems, unflagMessage as apiUnflagMessage, type FlaggedItem }
 import { useFlagCount } from "@/contexts/flag-count-context";
 import { useAgentChatSheet } from "@/contexts/agent-chat-sheet-context";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 import { Flag, X } from "lucide-react";
 import { AgentAvatar } from "@/components/avatar";
 import { relativeTime } from "@/lib/time";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
 const FLAG_LIMIT = 30;
 
@@ -36,9 +38,12 @@ function FlagRow({
             <span className="text-sm text-foreground truncate flex-1 min-w-0">
               {item.message_content}
             </span>
-            <span className="text-xs text-muted-foreground shrink-0 ml-2" title={new Date(item.flagged_at).toLocaleString()}>
-              {relativeTime(item.flagged_at)}
-            </span>
+            <Tooltip>
+              <TooltipTrigger render={<span className="text-xs text-muted-foreground shrink-0 ml-2" />}>
+                {relativeTime(item.flagged_at)}
+              </TooltipTrigger>
+              <TooltipContent>{new Date(item.flagged_at).toLocaleString()}</TooltipContent>
+            </Tooltip>
           </div>
           <div className="flex items-center gap-1.5 mt-0.5">
             {item.agent_name && (
@@ -52,18 +57,25 @@ function FlagRow({
             )}
           </div>
         </div>
-        <button
-          type="button"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            onUnflag();
-          }}
-          className="flex items-center justify-center size-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0 cursor-pointer"
-          title="Unflag"
-        >
-          <X className="size-3.5" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onUnflag();
+                }}
+                className="text-muted-foreground"
+              />
+            }
+          >
+            <X className="size-3.5" />
+          </TooltipTrigger>
+          <TooltipContent>Unflag</TooltipContent>
+        </Tooltip>
       </div>
     </a>
   );

--- a/src/web/src/app/(app)/w/[slug]/home/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/home/page.tsx
@@ -32,6 +32,7 @@ import { useWorkspace } from "@/contexts/workspace-context";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useAgentChatSheet } from "@/contexts/agent-chat-sheet-context";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { AgentPreviewCard } from "@/components/agent-preview-card";
 import {
   listAgentLinks,
@@ -428,15 +429,21 @@ function AgentCanvas({ onAgentClick }: { onAgentClick?: (agent: Agent) => void }
       </div>
 
       {/* Create agent button */}
-      <button
-        type="button"
-        className="absolute top-4 right-4 size-8 rounded-lg bg-background/80 backdrop-blur-sm ring-1 ring-foreground/5 flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent transition-colors animate-[fade-up_300ms_ease-out_both]"
-        style={{ animationDelay: "200ms" }}
-        onClick={() => router.push(`/w/${slug}/agents/new`)}
-        title="Create new agent"
-      >
-        <Plus className="size-4" />
-      </button>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              className="absolute top-4 right-4 size-8 rounded-lg bg-background/80 backdrop-blur-sm ring-1 ring-foreground/5 flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent transition-colors animate-[fade-up_300ms_ease-out_both]"
+              style={{ animationDelay: "200ms" }}
+              onClick={() => router.push(`/w/${slug}/agents/new`)}
+            />
+          }
+        >
+          <Plus className="size-4" />
+        </TooltipTrigger>
+        <TooltipContent>Create new agent</TooltipContent>
+      </Tooltip>
     </div>
   );
 }
@@ -493,14 +500,20 @@ function MobileAgentList({ onAgentClick }: { onAgentClick?: (agent: Agent) => vo
           );
         })}
       </div>
-      <button
-        type="button"
-        className="absolute top-4 right-4 size-8 rounded-lg bg-background/80 backdrop-blur-sm ring-1 ring-foreground/5 flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-        onClick={() => router.push(`/w/${slug}/agents/new`)}
-        title="Create new agent"
-      >
-        <Plus className="size-4" />
-      </button>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              className="absolute top-4 right-4 size-8 rounded-lg bg-background/80 backdrop-blur-sm ring-1 ring-foreground/5 flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+              onClick={() => router.push(`/w/${slug}/agents/new`)}
+            />
+          }
+        >
+          <Plus className="size-4" />
+        </TooltipTrigger>
+        <TooltipContent>Create new agent</TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/src/web/src/app/(app)/w/[slug]/runtimes/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/runtimes/page.tsx
@@ -20,6 +20,7 @@ import {
   SheetBody,
 } from "@/components/ui/sheet";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { toast } from "sonner";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Monitor, Plus } from "lucide-react";
@@ -433,17 +434,23 @@ export default function RuntimesPage() {
                           <p className="text-[11px] text-muted-foreground mb-1.5">
                             Bring this machine online:
                           </p>
-                          <div
-                            className="relative overflow-hidden rounded-md bg-muted px-2.5 py-1.5 font-mono text-[11px] text-muted-foreground cursor-pointer hover:bg-muted/80 transition-colors"
-                            onClick={() => {
-                              navigator.clipboard.writeText(`${cliCmd()} daemon start`);
-                              toast.success("Copied to clipboard");
-                            }}
-                            title="Click to copy"
-                          >
-                            <span className="absolute inset-0 -translate-x-full animate-[shimmer_2.5s_infinite] bg-linear-to-r from-transparent via-(--shimmer-peak) to-transparent" />
-                            <span className="relative">{cliCmd()} daemon start</span>
-                          </div>
+                          <Tooltip>
+                            <TooltipTrigger
+                              render={
+                                <div
+                                  className="relative overflow-hidden rounded-md bg-muted px-2.5 py-1.5 font-mono text-[11px] text-muted-foreground cursor-pointer hover:bg-muted/80 transition-colors"
+                                  onClick={() => {
+                                    navigator.clipboard.writeText(`${cliCmd()} daemon start`);
+                                    toast.success("Copied to clipboard");
+                                  }}
+                                />
+                              }
+                            >
+                              <span className="absolute inset-0 -translate-x-full animate-[shimmer_2.5s_infinite] bg-linear-to-r from-transparent via-(--shimmer-peak) to-transparent" />
+                              <span className="relative">{cliCmd()} daemon start</span>
+                            </TooltipTrigger>
+                            <TooltipContent>Click to copy</TooltipContent>
+                          </Tooltip>
                         </div>
                       )}
                     </div>

--- a/src/web/src/app/(app)/w/[slug]/settings/members-tab.tsx
+++ b/src/web/src/app/(app)/w/[slug]/settings/members-tab.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 function getInviteLink(token: string) {
@@ -157,25 +158,29 @@ export function MembersTab() {
                     </div>
                     <div className="flex items-center gap-1 ml-2 shrink-0">
                       {!isExpired && (
-                        <Button
+                        <Tooltip>
+                          <TooltipTrigger render={<Button
+                            size="sm"
+                            variant="ghost"
+                            className="h-7 w-7 p-0"
+                            onClick={() => handleCopyInvite(invite.token)}
+                          />}>
+                            <Copy className="size-3.5" />
+                          </TooltipTrigger>
+                          <TooltipContent>Copy invite link</TooltipContent>
+                        </Tooltip>
+                      )}
+                      <Tooltip>
+                        <TooltipTrigger render={<Button
                           size="sm"
                           variant="ghost"
-                          className="h-7 w-7 p-0"
-                          onClick={() => handleCopyInvite(invite.token)}
-                          title="Copy invite link"
-                        >
-                          <Copy className="size-3.5" />
-                        </Button>
-                      )}
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        className="h-7 w-7 p-0 text-destructive hover:text-destructive"
-                        onClick={() => handleRevokeInvite(invite.id)}
-                        title="Revoke invite"
-                      >
-                        <Trash2 className="size-3.5" />
-                      </Button>
+                          className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+                          onClick={() => handleRevokeInvite(invite.id)}
+                        />}>
+                          <Trash2 className="size-3.5" />
+                        </TooltipTrigger>
+                        <TooltipContent>Revoke invite</TooltipContent>
+                      </Tooltip>
                     </div>
                   </div>
                 );
@@ -241,15 +246,17 @@ export function MembersTab() {
 
                 {/* Remove button — owner only, not on self */}
                 {isOwner && !isSelf && (
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive shrink-0"
-                    onClick={() => handleRemoveMember(member.id)}
-                    title="Remove member"
-                  >
-                    <UserMinus className="size-3.5" />
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger render={<Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive shrink-0"
+                      onClick={() => handleRemoveMember(member.id)}
+                    />}>
+                      <UserMinus className="size-3.5" />
+                    </TooltipTrigger>
+                    <TooltipContent>Remove member</TooltipContent>
+                  </Tooltip>
                 )}
               </div>
             );

--- a/src/web/src/app/(app)/w/[slug]/threads/[traceId]/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/threads/[traceId]/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { useWorkspace } from "@/contexts/workspace-context";
 import { getTrace, type TraceTask } from "@/lib/api";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -133,9 +134,12 @@ function TaskNode({ node, slug }: { node: TreeNode; slug: string }) {
             <span className="text-sm text-foreground truncate flex-1 min-w-0">
               {node.prompt.split("\n")[0]}
             </span>
-            <span className="text-xs text-muted-foreground shrink-0 ml-2" title={new Date(node.created_at).toLocaleString()}>
-              {relativeTime(node.created_at)}
-            </span>
+            <Tooltip>
+              <TooltipTrigger render={<span className="text-xs text-muted-foreground shrink-0 ml-2" />}>
+                {relativeTime(node.created_at)}
+              </TooltipTrigger>
+              <TooltipContent>{new Date(node.created_at).toLocaleString()}</TooltipContent>
+            </Tooltip>
           </div>
           <div className="flex items-center gap-1.5">
             {node.agent?.name && (

--- a/src/web/src/app/(app)/w/[slug]/threads/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/threads/page.tsx
@@ -17,6 +17,8 @@ import {
 } from "@/components/ui/select";
 import { GitBranch, RefreshCw } from "lucide-react";
 import { AvatarRenderer, parseAvatarUrl } from "@/components/avatar";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
 const TRACE_LIMIT = 30;
 
@@ -99,9 +101,12 @@ function TraceRow({ trace, slug }: { trace: TraceListItem; slug: string }) {
             <span className="text-sm text-foreground truncate flex-1 min-w-0">
               {trace.root_prompt.split("\n")[0]}
             </span>
-            <span className="text-xs text-muted-foreground shrink-0 ml-2" title={new Date(trace.started_at).toLocaleString()}>
-              {relativeTime(trace.started_at)}
-            </span>
+            <Tooltip>
+              <TooltipTrigger render={<span className="text-xs text-muted-foreground shrink-0 ml-2" />}>
+                {relativeTime(trace.started_at)}
+              </TooltipTrigger>
+              <TooltipContent>{new Date(trace.started_at).toLocaleString()}</TooltipContent>
+            </Tooltip>
           </div>
           <div className="flex items-center gap-1.5">
             {trace.root_agent?.name && (
@@ -275,14 +280,21 @@ export default function TracesPage() {
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={loadInitial}
-            className="p-1.5 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-            title="Refresh"
-          >
-            <RefreshCw className="size-3.5" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={loadInitial}
+                  className="text-muted-foreground"
+                />
+              }
+            >
+              <RefreshCw className="size-3.5" />
+            </TooltipTrigger>
+            <TooltipContent>Refresh</TooltipContent>
+          </Tooltip>
         </div>
       </div>
 

--- a/src/web/src/app/(app)/w/[slug]/unread/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/unread/page.tsx
@@ -3,10 +3,12 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useWorkspace } from "@/contexts/workspace-context";
 import { useAgentContext } from "@/contexts/agent-context";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { listInboxItems, markAllInboxRead, type InboxItem } from "@/lib/api";
 import { useInboxCount } from "@/contexts/inbox-count-context";
 import { useAgentChatSheet } from "@/contexts/agent-chat-sheet-context";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Inbox, ListFilter, CheckCheck } from "lucide-react";
@@ -66,9 +68,12 @@ function InboxRow({ item, slug, onClick }: { item: InboxItem; slug: string; onCl
             <span className="text-sm text-foreground truncate flex-1 min-w-0">
               {item.root_prompt ?? item.title}
             </span>
-            <span className="text-xs text-muted-foreground shrink-0 ml-2" title={new Date(item.latest_response_at).toLocaleString()}>
-              {relativeTime(item.latest_response_at)}
-            </span>
+            <Tooltip>
+              <TooltipTrigger render={<span className="text-xs text-muted-foreground shrink-0 ml-2" />}>
+                {relativeTime(item.latest_response_at)}
+              </TooltipTrigger>
+              <TooltipContent>{new Date(item.latest_response_at).toLocaleString()}</TooltipContent>
+            </Tooltip>
           </div>
           <div className="flex items-center gap-1.5 mt-0.5">
             {item.agent_name && (
@@ -271,14 +276,15 @@ export default function InboxPage() {
             </PopoverContent>
           </Popover>
           {!loading && items.length > 0 && (
-            <button
-              type="button"
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={handleMarkAllRead}
-              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+              className="text-xs text-muted-foreground"
             >
               <CheckCheck className="size-3.5" />
               <span>Mark all as read</span>
-            </button>
+            </Button>
           )}
         </div>
       </div>

--- a/src/web/src/components/agent-chat/message-list.tsx
+++ b/src/web/src/components/agent-chat/message-list.tsx
@@ -2,6 +2,8 @@ import React, { memo, useState } from "react";
 import type { Agent, Artifact, Message, TaskApi as Task, TaskMessage } from "@alook/shared";
 
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { Streamdown } from "streamdown";
 import { highlightMentions } from "@/lib/highlight-mentions";
 import { TaskStream } from "@/components/task-stream";
@@ -207,44 +209,58 @@ export const MessageItem = memo(function MessageItem({
             <Streamdown controls={{ code: { copy: true, download: false }, table: { copy: true, download: false, fullscreen: true } }} linkSafety={{ enabled: false }} allowedTags={MENTION_ALLOWED_TAGS} literalTagContent={MENTION_LITERAL_TAGS} components={mentionComponents}>{highlightMentions(msg.content, agents)}</Streamdown>
           </div>
           <div className="flex flex-row items-center gap-1">
-            <button
-              type="button"
-              aria-label={copied ? "Copied" : "Copy message"}
-              title={copied ? "Copied" : "Copy"}
-              onClick={async (e) => {
-                e.stopPropagation();
-                try {
-                  await navigator.clipboard.writeText(msg.content);
-                  setCopied(true);
-                  toast.success("Copied to clipboard");
-                  setTimeout(() => setCopied(false), 2000);
-                } catch {
-                  toast.error("Failed to copy");
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    aria-label={copied ? "Copied" : "Copy message"}
+                    onClick={async (e) => {
+                      e.stopPropagation();
+                      try {
+                        await navigator.clipboard.writeText(msg.content);
+                        setCopied(true);
+                        toast.success("Copied to clipboard");
+                        setTimeout(() => setCopied(false), 2000);
+                      } catch {
+                        toast.error("Failed to copy");
+                      }
+                    }}
+                    className={cn(
+                      "self-start mb-1",
+                      copied
+                        ? "text-green-500 opacity-100"
+                        : "text-muted-foreground opacity-0 group-hover/msg:opacity-100"
+                    )}
+                  />
                 }
-              }}
-              className={cn(
-                "self-start mb-1 flex items-center justify-center size-6 rounded-md transition-all duration-150 cursor-pointer shrink-0",
-                copied
-                  ? "text-green-500 opacity-100"
-                  : "text-muted-foreground opacity-0 group-hover/msg:opacity-100 hover:text-foreground hover:bg-muted"
-              )}
-            >
-              {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
-            </button>
-            {onToggleFlag && (
-              <button
-                type="button"
-                onClick={() => onToggleFlag(msg.id)}
-                className={cn(
-                  "self-start mb-1 flex items-center justify-center size-6 rounded-md transition-all duration-150 cursor-pointer shrink-0",
-                  isFlagged
-                    ? "text-primary opacity-100"
-                    : "text-muted-foreground opacity-0 group-hover/msg:opacity-100 hover:text-foreground hover:bg-muted"
-                )}
-                title={isFlagged ? "Unflag" : "Flag"}
               >
-                <Flag className={cn("size-3.5", isFlagged && "fill-current")} />
-              </button>
+                {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+              </TooltipTrigger>
+              <TooltipContent>{copied ? "Copied" : "Copy"}</TooltipContent>
+            </Tooltip>
+            {onToggleFlag && (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="icon-xs"
+                      onClick={() => onToggleFlag(msg.id)}
+                      className={cn(
+                        "self-start mb-1",
+                        isFlagged
+                          ? "text-primary opacity-100"
+                          : "text-muted-foreground opacity-0 group-hover/msg:opacity-100"
+                      )}
+                    />
+                  }
+                >
+                  <Flag className={cn("size-3.5", isFlagged && "fill-current")} />
+                </TooltipTrigger>
+                <TooltipContent>{isFlagged ? "Unflag" : "Flag"}</TooltipContent>
+              </Tooltip>
             )}
           </div>
         </div>

--- a/src/web/src/components/agent-chat/message-list.tsx
+++ b/src/web/src/components/agent-chat/message-list.tsx
@@ -143,15 +143,81 @@ export const MessageItem = memo(function MessageItem({
       ? stepCount
       : 0;
 
+  const isTaskDone = hasTaskStream && activeTask && ["completed", "failed", "cancelled", "superseded"].includes(activeTask.status);
+
+  const actionButtons = msg.role === "assistant" ? (
+    <div className="flex flex-row items-center gap-1">
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              aria-label={copied ? "Copied" : "Copy message"}
+              onClick={async (e) => {
+                e.stopPropagation();
+                try {
+                  await navigator.clipboard.writeText(msg.content);
+                  setCopied(true);
+                  toast.success("Copied to clipboard");
+                  setTimeout(() => setCopied(false), 2000);
+                } catch {
+                  toast.error("Failed to copy");
+                }
+              }}
+              className={cn(
+                "self-start mb-1",
+                copied
+                  ? "text-green-500 opacity-100"
+                  : "text-muted-foreground opacity-0 group-hover/msg:opacity-100"
+              )}
+            />
+          }
+        >
+          {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+        </TooltipTrigger>
+        <TooltipContent>{copied ? "Copied" : "Copy"}</TooltipContent>
+      </Tooltip>
+      {onToggleFlag && (
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={() => onToggleFlag(msg.id)}
+                className={cn(
+                  "self-start mb-1",
+                  isFlagged
+                    ? "text-primary opacity-100"
+                    : "text-muted-foreground opacity-0 group-hover/msg:opacity-100"
+                )}
+              />
+            }
+          >
+            <Flag className={cn("size-3.5", isFlagged && "fill-current")} />
+          </TooltipTrigger>
+          <TooltipContent>{isFlagged ? "Unflag" : "Flag"}</TooltipContent>
+        </Tooltip>
+      )}
+    </div>
+  ) : null;
+
   return (
     <React.Fragment>
       {hasTaskStream && (
-        <TaskStream
-          task={activeTask}
-          messages={taskMessages}
-          connectionLost={connectionLost}
-          onRetry={onRetry}
-        />
+        <div className={cn(
+          "group/msg",
+          isFlagged && "bg-muted/30 rounded-lg px-2 -mx-2"
+        )}>
+          <TaskStream
+            task={activeTask}
+            messages={taskMessages}
+            connectionLost={connectionLost}
+            onRetry={onRetry}
+          />
+          {isTaskDone && actionButtons}
+        </div>
       )}
       {historicalStepCount > 0 && msg.task_id && (
         <HistoricalTaskSteps
@@ -208,61 +274,7 @@ export const MessageItem = memo(function MessageItem({
           <div className="markdown max-w-full min-w-0 px-1 py-1 text-base text-foreground">
             <Streamdown controls={{ code: { copy: true, download: false }, table: { copy: true, download: false, fullscreen: true } }} linkSafety={{ enabled: false }} allowedTags={MENTION_ALLOWED_TAGS} literalTagContent={MENTION_LITERAL_TAGS} components={mentionComponents}>{highlightMentions(msg.content, agents)}</Streamdown>
           </div>
-          <div className="flex flex-row items-center gap-1">
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button
-                    variant="ghost"
-                    size="icon-xs"
-                    aria-label={copied ? "Copied" : "Copy message"}
-                    onClick={async (e) => {
-                      e.stopPropagation();
-                      try {
-                        await navigator.clipboard.writeText(msg.content);
-                        setCopied(true);
-                        toast.success("Copied to clipboard");
-                        setTimeout(() => setCopied(false), 2000);
-                      } catch {
-                        toast.error("Failed to copy");
-                      }
-                    }}
-                    className={cn(
-                      "self-start mb-1",
-                      copied
-                        ? "text-green-500 opacity-100"
-                        : "text-muted-foreground opacity-0 group-hover/msg:opacity-100"
-                    )}
-                  />
-                }
-              >
-                {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
-              </TooltipTrigger>
-              <TooltipContent>{copied ? "Copied" : "Copy"}</TooltipContent>
-            </Tooltip>
-            {onToggleFlag && (
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <Button
-                      variant="ghost"
-                      size="icon-xs"
-                      onClick={() => onToggleFlag(msg.id)}
-                      className={cn(
-                        "self-start mb-1",
-                        isFlagged
-                          ? "text-primary opacity-100"
-                          : "text-muted-foreground opacity-0 group-hover/msg:opacity-100"
-                      )}
-                    />
-                  }
-                >
-                  <Flag className={cn("size-3.5", isFlagged && "fill-current")} />
-                </TooltipTrigger>
-                <TooltipContent>{isFlagged ? "Unflag" : "Flag"}</TooltipContent>
-              </Tooltip>
-            )}
-          </div>
+          {actionButtons}
         </div>
       ) : null}
     </React.Fragment>

--- a/src/web/src/components/agent-status-badge.tsx
+++ b/src/web/src/components/agent-status-badge.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { badgeVariants } from "@/components/ui/badge";
 import { Badge } from "@/components/ui/badge";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import { listWorkspaceActiveTasks, type WorkspaceActiveTask } from "@/lib/api";
@@ -82,14 +83,19 @@ export function AgentStatusBadge({ isOnline, taskCount, agentId }: AgentStatusBa
 
   if (!isOnline) {
     return (
-      <Badge
-        variant="outline"
-        render={<Link href={`/w/${slug}/runtimes`} title="Runtime offline — click to manage runtimes" />}
-        className={badgeBase}
-      >
-        <StatusDot online={false} />
-        <span className="hidden sm:inline">Offline</span>
-      </Badge>
+      <Tooltip>
+        <TooltipTrigger render={
+          <Badge
+            variant="outline"
+            render={<Link href={`/w/${slug}/runtimes`} />}
+            className={badgeBase}
+          >
+            <StatusDot online={false} />
+            <span className="hidden sm:inline">Offline</span>
+          </Badge>
+        } />
+        <TooltipContent>Runtime offline — click to manage runtimes</TooltipContent>
+      </Tooltip>
     );
   }
 

--- a/src/web/src/components/app-sidebar.tsx
+++ b/src/web/src/components/app-sidebar.tsx
@@ -635,20 +635,26 @@ export function AppSidebar({ onNavigate }: { onNavigate?: () => void } = {}) {
             </TooltipContent>
           </Tooltip>
         ) : (
-          <button
-            type="button"
-            title="New agent"
-            onClick={() => { router.push(`${prefix}/agents/new`); onNavigate?.(); }}
-            className={cn(
-              "flex shrink-0 items-center justify-center size-10 rounded-xl transition-colors duration-200 cursor-pointer",
-              "border border-dashed border-foreground/15 text-muted-foreground",
-              "hover:border-foreground/30 hover:text-foreground hover:bg-accent",
-              isCreateAgent &&
-                "border-solid border-foreground/25 bg-accent text-foreground"
-            )}
-          >
-            <Plus className="size-4" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <button
+                  type="button"
+                  onClick={() => { router.push(`${prefix}/agents/new`); onNavigate?.(); }}
+                  className={cn(
+                    "flex shrink-0 items-center justify-center size-10 rounded-xl transition-colors duration-200 cursor-pointer",
+                    "border border-dashed border-foreground/15 text-muted-foreground",
+                    "hover:border-foreground/30 hover:text-foreground hover:bg-accent",
+                    isCreateAgent &&
+                      "border-solid border-foreground/25 bg-accent text-foreground"
+                  )}
+                />
+              }
+            >
+              <Plus className="size-4" />
+            </TooltipTrigger>
+            <TooltipContent>New agent</TooltipContent>
+          </Tooltip>
         )}
       </div>
 

--- a/src/web/src/components/avatar/avatar-generator.tsx
+++ b/src/web/src/components/avatar/avatar-generator.tsx
@@ -15,6 +15,7 @@ import {
   randomConfig,
 } from "./avatar-parts";
 import { cn } from "@/lib/utils";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
 // ─────────────────────────────────────────────────────────────
 // CYCLER — left/right carousel for picking a part
@@ -315,20 +316,25 @@ export function AvatarGenerator({ config, onChange, layout = "vertical", mobile 
             </div>
             <div className={cn("flex flex-wrap p-1", mobile ? "gap-3" : "gap-2")}>
               {BG_COLORS.map((c, i) => (
-                <button
-                  key={c.value}
-                  type="button"
-                  onClick={() => setField("bg", i)}
-                  title={c.name}
-                  className={cn(
-                    "rounded-full transition-shadow",
-                    mobile ? "size-8" : "size-7",
-                    config.bg === i
-                      ? "ring-2 ring-primary ring-offset-2"
-                      : "ring-1 ring-border"
-                  )}
-                  style={{ background: `linear-gradient(135deg, ${c.gradient[0]}, ${c.gradient[1]}, ${c.gradient[2]})` }}
-                />
+                <Tooltip key={c.value}>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        type="button"
+                        onClick={() => setField("bg", i)}
+                        className={cn(
+                          "rounded-full transition-shadow",
+                          mobile ? "size-8" : "size-7",
+                          config.bg === i
+                            ? "ring-2 ring-primary ring-offset-2"
+                            : "ring-1 ring-border"
+                        )}
+                        style={{ background: `linear-gradient(135deg, ${c.gradient[0]}, ${c.gradient[1]}, ${c.gradient[2]})` }}
+                      />
+                    }
+                  />
+                  <TooltipContent>{c.name}</TooltipContent>
+                </Tooltip>
               ))}
             </div>
           </div>

--- a/src/web/src/components/canvas/agent-chat-sheet.tsx
+++ b/src/web/src/components/canvas/agent-chat-sheet.tsx
@@ -17,6 +17,7 @@ import { ChannelBar } from "@/components/channel-bar";
 import { AgentChatView } from "@/components/agent-chat/agent-chat-view";
 import { ArrowUpRight, XIcon } from "lucide-react";
 import { Button, buttonVariants } from "@/components/ui/button";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
 interface AgentChatSheetProps {
   open: boolean;
@@ -80,19 +81,25 @@ export function AgentChatSheet({ open, onOpenChange, agent, targetConvId, scroll
             const qs = params.toString();
             const fullPageUrl = `/w/${slug}/agents/${agent.id}${qs ? `?${qs}` : ""}`;
             return (
-              <a
-                href={fullPageUrl}
-                onClick={(e) => {
-                  if (e.metaKey || e.ctrlKey || e.shiftKey) return;
-                  e.preventDefault();
-                  onOpenChange(false);
-                  router.push(fullPageUrl);
-                }}
-                title="Open full page"
-                className={buttonVariants({ variant: "ghost", size: "icon-sm" })}
-              >
-                <ArrowUpRight />
-              </a>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <a
+                      href={fullPageUrl}
+                      onClick={(e) => {
+                        if (e.metaKey || e.ctrlKey || e.shiftKey) return;
+                        e.preventDefault();
+                        onOpenChange(false);
+                        router.push(fullPageUrl);
+                      }}
+                      className={buttonVariants({ variant: "ghost", size: "icon-sm" })}
+                    />
+                  }
+                >
+                  <ArrowUpRight />
+                </TooltipTrigger>
+                <TooltipContent>Open full page</TooltipContent>
+              </Tooltip>
             );
           })()}
           <SheetClose

--- a/src/web/src/components/connect-machine-steps.tsx
+++ b/src/web/src/components/connect-machine-steps.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useEffect } from "react";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { Check } from "lucide-react";
 import { toast } from "sonner";
 import { cliCmd, daemonStartCmd } from "@/lib/utils";
@@ -73,16 +74,22 @@ export function ConnectMachineSteps({
           </div>
         ) : generatedToken ? (
           <div className="pl-7 space-y-2">
-            <div
-              className="rounded-md bg-muted p-2.5 font-mono text-xs text-muted-foreground cursor-pointer hover:bg-muted/80 transition-colors break-all"
-              onClick={copyRegister}
-              title="Click to copy"
-            >
-              {cliCmd()} register --token{" "}
-              <span className="text-foreground/70">
-                {generatedToken}
-              </span>
-            </div>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <div
+                    className="rounded-md bg-muted p-2.5 font-mono text-xs text-muted-foreground cursor-pointer hover:bg-muted/80 transition-colors break-all"
+                    onClick={copyRegister}
+                  />
+                }
+              >
+                {cliCmd()} register --token{" "}
+                <span className="text-foreground/70">
+                  {generatedToken}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>Click to copy</TooltipContent>
+            </Tooltip>
             {!registered && (
               <Button
                 size="sm"
@@ -107,13 +114,19 @@ export function ConnectMachineSteps({
         <p className="text-xs text-muted-foreground pl-7">
           The daemon connects your local agents to Alook.
         </p>
-        <div
-          className="ml-7 rounded-md bg-muted p-2.5 font-mono text-xs text-muted-foreground cursor-pointer hover:bg-muted/80 transition-colors"
-          onClick={copyDaemon}
-          title="Click to copy"
-        >
-          {daemonCmd}
-        </div>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <div
+                className="ml-7 rounded-md bg-muted p-2.5 font-mono text-xs text-muted-foreground cursor-pointer hover:bg-muted/80 transition-colors"
+                onClick={copyDaemon}
+              />
+            }
+          >
+            {daemonCmd}
+          </TooltipTrigger>
+          <TooltipContent>Click to copy</TooltipContent>
+        </Tooltip>
         {registered && (
           <div className="pl-7">
             <Button

--- a/src/web/src/components/custom-email-form.tsx
+++ b/src/web/src/components/custom-email-form.tsx
@@ -11,6 +11,7 @@ import {
   SheetTitle,
   SheetBody,
 } from "@/components/ui/sheet";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import {
   listEmailAccounts,
@@ -364,15 +365,21 @@ export function CustomEmailForm({ agentId, workspaceId, onDataChange, getDataRef
             <div>
               <div className="flex items-center gap-2">
                 <h2 className="font-heading text-lg font-semibold">Custom Email</h2>
-                <a
-                  href={`/w/${slug}/help/email-setup`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-muted-foreground hover:text-foreground transition-colors"
-                  title="How to get IMAP/SMTP credentials"
-                >
-                  <CircleHelp className="size-4" />
-                </a>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <a
+                        href={`/w/${slug}/help/email-setup`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-muted-foreground hover:text-foreground transition-colors"
+                      />
+                    }
+                  >
+                    <CircleHelp className="size-4" />
+                  </TooltipTrigger>
+                  <TooltipContent>How to get IMAP/SMTP credentials</TooltipContent>
+                </Tooltip>
               </div>
               <p className="text-sm text-muted-foreground mt-1">
                 Connect your own mailbox to send and receive email as your identity.
@@ -387,24 +394,38 @@ export function CustomEmailForm({ agentId, workspaceId, onDataChange, getDataRef
                     <span className="text-sm truncate">{existing.email_address}</span>
                   </div>
                   <div className="flex items-center gap-1 shrink-0">
-                    <button
-                      type="button"
-                      onClick={handleSync}
-                      disabled={syncing}
-                      title="Sync now"
-                      className="rounded-full p-1 text-muted-foreground hover:bg-muted transition-colors"
-                    >
-                      <RefreshCw className={cn("size-3.5", syncing && "animate-spin")} />
-                    </button>
-                    <button
-                      type="button"
-                      onClick={handleDelete}
-                      disabled={deleting}
-                      title="Remove"
-                      className="rounded-full p-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
-                    >
-                      {deleting ? <Loader2 className="size-3.5 animate-spin" /> : <XIcon className="size-3.5" />}
-                    </button>
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <Button
+                            variant="ghost"
+                            size="icon-xs"
+                            onClick={handleSync}
+                            disabled={syncing}
+                            className="rounded-full text-muted-foreground"
+                          />
+                        }
+                      >
+                        <RefreshCw className={cn("size-3.5", syncing && "animate-spin")} />
+                      </TooltipTrigger>
+                      <TooltipContent>Sync now</TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <Button
+                            variant="ghost"
+                            size="icon-xs"
+                            onClick={handleDelete}
+                            disabled={deleting}
+                            className="rounded-full text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                          />
+                        }
+                      >
+                        {deleting ? <Loader2 className="size-3.5 animate-spin" /> : <XIcon className="size-3.5" />}
+                      </TooltipTrigger>
+                      <TooltipContent>Remove</TooltipContent>
+                    </Tooltip>
                   </div>
                 </div>
                 {existing.error_message && (

--- a/src/web/src/components/dashboard-navbar.tsx
+++ b/src/web/src/components/dashboard-navbar.tsx
@@ -18,6 +18,7 @@ import {
   deleteMachine,
 } from "@/lib/api";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { Logo } from "@/components/logo";
 import { toast } from "sonner";
 import type { AgentRuntime as Runtime } from "@alook/shared";
@@ -78,20 +79,26 @@ function OnboardingSteps({
           </div>
         ) : generatedToken ? (
           <div className="pl-7 space-y-2">
-            <div
-              className="rounded-md bg-muted p-2.5 font-mono text-xs text-muted-foreground cursor-pointer hover:bg-muted/80 transition-colors"
-              onClick={() =>
-                copyToClipboard(
-                  `${cliCmd()} register --token ${generatedToken}`
-                )
-              }
-              title="Click to copy"
-            >
-              {cliCmd()} register --token{" "}
-              <span className="text-foreground/70">
-                {generatedToken.slice(0, 12)}...
-              </span>
-            </div>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <div
+                    className="rounded-md bg-muted p-2.5 font-mono text-xs text-muted-foreground cursor-pointer hover:bg-muted/80 transition-colors"
+                    onClick={() =>
+                      copyToClipboard(
+                        `${cliCmd()} register --token ${generatedToken}`
+                      )
+                    }
+                  />
+                }
+              >
+                {cliCmd()} register --token{" "}
+                <span className="text-foreground/70">
+                  {generatedToken.slice(0, 12)}...
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>Click to copy</TooltipContent>
+            </Tooltip>
             <Button
               size="sm"
               onClick={() => {
@@ -121,15 +128,21 @@ function OnboardingSteps({
         <p className="text-[11px] text-muted-foreground pl-7">
           The daemon connects your local agents to Alook.
         </p>
-        <div
-          className="ml-7 rounded-md bg-muted p-2.5 font-mono text-xs text-muted-foreground cursor-pointer hover:bg-muted/80 transition-colors"
-          onClick={() =>
-            copyToClipboard(daemonStartCmd())
-          }
-          title="Click to copy"
-        >
-          {daemonStartCmd()}
-        </div>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <div
+                className="ml-7 rounded-md bg-muted p-2.5 font-mono text-xs text-muted-foreground cursor-pointer hover:bg-muted/80 transition-colors"
+                onClick={() =>
+                  copyToClipboard(daemonStartCmd())
+                }
+              />
+            }
+          >
+            {daemonStartCmd()}
+          </TooltipTrigger>
+          <TooltipContent>Click to copy</TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );

--- a/src/web/src/components/email-compose.tsx
+++ b/src/web/src/components/email-compose.tsx
@@ -13,6 +13,7 @@ import Image from "@tiptap/extension-image";
 import { EmailToolbar } from "@/components/email-toolbar";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import type { EmailAttachment } from "@alook/shared";
 import { toast } from "sonner";
 import { Send, X, Loader2, Paperclip, File as FileIcon } from "lucide-react";
@@ -204,20 +205,27 @@ export function EmailCompose({
             className="hidden"
             onChange={handleFileSelect}
           />
-          <button
-            type="button"
-            title="Attach file"
-            disabled={uploading}
-            onMouseDown={(e) => e.preventDefault()}
-            onClick={() => fileInputRef.current?.click()}
-            className="flex items-center justify-center size-7 rounded-md transition-colors cursor-pointer text-muted-foreground/70 hover:text-foreground hover:bg-accent disabled:opacity-40"
-          >
-            {uploading ? (
-              <Loader2 className="size-3.5 animate-spin" />
-            ) : (
-              <Paperclip className="size-3.5" />
-            )}
-          </button>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  disabled={uploading}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => fileInputRef.current?.click()}
+                  className="text-muted-foreground/70"
+                />
+              }
+            >
+              {uploading ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <Paperclip className="size-3.5" />
+              )}
+            </TooltipTrigger>
+            <TooltipContent>Attach file</TooltipContent>
+          </Tooltip>
         </div>
       </div>
 

--- a/src/web/src/components/email-toolbar.tsx
+++ b/src/web/src/components/email-toolbar.tsx
@@ -2,6 +2,8 @@
 
 import type { Editor } from "@tiptap/react";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import {
   Bold,
   Italic,
@@ -38,21 +40,26 @@ function ToolbarButton({
   children: React.ReactNode;
 }) {
   return (
-    <button
-      type="button"
-      title={title}
-      disabled={disabled}
-      onMouseDown={(e) => e.preventDefault()}
-      onClick={onClick}
-      className={cn(
-        "flex items-center justify-center size-7 rounded-md transition-colors cursor-pointer",
-        "text-muted-foreground/70 hover:text-foreground hover:bg-accent",
-        active && "bg-accent text-foreground",
-        disabled && "opacity-40 pointer-events-none"
-      )}
-    >
-      {children}
-    </button>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            disabled={disabled}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={onClick}
+            className={cn(
+              "text-muted-foreground/70",
+              active && "bg-accent text-foreground"
+            )}
+          />
+        }
+      >
+        {children}
+      </TooltipTrigger>
+      <TooltipContent>{title}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/src/web/src/components/runtime-version-gate.tsx
+++ b/src/web/src/components/runtime-version-gate.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { AlertTriangle, RefreshCw, Terminal } from "lucide-react";
 import { toast } from "sonner";
 import type { AgentRuntime } from "@alook/shared";
@@ -148,16 +149,22 @@ export function RuntimeVersionGate() {
               Update taking too long?
             </div>
             <p className="mb-1">Run this command on the machine to update manually:</p>
-            <code
-              className="block rounded bg-background px-2 py-1 font-mono text-[11px] cursor-pointer hover:bg-background/80 transition-colors"
-              title="Click to copy"
-              onClick={() => {
-                navigator.clipboard.writeText(MANUAL_UPDATE_CMD);
-                toast.success("Copied to clipboard");
-              }}
-            >
-              {MANUAL_UPDATE_CMD}
-            </code>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <code
+                    className="block rounded bg-background px-2 py-1 font-mono text-[11px] cursor-pointer hover:bg-background/80 transition-colors"
+                    onClick={() => {
+                      navigator.clipboard.writeText(MANUAL_UPDATE_CMD);
+                      toast.success("Copied to clipboard");
+                    }}
+                  />
+                }
+              >
+                {MANUAL_UPDATE_CMD}
+              </TooltipTrigger>
+              <TooltipContent>Click to copy</TooltipContent>
+            </Tooltip>
           </div>
         )}
       </DialogContent>


### PR DESCRIPTION
# Why we need this PR?

Improve UI consistency by replacing all native HTML `title` attributes with the project's `<Tooltip>` component, and replacing safe native `<button>` elements with the `<Button>` component.

## What changed

### 1. Native `title` → `<Tooltip>` component (23 files, ~50+ instances)
- All icon buttons, action buttons, and timestamp hover text now use the project's `<Tooltip>` from `@base-ui/react` instead of browser-native `title`
- Provides consistent styled tooltips with animations across the app
- Skipped cases where `title` is not a tooltip: `ConfirmDialog` title props, `<iframe>` accessibility, component props, calendar event labels

### 2. Native `<button>` → `<Button>` component (9 files, ~20 instances)
- Replaced clear-cut ghost icon buttons with `<Button variant="ghost" size="icon-sm|icon-xs|sm">`
- Each replacement gains: unified focus ring, disabled state handling, active press feedback, and SVG icon defaults
- Skipped specialized UI (calendar cells, avatar picker, sidebar navigation, tab-like buttons, dropdown list items)

### Files changed
- `email-toolbar.tsx` — ToolbarButton uses Tooltip + Button internally (covers 15 editor buttons)
- `message-list.tsx` — Copy/Flag buttons
- `connect-machine-steps.tsx`, `dashboard-navbar.tsx`, `runtime-version-gate.tsx` — "Click to copy" elements
- `app-sidebar.tsx` — "New agent" button
- `custom-email-form.tsx` — Sync/Remove buttons
- `email-compose.tsx` — Attach file button
- `agent-chat-sheet.tsx` — "Open full page" link
- `threads/page.tsx`, `flags/page.tsx` — Refresh/Unflag + timestamp tooltips
- `members-tab.tsx` — Copy invite link, Revoke, Remove member
- `agents/[id]/email/page.tsx` — Copy/Reply/Forward/Delete buttons
- `agents/[id]/activity/page.tsx` — Retry task + timestamp
- `agents/[id]/files/page.tsx` — Copy full path
- `agents/[id]/layout.tsx` — Agent description tooltip
- `agents/new/page.tsx` — Show guided tour
- `home/page.tsx` — Create new agent buttons
- `runtimes/page.tsx` — "Click to copy" daemon command
- `agent-status-badge.tsx` — Runtime offline badge
- `avatar-generator.tsx` — Color picker buttons
- `unread/page.tsx` — Mark all read + timestamp
- `threads/[traceId]/page.tsx` — Timestamp tooltip

## Checklist
- [ ] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)