### PR TITLE
fix(web): resolve Better Auth dual module hazard and D1 query timeouts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11266,7 +11266,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.6
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
@@ -11289,7 +11289,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11304,13 +11304,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -11325,7 +11325,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3

--- a/src/shared/src/db/schema.ts
+++ b/src/shared/src/db/schema.ts
@@ -223,6 +223,7 @@ export const agentRuntime = sqliteTable(
       t.daemonId,
       t.provider
     ),
+    index("idx_agent_runtime_workspace_daemon").on(t.workspaceId, t.daemonId),
   ]
 );
 
@@ -376,6 +377,7 @@ export const agentTaskQueue = sqliteTable(
       .on(t.conversationId, t.status),
     index("idx_task_queue_trace").on(t.traceId),
     index("idx_task_queue_parent").on(t.parentTaskId),
+    index("idx_task_queue_workspace_type_status").on(t.workspaceId, t.type, t.status),
     foreignKey({
       columns: [t.agentId, t.workspaceId],
       foreignColumns: [agent.id, agent.workspaceId],

--- a/src/web/migrations/0028_add_runtime_and_task_indexes.sql
+++ b/src/web/migrations/0028_add_runtime_and_task_indexes.sql
@@ -1,0 +1,13 @@
+-- Add missing indexes for agent_runtime and agent_task_queue tables
+-- Fixes D1 query timeouts on high-frequency daemon poll and runtime sweep paths
+
+-- agent_runtime: fast lookup by (workspace_id, daemon_id) for daemon task polling
+-- The existing unique constraint on (workspace_id, daemon_id, provider) doesn't
+-- efficiently cover queries filtering only by workspace_id + daemon_id.
+CREATE INDEX IF NOT EXISTS idx_agent_runtime_workspace_daemon
+  ON agent_runtime(workspace_id, daemon_id);
+
+-- agent_task_queue: covers failStaleKillTasks() sweep query filtering by
+-- (workspace_id, type, status) during GET /api/runtimes
+CREATE INDEX IF NOT EXISTS idx_task_queue_workspace_type_status
+  ON agent_task_queue(workspace_id, type, status);

--- a/src/web/next.config.ts
+++ b/src/web/next.config.ts
@@ -2,6 +2,10 @@ import type { NextConfig } from "next";
 import path from "node:path";
 
 const nextConfig: NextConfig = {
+	// Prevent the bundler from creating duplicate copies of @better-auth/core,
+	// which breaks AsyncLocalStorage-based request state (dual module hazard).
+	// See: https://www.better-auth.com/docs/reference/faq#troubleshooting
+	serverExternalPackages: ["better-auth", "@better-auth/core"],
 	turbopack: {
 		root: path.resolve(__dirname, "../.."),
 	},

--- a/src/web/src/app/api/runtimes/route.test.ts
+++ b/src/web/src/app/api/runtimes/route.test.ts
@@ -12,6 +12,7 @@ vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
 
 vi.mock("@alook/shared", () => ({
   createDb: vi.fn(() => ({})),
+  createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
   queries: {
     runtime: {
       listAgentRuntimes: (...args: unknown[]) => mockListAgentRuntimes(...args),

--- a/src/web/src/app/api/runtimes/route.ts
+++ b/src/web/src/app/api/runtimes/route.ts
@@ -1,5 +1,5 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { queries } from "@alook/shared"
+import { queries, createLogger } from "@alook/shared"
 import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
@@ -7,6 +7,8 @@ import { writeJSON } from "@/lib/middleware/helpers";
 import { runtimeToResponse } from "@/lib/api/responses";
 import { sweepStaleState } from "@/lib/services/sweep";
 import { cacheKeys } from "@/lib/cache";
+
+const log = createLogger({ service: "api:runtimes" })
 
 export const GET = withAuth(async (req, ctx) => {
   const ws = await withWorkspaceMember(req, ctx);
@@ -16,7 +18,11 @@ export const GET = withAuth(async (req, ctx) => {
   const db = getDb((env as Env).DB)
 
   // Sweep stale state: mark offline runtimes, fail stuck tasks, reconcile agents
-  await sweepStaleState(db, ws.workspaceId);
+  try {
+    await sweepStaleState(db, ws.workspaceId);
+  } catch (err) {
+    log.warn("sweepStaleState failed, continuing", { workspaceId: ws.workspaceId, err: String(err) })
+  }
 
   const runtimes = await queries.runtime.listAgentRuntimes(db, ws.workspaceId);
 

--- a/src/web/src/lib/db.test.ts
+++ b/src/web/src/lib/db.test.ts
@@ -21,7 +21,7 @@ describe("withD1Retry", () => {
   it("throws after all retries exhausted", async () => {
     const fn = vi.fn().mockRejectedValue(new Error("D1 down"));
     await expect(withD1Retry(fn)).rejects.toThrow("D1 down");
-    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenCalledTimes(4);
   });
 
   it("respects custom retry count", async () => {

--- a/src/web/src/lib/db.ts
+++ b/src/web/src/lib/db.ts
@@ -7,7 +7,7 @@ export function getDb(d1: D1Database): Database {
   return createDb(session as unknown as Parameters<typeof createDb>[0])
 }
 
-export async function withD1Retry<T>(fn: () => Promise<T>, retries = 1): Promise<T> {
+export async function withD1Retry<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
   for (let i = 0; i <= retries; i++) {
     try {
       return await fn();


### PR DESCRIPTION
# Why we need this PR?

Production error logs showed three categories of recurring errors affecting multiple users across TW/CA/CN/JP/FI:
1. **Better Auth `INTERNAL_SERVER_ERROR: No request state found`** — on all authenticated API endpoints
2. **D1 query failures on `agent_runtime`** — during daemon task polling
3. **D1 query failures on `agent_task_queue`** — during stale task cleanup, cascading to 500 on GET /api/runtimes

## What changed

### Better Auth Dual Module Hazard (P0)
- Added `better-auth` and `@better-auth/core` to `serverExternalPackages` in `next.config.ts`
- Root cause: the bundler was creating duplicate instances of `@better-auth/core`, each with its own `AsyncLocalStorage`. `runWithRequestState` created context in one instance while `defineRequestState` looked for it in another — causing the "No request state found" error
- This is a [documented issue](https://www.better-auth.com/docs/reference/faq#troubleshooting) in Better Auth v1.4+

### Missing D1 Indexes (P1)
- Added `idx_agent_runtime_workspace_daemon` on `agent_runtime(workspace_id, daemon_id)` — covers the high-frequency daemon poll query that was doing full table scans
- Added `idx_task_queue_workspace_type_status` on `agent_task_queue(workspace_id, type, status)` — covers the `failStaleKillTasks()` sweep query
- Migration: `0028_add_runtime_and_task_indexes.sql`

### Error Handling & Resilience (P2)
- Wrapped `sweepStaleState()` in try-catch in `GET /api/runtimes` so cleanup failures no longer return 500
- Increased `withD1Retry` default retries from 1 to 3 for better transient failure recovery

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...