### PR TITLE
fix(web): add D1 retry and error handling to daemon API routes

### DIFF
--- a/src/web/src/app/api/daemon/deregister/route.test.ts
+++ b/src/web/src/app/api/daemon/deregister/route.test.ts
@@ -44,8 +44,14 @@ describe("POST /api/daemon/deregister", () => {
 
     vi.doMock("@opennextjs/cloudflare", () => mocks["@opennextjs/cloudflare"]);
     vi.doMock("@alook/shared", mocks["@alook/shared"]);
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+    vi.doMock("@/lib/db", () => ({
+      getDb: vi.fn(() => ({})),
+      withD1Retry: vi.fn((fn: () => Promise<any>) => fn()),
+    }));
     vi.doMock("@/lib/broadcast", () => mocks["@/lib/broadcast"]);
+    vi.doMock("@/lib/logger", () => ({
+      log: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+    }));
     vi.doMock("@/lib/middleware/auth", () => ({
       withAuth: vi.fn((handler: any) => async (req: any, ctx?: any) => {
         const params =
@@ -107,5 +113,18 @@ describe("POST /api/daemon/deregister", () => {
 
     expect(res.status).toBe(403);
     expect(body.error).toContain("machine token required");
+  });
+
+  it("still returns ok when setMachineLastSeenNull fails (D1 transient error)", async () => {
+    const POST = await loadRoute(daemonAuth);
+
+    mockSetMachineLastSeenNull.mockRejectedValue(new Error("D1 timeout"));
+    mockBroadcastToUser.mockResolvedValue(undefined);
+
+    const res = await POST(makeReq({ daemon_id: "d1" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ status: "ok" });
   });
 });

--- a/src/web/src/app/api/daemon/deregister/route.ts
+++ b/src/web/src/app/api/daemon/deregister/route.ts
@@ -6,6 +6,7 @@ import { withAuth } from "@/lib/middleware/auth";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
 import { DeregisterRequestSchema } from "@alook/shared";
 import { broadcastToUser } from "@/lib/broadcast";
+import { log } from "@/lib/logger";
 
 export const POST = withAuth(async (req: NextRequest, ctx) => {
   const { env } = getCloudflareContext()
@@ -18,12 +19,16 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     return writeError("Forbidden: machine token required", 403);
   }
 
-  // Set machine last_seen_at to null (single write, isOnline() returns false immediately)
-  await queries.machine.setMachineLastSeenNull(
-    db,
-    body.daemon_id,
-    ctx.workspaceId,
-  );
+  // Set machine last_seen_at to null — non-critical, daemon is already shutting down
+  try {
+    await queries.machine.setMachineLastSeenNull(
+      db,
+      body.daemon_id,
+      ctx.workspaceId,
+    );
+  } catch (e) {
+    log.warn("deregister: setMachineLastSeenNull failed", { daemonId: body.daemon_id, err: String(e) });
+  }
 
   // Single broadcast at daemon level
   broadcastToUser(ctx.userId, {

--- a/src/web/src/app/api/daemon/register/route.test.ts
+++ b/src/web/src/app/api/daemon/register/route.test.ts
@@ -54,12 +54,18 @@ describe("POST /api/daemon/register", () => {
 
     vi.doMock("@opennextjs/cloudflare", () => mocks["@opennextjs/cloudflare"]);
     vi.doMock("@alook/shared", mocks["@alook/shared"]);
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+    vi.doMock("@/lib/db", () => ({
+      getDb: vi.fn(() => ({})),
+      withD1Retry: vi.fn((fn: () => Promise<any>) => fn()),
+    }));
     vi.doMock("@/lib/broadcast", () => mocks["@/lib/broadcast"]);
     vi.doMock("@/lib/api/responses", () => mocks["@/lib/api/responses"]);
     vi.doMock("@/lib/cache", () => ({
       invalidate: vi.fn(),
       cacheKeys: { runtimeIds: (...a: any[]) => a.join(":") },
+    }));
+    vi.doMock("@/lib/logger", () => ({
+      log: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
     }));
     vi.doMock("@/lib/middleware/auth", () => ({
       withAuth: vi.fn((handler: any) => async (req: any, ctx?: any) => {
@@ -177,5 +183,21 @@ describe("POST /api/daemon/register", () => {
     const res = await POST(makeReq(validBody));
 
     expect(res.status).toBe(200);
+  });
+
+  it("still registers runtimes when upsertMachine fails (D1 transient error)", async () => {
+    const POST = await loadRoute(authCtx);
+
+    mockGetMember.mockResolvedValue({ userId: "u1", workspaceId: "w1" });
+    mockUpsertMachine.mockRejectedValue(new Error("D1 timeout"));
+    mockUpsertAgentRuntime.mockResolvedValue({ id: "r1" });
+    mockBroadcastToUser.mockResolvedValue(undefined);
+
+    const res = await POST(makeReq(validBody));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.runtimes).toEqual([{ id: "r1" }]);
+    expect(mockUpsertAgentRuntime).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/web/src/app/api/daemon/register/route.ts
+++ b/src/web/src/app/api/daemon/register/route.ts
@@ -1,13 +1,14 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare"
 import { queries } from "@alook/shared"
-import { getDb } from "@/lib/db"
+import { getDb, withD1Retry } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { writeJSON, parseBody } from "@/lib/middleware/helpers";
 import { runtimeToResponse } from "@/lib/api/responses";
 import { RegisterDaemonRequestSchema, generateWorkspaceSlug } from "@alook/shared";
 import { broadcastToUser } from "@/lib/broadcast";
 import { invalidate, cacheKeys } from "@/lib/cache";
+import { log } from "@/lib/logger";
 
 export const POST = withAuth(async (req: NextRequest, ctx) => {
   const { env } = getCloudflareContext()
@@ -26,19 +27,19 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
 
   if (!workspaceId) {
     // Check if user already has a workspace before creating a new one
-    const existing = await queries.workspace.listWorkspaces(db, ctx.userId);
+    const existing = await withD1Retry(() => queries.workspace.listWorkspaces(db, ctx.userId));
     if (existing.length > 0) {
       workspaceId = existing[0].id;
     } else {
-      const ws = await queries.workspace.createWorkspace(db, {
+      const ws = await withD1Retry(() => queries.workspace.createWorkspace(db, {
         name: "Personal",
         slug: generateWorkspaceSlug(),
-      });
-      await queries.member.createMember(db, {
+      }));
+      await withD1Retry(() => queries.member.createMember(db, {
         workspaceId: ws.id,
         userId: ctx.userId,
         role: "owner",
-      });
+      }));
       workspaceId = ws.id;
     }
   }
@@ -48,21 +49,25 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     return writeJSON({ error: "workspace_id does not match token" }, 403);
   }
 
-  const membership = await queries.member.getMemberByUserAndWorkspace(
+  const membership = await withD1Retry(() => queries.member.getMemberByUserAndWorkspace(
     db,
     ctx.userId,
     workspaceId
-  );
+  ));
   if (!membership) {
     return writeJSON({ error: "workspace not found" }, 404);
   }
 
-  // Upsert machine row (1 write for liveness)
-  await queries.machine.upsertMachine(db, {
-    daemonId,
-    workspaceId,
-    deviceInfo: deviceName.trim(),
-  });
+  // Upsert machine row (1 write for liveness) — non-critical
+  try {
+    await queries.machine.upsertMachine(db, {
+      daemonId,
+      workspaceId,
+      deviceInfo: deviceName.trim(),
+    });
+  } catch (e) {
+    log.warn("register: machine upsert failed", { daemonId, err: String(e) });
+  }
 
   const results = [];
   for (const rt of runtimes) {
@@ -75,14 +80,14 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
       ...(workspacesRoot ? { workspaces_root: workspacesRoot } : {}),
     };
 
-    const result = await queries.runtime.upsertAgentRuntime(db, {
+    const result = await withD1Retry(() => queries.runtime.upsertAgentRuntime(db, {
       workspaceId,
       daemonId,
       runtimeMode,
       provider,
       deviceInfo,
       metadata,
-    });
+    }));
     results.push({ ...result, machineLastSeenAt: new Date().toISOString() });
   }
 

--- a/src/web/src/app/api/daemon/routes.test.ts
+++ b/src/web/src/app/api/daemon/routes.test.ts
@@ -34,7 +34,10 @@ function baseMocks() {
 function applyBase() {
   const m = baseMocks();
   vi.doMock("@opennextjs/cloudflare", m["@opennextjs/cloudflare"]);
-  vi.doMock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+  vi.doMock("@/lib/db", () => ({
+    getDb: vi.fn(() => ({})),
+    withD1Retry: vi.fn((fn: () => Promise<any>) => fn()),
+  }));
   vi.doMock("@/lib/middleware/auth", m["@/lib/middleware/auth"]);
   vi.doMock("@/lib/middleware/helpers", m["@/lib/middleware/helpers"]);
   vi.doMock("@/lib/logger", m["@/lib/logger"]);

--- a/src/web/src/app/api/daemon/tasks/[taskId]/messages/route.test.ts
+++ b/src/web/src/app/api/daemon/tasks/[taskId]/messages/route.test.ts
@@ -11,7 +11,10 @@ let mockAuthCtx: Record<string, unknown> = { userId: "u1", email: "u@t.com", wor
 vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(() => ({ env: { DB: { withSession: () => ({}) } } })),
 }));
-vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+vi.mock("@/lib/db", () => ({
+  getDb: vi.fn(() => ({})),
+  withD1Retry: vi.fn((fn: () => Promise<any>) => fn()),
+}));
 vi.mock("@alook/shared", async () => {
   const real = await vi.importActual<typeof import("@alook/shared")>("@alook/shared");
   return {

--- a/src/web/src/app/api/daemon/tasks/[taskId]/messages/route.ts
+++ b/src/web/src/app/api/daemon/tasks/[taskId]/messages/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare"
 import { queries } from "@alook/shared"
-import { getDb } from "@/lib/db"
+import { getDb, withD1Retry } from "@/lib/db";
 import type { TaskMessage } from "@alook/shared"
 import { withAuth } from "@/lib/middleware/auth";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
@@ -23,7 +23,7 @@ export const GET = withAuth(async (_req, ctx) => {
     return writeError("task_id is required", 400);
   }
 
-  const messages = await queries.taskMessage.listTaskMessages(db, taskId, ctx.workspaceId);
+  const messages = await withD1Retry(() => queries.taskMessage.listTaskMessages(db, taskId, ctx.workspaceId));
   return writeJSON(messages.map(taskMessageToResponse));
 });
 
@@ -40,7 +40,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     return writeError("task_id is required", 400);
   }
 
-  const task = await queries.task.getTask(db, taskId, ctx.workspaceId);
+  const task = await withD1Retry(() => queries.task.getTask(db, taskId, ctx.workspaceId));
   if (!task) {
     return writeError("task not found", 404);
   }

--- a/src/web/src/app/api/daemon/tasks/[taskId]/status/route.test.ts
+++ b/src/web/src/app/api/daemon/tasks/[taskId]/status/route.test.ts
@@ -6,7 +6,10 @@ const mockGetTaskStatus = vi.fn();
 vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
 }));
-vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+vi.mock("@/lib/db", () => ({
+  getDb: vi.fn(() => ({})),
+  withD1Retry: vi.fn((fn: () => Promise<any>) => fn()),
+}));
 
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),

--- a/src/web/src/app/api/daemon/tasks/[taskId]/status/route.ts
+++ b/src/web/src/app/api/daemon/tasks/[taskId]/status/route.ts
@@ -1,6 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
 import { queries } from "@alook/shared"
-import { getDb } from "@/lib/db"
+import { getDb, withD1Retry } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { writeJSON, writeError } from "@/lib/middleware/helpers";
 
@@ -17,7 +17,7 @@ export const GET = withAuth(async (_req, ctx) => {
     return writeError("task_id is required", 400);
   }
 
-  const status = await queries.task.getTaskStatus(db, taskId, ctx.workspaceId);
+  const status = await withD1Retry(() => queries.task.getTaskStatus(db, taskId, ctx.workspaceId));
   if (!status) {
     return writeError("task not found", 404);
   }

--- a/src/web/src/app/api/daemon/tasks/poll/route.test.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.test.ts
@@ -25,7 +25,10 @@ vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
 }));
 
-vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+vi.mock("@/lib/db", () => ({
+  getDb: vi.fn(() => ({})),
+  withD1Retry: vi.fn((fn: () => Promise<any>) => fn()),
+}));
 
 vi.mock("@alook/shared", async () => {
   const real = await vi.importActual<typeof import("@alook/shared")>("@alook/shared");
@@ -762,5 +765,49 @@ describe("POST /api/daemon/tasks/poll", () => {
     expect(res.status).toBe(200);
     expect(body.tasks).toEqual([]);
     expect(body.meetings).toBeUndefined();
+  });
+
+  it("still returns tasks when upsertMachine fails (D1 transient error)", async () => {
+    mockUpsertMachine.mockRejectedValue(new Error("D1 timeout"));
+    mockGetRuntimeIdsByDaemon.mockResolvedValue(["r1"]);
+    mockSweepStaleState.mockResolvedValue(undefined);
+    mockBroadcastToUser.mockResolvedValue(undefined);
+    mockClaimTasksForRuntimes.mockResolvedValue([]);
+
+    const res = await POST(postReq({ daemon_id: "d1" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.tasks).toEqual([]);
+  });
+
+  it("still returns tasks when sweepStaleState fails (D1 transient error)", async () => {
+    mockUpsertMachine.mockResolvedValue({});
+    mockGetRuntimeIdsByDaemon.mockResolvedValue(["r1"]);
+    mockSweepStaleState.mockRejectedValue(new Error("D1 timeout"));
+    mockBroadcastToUser.mockResolvedValue(undefined);
+    mockClaimTasksForRuntimes.mockResolvedValue([]);
+
+    const res = await POST(postReq({ daemon_id: "d1" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.tasks).toEqual([]);
+  });
+
+  it("still returns tasks when pending check fails (D1 transient error)", async () => {
+    mockUpsertMachine.mockResolvedValue({});
+    mockGetRuntimeIdsByDaemon.mockResolvedValue(["r1"]);
+    mockSweepStaleState.mockResolvedValue(undefined);
+    mockBroadcastToUser.mockResolvedValue(undefined);
+    mockClaimTasksForRuntimes.mockResolvedValue([]);
+    mockGetMachineByDaemon.mockRejectedValue(new Error("D1 timeout"));
+
+    const res = await POST(postReq({ daemon_id: "d1", cli_version: "0.1.0" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.tasks).toEqual([]);
+    expect(body.pending_update).toBeUndefined();
   });
 });

--- a/src/web/src/app/api/daemon/tasks/poll/route.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { queries, PollRequestSchema, semverGte, toAlookAddress, type FileRequestItem, type PollMeetingItem } from "@alook/shared";
-import { getDb } from "@/lib/db"
+import { getDb, withD1Retry } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
 import { taskToResponse } from "@/lib/api/responses";
@@ -35,11 +35,16 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
   }
 
   // 2. Liveness: upsert machine row only when runtimes exist
-  await queries.machine.upsertMachine(db, {
-    daemonId: body.daemon_id,
-    workspaceId: ctx.workspaceId,
-    deviceInfo: body.daemon_id,
-  });
+  // Non-critical — D1 transient failures should not block task polling
+  try {
+    await queries.machine.upsertMachine(db, {
+      daemonId: body.daemon_id,
+      workspaceId: ctx.workspaceId,
+      deviceInfo: body.daemon_id,
+    });
+  } catch (e) {
+    log.warn("machine upsert failed", { daemonId: body.daemon_id, err: String(e) });
+  }
 
   broadcastToUser(ctx.userId, {
     type: "runtime.status",
@@ -48,8 +53,12 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     status: "online",
   }).catch(() => {});
 
-  // 3. Housekeeping: sweep stale state
-  await sweepStaleState(db, ctx.workspaceId);
+  // 3. Housekeeping: sweep stale state — non-critical
+  try {
+    await sweepStaleState(db, ctx.workspaceId);
+  } catch (e) {
+    log.warn("sweep failed", { workspaceId: ctx.workspaceId, err: String(e) });
+  }
 
   // 3b. Promote due calendar events into queued tasks before task claiming so
   // they are eligible in the same poll response.
@@ -70,19 +79,19 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
 
   // 4. Task claiming
   const taskService = new TaskService(db);
-  const claimed = await taskService.claimTasksForRuntimes(
+  const claimed = await withD1Retry(() => taskService.claimTasksForRuntimes(
     runtimeIds,
     body.max_tasks,
     ctx.workspaceId!,
-  );
+  ));
 
   // Batch-fetch shared data before the task loop to avoid N+1 queries
   const nonKillTasks = claimed.filter((t) => t.type !== "kill_task");
   const agentIds = [...new Set(nonKillTasks.map((t) => t.agentId))];
 
   const [allAgents, allEmailAccounts, allColleagues] = await Promise.all([
-    queries.agent.getAgentsByIds(db, agentIds, ctx.workspaceId!),
-    queries.emailAccount.getEmailAccountsByAgents(db, agentIds, ctx.workspaceId!),
+    withD1Retry(() => queries.agent.getAgentsByIds(db, agentIds, ctx.workspaceId!)),
+    withD1Retry(() => queries.emailAccount.getEmailAccountsByAgents(db, agentIds, ctx.workspaceId!)),
     queries.agentLink.getColleaguesForAgents(db, agentIds, ctx.workspaceId!).catch(() => [] as Awaited<ReturnType<typeof queries.agentLink.getColleaguesForAgents>>),
   ]);
 
@@ -193,32 +202,35 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     });
   }
 
-  // 5. Pending update check
-  const machineRow = await queries.machine.getMachineByDaemon(
-    db,
-    body.daemon_id,
-    ctx.workspaceId,
-  );
+  // 5. Pending update & rescan check — non-critical
   let pendingUpdate: { version: string } | undefined;
-  if (machineRow?.pendingUpdateVersion && body.cli_version) {
-    if (semverGte(body.cli_version, machineRow.pendingUpdateVersion)) {
-      await queries.machine.clearPendingUpdateVersion(db, body.daemon_id, ctx.workspaceId);
-      broadcastToUser(ctx.userId, {
-        type: "runtime.status",
-        daemonId: body.daemon_id,
-        workspaceId: ctx.workspaceId,
-        status: "online",
-      }).catch(() => {});
-    } else {
-      pendingUpdate = { version: machineRow.pendingUpdateVersion };
-    }
-  }
-
-  // 6. Pending rescan check
   let pendingRescan: boolean | undefined;
-  if (machineRow?.pendingRescan) {
-    pendingRescan = true;
-    await queries.machine.clearPendingRescan(db, body.daemon_id, ctx.workspaceId);
+  try {
+    const machineRow = await queries.machine.getMachineByDaemon(
+      db,
+      body.daemon_id,
+      ctx.workspaceId,
+    );
+    if (machineRow?.pendingUpdateVersion && body.cli_version) {
+      if (semverGte(body.cli_version, machineRow.pendingUpdateVersion)) {
+        await queries.machine.clearPendingUpdateVersion(db, body.daemon_id, ctx.workspaceId);
+        broadcastToUser(ctx.userId, {
+          type: "runtime.status",
+          daemonId: body.daemon_id,
+          workspaceId: ctx.workspaceId,
+          status: "online",
+        }).catch(() => {});
+      } else {
+        pendingUpdate = { version: machineRow.pendingUpdateVersion };
+      }
+    }
+
+    if (machineRow?.pendingRescan) {
+      pendingRescan = true;
+      await queries.machine.clearPendingRescan(db, body.daemon_id, ctx.workspaceId);
+    }
+  } catch (e) {
+    log.warn("pending check failed", { daemonId: body.daemon_id, err: String(e) });
   }
 
   // 7. Pending file browse requests + cleanup

--- a/src/web/src/app/api/daemon/workspace/report/route.test.ts
+++ b/src/web/src/app/api/daemon/workspace/report/route.test.ts
@@ -9,7 +9,10 @@ vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
 }));
 
-vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+vi.mock("@/lib/db", () => ({
+  getDb: vi.fn(() => ({})),
+  withD1Retry: vi.fn((fn: () => Promise<any>) => fn()),
+}));
 
 vi.mock("@alook/shared", async () => {
   const real = await vi.importActual<typeof import("@alook/shared")>("@alook/shared");

--- a/src/web/src/app/api/daemon/workspace/report/route.ts
+++ b/src/web/src/app/api/daemon/workspace/report/route.ts
@@ -3,7 +3,7 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { queries, WorkspaceFileReportSchema } from "@alook/shared";
 import { withAuth } from "@/lib/middleware/auth";
 import { parseBody, writeJSON, writeError } from "@/lib/middleware/helpers";
-import { getDb } from "@/lib/db";
+import { getDb, withD1Retry } from "@/lib/db";
 import { broadcastToUser } from "@/lib/broadcast";
 
 export const POST = withAuth(async (req: NextRequest, ctx) => {
@@ -17,7 +17,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
   const [body, err] = await parseBody(req, WorkspaceFileReportSchema);
   if (err) return err;
 
-  const row = await queries.workspaceFileRequest.getRequest(db, body.request_id);
+  const row = await withD1Retry(() => queries.workspaceFileRequest.getRequest(db, body.request_id));
   if (!row) return writeError("request not found", 404);
 
   const result = {
@@ -28,7 +28,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     path: body.path,
   };
 
-  await queries.workspaceFileRequest.completeRequest(db, row.id, result);
+  await withD1Retry(() => queries.workspaceFileRequest.completeRequest(db, row.id, result));
 
   broadcastToUser(ctx.userId, {
     type: "workspace.files",

--- a/src/web/src/lib/db.test.ts
+++ b/src/web/src/lib/db.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+import { withD1Retry } from "./db";
+
+describe("withD1Retry", () => {
+  it("returns result on first success", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    const result = await withD1Retry(fn);
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries once on transient failure then succeeds", async () => {
+    const fn = vi.fn()
+      .mockRejectedValueOnce(new Error("D1 timeout"))
+      .mockResolvedValueOnce("recovered");
+    const result = await withD1Retry(fn);
+    expect(result).toBe("recovered");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after all retries exhausted", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("D1 down"));
+    await expect(withD1Retry(fn)).rejects.toThrow("D1 down");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("respects custom retry count", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("fail"));
+    await expect(withD1Retry(fn, 3)).rejects.toThrow("fail");
+    expect(fn).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not retry when retries is 0", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("fail"));
+    await expect(withD1Retry(fn, 0)).rejects.toThrow("fail");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/web/src/lib/db.ts
+++ b/src/web/src/lib/db.ts
@@ -6,3 +6,14 @@ export function getDb(d1: D1Database): Database {
   // Native Drizzle support tracked at https://github.com/drizzle-team/drizzle-orm/issues/4522
   return createDb(session as unknown as Parameters<typeof createDb>[0])
 }
+
+export async function withD1Retry<T>(fn: () => Promise<T>, retries = 1): Promise<T> {
+  for (let i = 0; i <= retries; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (i === retries) throw err;
+    }
+  }
+  throw new Error("unreachable");
+}


### PR DESCRIPTION
# Why we need this PR?

D1 transient failures (timeouts, temporary unavailability) were causing unhandled 500 errors across all daemon API endpoints. Production observability logs showed repeated `Failed query` errors on `machine` upsert and `agent_task_queue` select during a D1 hiccup window — these crashed the entire request even though some of the failing operations were non-critical.

## What changed

### New utility
- **`withD1Retry(fn, retries=1)`** in `src/web/src/lib/db.ts` — lightweight generic retry wrapper for D1 queries

### Critical queries → `withD1Retry` (retry once on failure)
- `register/route.ts` — workspace, member, runtime upsert queries
- `poll/route.ts` — task claiming, agent/email batch-fetch
- `status/route.ts` — getTaskStatus
- `messages/route.ts` — getTask, listTaskMessages
- `workspace/report/route.ts` — getRequest, completeRequest

### Non-critical queries → `try/catch` (warn and continue)
- `poll/route.ts` — upsertMachine, sweepStaleState, pending update/rescan check
- `register/route.ts` — upsertMachine (machine heartbeat shouldn't block runtime registration)
- `deregister/route.ts` — setMachineLastSeenNull (daemon is already shutting down)

### Tests
- New `db.test.ts` with 5 test cases for `withD1Retry` (success, retry-then-succeed, exhausted retries, custom count, zero retries)
- D1 failure resilience tests added to poll, register, and deregister route tests
- All existing test mocks updated to include `withD1Retry`

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)