### PR TITLE
fix: add missing cache invalidations across API routes

### DIFF
--- a/src/web/src/app/api/agents/[id]/access/[userId]/route.ts
+++ b/src/web/src/app/api/agents/[id]/access/[userId]/route.ts
@@ -27,6 +27,7 @@ export const DELETE = withAuth(async (req: NextRequest, ctx) => {
   await Promise.all([
     invalidate(cacheKeys.allAgents(ws.workspaceId)),
     invalidate(cacheKeys.allAgentAccess(ws.workspaceId)),
+    invalidate(cacheKeys.allColleagues(ws.workspaceId)),
   ]);
   return new Response(null, { status: 204 });
 });

--- a/src/web/src/app/api/agents/[id]/access/route.ts
+++ b/src/web/src/app/api/agents/[id]/access/route.ts
@@ -47,6 +47,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
   await Promise.all([
     invalidate(cacheKeys.allAgents(ws.workspaceId)),
     invalidate(cacheKeys.allAgentAccess(ws.workspaceId)),
+    invalidate(cacheKeys.allColleagues(ws.workspaceId)),
   ]);
   return writeJSON({ id: access.id, user_id: access.userId }, 201);
 });

--- a/src/web/src/app/api/agents/[id]/route.ts
+++ b/src/web/src/app/api/agents/[id]/route.ts
@@ -77,6 +77,8 @@ export const PATCH = withAuth(async (req, ctx) => {
     invalidate(cacheKeys.agent(ws.workspaceId, id)),
     invalidate(cacheKeys.allAgents(ws.workspaceId)),
     invalidate(cacheKeys.allHandles(ws.workspaceId)),
+    invalidate(cacheKeys.allAgentAccess(ws.workspaceId)),
+    invalidate(cacheKeys.allColleagues(ws.workspaceId)),
   ]);
 
   return writeJSON(agentToResponse(updated));
@@ -108,6 +110,7 @@ export const DELETE = withAuth(async (req, ctx) => {
     invalidate(cacheKeys.allAgents(ws.workspaceId)),
     invalidate(cacheKeys.allHandles(ws.workspaceId)),
     invalidate(cacheKeys.allAgentAccess(ws.workspaceId)),
+    invalidate(cacheKeys.allColleagues(ws.workspaceId)),
   ]);
 
   return new Response(null, { status: 204 });

--- a/src/web/src/app/api/agents/[id]/whitelist/route.ts
+++ b/src/web/src/app/api/agents/[id]/whitelist/route.ts
@@ -69,6 +69,7 @@ export const POST = withAuth(async (req, ctx) => {
       );
       const dateStr = new Date().toISOString().slice(0, 10);
       invalidate(cacheKeys.overviewTaskStats(ws.workspaceId, dateStr)).catch(() => {});
+      invalidate(cacheKeys.activeTaskCounts(ws.workspaceId)).catch(() => {});
     } catch {
       // Best-effort — don't fail the whitelist operation
     }

--- a/src/web/src/app/api/agents/route.ts
+++ b/src/web/src/app/api/agents/route.ts
@@ -111,6 +111,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
       );
       const dateStr = new Date().toISOString().slice(0, 10);
       invalidate(cacheKeys.overviewTaskStats(ws.workspaceId, dateStr)).catch(() => {});
+      invalidate(cacheKeys.activeTaskCounts(ws.workspaceId)).catch(() => {});
     } catch {
       // Best-effort — don't fail agent creation
     }

--- a/src/web/src/app/api/daemon/deregister/route.ts
+++ b/src/web/src/app/api/daemon/deregister/route.ts
@@ -31,7 +31,10 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     log.warn("deregister: setMachineLastSeenNull failed", { daemonId: body.daemon_id, err: String(e) });
   }
 
-  await invalidate(cacheKeys.allRuntimes(ctx.workspaceId));
+  await Promise.all([
+    invalidate(cacheKeys.runtimeIds(ctx.workspaceId, body.daemon_id)),
+    invalidate(cacheKeys.allRuntimes(ctx.workspaceId)),
+  ]);
 
   // Single broadcast at daemon level
   broadcastToUser(ctx.userId, {

--- a/src/web/src/app/api/daemon/tasks/[taskId]/supersede/route.ts
+++ b/src/web/src/app/api/daemon/tasks/[taskId]/supersede/route.ts
@@ -6,7 +6,7 @@ import { writeJSON, writeError } from "@/lib/middleware/helpers";
 import { taskToResponse } from "@/lib/api/responses";
 import { TaskService } from "@/lib/services/task";
 import { broadcastToUser } from "@/lib/broadcast";
-import { invalidate, cacheKeys } from "@/lib/cache";
+import { invalidate, invalidateByPrefix, cacheKeys } from "@/lib/cache";
 
 export const POST = withAuth(async (req: NextRequest, ctx) => {
   if (!ctx.workspaceId) {
@@ -26,6 +26,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     const task = await taskService.supersedeTask(taskId, ctx.workspaceId);
     const dateStr = new Date().toISOString().slice(0, 10);
     invalidate(cacheKeys.overviewTaskStats(ctx.workspaceId, dateStr)).catch(() => {});
+    invalidateByPrefix(cacheKeys.inboxCountPrefix(ctx.userId, ctx.workspaceId)).catch(() => {});
     broadcastToUser(ctx.userId, { type: "task.updated", taskId, agentId: task.agentId, status: "superseded" }).catch(() => {});
     return writeJSON(taskToResponse(task));
   } catch (e: unknown) {

--- a/src/web/src/app/api/email/send/route.test.ts
+++ b/src/web/src/app/api/email/send/route.test.ts
@@ -32,8 +32,10 @@ vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
 
 vi.mock("@/lib/cache", () => ({
   cached: vi.fn((_key: string, _ttl: number, fn: () => Promise<any>) => fn()),
+  invalidate: vi.fn(() => Promise.resolve()),
   cacheKeys: {
     allEmailAccounts: (ws: string) => `ea:${ws}`,
+    overviewEmailStats: (ws: string) => `ov_email:${ws}`,
   },
 }));
 

--- a/src/web/src/app/api/email/send/route.ts
+++ b/src/web/src/app/api/email/send/route.ts
@@ -8,7 +8,7 @@ import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
 import { emailToResponse } from "@/lib/api/responses";
 import { broadcastToUser } from "@/lib/broadcast";
-import { cached, cacheKeys } from "@/lib/cache";
+import { cached, invalidate, cacheKeys } from "@/lib/cache";
 
 async function broadcastEmailSentEvent(
   db: Parameters<typeof queries.message.createMessage>[0],
@@ -179,6 +179,8 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
         status: "sent",
       });
 
+      invalidate(cacheKeys.overviewEmailStats(ws.workspaceId)).catch(() => {});
+
       if (validatedConversationId) {
         const threadId = extractThreadId(body.references, body.inReplyTo, messageId);
         if (threadId) {
@@ -253,6 +255,8 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     direction: "outbound",
     status: "sent",
   });
+
+  invalidate(cacheKeys.overviewEmailStats(ws.workspaceId)).catch(() => {});
 
   if (validatedConversationId && emailResult.messageId) {
     const threadId = extractThreadId(body.references, body.inReplyTo, emailResult.messageId);

--- a/src/web/src/app/api/studios/route.test.ts
+++ b/src/web/src/app/api/studios/route.test.ts
@@ -28,6 +28,7 @@ vi.mock("@/lib/cache", () => ({
     allAgentAccess: (ws: string) => `aa:${ws}`,
     allMembers: (ws: string) => `members:${ws}`,
     overviewTaskStats: (ws: string, d: string) => `ov_task:${ws}:${d}`,
+    agentLinks: (ws: string) => `al:${ws}`,
   },
 }));
 

--- a/src/web/src/app/api/studios/route.ts
+++ b/src/web/src/app/api/studios/route.ts
@@ -244,6 +244,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     invalidate(cacheKeys.allAgentAccess(ws.workspaceId)),
     invalidate(cacheKeys.allMembers(ws.workspaceId)),
     invalidate(cacheKeys.overviewTaskStats(ws.workspaceId, dateStr)),
+    invalidate(cacheKeys.agentLinks(ws.workspaceId)),
   ]);
 
   // Pin leader agent by default

--- a/src/web/src/lib/middleware/auth.ts
+++ b/src/web/src/lib/middleware/auth.ts
@@ -3,7 +3,7 @@ import { getCloudflareContext } from "@opennextjs/cloudflare"
 import { queries } from "@alook/shared"
 import { getDb } from "@/lib/db"
 import { createAuth } from "@/lib/auth"
-import { cached, cacheKeys, bindCacheKV } from "@/lib/cache"
+import { cached, cacheKeys, bindCacheKV, throttled } from "@/lib/cache"
 
 export interface AuthContext {
   userId: string
@@ -45,13 +45,10 @@ export function withAuth(handler: AuthenticatedHandler) {
           if (!mt) {
             return NextResponse.json({ error: "invalid token" }, { status: 401 })
           }
-          cached(
+          throttled(
             cacheKeys.machineTokenLastUsed(raw),
             900,
-            async () => {
-              await queries.machineToken.updateMachineTokenLastUsed(db, mt.id);
-              return "1";
-            },
+            () => queries.machineToken.updateMachineTokenLastUsed(db, mt.id),
           ).catch(() => {});
           const authCtx: AuthContext = {
             userId: mt.userId,

--- a/src/web/src/lib/services/sweep.ts
+++ b/src/web/src/lib/services/sweep.ts
@@ -56,6 +56,7 @@ export async function sweepStaleState(db: Database, workspaceId: string) {
     await Promise.all([
       invalidate(cacheKeys.allAgents(workspaceId)),
       invalidate(cacheKeys.overviewTaskStats(workspaceId, dateStr)),
+      invalidate(cacheKeys.activeTaskCounts(workspaceId)),
     ]).catch(() => {});
   }
 }


### PR DESCRIPTION
# Why we need this PR?

Comprehensive audit of `src/web/src/lib/cache.ts` usage revealed multiple cache invalidation gaps that could cause stale data to be served to users.

## What changed

**Semantic fix:**
- `auth.ts`: Replace misused `cached()` with `throttled()` for token last-used tracking — cached() is a read-through pattern, not a throttle mechanism

**Missing invalidations added:**
- `daemon/deregister`: Invalidate `runtimeIds` cache (previously only cleared `allRuntimes`, causing stale task dispatch for up to 10min)
- `daemon/tasks/supersede`: Add `inboxCount` prefix invalidation (matching `complete` and `fail` routes)
- `agents/[id]` PATCH: Add `allAgentAccess` + `allColleagues` invalidation on visibility change
- `agents/[id]` DELETE: Add `allColleagues` invalidation
- `agents` POST + `whitelist` POST: Add `activeTaskCounts` invalidation after welcome task enqueue
- `email/send`: Add `overviewEmailStats` invalidation after sending (both local and remote delivery paths)
- `agents/access` grant/revoke: Add `allColleagues` invalidation
- `studios` POST: Add `agentLinks` invalidation after creating agent links
- `sweep.ts`: Add `activeTaskCounts` invalidation after failing stale tasks

**Test updates:**
- `email/send/route.test.ts`: Add `invalidate` and `overviewEmailStats` to cache mock
- `studios/route.test.ts`: Add `agentLinks` to cache mock

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)