### PR TITLE
Add derived channel tag metadata

### DIFF
--- a/src/cli/daemon/execenv/__tests__/context.test.ts
+++ b/src/cli/daemon/execenv/__tests__/context.test.ts
@@ -39,7 +39,11 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     prompt: "do something",
     status: "running",
     priority: 0,
+    type: "user_dm_message",
     createdAt: "2026-01-01T00:00:00Z",
+    traceId: null,
+    parentTaskId: null,
+    channel: "default",
     agent: { name: "test-agent", instructions: "Be helpful and concise." },
     ...overrides,
   };

--- a/src/cli/daemon/execenv/__tests__/index.test.ts
+++ b/src/cli/daemon/execenv/__tests__/index.test.ts
@@ -109,6 +109,7 @@ describe("prepare", () => {
       ALOOK_CONVERSATION_ID: "c1",
       ALOOK_TRACE_ID: "",
       ALOOK_CHANNEL: "default",
+      ALOOK_CHANNEL_TAG: "default",
       ALOOK_HEALTH_PORT: expect.any(String),
     });
   });

--- a/src/cli/daemon/execenv/__tests__/timeline.test.ts
+++ b/src/cli/daemon/execenv/__tests__/timeline.test.ts
@@ -265,6 +265,11 @@ describe("timeline", () => {
       const entry = createTimelineEntry("t_c2", "test", "user_dm_message");
       expect(entry.context_key).toBeNull();
     });
+
+    it("includes channel_tag snapshot when provided", () => {
+      const entry = createTimelineEntry("t_tag", "test", "user_dm_message", undefined, 1234, "claude", "conv_abc", null, "ops");
+      expect(entry.channel_tag).toBe("ops");
+    });
   });
 
   describe("findRunningPidByTaskId", () => {

--- a/src/cli/daemon/execenv/context.test.ts
+++ b/src/cli/daemon/execenv/context.test.ts
@@ -15,6 +15,9 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     priority: 0,
     type: "user_dm_message",
     createdAt: "2024-01-01T00:00:00Z",
+    traceId: null,
+    parentTaskId: null,
+    channel: "default",
     ...overrides,
   };
 }

--- a/src/cli/daemon/execenv/index.ts
+++ b/src/cli/daemon/execenv/index.ts
@@ -33,6 +33,7 @@ export function prepare(
     ALOOK_CONVERSATION_ID: task.conversationId,
     ALOOK_TRACE_ID: task.traceId ?? "",
     ALOOK_CHANNEL: task.channel ?? "default",
+    ALOOK_CHANNEL_TAG: task.channel ?? "default",
     ALOOK_HEALTH_PORT: process.env.ALOOK_HEALTH_PORT || "19514",
   };
 

--- a/src/cli/daemon/execenv/timeline.ts
+++ b/src/cli/daemon/execenv/timeline.ts
@@ -36,6 +36,7 @@ export interface ContextTimelineEntry {
   agent_responses: string[];
   errmsg: string | null;
   provider: string | null;
+  channel_tag?: string | null;
   detailed_log: string | null;
 }
 
@@ -203,6 +204,7 @@ export function createTimelineEntry(
   provider?: string,
   contextKey?: string | null,
   detailedLog?: string | null,
+  channelTag?: string | null,
 ): ContextTimelineEntry {
   return {
     task_id: taskId,
@@ -216,6 +218,7 @@ export function createTimelineEntry(
     agent_responses: [],
     errmsg: null,
     provider: provider ?? null,
+    channel_tag: channelTag ?? null,
     detailed_log: detailedLog ?? null,
   };
 }

--- a/src/cli/daemon/prompt.test.ts
+++ b/src/cli/daemon/prompt.test.ts
@@ -14,6 +14,9 @@ function makeTask(prompt: string, type = "user_dm_message"): Task {
     status: "pending",
     priority: 1,
     createdAt: new Date().toISOString(),
+    traceId: null,
+    parentTaskId: null,
+    channel: "default",
   };
 }
 
@@ -22,7 +25,17 @@ describe("buildPrompt", () => {
     const task = makeTask("Fix the login bug");
     const parsed = JSON.parse(buildPrompt(task));
     expect(parsed.type).toBe("user_dm_message");
+    expect(parsed.channel_tag).toBe("default");
     expect(parsed.instruction).toBe("Fix the login bug");
+  });
+
+  it("includes channel_tag as a structured field", () => {
+    const task: Task = {
+      ...makeTask("Fix the login bug"),
+      channel: "ops",
+    };
+    const parsed = JSON.parse(buildPrompt(task));
+    expect(parsed.channel_tag).toBe("ops");
   });
 
   it("handles empty prompt", () => {
@@ -35,7 +48,7 @@ describe("buildPrompt", () => {
   it("includes the task type in output", () => {
     const task = makeTask("Check inbox", "email_inbound");
     expect(buildPrompt(task)).toBe(
-      JSON.stringify({ type: "email_inbound", instruction: "Check inbox" }),
+      JSON.stringify({ type: "email_inbound", channel_tag: "default", instruction: "Check inbox" }),
     );
   });
 

--- a/src/cli/daemon/prompt.ts
+++ b/src/cli/daemon/prompt.ts
@@ -38,7 +38,11 @@ function buildDmNotice(name: string, email: string): string {
 }
 
 export function buildPrompt(task: Task, attachments?: Attachment[]): string {
-  const obj: Record<string, unknown> = { type: task.type, instruction: task.prompt };
+  const obj: Record<string, unknown> = {
+    type: task.type,
+    channel_tag: task.channel ?? "default",
+    instruction: task.prompt,
+  };
   if (task.type === "user_dm_message") {
     obj.notice = DM_RESPONSE_NOTICE;
   }

--- a/src/cli/daemon/session-runner.test.ts
+++ b/src/cli/daemon/session-runner.test.ts
@@ -43,6 +43,7 @@ const mockCreateTimelineEntry = vi.fn(
     provider?: string,
     contextKey?: string | null,
     detailedLog?: string | null,
+    channelTag?: string | null,
   ) => ({
     task_id: taskId,
     context_key: contextKey ?? null,
@@ -55,6 +56,7 @@ const mockCreateTimelineEntry = vi.fn(
     agent_responses: [],
     errmsg: null,
     provider: provider || null,
+    channel_tag: channelTag ?? null,
     detailed_log: detailedLog ?? null,
   }),
 );
@@ -125,6 +127,9 @@ function makeInput(overrides?: Partial<SessionRunnerInput>): SessionRunnerInput 
       type: "user_dm_message",
       contextKey: "c1",
       createdAt: "2026-01-01T00:00:00Z",
+      traceId: null,
+      parentTaskId: null,
+      channel: "default",
     },
     provider: "claude",
     cliPath: "claude",
@@ -263,6 +268,7 @@ describe("session-runner runSession", () => {
       "claude",
       "c1",
       undefined,
+      "default",
     );
     expect(mockInitEntryAsync).toHaveBeenCalledWith(
       "/tmp/ws/ws1/a1/workdir/.context_timeline",
@@ -310,6 +316,7 @@ describe("session-runner runSession", () => {
       "claude",
       "c1",
       "/tmp/logs/t1.log",
+      "default",
     );
   });
 
@@ -736,6 +743,7 @@ describe("session-runner runSession", () => {
       "codex",
       "c1",
       undefined,
+      "default",
     );
   });
 

--- a/src/cli/daemon/session-runner.ts
+++ b/src/cli/daemon/session-runner.ts
@@ -170,7 +170,7 @@ export async function runSession(input: SessionRunnerInput): Promise<void> {
   // Timeline entry: write IMMEDIATELY so KILL_TASK can find our PID
   await initEntryAsync(
     timelineDir,
-    createTimelineEntry(task.id, task.prompt, task.type, undefined, process.pid, provider, task.contextKey, input.logFilePath),
+    createTimelineEntry(task.id, task.prompt, task.type, undefined, process.pid, provider, task.contextKey, input.logFilePath, task.channel ?? "default"),
   );
 
   const { workDir, env } = prepare(

--- a/src/cli/daemon/types.ts
+++ b/src/cli/daemon/types.ts
@@ -157,6 +157,6 @@ export function fromApiTask(api: import("@alook/shared").TaskApi): Task {
     createdAt: api.created_at,
     traceId: api.trace_id ?? null,
     parentTaskId: api.parent_task_id ?? null,
-    channel: api.channel ?? null,
+    channel: api.channel ?? "default",
   };
 }

--- a/src/shared/src/schemas.ts
+++ b/src/shared/src/schemas.ts
@@ -91,6 +91,7 @@ export const TaskApiBaseSchema = z.object({
   trace_id: z.string().nullable().optional(),
   parent_task_id: z.string().nullable().optional(),
   channel: z.string().nullable().optional(),
+  channel_tag: z.string().nullable().optional(),
 });
 export type TaskApiBase = z.infer<typeof TaskApiBaseSchema>;
 

--- a/src/shared/src/types.ts
+++ b/src/shared/src/types.ts
@@ -67,6 +67,7 @@ export interface Conversation {
   title: string;
   type: string;
   channel: string;
+  channel_tag?: string;
   created_at: string;
   message_count?: number;
 }

--- a/src/web/src/app/api/agents/[id]/chat-init/route.test.ts
+++ b/src/web/src/app/api/agents/[id]/chat-init/route.test.ts
@@ -100,6 +100,14 @@ vi.mock("@/lib/api/responses", () => ({
     agent_id: t.agentId,
     created_at: t.createdAt,
   })),
+  taskToResponseWithChannel: vi.fn((t: any, channel?: string | null) => ({
+    id: t.id,
+    status: t.status,
+    agent_id: t.agentId,
+    created_at: t.createdAt,
+    channel: channel ?? "default",
+    channel_tag: channel ?? "default",
+  })),
   taskMessageToResponse: vi.fn((m: any) => ({
     id: m.id,
     task_id: m.taskId,

--- a/src/web/src/app/api/agents/[id]/chat-init/route.ts
+++ b/src/web/src/app/api/agents/[id]/chat-init/route.ts
@@ -7,7 +7,7 @@ import { writeJSON, writeError } from "@/lib/middleware/helpers";
 import {
   conversationToResponse,
   messageToResponse,
-  taskToResponse,
+  taskToResponseWithChannel,
   taskMessageToResponse,
 } from "@/lib/api/responses";
 import { TaskService } from "@/lib/services/task";
@@ -117,7 +117,7 @@ export const POST = withAuth(async (req, ctx) => {
     messages: messages.map(messageToResponse),
     artifacts: artifacts.map(queries.artifact.artifactToResponse),
     buffered_messages: resolvedBuffered.map(messageToResponse),
-    active_task: resolvedActiveTask ? taskToResponse(resolvedActiveTask) : null,
+    active_task: resolvedActiveTask ? taskToResponseWithChannel(resolvedActiveTask, conversation.channel) : null,
     task_messages: taskMessages,
     has_more_messages: hasMoreMessages,
     has_more_conversations: hasMoreConvs,

--- a/src/web/src/app/api/agents/active-tasks/route.ts
+++ b/src/web/src/app/api/agents/active-tasks/route.ts
@@ -24,6 +24,7 @@ export const GET = withAuth(async (req, ctx) => {
 
   return writeJSON({
     tasks: tasks.map((t) => ({
+      channel_tag: t.channel ?? "default",
       id: t.id,
       agent_id: t.agentId,
       agent: agentMap.get(t.agentId) ?? null,

--- a/src/web/src/app/api/conversations/[id]/active-task/route.test.ts
+++ b/src/web/src/app/api/conversations/[id]/active-task/route.test.ts
@@ -57,6 +57,11 @@ vi.mock("@/lib/middleware/workspace", () => ({
 }));
 vi.mock("@/lib/api/responses", () => ({
   taskToResponse: (...args: any[]) => mockTaskToResponse(...args),
+  taskToResponseWithChannel: (task: any, channel?: string | null) => ({
+    ...mockTaskToResponse(task),
+    channel: channel ?? "default",
+    channel_tag: channel ?? "default",
+  }),
 }));
 
 const mockCancelActiveTask = vi.fn();
@@ -87,7 +92,12 @@ describe("GET /api/conversations/[id]/active-task", () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body).toEqual({ id: "t1", status: "running" });
+    expect(body).toEqual({
+      id: "t1",
+      status: "running",
+      channel: "default",
+      channel_tag: "default",
+    });
     expect(mockGetActiveTaskByConversation).toHaveBeenCalledWith({}, "c1", "w1");
   });
 
@@ -131,7 +141,12 @@ describe("DELETE /api/conversations/[id]/active-task", () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body).toEqual({ id: "t1", status: "cancelled" });
+    expect(body).toEqual({
+      id: "t1",
+      status: "cancelled",
+      channel: "default",
+      channel_tag: "default",
+    });
   });
 
   it("returns 404 when no active task", async () => {

--- a/src/web/src/app/api/conversations/[id]/active-task/route.ts
+++ b/src/web/src/app/api/conversations/[id]/active-task/route.ts
@@ -4,7 +4,7 @@ import { getDb } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError } from "@/lib/middleware/helpers";
-import { taskToResponse } from "@/lib/api/responses";
+import { taskToResponseWithChannel } from "@/lib/api/responses";
 import { TaskService } from "@/lib/services/task";
 import { broadcastToUser } from "@/lib/broadcast";
 import { invalidate, cacheKeys } from "@/lib/cache";
@@ -31,7 +31,7 @@ export const GET = withAuth(async (req, ctx) => {
     return new Response(null, { status: 204 });
   }
 
-  return writeJSON(taskToResponse(task));
+  return writeJSON(taskToResponseWithChannel(task, conversation.channel));
 });
 
 export const DELETE = withAuth(async (req, ctx) => {
@@ -67,5 +67,5 @@ export const DELETE = withAuth(async (req, ctx) => {
     status: "cancelled",
   }).catch(() => {});
 
-  return writeJSON(taskToResponse(cancelled));
+  return writeJSON(taskToResponseWithChannel(cancelled, conversation.channel));
 });

--- a/src/web/src/app/api/conversations/[id]/init/route.ts
+++ b/src/web/src/app/api/conversations/[id]/init/route.ts
@@ -7,7 +7,7 @@ import { writeJSON, writeError } from "@/lib/middleware/helpers";
 import {
   conversationToResponse,
   messageToResponse,
-  taskToResponse,
+  taskToResponseWithChannel,
   taskMessageToResponse,
 } from "@/lib/api/responses";
 import { TaskService } from "@/lib/services/task";
@@ -125,7 +125,7 @@ export const GET = withAuth(async (req, ctx) => {
     buffered_messages: resolvedBuffered.map(messageToResponse),
     flagged_message_ids: flaggedMessageIds,
     step_counts: stepCounts,
-    active_task: resolvedActiveTask ? taskToResponse(resolvedActiveTask) : null,
+    active_task: resolvedActiveTask ? taskToResponseWithChannel(resolvedActiveTask, conversation.channel) : null,
     task_messages: taskMessages,
     cache_valid: cacheValid,
   });

--- a/src/web/src/app/api/conversations/[id]/messages/route.test.ts
+++ b/src/web/src/app/api/conversations/[id]/messages/route.test.ts
@@ -53,6 +53,11 @@ vi.mock("@/lib/middleware/workspace", () => ({
 vi.mock("@/lib/api/responses", () => ({
   messageToResponse: (...args: any[]) => mockMessageToResponse(...args),
   taskToResponse: (...args: any[]) => mockTaskToResponse(...args),
+  taskToResponseWithChannel: (task: any, channel?: string | null) => ({
+    ...mockTaskToResponse(task),
+    channel: channel ?? "default",
+    channel_tag: channel ?? "default",
+  }),
 }));
 vi.mock("@/lib/services/task", () => {
   return {
@@ -202,7 +207,12 @@ describe("POST /api/conversations/[id]/messages", () => {
 
     expect(res.status).toBe(201);
     expect(body.message).toEqual({ id: "m1", content: "Hi there" });
-    expect(body.task).toEqual({ id: "t1", status: "pending" });
+    expect(body.task).toEqual({
+      id: "t1",
+      status: "pending",
+      channel: "default",
+      channel_tag: "default",
+    });
     expect(mockEnqueueTask).toHaveBeenCalledWith("a1", "c1", "w1", "Hi there", "user_dm_message", expect.objectContaining({ contextKey: "c1", traceId: expect.stringMatching(/^tr_/), parentTaskId: null }));
   });
 

--- a/src/web/src/app/api/conversations/[id]/messages/route.ts
+++ b/src/web/src/app/api/conversations/[id]/messages/route.ts
@@ -6,7 +6,7 @@ import { nanoid } from "nanoid";
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
-import { messageToResponse, taskToResponse } from "@/lib/api/responses";
+import { messageToResponse, taskToResponseWithChannel } from "@/lib/api/responses";
 import { TaskService } from "@/lib/services/task";
 import { log } from "@/lib/logger";
 import { broadcastToUser } from "@/lib/broadcast";
@@ -209,7 +209,10 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     invalidate(cacheKeys.overviewTaskStats(ws.workspaceId, dateStr)).catch(() => {});
     broadcastToUser(ctx.userId, { type: "task.updated", taskId: task.id, agentId: task.agentId, status: "queued" }).catch(() => {});
     return writeJSON(
-      { message: messageToResponse(message), task: taskToResponse(task) },
+      {
+        message: messageToResponse(message),
+        task: taskToResponseWithChannel(task, conversation.channel),
+      },
       201
     );
   } catch (err: unknown) {

--- a/src/web/src/app/api/daemon/tasks/poll/route.test.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.test.ts
@@ -148,6 +148,16 @@ vi.mock("@/lib/api/responses", () => ({
     prompt: t.prompt,
     status: t.status,
   }),
+  taskToResponseWithChannel: (t: any, channel?: string | null) => ({
+    id: t.id,
+    agent_id: t.agentId,
+    runtime_id: t.runtimeId,
+    workspace_id: t.workspaceId,
+    prompt: t.prompt,
+    status: t.status,
+    channel: channel ?? "default",
+    channel_tag: channel ?? "default",
+  }),
 }));
 
 import { POST } from "./route";

--- a/src/web/src/app/api/email/notify/route.test.ts
+++ b/src/web/src/app/api/email/notify/route.test.ts
@@ -75,6 +75,11 @@ vi.mock("@/lib/broadcast", () => ({
 
 vi.mock("@/lib/api/responses", () => ({
   taskToResponse: (t: unknown) => t,
+  taskToResponseWithChannel: (t: any, channel?: string | null) => ({
+    ...t,
+    channel: channel ?? "default",
+    channel_tag: channel ?? "default",
+  }),
 }));
 
 import { POST } from "./route";

--- a/src/web/src/app/api/email/notify/route.ts
+++ b/src/web/src/app/api/email/notify/route.ts
@@ -6,7 +6,7 @@ import { getDb } from "@/lib/db"
 import { writeJSON, parseBody } from "@/lib/middleware/helpers"
 import { TaskService } from "@/lib/services/task"
 import { broadcastToUser } from "@/lib/broadcast"
-import { taskToResponse } from "@/lib/api/responses"
+import { taskToResponseWithChannel } from "@/lib/api/responses"
 import { invalidate, cacheKeys } from "@/lib/cache"
 
 export async function POST(req: NextRequest) {
@@ -55,6 +55,7 @@ export async function POST(req: NextRequest) {
 
     let conversationId: string | null = null;
     let conversationType: string = TASK_TYPES.EMAIL_NOTIFICATION;
+    let conversationChannel = "default";
     let dmUser: { name: string; email: string } | undefined;
 
     if (mapKey) {
@@ -65,6 +66,7 @@ export async function POST(req: NextRequest) {
       const conv = await queries.conversation.getConversation(db, conversationId, body.workspaceId);
       if (conv) {
         conversationType = conv.type;
+        conversationChannel = conv.channel ?? "default";
         if (conv.type === TASK_TYPES.USER_DM_MESSAGE && conv.userId) {
           const u = await queries.user.getUser(db, conv.userId);
           if (u) dmUser = { name: u.name, email: u.email };
@@ -88,6 +90,7 @@ export async function POST(req: NextRequest) {
         ...(inheritedChannel && inheritedChannel !== "default" ? { channel: inheritedChannel } : {}),
       })
       conversationId = conv.id;
+      conversationChannel = conv.channel ?? "default";
 
       if (mapKey) {
         await queries.conversationMap.createMapping(db, {
@@ -137,7 +140,7 @@ export async function POST(req: NextRequest) {
       broadcastToUser(agent.ownerId, {
         type: "task.created",
         conversationId,
-        task: taskToResponse(task),
+        task: taskToResponseWithChannel(task, conversationChannel),
       }).catch(() => {});
     }
   }

--- a/src/web/src/app/api/issues/[id]/route.test.ts
+++ b/src/web/src/app/api/issues/[id]/route.test.ts
@@ -59,6 +59,12 @@ vi.mock("@/lib/middleware/workspace", () => ({
 vi.mock("@/lib/api/responses", () => ({
   issueToResponse: (i: any) => ({ id: i.id, status: i.status, conversation_id: i.conversationId }),
   messageToResponse: (m: any) => ({ id: m.id, role: m.role, content: m.content }),
+  taskToResponseWithChannel: (t: any, channel?: string | null) => ({
+    id: t.id,
+    status: t.status,
+    channel: channel ?? "default",
+    channel_tag: channel ?? "default",
+  }),
 }));
 
 vi.mock("@/lib/logger", () => ({

--- a/src/web/src/app/api/issues/[id]/route.ts
+++ b/src/web/src/app/api/issues/[id]/route.ts
@@ -11,7 +11,7 @@ import { getDb } from "@/lib/db";
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { parseBody, writeError, writeJSON } from "@/lib/middleware/helpers";
-import { issueToResponse, messageToResponse, taskToResponse } from "@/lib/api/responses";
+import { issueToResponse, messageToResponse, taskToResponseWithChannel } from "@/lib/api/responses";
 import { TaskService } from "@/lib/services/task";
 import { broadcastToUser } from "@/lib/broadcast";
 import { invalidate, cacheKeys } from "@/lib/cache";
@@ -124,7 +124,7 @@ export const PATCH = withAuth(async (req: NextRequest, ctx) => {
       broadcastToUser(ctx.userId, { type: "task.updated", taskId: task.id, agentId: task.agentId, status: "queued" }).catch(() => {});
       return writeJSON({
         ...issueToResponse(issue),
-        task: taskToResponse(task),
+        task: taskToResponseWithChannel(task, conversation.channel),
       });
     } catch (taskErr) {
       await queries.issue.updateIssue(db, id, ws.workspaceId, { status: "todo" });

--- a/src/web/src/app/api/issues/route.test.ts
+++ b/src/web/src/app/api/issues/route.test.ts
@@ -65,6 +65,12 @@ vi.mock("@/lib/api/responses", () => ({
   issueToResponse: (i: any) => ({ id: i.id, agent_id: i.agentId, title: i.title, status: i.status }),
   messageToResponse: (m: any) => ({ id: m.id, content: m.content }),
   taskToResponse: (t: any) => ({ id: t.id, type: t.type }),
+  taskToResponseWithChannel: (t: any, channel?: string | null) => ({
+    id: t.id,
+    type: t.type,
+    channel: channel ?? "default",
+    channel_tag: channel ?? "default",
+  }),
 }));
 
 import { GET, POST } from "./route";

--- a/src/web/src/app/api/issues/route.ts
+++ b/src/web/src/app/api/issues/route.ts
@@ -6,7 +6,7 @@ import { getDb } from "@/lib/db";
 import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { parseBody, writeError, writeJSON } from "@/lib/middleware/helpers";
-import { issueToResponse, messageToResponse, taskToResponse } from "@/lib/api/responses";
+import { issueToResponse, messageToResponse, taskToResponseWithChannel } from "@/lib/api/responses";
 import { TaskService } from "@/lib/services/task";
 import { broadcastToUser } from "@/lib/broadcast";
 import { invalidate, cacheKeys } from "@/lib/cache";
@@ -217,7 +217,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
       {
         issue: issueToResponse(issue),
         message: messageToResponse(eventMessage),
-        task: taskToResponse(task),
+        task: taskToResponseWithChannel(task, conversation.channel),
       },
       201
     );

--- a/src/web/src/app/api/traces/[traceId]/route.ts
+++ b/src/web/src/app/api/traces/[traceId]/route.ts
@@ -50,5 +50,5 @@ export const GET = withAuth(async (req: NextRequest, ctx) => {
     completed_at: t.completedAt,
   }));
 
-  return writeJSON({ trace_id: traceId, channel, tasks: traceTasks });
+  return writeJSON({ trace_id: traceId, channel, channel_tag: channel, tasks: traceTasks });
 });

--- a/src/web/src/app/api/traces/route.ts
+++ b/src/web/src/app/api/traces/route.ts
@@ -44,6 +44,7 @@ export const GET = withAuth(async (req: NextRequest, ctx) => {
     started_at: t.startedAt,
     completed_at: t.completedAt,
     channel: t.channel,
+    channel_tag: t.channel,
   }));
 
   return writeJSON({ traces, has_more: result.hasMore });

--- a/src/web/src/components/canvas/active-tasks-float.tsx
+++ b/src/web/src/components/canvas/active-tasks-float.tsx
@@ -34,6 +34,7 @@ function TaskRow({
   onOpenChat: (agentId: string, opts: { conversationId?: string; taskId?: string }) => void;
 }) {
   const isRunning = task.status === "running";
+  const channelTag = task.channel_tag ?? task.channel ?? "default";
   const href = `/w/${slug}/agents/${task.agent_id}?task=${task.id}&conv=${task.conversation_id}`;
 
   const handleClick = useCallback((e: React.MouseEvent) => {
@@ -65,7 +66,7 @@ function TaskRow({
             {task.agent?.name ?? "Unknown"}
           </span>
           <span className="text-xs text-muted-foreground shrink-0">
-            #{task.channel}
+            [#{channelTag}]
           </span>
         </div>
         <p className="text-xs text-muted-foreground truncate leading-tight">

--- a/src/web/src/lib/api.ts
+++ b/src/web/src/lib/api.ts
@@ -522,6 +522,7 @@ export interface WorkspaceActiveTask {
   type: string;
   conversation_id: string;
   channel: string;
+  channel_tag?: string | null;
   created_at: string;
 }
 
@@ -1201,6 +1202,7 @@ export interface TraceListItem {
   started_at: string;
   completed_at: string | null;
   channel: string;
+  channel_tag?: string | null;
 }
 
 export interface TraceTask {
@@ -1233,6 +1235,6 @@ export const listTraces = (
 };
 
 export const getTrace = (traceId: string, workspaceId: string) =>
-  apiFetch<{ trace_id: string; channel: string; tasks: TraceTask[] }>(
+  apiFetch<{ trace_id: string; channel: string; channel_tag?: string | null; tasks: TraceTask[] }>(
     `/api/traces/${traceId}${wsQuery(workspaceId)}`
   );

--- a/src/web/src/lib/api/responses.test.ts
+++ b/src/web/src/lib/api/responses.test.ts
@@ -5,6 +5,7 @@ import {
   agentToResponse,
   agentLinkToResponse,
   taskToResponse,
+  taskToResponseWithChannel,
   conversationToResponse,
   channelToResponse,
   messageToResponse,
@@ -263,8 +264,22 @@ describe("taskToResponse Zod validation", () => {
     expect(res).toHaveProperty("conversation_id");
     expect(res).toHaveProperty("workspace_id");
     expect(res).toHaveProperty("created_at");
+    expect(res).not.toHaveProperty("channel");
+    expect(res).not.toHaveProperty("channel_tag");
     expect(res).not.toHaveProperty("agentId");
     expect(res).not.toHaveProperty("runtimeId");
+  });
+
+  it("adds channel metadata from the explicit channel helper", () => {
+    const res = taskToResponseWithChannel(validTask, "ops");
+    expect(res.channel).toBe("ops");
+    expect(res.channel_tag).toBe("ops");
+  });
+
+  it("defaults explicit channel metadata to default", () => {
+    const res = taskToResponseWithChannel(validTask, null);
+    expect(res.channel).toBe("default");
+    expect(res.channel_tag).toBe("default");
   });
 });
 
@@ -352,9 +367,9 @@ describe("AgentResponse shape", () => {
 });
 
 describe("ConversationResponse shape", () => {
-  it("has expected keys: id, agent_id, title, type, channel, created_at", () => {
+  it("has expected keys: id, agent_id, title, type, channel, channel_tag, created_at", () => {
     const res = conversationToResponse({ id: "c1", agentId: "a1", title: "Chat", type: "user_dm_message", channel: "default", createdAt: ts });
-    expect(Object.keys(res).sort()).toEqual(["agent_id", "channel", "created_at", "id", "title", "type"]);
+    expect(Object.keys(res).sort()).toEqual(["agent_id", "channel", "channel_tag", "created_at", "id", "title", "type"]);
   });
 
   it("defaults type to user_dm_message when the column is absent", () => {
@@ -365,11 +380,13 @@ describe("ConversationResponse shape", () => {
   it("defaults channel to 'default' when the column is absent", () => {
     const res = conversationToResponse({ id: "c1", agentId: "a1", title: "Chat", createdAt: ts });
     expect(res.channel).toBe("default");
+    expect(res.channel_tag).toBe("default");
   });
 
   it("preserves channel value when present", () => {
     const res = conversationToResponse({ id: "c1", agentId: "a1", title: "Chat", channel: "work", createdAt: ts });
     expect(res.channel).toBe("work");
+    expect(res.channel_tag).toBe("work");
   });
 
   it("surfaces email_notification and calendar_event types", () => {

--- a/src/web/src/lib/api/responses.ts
+++ b/src/web/src/lib/api/responses.ts
@@ -71,7 +71,7 @@ export function emailToResponse(e: any) {
   };
 }
 
-export function taskToResponse(t: {
+type TaskResponseInput = {
   id: string;
   agentId: string;
   runtimeId: string;
@@ -91,7 +91,9 @@ export function taskToResponse(t: {
   createdAt: Date | string;
   traceId?: string | null;
   parentTaskId?: string | null;
-}) {
+};
+
+export function taskToResponse(t: TaskResponseInput) {
   return TaskApiBaseSchema.parse({
     id: t.id,
     agent_id: t.agentId,
@@ -115,13 +117,24 @@ export function taskToResponse(t: {
   });
 }
 
+export function taskToResponseWithChannel(t: TaskResponseInput, channelValue?: string | null) {
+  const channel = channelValue ?? "default";
+  return {
+    ...taskToResponse(t),
+    channel,
+    channel_tag: channel,
+  };
+}
+
 export function conversationToResponse(c: any) {
+  const channel = c.channel ?? "default";
   const resp: any = {
     id: c.id,
     agent_id: c.agentId,
     title: c.title,
     type: c.type ?? TASK_TYPES.USER_DM_MESSAGE,
-    channel: c.channel ?? "default",
+    channel,
+    channel_tag: channel,
     created_at: formatTimestamp(c.createdAt),
   };
   if (c.messageCount !== undefined) {

--- a/src/web/src/lib/services/task-payload-builder.test.ts
+++ b/src/web/src/lib/services/task-payload-builder.test.ts
@@ -57,6 +57,17 @@ vi.mock("@/lib/api/responses", () => ({
     status: t.status,
     type: t.type,
   }),
+  taskToResponseWithChannel: (t: any, channel?: string | null) => ({
+    id: t.id,
+    agent_id: t.agentId,
+    runtime_id: t.runtimeId,
+    workspace_id: t.workspaceId,
+    prompt: t.prompt,
+    status: t.status,
+    type: t.type,
+    channel: channel ?? "default",
+    channel_tag: channel ?? "default",
+  }),
 }));
 
 import { TaskPayloadBuilder } from "./task-payload-builder";

--- a/src/web/src/lib/services/task-payload-builder.ts
+++ b/src/web/src/lib/services/task-payload-builder.ts
@@ -1,6 +1,6 @@
 import type { Database, ClaimedTaskRow } from "@alook/shared";
 import { queries, TASK_TYPES, toAlookAddress } from "@alook/shared";
-import { taskToResponse } from "@/lib/api/responses";
+import { taskToResponse, taskToResponseWithChannel } from "@/lib/api/responses";
 import { cached, cacheKeys } from "@/lib/cache";
 
 export class TaskPayloadBuilder {
@@ -124,8 +124,7 @@ export class TaskPayloadBuilder {
       }));
 
       results.push({
-        ...taskToResponse(task),
-        channel: taskChannel,
+        ...taskToResponseWithChannel(task, taskChannel),
         sender,
         agent: agent
           ? {

--- a/src/web/src/lib/services/task.test.ts
+++ b/src/web/src/lib/services/task.test.ts
@@ -63,6 +63,11 @@ vi.mock("@/lib/broadcast", () => ({
 vi.mock("@/lib/api/responses", () => ({
   messageToResponse: (m: unknown) => m,
   taskToResponse: (t: unknown) => t,
+  taskToResponseWithChannel: (t: any, channel?: string | null) => ({
+    ...t,
+    channel: channel ?? "default",
+    channel_tag: channel ?? "default",
+  }),
 }));
 
 import { TaskService } from "./task";

--- a/src/web/src/lib/services/task.ts
+++ b/src/web/src/lib/services/task.ts
@@ -2,7 +2,7 @@ import type { Database } from "@alook/shared";
 import { queries, TASK_TYPES, MAX_TASKS_PER_TRACE } from "@alook/shared";
 import { log } from "@/lib/logger";
 import { broadcastToUser, broadcastToDaemon } from "@/lib/broadcast";
-import { messageToResponse, taskToResponse } from "@/lib/api/responses";
+import { messageToResponse, taskToResponseWithChannel } from "@/lib/api/responses";
 import { invalidate, cacheKeys } from "@/lib/cache";
 import { TaskPayloadBuilder } from "@/lib/services/task-payload-builder";
 
@@ -386,7 +386,7 @@ export class TaskService {
         type: "followup.dispatched",
         conversationId,
         message: messageToResponse(activated),
-        task: taskToResponse(task),
+        task: taskToResponseWithChannel(task, conversation.channel),
       }).catch(() => {});
 
       return task;


### PR DESCRIPTION
## What are we doing?

This PR adds a minimal `channel_tag` MVP across Alook API responses, daemon runtime context, timeline metadata, and active-task UI.

The core architecture decision is that `conversation.channel` remains the canonical source of truth. `channel_tag` is introduced only as a derived, visible metadata alias at system boundaries, not as a new persistence layer, routing layer, or permission boundary.

## New feature / behavior

- Conversation API responses expose `channel_tag`, derived from `conversation.channel`.
- Task API payloads can carry `channel_tag`, derived from the task/conversation channel.
- Daemon runtime receives `ALOOK_CHANNEL_TAG` alongside existing `ALOOK_CHANNEL`.
- Agent prompts include a structured `channel_tag` field, so agents can see the active channel context without relying on free-text guessing.
- Context timeline entries can include an optional `channel_tag` diagnostic snapshot.
- Active task UI shows a visible `[#tag]` label, making channel context easier to scan.

## Why this matters

This gives agents a lightweight channel-awareness surface for:

- classification: logs/tasks can be grouped by channel context;
- identification: agents can clearly see which channel context a task belongs to;
- retrieval readiness: future memory/experience search can use the tag as a stable metadata hook;
- context reminder: the active task surface and prompt make channel context obvious.

This deliberately does not implement cross-agent shared memory yet. It creates the stable metadata surface needed for that future work.

## Architecture notes

### Channel vs channel_tag

`channel` is the canonical routing and conversation partition value. It is the source of truth already present in the system.

`channel_tag` is a derived boundary/display alias. It exists so API clients, daemon prompts, timeline snapshots, and UI surfaces have a clear field named for classification and recall use cases.

They intentionally overlap in value today. That overlap is by design: the tag is visible and portable, while the channel remains authoritative.

### What this PR intentionally avoids

- No DB columns or migrations for `message.channel_tag` or task queue `channel_tag`.
- No second source of truth.
- No changes to `context_key`, session resume, steering, permissions, or filtering semantics.
- Timeline `channel_tag` is diagnostic metadata only; it is not used for lookup or control flow.

## Validation

Run after fetching latest `origin/main` and rebasing this PR branch onto v0.0.85 (`b755097`):

- `git diff --check origin/main...HEAD` passed.
- `npx pnpm@10.33.0 --filter @alook/shared typecheck` passed.
- `npx pnpm@10.33.0 --filter @alook/web typecheck` passed.
- `npx pnpm@10.33.0 --filter @alook/cli typecheck` passed.
- `npx pnpm@10.33.0 --filter @alook/shared test` passed: 21 files / 235 tests.
- `npx pnpm@10.33.0 --filter @alook/cli test -- --runInBand src/cli/daemon/prompt.test.ts src/cli/daemon/execenv/__tests__/index.test.ts src/cli/daemon/execenv/__tests__/timeline.test.ts src/cli/daemon/session-runner.test.ts` passed: 35 files / 658 tests.
- `npx pnpm@10.33.0 --filter @alook/web exec vitest run src/lib/api/responses.test.ts src/app/api/conversations/[id]/messages/route.test.ts src/app/api/conversations/[id]/active-task/route.test.ts` passed: 3 files / 69 tests.

## Notes

The original development work happened on a PET preview branch with unrelated history. This PR is intentionally created from a clean branch off the latest `origin/main` and contains only the derived `channel_tag` metadata change.
