### PR TITLE
fix(web): reduce D1 heartbeat throttle to stay under offline threshold

### DIFF
--- a/src/web/src/app/api/daemon/tasks/poll/route.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.ts
@@ -34,7 +34,8 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     return writeJSON({ tasks: [], evicted: true });
   }
 
-  // 2. Liveness: write heartbeat to KV (fast) + throttle D1 upsert to every 60s
+  // 2. Liveness: write heartbeat to KV (fast) + D1 upsert throttled to stay under OFFLINE_THRESHOLD
+  // KV is eventually consistent across colos, so D1 must stay fresh enough as fallback.
   // Non-critical — D1 transient failures should not block task polling
   const kv = (env as Env).CACHE_KV ?? null;
   if (kv) {
@@ -47,7 +48,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
   try {
     await cached(
       `hb_d1:${ctx.workspaceId}:${body.daemon_id}`,
-      60,
+      7,
       async () => {
         await queries.machine.upsertMachine(db, {
           daemonId: body.daemon_id,

--- a/src/web/src/app/api/daemon/tasks/poll/route.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { queries, PollRequestSchema, semverGte, toAlookAddress, type FileRequestItem, type PollMeetingItem } from "@alook/shared";
+import { queries, PollRequestSchema, semverGte, toAlookAddress, OFFLINE_THRESHOLD_MS, POLL_INTERVAL_MS, type FileRequestItem, type PollMeetingItem } from "@alook/shared";
 import { getDb, withD1Retry } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
@@ -36,6 +36,8 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
 
   // 2. Liveness: write heartbeat to KV (fast) + D1 upsert throttled to stay under OFFLINE_THRESHOLD
   // KV is eventually consistent across colos, so D1 must stay fresh enough as fallback.
+  // Derived from timing constants so it auto-adapts if threshold or poll interval changes.
+  const D1_HEARTBEAT_THROTTLE_S = Math.floor((OFFLINE_THRESHOLD_MS - POLL_INTERVAL_MS) / 1000) - 1;
   // Non-critical — D1 transient failures should not block task polling
   const kv = (env as Env).CACHE_KV ?? null;
   if (kv) {
@@ -48,7 +50,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
   try {
     await cached(
       `hb_d1:${ctx.workspaceId}:${body.daemon_id}`,
-      7,
+      D1_HEARTBEAT_THROTTLE_S,
       async () => {
         await queries.machine.upsertMachine(db, {
           daemonId: body.daemon_id,

--- a/src/web/src/app/api/runtimes/route.ts
+++ b/src/web/src/app/api/runtimes/route.ts
@@ -26,7 +26,7 @@ export const GET = withAuth(async (req, ctx) => {
     await Promise.all(runtimes.map(async (rt) => {
       if (rt.daemonId) {
         const hb = await kv.get(cacheKeys.heartbeat(ws.workspaceId, rt.daemonId)).catch(() => null);
-        if (hb) (rt as any).machineLastSeenAt = hb;
+        if (hb) rt.machineLastSeenAt = hb;
       }
     }));
   }


### PR DESCRIPTION
## Summary

Fixes machine showing offline immediately after #80 deploy.

**Root cause**: D1 heartbeat was throttled to 60s, but `OFFLINE_THRESHOLD_MS = 9s`. KV heartbeat compensates for same-colo requests, but KV is eventually consistent across colos (up to 60s propagation). When `GET /api/runtimes` hits a different colo than the daemon's poll, KV heartbeat isn't visible, and the D1 fallback is stale → shows offline.

**Fix**: Reduced D1 heartbeat throttle from 60s to 7s (just under the 9s offline threshold). This ensures D1 always has a fresh enough value regardless of KV cross-colo delay.

## Test plan

- [x] TypeScript compiles
- [x] 37 poll tests pass
- [ ] Verify daemon stays online in UI after deploy