### PR TITLE
perf(web): reduce D1 pressure in tasks/poll via KV caching

### DIFF
--- a/src/web/src/app/api/agent-links/[id]/route.ts
+++ b/src/web/src/app/api/agent-links/[id]/route.ts
@@ -5,6 +5,7 @@ import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
 import { agentLinkToResponse } from "@/lib/api/responses";
+import { invalidateMany, cacheKeys } from "@/lib/cache";
 
 export const PATCH = withAuth(async (req, ctx) => {
   const ws = await withWorkspaceMember(req, ctx);
@@ -24,6 +25,11 @@ export const PATCH = withAuth(async (req, ctx) => {
   });
   if (!updated) return writeError("agent link not found", 404);
 
+  await invalidateMany([
+    cacheKeys.colleaguesByAgent(ws.workspaceId, updated.sourceAgentId),
+    cacheKeys.colleaguesByAgent(ws.workspaceId, updated.targetAgentId),
+  ]);
+
   return writeJSON(agentLinkToResponse(updated));
 });
 
@@ -39,6 +45,11 @@ export const DELETE = withAuth(async (req, ctx) => {
 
   const deleted = await queries.agentLink.remove(db, id, ws.workspaceId);
   if (!deleted) return writeError("agent link not found", 404);
+
+  await invalidateMany([
+    cacheKeys.colleaguesByAgent(ws.workspaceId, deleted.sourceAgentId),
+    cacheKeys.colleaguesByAgent(ws.workspaceId, deleted.targetAgentId),
+  ]);
 
   return writeJSON(agentLinkToResponse(deleted));
 });

--- a/src/web/src/app/api/agent-links/route.ts
+++ b/src/web/src/app/api/agent-links/route.ts
@@ -10,6 +10,7 @@ import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
 import { agentLinkToResponse } from "@/lib/api/responses";
+import { invalidateMany, cacheKeys } from "@/lib/cache";
 
 export const GET = withAuth(async (req: NextRequest, ctx) => {
   const ws = await withWorkspaceMember(req, ctx);
@@ -54,6 +55,10 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
       targetAgentId: body.target_agent_id,
       instruction: body.instruction,
     });
+    await invalidateMany([
+      cacheKeys.colleaguesByAgent(ws.workspaceId, body.source_agent_id),
+      cacheKeys.colleaguesByAgent(ws.workspaceId, body.target_agent_id),
+    ]);
     return writeJSON(agentLinkToResponse(created), 201);
   } catch (e) {
     if (isUniqueConstraintError(e)) {

--- a/src/web/src/app/api/agents/[id]/email-accounts/[accountId]/route.ts
+++ b/src/web/src/app/api/agents/[id]/email-accounts/[accountId]/route.ts
@@ -5,6 +5,7 @@ import { encrypt } from "@alook/shared/crypto"
 import { withAuth } from "@/lib/middleware/auth"
 import { withWorkspaceMember } from "@/lib/middleware/workspace"
 import { writeJSON, writeError, parseBody, formatTimestamp, formatTimestampNullable } from "@/lib/middleware/helpers"
+import { invalidate, cacheKeys } from "@/lib/cache"
 
 type AgentEmailAccountRow = Awaited<ReturnType<typeof queries.emailAccount.getEmailAccountsByAgent>>[number]
 
@@ -77,6 +78,8 @@ export const PATCH = withAuth(async (req, ctx) => {
   const updated = await queries.emailAccount.updateEmailAccount(db, accountId, ws.workspaceId, data)
   if (!updated) return writeError("update failed", 500)
 
+  await invalidate(cacheKeys.emailAccountsByAgent(ws.workspaceId, agentId));
+
   const hasCredentialChange = body.imapUsername || body.imapPassword || body.smtpUsername || body.smtpPassword || body.imapHost || body.smtpHost
   if (hasCredentialChange) {
     await callEmailWorker(cfEnv, `/imap/stop?accountId=${accountId}`)
@@ -105,6 +108,8 @@ export const DELETE = withAuth(async (req, ctx) => {
 
   const deleted = await queries.emailAccount.deleteEmailAccount(db, accountId, ws.workspaceId)
   if (!deleted) return writeError("delete failed", 500)
+
+  await invalidate(cacheKeys.emailAccountsByAgent(ws.workspaceId, agentId));
 
   return writeJSON({ ok: true })
 })

--- a/src/web/src/app/api/agents/[id]/email-accounts/route.ts
+++ b/src/web/src/app/api/agents/[id]/email-accounts/route.ts
@@ -5,6 +5,7 @@ import { encrypt } from "@alook/shared/crypto"
 import { withAuth } from "@/lib/middleware/auth"
 import { withWorkspaceMember } from "@/lib/middleware/workspace"
 import { writeJSON, writeError, parseBody, formatTimestamp, formatTimestampNullable } from "@/lib/middleware/helpers"
+import { invalidate, cacheKeys } from "@/lib/cache"
 
 type AgentEmailAccountRow = Awaited<ReturnType<typeof queries.emailAccount.getEmailAccountsByAgent>>[number]
 
@@ -94,6 +95,8 @@ export const POST = withAuth(async (req, ctx) => {
       method: "POST",
     }).catch(() => {})
   }
+
+  await invalidate(cacheKeys.emailAccountsByAgent(ws.workspaceId, agentId));
 
   return writeJSON(accountToResponse(account), 201)
 })

--- a/src/web/src/app/api/agents/[id]/route.ts
+++ b/src/web/src/app/api/agents/[id]/route.ts
@@ -99,5 +99,7 @@ export const DELETE = withAuth(async (req, ctx) => {
     return writeError("agent not found", 404);
   }
 
+  await invalidate(cacheKeys.agent(ws.workspaceId, id));
+
   return new Response(null, { status: 204 });
 });

--- a/src/web/src/app/api/daemon/tasks/poll/route.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.ts
@@ -14,7 +14,7 @@ import { log } from "@/lib/logger";
 export const POST = withAuth(async (req: NextRequest, ctx) => {
   const { env } = getCloudflareContext();
   const db = getDb((env as Env).DB);
-  const { cached, cacheKeys } = await import("@/lib/cache");
+  const { cached, cachedBatch, cacheKeys } = await import("@/lib/cache");
 
   const [body, err] = await parseBody(req, PollRequestSchema);
   if (err) return err;
@@ -34,14 +34,29 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     return writeJSON({ tasks: [], evicted: true });
   }
 
-  // 2. Liveness: upsert machine row only when runtimes exist
+  // 2. Liveness: write heartbeat to KV (fast) + throttle D1 upsert to every 60s
   // Non-critical — D1 transient failures should not block task polling
+  const kv = (env as Env).CACHE_KV ?? null;
+  if (kv) {
+    kv.put(
+      cacheKeys.heartbeat(ctx.workspaceId, body.daemon_id),
+      new Date().toISOString(),
+      { expirationTtl: 15 },
+    ).catch(() => {});
+  }
   try {
-    await queries.machine.upsertMachine(db, {
-      daemonId: body.daemon_id,
-      workspaceId: ctx.workspaceId,
-      deviceInfo: body.daemon_id,
-    });
+    await cached(
+      `hb_d1:${ctx.workspaceId}:${body.daemon_id}`,
+      60,
+      async () => {
+        await queries.machine.upsertMachine(db, {
+          daemonId: body.daemon_id,
+          workspaceId: ctx.workspaceId!,
+          deviceInfo: body.daemon_id,
+        });
+        return "1";
+      },
+    );
   } catch (e) {
     log.warn("machine upsert failed", { daemonId: body.daemon_id, err: String(e) });
   }
@@ -60,15 +75,21 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     log.warn("sweep failed", { workspaceId: ctx.workspaceId, err: String(e) });
   }
 
-  // 3b. Promote due calendar events into queued tasks before task claiming so
-  // they are eligible in the same poll response.
+  // 3b. Promote due calendar events — throttled to once per 30s per workspace
   try {
-    const enqueued = await promoteDueCalendarEventsForWorkspace(
-      db,
-      ctx.workspaceId,
-    );
-    if (enqueued > 0) {
-      log.info("calendar: enqueued", { workspaceId: ctx.workspaceId, enqueued });
+    let calRun = false;
+    await cached(`cal:${ctx.workspaceId}`, 30, async () => {
+      calRun = true;
+      return "1";
+    }).catch(() => { calRun = true; });
+    if (calRun) {
+      const enqueued = await promoteDueCalendarEventsForWorkspace(
+        db,
+        ctx.workspaceId,
+      );
+      if (enqueued > 0) {
+        log.info("calendar: enqueued", { workspaceId: ctx.workspaceId, enqueued });
+      }
     }
   } catch (err) {
     log.warn("calendar: promote failed", {
@@ -86,14 +107,41 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
   ));
 
   // Batch-fetch shared data before the task loop to avoid N+1 queries
+  // Uses KV cache for stable data (agents, emails, colleagues)
   const nonKillTasks = claimed.filter((t) => t.type !== "kill_task");
   const agentIds = [...new Set(nonKillTasks.map((t) => t.agentId))];
 
-  const [allAgents, allEmailAccounts, allColleagues] = await Promise.all([
-    withD1Retry(() => queries.agent.getAgentsByIds(db, agentIds, ctx.workspaceId!)),
-    withD1Retry(() => queries.emailAccount.getEmailAccountsByAgents(db, agentIds, ctx.workspaceId!)),
-    queries.agentLink.getColleaguesForAgents(db, agentIds, ctx.workspaceId!).catch(() => [] as Awaited<ReturnType<typeof queries.agentLink.getColleaguesForAgents>>),
-  ]);
+  const [allAgents, allEmailAccounts, allColleagues] = agentIds.length > 0
+    ? await Promise.all([
+        cachedBatch(
+          agentIds.map((id) => cacheKeys.agent(ctx.workspaceId!, id)),
+          300,
+          async (missingKeys) => {
+            const missingIds = missingKeys.map((k) => k.split(":").pop()!);
+            const agents = await withD1Retry(() => queries.agent.getAgentsByIds(db, missingIds, ctx.workspaceId!));
+            const result = new Map<string, (typeof agents)[number]>();
+            for (const a of agents) {
+              result.set(cacheKeys.agent(ctx.workspaceId!, a.id), a);
+            }
+            return result;
+          },
+        ).then((m) => [...m.values()]),
+        Promise.all(
+          agentIds.map((id) =>
+            cached(cacheKeys.emailAccountsByAgent(ctx.workspaceId!, id), 900, () =>
+              queries.emailAccount.getEmailAccountsByAgents(db, [id], ctx.workspaceId!),
+            ),
+          ),
+        ).then((arrays) => arrays.flat()),
+        Promise.all(
+          agentIds.map((id) =>
+            cached(cacheKeys.colleaguesByAgent(ctx.workspaceId!, id), 300, () =>
+              queries.agentLink.getColleaguesForAgents(db, [id], ctx.workspaceId!),
+            ).catch(() => [] as Awaited<ReturnType<typeof queries.agentLink.getColleaguesForAgents>>),
+          ),
+        ).then((arrays) => arrays.flat()),
+      ])
+    : [[], [], [] as Awaited<ReturnType<typeof queries.agentLink.getColleaguesForAgents>>];
 
   const agentMap = new Map(allAgents.map((a) => [a.id, a]));
   const emailAccountsByAgent = new Map<string, string[]>();
@@ -130,23 +178,27 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     let instructions = agent?.instructions ?? "";
     if (agent?.ownerId) {
       if (!memberCache.has(agent.ownerId)) {
-        const m = await queries.member.getMemberByUserAndWorkspace(
-          db,
-          agent.ownerId,
-          task.workspaceId,
+        const m = await cached(
+          cacheKeys.member(task.workspaceId, agent.ownerId),
+          600,
+          () => queries.member.getMemberByUserAndWorkspace(db, agent.ownerId!, task.workspaceId),
         );
         memberCache.set(agent.ownerId, m ? { globalInstruction: m.globalInstruction } : null);
       }
-      const cached = memberCache.get(agent.ownerId);
-      if (cached?.globalInstruction) {
-        instructions = [cached.globalInstruction, instructions].filter(Boolean).join("\n\n");
+      const cachedMember = memberCache.get(agent.ownerId);
+      if (cachedMember?.globalInstruction) {
+        instructions = [cachedMember.globalInstruction, instructions].filter(Boolean).join("\n\n");
       }
     }
 
     let ownerName: string | null = null;
     if (agent?.ownerId) {
       if (!userCache.has(agent.ownerId)) {
-        const u = await queries.user.getUser(db, agent.ownerId);
+        const u = await cached(
+          cacheKeys.user(agent.ownerId),
+          1800,
+          () => queries.user.getUser(db, agent.ownerId!),
+        );
         userCache.set(agent.ownerId, u ? { name: u.name, email: u.email } : null);
       }
       ownerName = userCache.get(agent.ownerId)?.name ?? null;
@@ -162,7 +214,11 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     let sender: { name: string; email: string; is_owner: boolean } | null = null;
     if (task.type === "user_dm_message" && convo?.userId) {
       if (!userCache.has(convo.userId)) {
-        const u = await queries.user.getUser(db, convo.userId);
+        const u = await cached(
+          cacheKeys.user(convo.userId),
+          1800,
+          () => queries.user.getUser(db, convo!.userId!),
+        );
         userCache.set(convo.userId, u ? { name: u.name, email: u.email } : null);
       }
       const cachedUser = userCache.get(convo.userId);
@@ -202,41 +258,94 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     });
   }
 
-  // 5. Pending update & rescan check — non-critical
+  // 5. Pending update & rescan check + meeting claim — throttled to once per 30s
   let pendingUpdate: { version: string } | undefined;
   let pendingRescan: boolean | undefined;
+  let meetings: PollMeetingItem[] | undefined;
+  const miscKey = `misc:${ctx.workspaceId}:${body.daemon_id}`;
+  let runMisc = false;
   try {
-    const machineRow = await queries.machine.getMachineByDaemon(
-      db,
-      body.daemon_id,
-      ctx.workspaceId,
-    );
-    if (machineRow?.pendingUpdateVersion && body.cli_version) {
-      if (semverGte(body.cli_version, machineRow.pendingUpdateVersion)) {
-        await queries.machine.clearPendingUpdateVersion(db, body.daemon_id, ctx.workspaceId);
-        broadcastToUser(ctx.userId, {
-          type: "runtime.status",
-          daemonId: body.daemon_id,
-          workspaceId: ctx.workspaceId,
-          status: "online",
-        }).catch(() => {});
-      } else {
-        pendingUpdate = { version: machineRow.pendingUpdateVersion };
+    await cached(miscKey, 30, async () => { runMisc = true; return "1"; });
+  } catch { runMisc = true; }
+
+  if (runMisc) {
+    try {
+      const machineRow = await queries.machine.getMachineByDaemon(
+        db,
+        body.daemon_id,
+        ctx.workspaceId,
+      );
+      if (machineRow?.pendingUpdateVersion && body.cli_version) {
+        if (semverGte(body.cli_version, machineRow.pendingUpdateVersion)) {
+          await queries.machine.clearPendingUpdateVersion(db, body.daemon_id, ctx.workspaceId);
+          broadcastToUser(ctx.userId, {
+            type: "runtime.status",
+            daemonId: body.daemon_id,
+            workspaceId: ctx.workspaceId,
+            status: "online",
+          }).catch(() => {});
+        } else {
+          pendingUpdate = { version: machineRow.pendingUpdateVersion };
+        }
       }
+
+      if (machineRow?.pendingRescan) {
+        pendingRescan = true;
+        await queries.machine.clearPendingRescan(db, body.daemon_id, ctx.workspaceId);
+      }
+    } catch (e) {
+      log.warn("pending check failed", { daemonId: body.daemon_id, err: String(e) });
     }
 
-    if (machineRow?.pendingRescan) {
-      pendingRescan = true;
-      await queries.machine.clearPendingRescan(db, body.daemon_id, ctx.workspaceId);
+    // Meeting claim — 5min claim window, 30s throttle is safe
+    try {
+      const CLAIM_WINDOW_MS = 5 * 60 * 1000;
+      const windowEnd = new Date(Date.now() + CLAIM_WINDOW_MS);
+      const now = new Date().toISOString();
+
+      const scheduled = await queries.meetingSession.listScheduledMeetings(
+        db,
+        ctx.workspaceId,
+        windowEnd.toISOString(),
+      );
+
+      if (scheduled.length > 0) {
+        const ids = scheduled.map((m) => m.id);
+        const claimedRows = await queries.meetingSession.claimMeetingSessions(
+          db,
+          ids,
+          ctx.workspaceId,
+          now,
+        );
+        if (claimedRows.length > 0) {
+          const scheduledMap = new Map(scheduled.map((m) => [m.id, m]));
+          meetings = claimedRows.map((row) => {
+            const sched = scheduledMap.get(row.id);
+            return {
+              id: row.id,
+              meeting_url: row.meetingUrl,
+              participants: row.participants as string[],
+              workspace_id: row.workspaceId,
+              agent_id: row.agentId,
+              agent_name: sched?.agentName || "",
+              title: sched?.title || undefined,
+            };
+          });
+        }
+      }
+    } catch (e) {
+      log.warn("meeting-claim: failed in poll", { err: String(e) });
     }
-  } catch (e) {
-    log.warn("pending check failed", { daemonId: body.daemon_id, err: String(e) });
   }
 
-  // 7. Pending file browse requests + cleanup
+  // File browse requests — expireStale throttled to 5s, but check pending every poll
   let fileRequests: FileRequestItem[] | undefined;
   try {
-    await queries.workspaceFileRequest.expireStale(db, ctx.workspaceId);
+    let expireRun = false;
+    await cached(`expire_fr:${ctx.workspaceId}`, 5, async () => { expireRun = true; return "1"; }).catch(() => { expireRun = true; });
+    if (expireRun) {
+      await queries.workspaceFileRequest.expireStale(db, ctx.workspaceId);
+    }
     const pending = await queries.workspaceFileRequest.getPendingByWorkspace(db, ctx.workspaceId);
     if (pending.length > 0) {
       fileRequests = pending.map((r) => ({
@@ -249,47 +358,6 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     }
   } catch (e) {
     log.warn("file-requests: poll failed", { err: String(e) });
-  }
-
-  // 8. Meeting claim — piggyback on poll to avoid a separate HTTP request
-  let meetings: PollMeetingItem[] | undefined;
-  try {
-    const CLAIM_WINDOW_MS = 5 * 60 * 1000;
-    const windowEnd = new Date(Date.now() + CLAIM_WINDOW_MS);
-    const now = new Date().toISOString();
-
-    const scheduled = await queries.meetingSession.listScheduledMeetings(
-      db,
-      ctx.workspaceId,
-      windowEnd.toISOString(),
-    );
-
-    if (scheduled.length > 0) {
-      const ids = scheduled.map((m) => m.id);
-      const claimedRows = await queries.meetingSession.claimMeetingSessions(
-        db,
-        ids,
-        ctx.workspaceId,
-        now,
-      );
-      if (claimedRows.length > 0) {
-        const scheduledMap = new Map(scheduled.map((m) => [m.id, m]));
-        meetings = claimedRows.map((row) => {
-          const sched = scheduledMap.get(row.id);
-          return {
-            id: row.id,
-            meeting_url: row.meetingUrl,
-            participants: row.participants as string[],
-            workspace_id: row.workspaceId,
-            agent_id: row.agentId,
-            agent_name: sched?.agentName || "",
-            title: sched?.title || undefined,
-          };
-        });
-      }
-    }
-  } catch (e) {
-    log.warn("meeting-claim: failed in poll", { err: String(e) });
   }
 
   return writeJSON({

--- a/src/web/src/app/api/runtimes/route.ts
+++ b/src/web/src/app/api/runtimes/route.ts
@@ -6,6 +6,7 @@ import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON } from "@/lib/middleware/helpers";
 import { runtimeToResponse } from "@/lib/api/responses";
 import { sweepStaleState } from "@/lib/services/sweep";
+import { cacheKeys } from "@/lib/cache";
 
 export const GET = withAuth(async (req, ctx) => {
   const ws = await withWorkspaceMember(req, ctx);
@@ -18,5 +19,17 @@ export const GET = withAuth(async (req, ctx) => {
   await sweepStaleState(db, ws.workspaceId);
 
   const runtimes = await queries.runtime.listAgentRuntimes(db, ws.workspaceId);
+
+  // Overlay KV heartbeats for real-time online status
+  const kv = (env as Env).CACHE_KV ?? null;
+  if (kv) {
+    await Promise.all(runtimes.map(async (rt) => {
+      if (rt.daemonId) {
+        const hb = await kv.get(cacheKeys.heartbeat(ws.workspaceId, rt.daemonId)).catch(() => null);
+        if (hb) (rt as any).machineLastSeenAt = hb;
+      }
+    }));
+  }
+
   return writeJSON(runtimes.map(runtimeToResponse));
 });

--- a/src/web/src/lib/cache.test.ts
+++ b/src/web/src/lib/cache.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { cached, cachedBatch, invalidate, invalidateMany, bindCacheKV, cacheKeys, getKV } from "./cache";
+
+function createMockKV() {
+  const store = new Map<string, { value: string; expiration?: number }>();
+  return {
+    get: vi.fn(async (key: string) => store.get(key)?.value ?? null),
+    put: vi.fn(async (key: string, value: string, opts?: { expirationTtl?: number }) => {
+      store.set(key, { value, expiration: opts?.expirationTtl });
+    }),
+    delete: vi.fn(async (key: string) => { store.delete(key); }),
+    _store: store,
+  } as unknown as KVNamespace & { _store: Map<string, { value: string; expiration?: number }> };
+}
+
+describe("cache", () => {
+  let mockKV: ReturnType<typeof createMockKV>;
+
+  beforeEach(() => {
+    mockKV = createMockKV();
+    bindCacheKV(mockKV);
+  });
+
+  describe("cached()", () => {
+    it("returns cached value on KV hit", async () => {
+      mockKV._store.set("test-key", { value: JSON.stringify({ data: "from-kv" }) });
+      const fn = vi.fn(async () => ({ data: "from-db" }));
+
+      const result = await cached("test-key", 300, fn);
+
+      expect(result).toEqual({ data: "from-kv" });
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    it("calls fn and stores to KV on cache miss", async () => {
+      const fn = vi.fn(async () => ({ data: "from-db" }));
+
+      const result = await cached("miss-key", 600, fn);
+
+      expect(result).toEqual({ data: "from-db" });
+      expect(fn).toHaveBeenCalledOnce();
+      expect(mockKV.put).toHaveBeenCalledWith(
+        "miss-key",
+        JSON.stringify({ data: "from-db" }),
+        { expirationTtl: 600 },
+      );
+    });
+
+    it("falls back to fn when KV read throws", async () => {
+      (mockKV.get as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("KV down"));
+      const fn = vi.fn(async () => ({ data: "fallback" }));
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const result = await cached("error-key", 300, fn);
+
+      expect(result).toEqual({ data: "fallback" });
+      expect(fn).toHaveBeenCalledOnce();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[cache] KV read failed for error-key"),
+        expect.any(Error),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it("still returns value when KV write throws", async () => {
+      (mockKV.put as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("KV write error"));
+      const fn = vi.fn(async () => ({ data: "ok" }));
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const result = await cached("write-fail-key", 300, fn);
+
+      expect(result).toEqual({ data: "ok" });
+      // Wait for async catch handler
+      await new Promise((r) => setTimeout(r, 10));
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[cache] KV write failed for write-fail-key"),
+        expect.any(Error),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it("does not store null values to KV", async () => {
+      const fn = vi.fn(async () => null);
+
+      const result = await cached("null-key", 300, fn as () => Promise<unknown>);
+
+      expect(result).toBeNull();
+      expect(mockKV.put).not.toHaveBeenCalled();
+    });
+
+    it("falls back to fn when KV is not bound", async () => {
+      bindCacheKV(null);
+      const fn = vi.fn(async () => ({ data: "no-kv" }));
+
+      const result = await cached("no-kv-key", 300, fn);
+
+      expect(result).toEqual({ data: "no-kv" });
+      expect(fn).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("cachedBatch()", () => {
+    it("returns all from KV on full cache hit", async () => {
+      mockKV._store.set("k1", { value: JSON.stringify("v1") });
+      mockKV._store.set("k2", { value: JSON.stringify("v2") });
+      const fetchMissing = vi.fn();
+
+      const result = await cachedBatch(["k1", "k2"], 300, fetchMissing);
+
+      expect(result.get("k1")).toBe("v1");
+      expect(result.get("k2")).toBe("v2");
+      expect(fetchMissing).not.toHaveBeenCalled();
+    });
+
+    it("fetches missing keys from D1 and stores in KV", async () => {
+      mockKV._store.set("k1", { value: JSON.stringify("cached") });
+      const fetchMissing = vi.fn(async (keys: string[]) => {
+        const m = new Map<string, string>();
+        for (const k of keys) m.set(k, `fetched-${k}`);
+        return m;
+      });
+
+      const result = await cachedBatch(["k1", "k2", "k3"], 300, fetchMissing);
+
+      expect(result.get("k1")).toBe("cached");
+      expect(result.get("k2")).toBe("fetched-k2");
+      expect(result.get("k3")).toBe("fetched-k3");
+      expect(fetchMissing).toHaveBeenCalledWith(["k2", "k3"]);
+      expect(mockKV.put).toHaveBeenCalledTimes(2);
+    });
+
+    it("falls back to full D1 fetch when KV throws", async () => {
+      (mockKV.get as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("KV down"));
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const fetchMissing = vi.fn(async (keys: string[]) => {
+        const m = new Map<string, string>();
+        for (const k of keys) m.set(k, `db-${k}`);
+        return m;
+      });
+
+      const result = await cachedBatch(["k1", "k2"], 300, fetchMissing);
+
+      expect(result.get("k1")).toBe("db-k1");
+      expect(result.get("k2")).toBe("db-k2");
+      expect(fetchMissing).toHaveBeenCalledWith(["k1", "k2"]);
+      warnSpy.mockRestore();
+    });
+
+    it("returns empty map for empty keys", async () => {
+      const fetchMissing = vi.fn();
+      const result = await cachedBatch([], 300, fetchMissing);
+      expect(result.size).toBe(0);
+      expect(fetchMissing).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("invalidate()", () => {
+    it("deletes key from KV", async () => {
+      mockKV._store.set("del-key", { value: "x" });
+      await invalidate("del-key");
+      expect(mockKV.delete).toHaveBeenCalledWith("del-key");
+    });
+
+    it("logs warning on KV delete failure", async () => {
+      (mockKV.delete as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("fail"));
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      await invalidate("fail-key");
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[cache] KV delete failed for fail-key"),
+        expect.any(Error),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it("does nothing when KV is not bound", async () => {
+      bindCacheKV(null);
+      await invalidate("no-kv-key");
+      expect(mockKV.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("invalidateMany()", () => {
+    it("deletes all specified keys", async () => {
+      await invalidateMany(["k1", "k2", "k3"]);
+      expect(mockKV.delete).toHaveBeenCalledTimes(3);
+      expect(mockKV.delete).toHaveBeenCalledWith("k1");
+      expect(mockKV.delete).toHaveBeenCalledWith("k2");
+      expect(mockKV.delete).toHaveBeenCalledWith("k3");
+    });
+
+    it("does not throw when some deletes fail", async () => {
+      (mockKV.delete as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error("fail"))
+        .mockResolvedValueOnce(undefined);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      await invalidateMany(["k1", "k2", "k3"]);
+
+      expect(mockKV.delete).toHaveBeenCalledTimes(3);
+      warnSpy.mockRestore();
+    });
+
+    it("handles empty keys array", async () => {
+      await invalidateMany([]);
+      expect(mockKV.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("cacheKeys", () => {
+    it("generates correct key formats", () => {
+      expect(cacheKeys.agent("ws1", "ag1")).toBe("ag:ws1:ag1");
+      expect(cacheKeys.member("ws1", "usr1")).toBe("mem:ws1:usr1");
+      expect(cacheKeys.user("usr1")).toBe("usr:usr1");
+      expect(cacheKeys.emailAccountsByAgent("ws1", "ag1")).toBe("ea:ws1:ag1");
+      expect(cacheKeys.colleaguesByAgent("ws1", "ag1")).toBe("col:ws1:ag1");
+      expect(cacheKeys.heartbeat("ws1", "d1")).toBe("hb:ws1:d1");
+      expect(cacheKeys.machineToken("al_1234567890abcdefghij_rest")).toBe("mt:al_1234567890abcdefg");
+      expect(cacheKeys.machineTokenLastUsed("al_1234567890abcdefghij_rest")).toBe("mt_lu:al_1234567890abcdefg");
+      expect(cacheKeys.runtimeIds("ws1", "d1")).toBe("rt:ws1:d1");
+    });
+  });
+
+  describe("KV complete failure scenario", () => {
+    it("all operations gracefully degrade when KV is entirely down", async () => {
+      const brokenKV = {
+        get: vi.fn().mockRejectedValue(new Error("503 Service Unavailable")),
+        put: vi.fn().mockRejectedValue(new Error("503 Service Unavailable")),
+        delete: vi.fn().mockRejectedValue(new Error("503 Service Unavailable")),
+      } as unknown as KVNamespace;
+      bindCacheKV(brokenKV);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      // cached() should fall through to fn
+      const result = await cached("key", 300, async () => "db-value");
+      expect(result).toBe("db-value");
+
+      // cachedBatch() should fetch all from D1
+      const batchResult = await cachedBatch(
+        ["k1", "k2"],
+        300,
+        async (keys) => new Map(keys.map((k) => [k, `val-${k}`])),
+      );
+      expect(batchResult.get("k1")).toBe("val-k1");
+      expect(batchResult.get("k2")).toBe("val-k2");
+
+      // invalidate() should not throw
+      await expect(invalidate("key")).resolves.toBeUndefined();
+      await expect(invalidateMany(["k1", "k2"])).resolves.toBeUndefined();
+
+      warnSpy.mockRestore();
+    });
+  });
+});

--- a/src/web/src/lib/cache.ts
+++ b/src/web/src/lib/cache.ts
@@ -4,7 +4,7 @@ export function bindCacheKV(kv: KVNamespace | null) {
   _kv = kv;
 }
 
-function getKV(): KVNamespace | null {
+export function getKV(): KVNamespace | null {
   return _kv ?? null;
 }
 
@@ -18,26 +18,94 @@ export async function cached<T>(
     try {
       const raw = await kv.get(key);
       if (raw) return JSON.parse(raw) as T;
-    } catch {}
+    } catch (err) {
+      console.warn(`[cache] KV read failed for ${key}:`, err);
+    }
   }
 
   const value = await fn();
 
   if (value != null && kv) {
-    kv.put(key, JSON.stringify(value), { expirationTtl: ttlSeconds }).catch(() => {});
+    kv.put(key, JSON.stringify(value), { expirationTtl: ttlSeconds }).catch((err) => {
+      console.warn(`[cache] KV write failed for ${key}:`, err);
+    });
   }
 
   return value;
 }
 
+/**
+ * Batch-get from KV. Returns { hits, misses } where hits is a Map of found entries
+ * and misses is the list of keys that need to be fetched from D1.
+ * On KV failure, all keys are returned as misses (graceful fallback).
+ */
+export async function cachedBatch<T>(
+  keys: string[],
+  ttlSeconds: number,
+  fetchMissing: (missingKeys: string[]) => Promise<Map<string, T>>,
+): Promise<Map<string, T>> {
+  if (keys.length === 0) return new Map();
+
+  const kv = getKV();
+  const result = new Map<string, T>();
+  let missingKeys = keys;
+
+  if (kv) {
+    const hits: string[] = [];
+    await Promise.all(
+      keys.map(async (key) => {
+        try {
+          const raw = await kv.get(key);
+          if (raw) {
+            result.set(key, JSON.parse(raw) as T);
+            hits.push(key);
+          }
+        } catch (err) {
+          console.warn(`[cache] KV batch read failed for ${key}:`, err);
+        }
+      }),
+    );
+    missingKeys = keys.filter((k) => !hits.includes(k));
+  }
+
+  if (missingKeys.length > 0) {
+    const fetched = await fetchMissing(missingKeys);
+    for (const [key, value] of fetched) {
+      result.set(key, value);
+      if (value != null && kv) {
+        kv.put(key, JSON.stringify(value), { expirationTtl: ttlSeconds }).catch((err) => {
+          console.warn(`[cache] KV batch write failed for ${key}:`, err);
+        });
+      }
+    }
+  }
+
+  return result;
+}
+
 export async function invalidate(key: string): Promise<void> {
   const kv = getKV();
-  if (kv) await kv.delete(key).catch(() => {});
+  if (kv) await kv.delete(key).catch((err) => {
+    console.warn(`[cache] KV delete failed for ${key}:`, err);
+  });
+}
+
+export async function invalidateMany(keys: string[]): Promise<void> {
+  const kv = getKV();
+  if (!kv || keys.length === 0) return;
+  await Promise.all(keys.map((key) => kv.delete(key).catch((err) => {
+    console.warn(`[cache] KV delete failed for ${key}:`, err);
+  })));
 }
 
 export const cacheKeys = {
   machineToken: (token: string) => `mt:${token.slice(0, 20)}`,
+  machineTokenLastUsed: (token: string) => `mt_lu:${token.slice(0, 20)}`,
   member: (workspaceId: string, userId: string) => `mem:${workspaceId}:${userId}`,
   runtimeIds: (workspaceId: string, daemonId: string) => `rt:${workspaceId}:${daemonId}`,
   agent: (workspaceId: string, agentId: string) => `ag:${workspaceId}:${agentId}`,
+  heartbeat: (workspaceId: string, daemonId: string) => `hb:${workspaceId}:${daemonId}`,
+  user: (userId: string) => `usr:${userId}`,
+  emailAccountsByAgent: (workspaceId: string, agentId: string) => `ea:${workspaceId}:${agentId}`,
+  colleaguesByAgent: (workspaceId: string, agentId: string) => `col:${workspaceId}:${agentId}`,
 };

--- a/src/web/src/lib/middleware/auth.ts
+++ b/src/web/src/lib/middleware/auth.ts
@@ -45,7 +45,14 @@ export function withAuth(handler: AuthenticatedHandler) {
           if (!mt) {
             return NextResponse.json({ error: "invalid token" }, { status: 401 })
           }
-          queries.machineToken.updateMachineTokenLastUsed(db, mt.id).catch(() => {})
+          cached(
+            cacheKeys.machineTokenLastUsed(raw),
+            900,
+            async () => {
+              await queries.machineToken.updateMachineTokenLastUsed(db, mt.id);
+              return "1";
+            },
+          ).catch(() => {});
           const authCtx: AuthContext = {
             userId: mt.userId,
             email: mt.userEmail,


### PR DESCRIPTION
## Summary

- **Problem**: `/api/daemon/tasks/poll` made ~20 D1 ops per request. When D1 experienced "Internal error in D1 DB storage caused object to be reset", all requests timed out (30-130s) or returned 500. Log analysis showed 76% D1 error rate during incident.
- **Solution**: KV-based caching + write throttling reduces D1 ops to 1-2 in the common case (no tasks pending). Full graceful degradation when KV is unavailable.

### Key changes

| Optimization | Before | After |
|---|---|---|
| Machine heartbeat | D1 write every poll | KV write every poll + D1 every 60s |
| Token lastUsedAt | D1 write every poll | D1 every 15min |
| Calendar promotion | D1 read+write every poll | Every 30s per workspace |
| Agent/user/member data | D1 read every poll | KV cached (5-30min TTL) |
| Pending update + meetings | D1 every poll | Every 30s |
| File request expiry | D1 DELETE every poll | Every 5s |

### Cache invalidation

All mutation endpoints now call `invalidate()` / `invalidateMany()` on related cache keys:
- `PATCH/DELETE /api/agents/[id]`
- `POST/PATCH/DELETE /api/agents/[id]/email-accounts`
- `POST/PATCH/DELETE /api/agent-links`

### KV failure handling

- All KV read errors → `console.warn` + transparent D1 fallback
- All KV write errors → `console.warn` + operation continues
- KV completely down → entire system works exactly as before (all D1)
- 18 new tests verify degradation behavior

## Test plan

- [x] TypeScript compiles clean (`tsc --noEmit` exit 0)
- [x] 89 existing related tests pass (auth, runtimes, poll, agents)
- [x] 18 new cache tests cover hit/miss/error/batch/invalidate
- [x] Lint passes (1 pre-existing warning only)
- [ ] Deploy to staging and monitor D1 rows_read/rows_written reduction
- [ ] Verify runtime online/offline status still updates correctly in UI
- [ ] Verify calendar events still fire within ~30s of schedule
- [ ] Verify file browse requests still work (30s window)