### PR TITLE
feat(cli): PTY-based Claude backend for interactive billing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,6 +139,19 @@
 
 
 # =============================================================================
+# Agent Backend
+# =============================================================================
+# Choose how Claude is invoked. "pipe" uses `claude -p` (default).
+# "pty" spawns an interactive PTY session (avoids programmatic billing).
+
+# ALOOK_CLAUDE_BACKEND=pipe
+
+# PTY mode tuning (only relevant when ALOOK_CLAUDE_BACKEND=pty)
+# ALOOK_PTY_QUIESCENT_MS=500
+# ALOOK_PTY_READY_TIMEOUT_MS=30000
+
+
+# =============================================================================
 # Agent Models
 # =============================================================================
 # Override the default model for each agent runtime.

--- a/src/cli/daemon/agent/ansi-scanner.ts
+++ b/src/cli/daemon/agent/ansi-scanner.ts
@@ -1,0 +1,65 @@
+/**
+ * ANSI terminal query responder for Ink-based TUI applications.
+ *
+ * When Claude Code starts, Ink sends DA1/DA2/DSR/XTVERSION queries to detect
+ * terminal capabilities. If these are not answered, the TUI hangs indefinitely.
+ * This scanner detects those queries in PTY output and writes appropriate responses.
+ */
+
+export interface TerminalWriter {
+  write(data: string): void;
+}
+
+/**
+ * Scans PTY output for terminal capability queries and responds to them.
+ * Returns true if any query was detected and responded to.
+ */
+export function handleTerminalQueries(
+  data: string,
+  terminal: TerminalWriter,
+): boolean {
+  let handled = false;
+
+  // DA1 — Primary Device Attributes: \x1b[c or \x1b[0c
+  // Respond as xterm-compatible terminal
+  if (/\x1b\[(?:0)?c/.test(data)) {
+    terminal.write("\x1b[?62;22c");
+    handled = true;
+  }
+
+  // DA2 — Secondary Device Attributes: \x1b[>c or \x1b[>0c
+  // Respond with xterm version
+  if (/\x1b\[>(?:0)?c/.test(data)) {
+    terminal.write("\x1b[>41;0;0c");
+    handled = true;
+  }
+
+  // DSR — Device Status Report / Cursor Position: \x1b[6n
+  // Respond with cursor at row 1, col 1
+  if (/\x1b\[6n/.test(data)) {
+    terminal.write("\x1b[1;1R");
+    handled = true;
+  }
+
+  // XTVERSION — Terminal version query: \x1b[>0q or \x1b[>q
+  if (/\x1b\[>(?:0)?q/.test(data)) {
+    terminal.write("\x1bP>|xterm(388)\x1b\\");
+    handled = true;
+  }
+
+  // Window size query (DTTERM): \x1b[18t
+  if (/\x1b\[18t/.test(data)) {
+    terminal.write("\x1b[8;24;80t");
+    handled = true;
+  }
+
+  return handled;
+}
+
+/**
+ * Strip ANSI escape sequences from terminal output for text inspection.
+ */
+export function stripAnsi(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1b(?:\[[0-9;]*[a-zA-Z]|\][^\x07]*\x07|\].*?\x1b\\|\[[\?\>\=]?[0-9;]*[a-zA-Z])/g, "");
+}

--- a/src/cli/daemon/agent/claude-pty.ts
+++ b/src/cli/daemon/agent/claude-pty.ts
@@ -1,0 +1,384 @@
+/**
+ * ClaudePTYBackend — runs Claude Code in an interactive PTY session.
+ *
+ * Instead of `claude -p` (programmatic mode, billed as Agent SDK usage),
+ * this backend spawns an interactive Claude TUI inside a pseudo-terminal,
+ * writes the prompt as if a human typed it, and reads structured events
+ * from the session JSONL file that Claude Code persists automatically.
+ *
+ * This preserves full streaming of text, thinking, tool-use, and tool-result
+ * events while being classified as "interactive" usage by Anthropic.
+ */
+
+import { spawn, type Subprocess } from "bun";
+import { openSync, readSync, closeSync, statSync, existsSync } from "fs";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import { handleTerminalQueries, stripAnsi } from "./ansi-scanner.js";
+import type { AgentBackend, AgentSession } from "./index.js";
+import type { ExecOptions, AgentMessage, AgentResult } from "../types.js";
+
+/** Safely write to a Bun subprocess stdin (which may be number | FileSink). */
+function writeToStdin(proc: Subprocess | undefined, data: string): void {
+  if (!proc?.stdin) return;
+  try {
+    if (typeof proc.stdin === "number") {
+      // Terminal mode may expose stdin as a raw fd
+      const { writeSync } = require("fs");
+      writeSync(proc.stdin, data);
+    } else if (typeof proc.stdin === "object" && "write" in proc.stdin) {
+      (proc.stdin as { write(data: string): void }).write(data);
+    }
+  } catch {
+    // stdin may be closed
+  }
+}
+
+/** How long to wait for PTY output to stabilize before considering TUI ready. */
+const QUIESCENT_MS = parseInt(process.env.ALOOK_PTY_QUIESCENT_MS || "500", 10);
+/** Maximum time to wait for TUI to become ready. */
+const READY_TIMEOUT_MS = parseInt(process.env.ALOOK_PTY_READY_TIMEOUT_MS || "30000", 10);
+/** Interval for polling session JSONL for new events. */
+const JSONL_POLL_MS = 200;
+
+export class ClaudePTYBackend implements AgentBackend {
+  name = "claude-pty";
+
+  constructor(private cliPath: string) {}
+
+  execute(prompt: string, options: ExecOptions): AgentSession {
+    const sessionId = options.resumeSessionId || randomUUID();
+    const startTime = Date.now();
+
+    // Build args for interactive mode (no -p flag)
+    const args: string[] = [];
+
+    if (options.resumeSessionId) {
+      args.push("--resume", options.resumeSessionId);
+    } else {
+      args.push("--session-id", sessionId);
+    }
+
+    args.push("--permission-mode", "bypassPermissions");
+
+    if (options.model) {
+      args.push("--model", options.model);
+    }
+    if (options.maxTurns) {
+      args.push("--max-turns", String(options.maxTurns));
+    }
+
+    // State
+    let lastDataTime = 0;
+    let tuiReady = false;
+    let promptWritten = false;
+    let lastOutput = "";
+    let lastError = "";
+    let resultStatus: AgentResult["status"] = "completed";
+    let timedOut = false;
+    let jsonlByteOffset = 0;
+    let proc: Subprocess | undefined;
+
+    // Message queue (same pattern as ClaudeBackend)
+    const messageQueue: AgentMessage[] = [];
+    let messageResolve: (() => void) | null = null;
+    let messageDone = false;
+
+    const pushMessage = (msg: AgentMessage) => {
+      messageQueue.push(msg);
+      if (messageResolve) {
+        const r = messageResolve;
+        messageResolve = null;
+        r();
+      }
+    };
+
+    // Session ID promise
+    let resolveSessionId: (id: string) => void;
+    const sessionIdPromise = new Promise<string>((resolve) => {
+      resolveSessionId = resolve;
+    });
+
+    // Result promise
+    const resultPromise = new Promise<AgentResult>((resolveResult) => {
+      const decoder = new TextDecoder();
+      let outputBuffer = "";
+
+      // --- Timeout handling ---
+      let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+      if (options.timeout) {
+        timeoutTimer = setTimeout(() => {
+          timedOut = true;
+          proc?.kill();
+        }, options.timeout);
+      }
+
+      // --- JSONL watcher ---
+      let jsonlPath: string | null = null;
+      let jsonlPollTimer: ReturnType<typeof setInterval> | undefined;
+
+      function findJsonlPath(cwd: string, sid: string): string {
+        // Claude Code encodes cwd by replacing / with -
+        const encoded = cwd.replace(/\//g, "-");
+        return join(
+          process.env.HOME || "~",
+          ".claude",
+          "projects",
+          encoded,
+          "sessions",
+          `${sid}.jsonl`,
+        );
+      }
+
+      function processJsonlLines() {
+        if (!jsonlPath || !existsSync(jsonlPath)) return;
+
+        let fileSize: number;
+        try {
+          fileSize = statSync(jsonlPath).size;
+        } catch {
+          return;
+        }
+        if (fileSize <= jsonlByteOffset) return;
+
+        let chunk: string;
+        try {
+          const fd = openSync(jsonlPath, "r");
+          const buf = Buffer.alloc(fileSize - jsonlByteOffset);
+          readSync(fd, buf, 0, buf.length, jsonlByteOffset);
+          closeSync(fd);
+          jsonlByteOffset = fileSize;
+          chunk = buf.toString("utf-8");
+        } catch {
+          return;
+        }
+
+        const newLines = chunk.split("\n").filter(Boolean);
+
+        for (const line of newLines) {
+          let event: Record<string, unknown>;
+          try {
+            event = JSON.parse(line);
+          } catch {
+            continue;
+          }
+
+          const eventType = event.type as string | undefined;
+
+          if (eventType === "assistant") {
+            const message = event.message as Record<string, unknown> | undefined;
+            if (!message) continue;
+
+            const content = message.content as
+              | { type: string; text?: string; thinking?: string; name?: string; id?: string; input?: Record<string, unknown> }[]
+              | undefined;
+
+            if (Array.isArray(content)) {
+              for (const block of content) {
+                if (block.type === "text") {
+                  lastOutput = block.text || "";
+                  pushMessage({ type: "text", content: block.text });
+                } else if (block.type === "thinking") {
+                  // Note: session JSONL uses `thinking` field, while pipe mode stream-json uses `text`.
+                  pushMessage({ type: "thinking", content: block.thinking });
+                } else if (block.type === "tool_use") {
+                  pushMessage({
+                    type: "tool-use",
+                    tool: block.name,
+                    callId: block.id,
+                    input: block.input,
+                  });
+                }
+              }
+            }
+
+            // Check for completion
+            const stopReason = message.stop_reason as string | undefined;
+            if (stopReason === "end_turn") {
+              // Send /exit to gracefully close the TUI
+              setTimeout(() => {
+                writeToStdin(proc, "/exit\n");
+              }, 300);
+            }
+          } else if (eventType === "user") {
+            const message = event.message as Record<string, unknown> | undefined;
+            if (!message) continue;
+
+            const content = message.content as
+              | { type: string; tool_use_id?: string; content?: string; is_error?: boolean }[]
+              | undefined;
+
+            if (Array.isArray(content)) {
+              for (const block of content) {
+                if (block.type === "tool_result") {
+                  pushMessage({
+                    type: "tool-result",
+                    callId: block.tool_use_id,
+                    output: typeof block.content === "string" ? block.content : JSON.stringify(block.content),
+                  });
+                }
+              }
+            }
+          }
+          // Ignore queue-operation, last-prompt, system, and other types
+        }
+      }
+
+      // --- Spawn PTY ---
+      try {
+        proc = spawn([this.cliPath, ...args], {
+          cwd: options.cwd,
+          env: { ...process.env, ...options.env, NO_COLOR: "1" },
+          terminal: {
+            cols: 120,
+            rows: 40,
+            data(_terminal, data) {
+              const text = data instanceof Uint8Array ? decoder.decode(data) : String(data);
+              outputBuffer += text;
+              lastDataTime = Date.now();
+
+              // Respond to Ink terminal queries
+              handleTerminalQueries(text, {
+                write: (s: string) => writeToStdin(proc, s),
+              });
+            },
+          },
+        });
+      } catch (err) {
+        resolveSessionId(sessionId);
+        messageDone = true;
+        if (messageResolve) {
+          const r = messageResolve;
+          messageResolve = null;
+          r();
+        }
+        resolveResult({
+          status: "failed",
+          output: "",
+          error: `Failed to spawn PTY: ${err}`,
+          durationMs: Date.now() - startTime,
+          sessionId,
+        });
+        return;
+      }
+
+      resolveSessionId(sessionId);
+
+      // --- TUI readiness detection ---
+      const readyCheckInterval = setInterval(() => {
+        const now = Date.now();
+
+        // Startup timeout: if TUI never becomes ready
+        if (!tuiReady && now - startTime > READY_TIMEOUT_MS) {
+          clearInterval(readyCheckInterval);
+          lastError = "PTY TUI failed to become ready within timeout";
+          resultStatus = "failed";
+          proc?.kill();
+          return;
+        }
+
+        // Check for quiescent state + prompt character
+        if (
+          !tuiReady &&
+          lastDataTime > 0 &&
+          now - lastDataTime > QUIESCENT_MS
+        ) {
+          const stripped = stripAnsi(outputBuffer);
+          if (stripped.includes("❯")) {
+            tuiReady = true;
+            clearInterval(readyCheckInterval);
+
+            // Write the prompt
+            if (!promptWritten) {
+              promptWritten = true;
+
+              // Start watching JSONL file
+              jsonlPath = findJsonlPath(options.cwd, sessionId);
+
+              // Poll for JSONL updates
+              jsonlPollTimer = setInterval(processJsonlLines, JSONL_POLL_MS);
+
+              // Write prompt to PTY stdin
+              writeToStdin(proc, prompt + "\n");
+            }
+          }
+        }
+      }, 100);
+
+      // --- Process exit handling ---
+      (async () => {
+        try {
+          const exitCode = await proc!.exited;
+
+          if (timeoutTimer) clearTimeout(timeoutTimer);
+          clearInterval(readyCheckInterval);
+          if (jsonlPollTimer) clearInterval(jsonlPollTimer);
+
+          // Final JSONL read to catch any remaining events
+          processJsonlLines();
+
+          if (timedOut) {
+            resultStatus = "timeout";
+          } else if (exitCode !== 0 && resultStatus === "completed") {
+            resultStatus = "failed";
+          }
+
+          messageDone = true;
+          if (messageResolve) {
+            const r = messageResolve;
+            messageResolve = null;
+            r();
+          }
+
+          resolveResult({
+            status: resultStatus,
+            output: lastOutput,
+            error: lastError,
+            durationMs: Date.now() - startTime,
+            sessionId,
+          });
+        } catch (err) {
+          messageDone = true;
+          if (messageResolve) {
+            const r = messageResolve;
+            messageResolve = null;
+            r();
+          }
+          resolveResult({
+            status: "failed",
+            output: lastOutput,
+            error: `PTY process error: ${err}`,
+            durationMs: Date.now() - startTime,
+            sessionId,
+          });
+        }
+      })();
+    });
+
+    // Async message iterator (same pattern as ClaudeBackend)
+    const messages: AsyncIterable<AgentMessage> = {
+      [Symbol.asyncIterator]() {
+        return {
+          async next(): Promise<IteratorResult<AgentMessage>> {
+            while (messageQueue.length === 0 && !messageDone) {
+              await new Promise<void>((resolve) => {
+                messageResolve = resolve;
+              });
+            }
+            if (messageQueue.length > 0) {
+              return { value: messageQueue.shift()!, done: false };
+            }
+            return { value: undefined as unknown as AgentMessage, done: true };
+          },
+        };
+      },
+    };
+
+    return {
+      pid: proc?.pid,
+      messages,
+      sessionId: sessionIdPromise,
+      result: resultPromise,
+    };
+  }
+}

--- a/src/cli/daemon/agent/claude-pty.ts
+++ b/src/cli/daemon/agent/claude-pty.ts
@@ -10,23 +10,35 @@
  * events while being classified as "interactive" usage by Anthropic.
  */
 
-import { spawn, type Subprocess } from "bun";
-import { openSync, readSync, closeSync, statSync, existsSync } from "fs";
+import { openSync, readSync, closeSync, statSync, existsSync, writeSync as fsWriteSync } from "fs";
 import { join } from "path";
 import { randomUUID } from "crypto";
 import { handleTerminalQueries, stripAnsi } from "./ansi-scanner.js";
 import type { AgentBackend, AgentSession } from "./index.js";
 import type { ExecOptions, AgentMessage, AgentResult } from "../types.js";
 
+/**
+ * Access Bun APIs at runtime without a static `import from "bun"`,
+ * which would break the bundler when target !== "bun".
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const BunRuntime = globalThis as any;
+
+interface BunProc {
+  pid: number;
+  stdin: unknown;
+  exited: Promise<number>;
+  kill(): void;
+}
+
 /** Safely write to a Bun subprocess stdin (which may be number | FileSink). */
-function writeToStdin(proc: Subprocess | undefined, data: string): void {
+function writeToStdin(proc: BunProc | undefined, data: string): void {
   if (!proc?.stdin) return;
   try {
     if (typeof proc.stdin === "number") {
       // Terminal mode may expose stdin as a raw fd
-      const { writeSync } = require("fs");
-      writeSync(proc.stdin, data);
-    } else if (typeof proc.stdin === "object" && "write" in proc.stdin) {
+      fsWriteSync(proc.stdin, data);
+    } else if (typeof proc.stdin === "object" && "write" in (proc.stdin as object)) {
       (proc.stdin as { write(data: string): void }).write(data);
     }
   } catch {
@@ -77,7 +89,7 @@ export class ClaudePTYBackend implements AgentBackend {
     let resultStatus: AgentResult["status"] = "completed";
     let timedOut = false;
     let jsonlByteOffset = 0;
-    let proc: Subprocess | undefined;
+    let proc: BunProc | undefined;
 
     // Message queue (same pattern as ClaudeBackend)
     const messageQueue: AgentMessage[] = [];
@@ -226,13 +238,14 @@ export class ClaudePTYBackend implements AgentBackend {
 
       // --- Spawn PTY ---
       try {
-        proc = spawn([this.cliPath, ...args], {
+        proc = BunRuntime.Bun.spawn([this.cliPath, ...args], {
           cwd: options.cwd,
           env: { ...process.env, ...options.env, NO_COLOR: "1" },
           terminal: {
             cols: 120,
             rows: 40,
-            data(_terminal, data) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            data(_terminal: any, data: any) {
               const text = data instanceof Uint8Array ? decoder.decode(data) : String(data);
               outputBuffer += text;
               lastDataTime = Date.now();

--- a/src/cli/daemon/agent/index.ts
+++ b/src/cli/daemon/agent/index.ts
@@ -1,5 +1,6 @@
 import type { ExecOptions, AgentMessage, AgentResult } from "../types.js";
 import { ClaudeBackend } from "./claude.js";
+import { ClaudePTYBackend } from "./claude-pty.js";
 import { CodexBackend } from "./codex.js";
 import { OpenCodeBackend } from "./opencode.js";
 import { execSync } from "child_process";
@@ -21,8 +22,13 @@ export function createBackend(
   cliPath: string,
 ): AgentBackend {
   switch (provider) {
-    case "claude":
+    case "claude": {
+      const backend = process.env.ALOOK_CLAUDE_BACKEND || "pipe";
+      if (backend === "pty") {
+        return new ClaudePTYBackend(cliPath);
+      }
       return new ClaudeBackend(cliPath);
+    }
     case "codex":
       return new CodexBackend(cliPath);
     case "opencode":


### PR DESCRIPTION
## Summary

- Adds `ClaudePTYBackend` that spawns Claude Code in an interactive PTY session instead of `claude -p`, so usage is classified as "interactive" rather than "programmatic" under Anthropic's June 15 billing split
- Reads all events (text, thinking, tool-use, tool-result) from Claude's session JSONL file, preserving full streaming — no UI degradation
- Switched via `ALOOK_CLAUDE_BACKEND=pty` env var; default (`pipe`) behavior unchanged

### New files
- `src/cli/daemon/agent/claude-pty.ts` — ClaudePTYBackend using Bun.Terminal API + session JSONL polling
- `src/cli/daemon/agent/ansi-scanner.ts` — Responds to Ink's DA1/DA2/DSR/XTVERSION terminal queries to prevent TUI hang

### Key design decisions
- PTY output is NOT parsed for content — only used for lifecycle control (readiness detection + `/exit`)
- Business data comes entirely from `~/.claude/projects/<encoded-cwd>/sessions/<id>.jsonl`
- Incremental byte-offset JSONL reading for performance on long sessions
- Zero new npm dependencies (uses Bun native PTY API)

## Test plan
- [ ] Set `ALOOK_CLAUDE_BACKEND=pty` and run a full task: prompt → thinking → tool-use → tool-result → final reply
- [ ] Verify AgentMessage stream matches pipe mode output
- [ ] Verify timeout handling (PTY startup timeout, execution timeout, JSONL inactivity)
- [ ] Verify no zombie processes after task completion
- [ ] Verify `ALOOK_CLAUDE_BACKEND=pipe` (default) still works unchanged
- [ ] Verify on Max subscription that usage is not billed to Agent SDK pool

🤖 Generated with [Claude Code](https://claude.com/claude-code)