### PR TITLE
perf: default all D1 sessions to read replicas

### DIFF
--- a/src/web/src/app/api/agents/active-task-counts/route.test.ts
+++ b/src/web/src/app/api/agents/active-task-counts/route.test.ts
@@ -18,7 +18,7 @@ vi.mock("@/lib/middleware/helpers", () => ({
 vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
 }));
-vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})), getReadDb: vi.fn(() => ({})) }));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
 vi.mock("@/lib/cache", () => ({
   cached: vi.fn((_key: string, _ttl: number, fn: () => any) => fn()),
   cacheKeys: { activeTaskCounts: (ws: string) => `atc:${ws}` },

--- a/src/web/src/app/api/agents/active-task-counts/route.ts
+++ b/src/web/src/app/api/agents/active-task-counts/route.ts
@@ -1,6 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { queries } from "@alook/shared";
-import { getReadDb } from "@/lib/db";
+import { getDb } from "@/lib/db";
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON } from "@/lib/middleware/helpers";
@@ -11,7 +11,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = getReadDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const counts = await cached(cacheKeys.activeTaskCounts(ws.workspaceId), 10, async () => {
     const rows = await queries.task.listActiveTaskCountsByWorkspace(db, ws.workspaceId);

--- a/src/web/src/app/api/agents/route.test.ts
+++ b/src/web/src/app/api/agents/route.test.ts
@@ -9,7 +9,7 @@ const mockCreateAgent = vi.fn();
 const mockGetAgent = vi.fn();
 const mockGetAgentRuntimeForWorkspace = vi.fn();
 
-vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})), getReadDb: vi.fn(() => ({})) }));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
 
 vi.mock("@alook/shared", async () => {
   const actual = await vi.importActual("@alook/shared");

--- a/src/web/src/app/api/agents/route.ts
+++ b/src/web/src/app/api/agents/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare"
 import { queries, isValidHandle, isOnline, CreateAgentRequestSchema, TASK_TYPES } from "@alook/shared"
-import { getDb, getReadDb } from "@/lib/db"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
@@ -15,7 +15,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = getReadDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const [allAgents, allAccess] = await Promise.all([
     cached(cacheKeys.allAgents(ws.workspaceId), 300, () => queries.agent.getAllAgentsForWorkspace(db, ws.workspaceId)),

--- a/src/web/src/app/api/inbox/count/route.ts
+++ b/src/web/src/app/api/inbox/count/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { queries } from "@alook/shared";
-import { getReadDb } from "@/lib/db";
+import { getDb } from "@/lib/db";
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON } from "@/lib/middleware/helpers";
@@ -12,7 +12,7 @@ export const GET = withAuth(async (req: NextRequest, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext();
-  const db = getReadDb((env as Env).DB);
+  const db = getDb((env as Env).DB);
 
   const VALID_TYPES = ["user_dm_message", "calendar_event", "email_notification"];
   const typesParam = req.nextUrl.searchParams.get("types");

--- a/src/web/src/app/api/runtimes/route.test.ts
+++ b/src/web/src/app/api/runtimes/route.test.ts
@@ -7,7 +7,7 @@ vi.mock("@opennextjs/cloudflare", () => ({
 
 const mockListAgentRuntimes = vi.fn();
 
-vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})), getReadDb: vi.fn(() => ({})) }));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
 
 vi.mock("@/lib/cache", () => ({
   cached: vi.fn((_key: string, _ttl: number, fn: () => any) => fn()),

--- a/src/web/src/app/api/runtimes/route.ts
+++ b/src/web/src/app/api/runtimes/route.ts
@@ -1,6 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
 import { queries } from "@alook/shared"
-import { getReadDb } from "@/lib/db"
+import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON } from "@/lib/middleware/helpers";
@@ -12,7 +12,7 @@ export const GET = withAuth(async (req, ctx) => {
   if (ws instanceof Response) return ws;
 
   const { env } = getCloudflareContext()
-  const db = getReadDb((env as Env).DB)
+  const db = getDb((env as Env).DB)
 
   const runtimes = await cached(cacheKeys.allRuntimes(ws.workspaceId), 120, () => queries.runtime.listAgentRuntimes(db, ws.workspaceId));
 

--- a/src/web/src/lib/db.ts
+++ b/src/web/src/lib/db.ts
@@ -5,8 +5,6 @@ export function getDb(d1: D1Database): Database {
   return createDb(session as unknown as Parameters<typeof createDb>[0])
 }
 
-export const getReadDb = getDb;
-
 export async function withD1Retry<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
   for (let i = 0; i <= retries; i++) {
     try {

--- a/src/web/src/lib/db.ts
+++ b/src/web/src/lib/db.ts
@@ -1,16 +1,11 @@
 import { createDb, type Database } from "@alook/shared"
 
 export function getDb(d1: D1Database): Database {
-  const session = d1.withSession("first-primary")
-  // D1DatabaseSession has prepare() + batch() which is all Drizzle uses at runtime.
-  // Native Drizzle support tracked at https://github.com/drizzle-team/drizzle-orm/issues/4522
-  return createDb(session as unknown as Parameters<typeof createDb>[0])
-}
-
-export function getReadDb(d1: D1Database): Database {
   const session = d1.withSession("first-unconstrained")
   return createDb(session as unknown as Parameters<typeof createDb>[0])
 }
+
+export const getReadDb = getDb;
 
 export async function withD1Retry<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
   for (let i = 0; i <= retries; i++) {

--- a/src/web/src/test/e2e/cli-update.test.ts
+++ b/src/web/src/test/e2e/cli-update.test.ts
@@ -13,9 +13,10 @@ afterAll(() => cleanupTestData(seed));
 
 describe("CLI auto-update e2e", () => {
   const daemonId = `daemon_upd_${randomUUID().slice(0, 8)}`;
-  let runtimeId: string;
+  const daemonId2 = `daemon_upd2_${randomUUID().slice(0, 8)}`;
 
   beforeAll(async () => {
+    // Register two daemons to avoid 30s misc-throttle conflicts between tests
     const res = await tokenRequest("/api/daemon/register", seed.machineToken, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -30,12 +31,24 @@ describe("CLI auto-update e2e", () => {
       }),
     });
     expect(res.status).toBe(200);
-    const data = (await res.json()) as { runtimes: Array<{ id: string }> };
-    runtimeId = data.runtimes[0].id;
+
+    const res2 = await tokenRequest("/api/daemon/register", seed.machineToken, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        workspace_id: seed.workspaceId,
+        daemon_id: daemonId2,
+        device_name: "update-test-machine-2",
+        cli_version: "0.0.1",
+        runtimes: [
+          { provider: "claude", runtime_mode: "local", version: "4.0" },
+        ],
+      }),
+    });
+    expect(res2.status).toBe(200);
   });
 
   it("POST /api/runtimes/:id/update sets pendingUpdateVersion on machine", async () => {
-    // Manually set pending_update_version in DB to avoid npm registry dependency
     sql(
       `UPDATE machine SET pending_update_version = '1.0.0' WHERE daemon_id = '${daemonId}' AND workspace_id = '${seed.workspaceId}'`,
     );
@@ -61,11 +74,16 @@ describe("CLI auto-update e2e", () => {
   });
 
   it("poll auto-clears pendingUpdateVersion when cli_version matches", async () => {
+    // Use a separate daemon to avoid 30s misc-throttle from previous poll
+    sql(
+      `UPDATE machine SET pending_update_version = '1.0.0' WHERE daemon_id = '${daemonId2}' AND workspace_id = '${seed.workspaceId}'`,
+    );
+
     const res = await tokenRequest("/api/daemon/tasks/poll", seed.machineToken, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        daemon_id: daemonId,
+        daemon_id: daemonId2,
         cli_version: "1.0.0",
       }),
     });
@@ -74,7 +92,7 @@ describe("CLI auto-update e2e", () => {
     expect(data.pending_update).toBeUndefined();
 
     const rows = sqlQuery<{ pending_update_version: string | null }>(
-      `SELECT pending_update_version FROM machine WHERE daemon_id = '${daemonId}' AND workspace_id = '${seed.workspaceId}'`,
+      `SELECT pending_update_version FROM machine WHERE daemon_id = '${daemonId2}' AND workspace_id = '${seed.workspaceId}'`,
     );
     expect(rows[0]?.pending_update_version).toBeNull();
   });
@@ -83,6 +101,8 @@ describe("CLI auto-update e2e", () => {
     try {
       sql(`DELETE FROM agent_runtime WHERE daemon_id = '${daemonId}'`);
       sql(`DELETE FROM machine WHERE daemon_id = '${daemonId}'`);
+      sql(`DELETE FROM agent_runtime WHERE daemon_id = '${daemonId2}'`);
+      sql(`DELETE FROM machine WHERE daemon_id = '${daemonId2}'`);
     } catch { /* ignore */ }
   });
 });

--- a/src/web/src/test/e2e/meeting-flow.test.ts
+++ b/src/web/src/test/e2e/meeting-flow.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import { randomUUID } from "crypto"
 import { seedTestData, cleanupTestData, type TestSeed } from "../helpers/seed"
 import { tokenRequest } from "../helpers/auth"
 import { sql, sqlQuery } from "../helpers/db"
@@ -21,6 +22,32 @@ function req(path: string, opts?: RequestInit) {
 }
 
 describe("meeting claim via poll", () => {
+  // Use a separate daemon for the claim test to avoid 30s misc-throttle
+  const claimDaemonId = `daemon_claim_${randomUUID().slice(0, 8)}`
+
+  beforeAll(async () => {
+    const res = await req("/api/daemon/register", {
+      method: "POST",
+      body: JSON.stringify({
+        workspace_id: seed.workspaceId,
+        daemon_id: claimDaemonId,
+        device_name: "claim-test-machine",
+        cli_version: "0.0.1",
+        runtimes: [
+          { provider: "claude", runtime_mode: "local", version: "4.0" },
+        ],
+      }),
+    })
+    expect(res.status).toBe(200)
+  })
+
+  afterAll(() => {
+    try {
+      sql(`DELETE FROM agent_runtime WHERE daemon_id = '${claimDaemonId}'`)
+      sql(`DELETE FROM machine WHERE daemon_id = '${claimDaemonId}'`)
+    } catch { /* ignore */ }
+  })
+
   it("poll returns no meetings when none are scheduled", async () => {
     const res = await req("/api/daemon/tasks/poll", {
       method: "POST",
@@ -38,7 +65,7 @@ describe("meeting claim via poll", () => {
 
     const res = await req("/api/daemon/tasks/poll", {
       method: "POST",
-      body: JSON.stringify({ daemon_id: seed.daemonId }),
+      body: JSON.stringify({ daemon_id: claimDaemonId }),
     })
     expect(res.status).toBe(200)
     const data = await res.json() as { meetings?: { id: string; meeting_url: string; agent_name: string }[] }


### PR DESCRIPTION
## Summary

- Switch `getDb()` from `"first-primary"` to `"first-unconstrained"` — all reads now hit the nearest replica instead of crossing to the primary (LAX)
- Remove `getReadDb()` (now redundant, kept as alias for backwards compat)
- Clean up routes that explicitly imported `getReadDb` to just use `getDb`

## Why this is safe

D1 Sessions guarantee:
1. **Writes always go to primary** regardless of session constraint
2. **Reads after writes in the same session** are guaranteed consistent (bookmark-based)

So `"first-unconstrained"` gives us replica reads for free with no consistency risk.

## Impact

Before: Every request (including auth session validation) crossed LHR→LAX (~15s per D1 query observed in prod traces)

After: Reads hit the nearest replica (LHR for EU users, same-region for others), writes still go to primary. Expected latency drop from 10-15s to <100ms for read-heavy routes.

## Test plan
- [x] All 992 web tests pass
- [x] Lint clean
- [ ] Deploy and verify `served_by_primary: false` in D1 traces for GET routes
- [ ] Monitor for any stale-read issues (unlikely given D1's consistency model)