### PR TITLE
perf: add missing indexes and fix N+1 query patterns

### DIFF
--- a/src/shared/src/db/queries/conversation.ts
+++ b/src/shared/src/db/queries/conversation.ts
@@ -1,4 +1,4 @@
-import { eq, and, desc, ne, lt, sql } from "drizzle-orm";
+import { eq, and, desc, ne, lt, sql, count as drizzleCount } from "drizzle-orm";
 import { conversation, message } from "../schema";
 import type { Database } from "../index";
 import { TASK_TYPES, type TaskType } from "../../constants";
@@ -82,10 +82,12 @@ export async function listConversationsByAgent(
       channel: conversation.channel,
       createdAt: conversation.createdAt,
       messageCount:
-        sql<number>`(SELECT COUNT(*) FROM message WHERE ${message.conversationId} = ${conversation.id} AND ${message.status} = 'active')`.mapWith(Number),
+        sql<number>`COUNT(CASE WHEN ${message.status} = 'active' THEN 1 END)`.mapWith(Number),
     })
     .from(conversation)
+    .leftJoin(message, eq(message.conversationId, conversation.id))
     .where(and(...conditions))
+    .groupBy(conversation.id)
     .orderBy(desc(conversation.createdAt));
 }
 

--- a/src/shared/src/db/queries/task.ts
+++ b/src/shared/src/db/queries/task.ts
@@ -625,14 +625,20 @@ export async function failStaleRunningTasks(db: Database, workspaceId: string, s
   const threshold = new Date(Date.now() - staleSeconds * 1000).toISOString();
 
   const staleRows = await db
-    .select({ id: agentTaskQueue.id })
+    .select({
+      id: agentTaskQueue.id,
+    })
     .from(agentTaskQueue)
+    .leftJoin(taskMessage, eq(taskMessage.taskId, agentTaskQueue.id))
     .where(
       and(
         eq(agentTaskQueue.workspaceId, workspaceId),
         eq(agentTaskQueue.status, "running"),
-        sql`coalesce((SELECT MAX(created_at) FROM task_message WHERE task_id = ${agentTaskQueue.id}), ${agentTaskQueue.startedAt}) < ${threshold}`
       )
+    )
+    .groupBy(agentTaskQueue.id)
+    .having(
+      sql`COALESCE(MAX(${taskMessage.createdAt}), ${agentTaskQueue.startedAt}) < ${threshold}`
     );
 
   if (staleRows.length === 0) return [];

--- a/src/shared/src/db/schema.ts
+++ b/src/shared/src/db/schema.ts
@@ -224,6 +224,7 @@ export const agentRuntime = sqliteTable(
       t.provider
     ),
     index("idx_agent_runtime_workspace_daemon").on(t.workspaceId, t.daemonId),
+    index("idx_agent_runtime_daemon_workspace").on(t.daemonId, t.workspaceId),
   ]
 );
 
@@ -308,6 +309,7 @@ export const conversation = sqliteTable(
   (t) => [
     index("idx_conversation_agent_lookup")
       .on(t.workspaceId, t.agentId, t.userId, t.type, t.channel, t.createdAt),
+    index("idx_conversation_ws_user").on(t.workspaceId, t.userId, t.createdAt),
     foreignKey({
       columns: [t.agentId, t.workspaceId],
       foreignColumns: [agent.id, agent.workspaceId],
@@ -380,6 +382,7 @@ export const agentTaskQueue = sqliteTable(
     index("idx_task_queue_parent").on(t.parentTaskId),
     index("idx_task_queue_workspace_type_status").on(t.workspaceId, t.type, t.status),
     index("idx_task_queue_workspace_status_dispatched").on(t.workspaceId, t.status, t.dispatchedAt),
+    index("idx_task_queue_inbox").on(t.workspaceId, t.status, t.completedAt),
     foreignKey({
       columns: [t.agentId, t.workspaceId],
       foreignColumns: [agent.id, agent.workspaceId],

--- a/src/web/migrations/0031_query_performance_indexes.sql
+++ b/src/web/migrations/0031_query_performance_indexes.sql
@@ -1,0 +1,21 @@
+-- Performance indexes for hot-path queries identified via audit
+-- Targets: daemon poll, inbox unread, conversation listing, stale task sweep
+
+-- 1. agent_runtime: queries filter by (daemon_id, workspace_id) but existing index
+--    idx_agent_runtime_workspace_daemon is (workspace_id, daemon_id) — wrong leading column
+--    for getRuntimeIdsByDaemon / deleteRuntimesByDaemonId which filter daemon_id first.
+CREATE INDEX IF NOT EXISTS idx_agent_runtime_daemon_workspace
+  ON agent_runtime(daemon_id, workspace_id);
+
+-- 2. agent_task_queue: inbox queries filter by
+--    (workspace_id, status IN ('completed','failed'), type, completed_at DESC)
+--    with parent_task_id IS NULL and trace_id IS NOT NULL.
+--    No existing index efficiently covers this access pattern.
+CREATE INDEX IF NOT EXISTS idx_task_queue_inbox
+  ON agent_task_queue(workspace_id, status, completed_at);
+
+-- 3. conversation: queries filter (workspace_id, user_id) without agent_id.
+--    The existing idx_conversation_agent_lookup starts with (workspace_id, agent_id, ...)
+--    so it cannot serve listConversations(workspace_id, userId) efficiently.
+CREATE INDEX IF NOT EXISTS idx_conversation_ws_user
+  ON conversation(workspace_id, user_id, created_at);


### PR DESCRIPTION
# Why we need this PR?

SQL audit identified missing indexes on hot-path queries (daemon poll @ 1200 req/hr/user, inbox unread count) and N+1 query patterns causing unnecessary DB load.

## What changed

**New indexes (migration 0031):**
- `idx_agent_runtime_daemon_workspace(daemon_id, workspace_id)` — existing index had wrong column order for `getRuntimeIdsByDaemon` queries
- `idx_task_queue_inbox(workspace_id, status, completed_at)` — covers inbox unread count/list queries that previously did full scans
- `idx_conversation_ws_user(workspace_id, user_id, created_at)` — covers `listConversations` which doesn't filter by agentId

**Query rewrites:**
- `listConversationsByAgent`: replaced per-row `SELECT COUNT(*)` subquery with `LEFT JOIN message + GROUP BY + COUNT(CASE WHEN ...)` — eliminates N+1
- `failStaleRunningTasks`: replaced correlated `SELECT MAX(created_at) FROM task_message WHERE task_id = ...` with `LEFT JOIN + GROUP BY + HAVING` — eliminates N subqueries

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...