### PR TITLE
perf: reduce D1 queries by ~1.7M/day via caching and indexes

### DIFF
--- a/src/shared/src/db/schema.ts
+++ b/src/shared/src/db/schema.ts
@@ -383,6 +383,15 @@ export const agentTaskQueue = sqliteTable(
     index("idx_task_queue_workspace_type_status").on(t.workspaceId, t.type, t.status),
     index("idx_task_queue_workspace_status_dispatched").on(t.workspaceId, t.status, t.dispatchedAt),
     index("idx_task_queue_inbox").on(t.workspaceId, t.status, t.completedAt),
+    index("idx_task_queue_runtime_pending")
+      .on(t.workspaceId, t.runtimeId, t.status)
+      .where(sql`status IN ('queued', 'dispatched')`),
+    index("idx_task_queue_agent_running")
+      .on(t.agentId, t.workspaceId, t.status)
+      .where(sql`status IN ('dispatched', 'running')`),
+    index("idx_task_queue_inbox_convo")
+      .on(t.workspaceId, t.status, t.conversationId, t.completedAt)
+      .where(sql`status IN ('completed', 'failed') AND parent_task_id IS NULL`),
     foreignKey({
       columns: [t.agentId, t.workspaceId],
       foreignColumns: [agent.id, agent.workspaceId],

--- a/src/web/migrations/0032_runtime_pending_indexes.sql
+++ b/src/web/migrations/0032_runtime_pending_indexes.sql
@@ -1,0 +1,24 @@
+-- Performance indexes for poll hot-path queries (D1 insights analysis 2026-05-20)
+-- Targets: listPendingTasksByRuntimes, countRunningTasks, inbox unread count
+
+-- 1. listPendingTasksByRuntimes: 310K calls/day, scans 60-87 rows/call
+--    Filters: workspace_id + runtime_id IN (?) + status IN ('queued','dispatched')
+--    No existing index covers runtime_id for this access pattern.
+CREATE INDEX IF NOT EXISTS idx_task_queue_runtime_pending
+  ON agent_task_queue(workspace_id, runtime_id, status)
+  WHERE status IN ('queued', 'dispatched');
+
+-- 2. countRunningTasks: 931 calls/day, scans 858 rows/call (24ms avg)
+--    Filters: agent_id + workspace_id + status IN ('dispatched','running')
+--    Existing idx_task_queue_pending covers ('queued','dispatched') but not 'running'.
+CREATE INDEX IF NOT EXISTS idx_task_queue_agent_running
+  ON agent_task_queue(agent_id, workspace_id, status)
+  WHERE status IN ('dispatched', 'running');
+
+-- 3. getUnreadCount (inbox badge): 8K calls/day, scans 884 rows/call
+--    Filters: workspace_id + status IN ('completed','failed') + parent_task_id IS NULL
+--    Existing idx_task_queue_inbox is (workspace_id, status, completed_at) without
+--    the conversation_id needed for COUNT(DISTINCT conversation_id).
+CREATE INDEX IF NOT EXISTS idx_task_queue_inbox_convo
+  ON agent_task_queue(workspace_id, status, conversation_id, completed_at)
+  WHERE status IN ('completed', 'failed') AND parent_task_id IS NULL;

--- a/src/web/src/app/api/agents/[id]/pin/route.ts
+++ b/src/web/src/app/api/agents/[id]/pin/route.ts
@@ -5,6 +5,7 @@ import { getDb } from "@/lib/db";
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError } from "@/lib/middleware/helpers";
+import { invalidate, cacheKeys } from "@/lib/cache";
 
 export const POST = withAuth(async (req: NextRequest, ctx) => {
   const ws = await withWorkspaceMember(req, ctx);
@@ -15,6 +16,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
   const agent = await queries.agent.getAgent(db, id, ws.workspaceId, ctx.userId);
   if (!agent) return writeError("agent not found", 404);
   const pin = await queries.agentPin.pinAgent(db, { agentId: id, workspaceId: ws.workspaceId, userId: ctx.userId });
+  invalidate(cacheKeys.pins(ws.workspaceId, ctx.userId)).catch(() => {});
   return writeJSON({ pinned: true }, pin ? 201 : 200);
 });
 
@@ -25,5 +27,6 @@ export const DELETE = withAuth(async (req: NextRequest, ctx) => {
   const { env } = await getCloudflareContext({ async: true });
   const db = getDb((env as Env).DB);
   await queries.agentPin.unpinAgent(db, id, ws.workspaceId, ctx.userId);
+  invalidate(cacheKeys.pins(ws.workspaceId, ctx.userId)).catch(() => {});
   return new Response(null, { status: 204 });
 });

--- a/src/web/src/app/api/agents/[id]/workspace/browse/route.ts
+++ b/src/web/src/app/api/agents/[id]/workspace/browse/route.ts
@@ -4,6 +4,7 @@ import { queries, WorkspaceFileBrowseRequestSchema } from "@alook/shared";
 import { withAuth } from "@/lib/middleware/auth";
 import { parseBody, writeJSON, writeError } from "@/lib/middleware/helpers";
 import { getDb } from "@/lib/db";
+import { cacheKeys } from "@/lib/cache";
 
 export const POST = withAuth(async (req: NextRequest, ctx) => {
   const { env } = getCloudflareContext();
@@ -27,6 +28,11 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     requestType: body.request_type,
     path: body.path,
   });
+
+  const kv = (env as Env).CACHE_KV ?? null;
+  if (kv) {
+    kv.put(cacheKeys.hasPendingFileRequest(workspaceId), "1", { expirationTtl: 60 }).catch(() => {});
+  }
 
   return writeJSON({ request_id: row.id });
 });

--- a/src/web/src/app/api/agents/pins/reorder/route.ts
+++ b/src/web/src/app/api/agents/pins/reorder/route.ts
@@ -5,6 +5,7 @@ import { getDb } from "@/lib/db";
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeError } from "@/lib/middleware/helpers";
+import { invalidate, cacheKeys } from "@/lib/cache";
 
 export const PUT = withAuth(async (req: NextRequest, ctx) => {
   const ws = await withWorkspaceMember(req, ctx);
@@ -32,5 +33,6 @@ export const PUT = withAuth(async (req: NextRequest, ctx) => {
   }
 
   await queries.agentPin.reorderPins(db, ws.workspaceId, ctx.userId, ids);
+  invalidate(cacheKeys.pins(ws.workspaceId, ctx.userId)).catch(() => {});
   return new Response(null, { status: 204 });
 });

--- a/src/web/src/app/api/agents/pins/route.ts
+++ b/src/web/src/app/api/agents/pins/route.ts
@@ -5,18 +5,22 @@ import { getDb } from "@/lib/db";
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON } from "@/lib/middleware/helpers";
+import { cached, cacheKeys } from "@/lib/cache";
 
 export const GET = withAuth(async (req: NextRequest, ctx) => {
   const ws = await withWorkspaceMember(req, ctx);
   if (ws instanceof Response) return ws;
   const { env } = await getCloudflareContext({ async: true });
   const db = getDb((env as Env).DB);
-  const [pins, sidebarOrder] = await Promise.all([
-    queries.agentPin.listPins(db, ws.workspaceId, ctx.userId),
-    queries.agentSidebarOrder.listOrder(db, ws.workspaceId, ctx.userId),
-  ]);
-  return writeJSON({
-    pins: pins.map((p) => ({ id: p.id, agent_id: p.agentId, created_at: p.createdAt, position: p.position })),
-    sidebar_order: sidebarOrder.map((o) => ({ agent_id: o.agentId, position: o.position })),
+  const data = await cached(cacheKeys.pins(ws.workspaceId, ctx.userId), 30, async () => {
+    const [pins, sidebarOrder] = await Promise.all([
+      queries.agentPin.listPins(db, ws.workspaceId, ctx.userId),
+      queries.agentSidebarOrder.listOrder(db, ws.workspaceId, ctx.userId),
+    ]);
+    return {
+      pins: pins.map((p) => ({ id: p.id, agent_id: p.agentId, created_at: p.createdAt, position: p.position })),
+      sidebar_order: sidebarOrder.map((o) => ({ agent_id: o.agentId, position: o.position })),
+    };
   });
+  return writeJSON(data);
 });

--- a/src/web/src/app/api/agents/sidebar/reorder/route.ts
+++ b/src/web/src/app/api/agents/sidebar/reorder/route.ts
@@ -5,7 +5,7 @@ import { getDb } from "@/lib/db";
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeError } from "@/lib/middleware/helpers";
-import { cached, cacheKeys } from "@/lib/cache";
+import { cached, cacheKeys, invalidate } from "@/lib/cache";
 
 export const PUT = withAuth(async (req: NextRequest, ctx) => {
   const ws = await withWorkspaceMember(req, ctx);
@@ -38,5 +38,6 @@ export const PUT = withAuth(async (req: NextRequest, ctx) => {
   }
 
   await queries.agentSidebarOrder.reorder(db, ws.workspaceId, ctx.userId, ids);
+  invalidate(cacheKeys.pins(ws.workspaceId, ctx.userId)).catch(() => {});
   return new Response(null, { status: 204 });
 });

--- a/src/web/src/app/api/daemon/tasks/poll/route.test.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.test.ts
@@ -131,6 +131,7 @@ vi.mock("@/lib/cache", () => ({
     member: (wsId: string, userId: string) => `mem:${wsId}:${userId}`,
     allHandles: (wsId: string) => `handles:${wsId}`,
     allMembers: (wsId: string) => `members:${wsId}`,
+    hasPendingFileRequest: (wsId: string) => `fr_p:${wsId}`,
   },
   throttled: vi.fn((_key: string, _interval: number, fn: () => Promise<void>) => fn().then(() => true)),
   invalidate: (...args: unknown[]) => mockInvalidate(...args),

--- a/src/web/src/app/api/daemon/tasks/poll/route.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.ts
@@ -36,8 +36,9 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
 
   // 2. Liveness: write heartbeat to KV (fast) + D1 upsert throttled via timestamp.
   // KV heartbeat is the primary source; D1 is the cross-colo fallback.
-  // Uses timestamp-based throttle (not KV TTL) so the interval can be < 60s.
-  const D1_HEARTBEAT_THROTTLE_S = Math.floor((OFFLINE_THRESHOLD_MS - POLL_INTERVAL_MS) / 1000) - 1;
+  // 15s throttle is safe: KV heartbeat (120s TTL) handles realtime liveness,
+  // D1 only needs to be fresh enough for cross-colo failover detection.
+  const D1_HEARTBEAT_THROTTLE_S = 15;
   const kv = (env as Env).CACHE_KV ?? null;
   if (kv) {
     kv.put(
@@ -317,21 +318,27 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     }
   }
 
-  // File browse requests — expireStale throttled to 5s, but check pending every poll
+  // File browse requests — skip D1 if KV negative cache says "no pending"
   let fileRequests: FileRequestItem[] | undefined;
   try {
     await throttled(`expire_fr:${ctx.workspaceId}`, 5, async () => {
       await queries.workspaceFileRequest.expireStale(db, ctx.workspaceId!);
     });
-    const pending = await queries.workspaceFileRequest.getPendingByWorkspace(db, ctx.workspaceId);
-    if (pending.length > 0) {
-      fileRequests = pending.map((r) => ({
-        id: r.id,
-        agent_id: r.agentId,
-        request_type: r.requestType as "tree" | "read",
-        path: r.path,
-      }));
-      await queries.workspaceFileRequest.markDispatched(db, pending.map((r) => r.id));
+    const kv = (env as Env).CACHE_KV ?? null;
+    const frFlag = kv ? await kv.get(cacheKeys.hasPendingFileRequest(ctx.workspaceId!)) : null;
+    if (frFlag !== "0") {
+      const pending = await queries.workspaceFileRequest.getPendingByWorkspace(db, ctx.workspaceId);
+      if (pending.length > 0) {
+        fileRequests = pending.map((r) => ({
+          id: r.id,
+          agent_id: r.agentId,
+          request_type: r.requestType as "tree" | "read",
+          path: r.path,
+        }));
+        await queries.workspaceFileRequest.markDispatched(db, pending.map((r) => r.id));
+      } else if (kv) {
+        kv.put(cacheKeys.hasPendingFileRequest(ctx.workspaceId!), "0", { expirationTtl: 60 }).catch(() => {});
+      }
     }
   } catch (e) {
     log.warn("file-requests: poll failed", { err: String(e) });

--- a/src/web/src/app/api/daemon/tasks/poll/route.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { queries, PollRequestSchema, semverGte, toAlookAddress, OFFLINE_THRESHOLD_MS, POLL_INTERVAL_MS, type FileRequestItem, type PollMeetingItem } from "@alook/shared";
+import { queries, PollRequestSchema, semverGte, toAlookAddress, type FileRequestItem, type PollMeetingItem } from "@alook/shared";
 import { getDb, withD1Retry } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";

--- a/src/web/src/app/api/studios/route.ts
+++ b/src/web/src/app/api/studios/route.ts
@@ -254,6 +254,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
       workspaceId: ws.workspaceId,
       userId: ctx.userId,
     });
+    invalidate(cacheKeys.pins(ws.workspaceId, ctx.userId)).catch(() => {});
   } catch {
     // Best-effort
   }

--- a/src/web/src/lib/cache.ts
+++ b/src/web/src/lib/cache.ts
@@ -168,4 +168,6 @@ export const cacheKeys = {
   inboxCount: (userId: string, workspaceId: string, types?: string[]) =>
     `inbox:${userId}:${workspaceId}:${types ? [...types].sort().join(",") : "*"}`,
   inboxCountPrefix: (userId: string, workspaceId: string) => `inbox:${userId}:${workspaceId}:`,
+  hasPendingFileRequest: (workspaceId: string) => `fr_p:${workspaceId}`,
+  pins: (workspaceId: string, userId: string) => `pins:${workspaceId}:${userId}`,
 };

--- a/src/web/src/lib/middleware/auth.test.ts
+++ b/src/web/src/lib/middleware/auth.test.ts
@@ -66,7 +66,7 @@ describe("withAuth middleware", () => {
       headers: { Authorization: "Bearer " },
     });
 
-    mockGetSession.mockResolvedValue(null);
+    mockGetSession.mockResolvedValue({ headers: new Headers(), response: null });
 
     const res = await wrapped(req);
     const body = await res.json();
@@ -77,7 +77,8 @@ describe("withAuth middleware", () => {
 
   it("authenticates valid Better Auth session and passes userId/email to handler", async () => {
     mockGetSession.mockResolvedValue({
-      user: { id: "user-1", email: "user@example.com" },
+      headers: new Headers(),
+      response: { user: { id: "user-1", email: "user@example.com" } },
     });
 
     const req = new NextRequest("http://localhost/api/test", {
@@ -94,7 +95,7 @@ describe("withAuth middleware", () => {
   });
 
   it("returns 401 when Better Auth session is null", async () => {
-    mockGetSession.mockResolvedValue(null);
+    mockGetSession.mockResolvedValue({ headers: new Headers(), response: null });
 
     const req = new NextRequest("http://localhost/api/test", {
       headers: { Authorization: "Bearer some-session-token" },
@@ -161,7 +162,8 @@ describe("withAuth middleware", () => {
 
   it("resolves dynamic params from context", async () => {
     mockGetSession.mockResolvedValue({
-      user: { id: "user-p", email: "p@example.com" },
+      headers: new Headers(),
+      response: { user: { id: "user-p", email: "p@example.com" } },
     });
 
     const req = new NextRequest("http://localhost/api/test");

--- a/src/web/src/lib/middleware/auth.ts
+++ b/src/web/src/lib/middleware/auth.ts
@@ -62,14 +62,17 @@ export function withAuth(handler: AuthenticatedHandler) {
       }
     }
 
-    // Fall back to Better Auth session
+    // Fall back to Better Auth session (with returnHeaders to propagate cookie cache refresh)
     const auth = createAuth(cloudflareEnv)
-    let session: Awaited<ReturnType<typeof auth.api.getSession>> = null
+    let sessionResult: { headers: Headers; response: Awaited<ReturnType<typeof auth.api.getSession>> } | null = null
     let lastErr: unknown
 
     for (let attempt = 0; attempt < 2; attempt++) {
       try {
-        session = await auth.api.getSession({ headers: req.headers })
+        sessionResult = await auth.api.getSession({
+          headers: req.headers,
+          returnHeaders: true,
+        }) as { headers: Headers; response: Awaited<ReturnType<typeof auth.api.getSession>> }
         lastErr = undefined
         break
       } catch (err) {
@@ -80,14 +83,26 @@ export function withAuth(handler: AuthenticatedHandler) {
     if (lastErr) {
       return NextResponse.json({ error: "session validation failed" }, { status: 503 })
     }
-    if (!session) {
+    if (!sessionResult?.response) {
       return NextResponse.json({ error: "unauthorized" }, { status: 401 })
     }
 
     const authCtx: AuthContext = {
-      userId: session.user.id,
-      email: session.user.email,
+      userId: sessionResult.response.user.id,
+      email: sessionResult.response.user.email,
     }
-    return handler(req, { ...authCtx, params: resolvedParams })
+    const res = await handler(req, { ...authCtx, params: resolvedParams })
+
+    // Forward Set-Cookie headers from Better Auth to refresh session_data cookie cache
+    const setCookies = sessionResult.headers.getSetCookie()
+    if (setCookies.length > 0) {
+      const mutableRes = new NextResponse(res.body, res)
+      for (const cookie of setCookies) {
+        mutableRes.headers.append("Set-Cookie", cookie)
+      }
+      return mutableRes
+    }
+
+    return res
   }
 }

--- a/src/web/src/middleware.ts
+++ b/src/web/src/middleware.ts
@@ -25,9 +25,12 @@ export async function middleware(request: NextRequest) {
   if (needsAuth) {
     const { env } = await getCloudflareContext({ async: true })
     const auth = createAuth(env as Env)
-    const session = await auth.api.getSession({ headers: request.headers })
+    const result = await auth.api.getSession({
+      headers: request.headers,
+      returnHeaders: true,
+    }) as { headers: Headers; response: unknown } | null
 
-    if (!session) {
+    if (!result?.response) {
       const signInUrl = new URL("/sign-in", request.url)
       const returnTo = pathname + request.nextUrl.search
       if (returnTo !== "/workspaces") {
@@ -35,19 +38,32 @@ export async function middleware(request: NextRequest) {
       }
       return NextResponse.redirect(signInUrl)
     }
+
+    const res = NextResponse.next()
+    for (const cookie of result.headers.getSetCookie()) {
+      res.headers.append("Set-Cookie", cookie)
+    }
+    return res
   }
 
   if (pathname === "/sign-in" || pathname === "/sign-up") {
     const { env } = await getCloudflareContext({ async: true })
     const auth = createAuth(env as Env)
-    const session = await auth.api.getSession({ headers: request.headers })
+    const result = await auth.api.getSession({
+      headers: request.headers,
+      returnHeaders: true,
+    }) as { headers: Headers; response: unknown } | null
 
-    if (session) {
+    if (result?.response) {
       const redirect = request.nextUrl.searchParams.get("redirect")
-      if (redirect && isSafeRedirect(redirect)) {
-        return NextResponse.redirect(new URL(redirect, request.url))
+      const target = redirect && isSafeRedirect(redirect)
+        ? new URL(redirect, request.url)
+        : new URL("/workspaces?auto", request.url)
+      const res = NextResponse.redirect(target)
+      for (const cookie of result.headers.getSetCookie()) {
+        res.headers.append("Set-Cookie", cookie)
       }
-      return NextResponse.redirect(new URL("/workspaces?auto", request.url))
+      return res
     }
   }
 


### PR DESCRIPTION
# Why we need this PR?

D1 insights show ~3.5M queries/day with significant waste: session auth on every request (cookie cache broken), file_request polling always hitting D1, pins/sidebar queried every 2s without caching, and agent_task_queue missing runtime_id indexes.

## What changed

### Cookie cache fix (saves ~1.1M queries/day)
- `withAuth` and Next.js middleware now pass `returnHeaders: true` to Better Auth's `getSession()` and forward Set-Cookie headers to the client
- This keeps the `session_data` signed cookie refreshed, so subsequent requests skip D1 session/user lookups
- Previously the cookie expired after 5 minutes and was never renewed, causing every request to hit D1

### File request KV negative cache (saves ~360K queries/day)
- Poll route stores `"0"` in KV when `workspace_file_request` table is empty for a workspace
- Subsequent polls skip the D1 query until a new file request is created (which sets `"1"`)
- Safe fallback: if KV flag is missing (null), always checks D1

### Pins/sidebar KV cache (saves ~270K queries/day)
- `/api/agents/pins` GET response cached in KV for 30 seconds
- Invalidated on pin/unpin/reorder/sidebar-reorder mutations and studio creation

### Machine heartbeat throttle (saves ~140K writes/day)
- D1 heartbeat upsert throttle increased from 5s to 15s
- KV heartbeat (120s TTL, updated every 3s poll) remains the primary liveness source
- D1 is only a cross-colo fallback, 15s freshness is sufficient

### Partial indexes for hot queries
- `idx_task_queue_runtime_pending`: covers `listPendingTasksByRuntimes` (310K calls/day, 60→~3 rows/call)
- `idx_task_queue_agent_running`: covers `countRunningTasks` (931 calls/day, 858→~3 rows/call)
- `idx_task_queue_inbox_convo`: covers `getUnreadCount` (8K calls/day, 884→~10 rows/call)

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...