### PR TITLE
fix(web): mobile hover interaction improvements

### DIFF
--- a/src/web/src/app/(app)/studio/new/client.tsx
+++ b/src/web/src/app/(app)/studio/new/client.tsx
@@ -282,7 +282,7 @@ export function StudioOnboardingClient({
   // Page 1: Scenario selection
   if (!scenarioId) {
     return (
-      <div className="relative flex min-h-dvh flex-col items-center justify-center p-6">
+      <div className="relative flex min-h-dvh flex-col items-center justify-center px-6 pt-14 pb-6 sm:p-6">
         <Button
           variant="ghost"
           size="sm"

--- a/src/web/src/components/agent-chat/message-list.tsx
+++ b/src/web/src/components/agent-chat/message-list.tsx
@@ -171,7 +171,7 @@ export const MessageItem = memo(function MessageItem({
                 "self-start mb-1",
                 copied
                   ? "text-green-500 opacity-100"
-                  : "text-muted-foreground opacity-0 group-hover/msg:opacity-100"
+                  : "text-muted-foreground md:opacity-0 md:group-hover/msg:opacity-100"
               )}
             />
           }
@@ -192,7 +192,7 @@ export const MessageItem = memo(function MessageItem({
                   "self-start mb-1",
                   isFlagged
                     ? "text-primary opacity-100"
-                    : "text-muted-foreground opacity-0 group-hover/msg:opacity-100"
+                    : "text-muted-foreground md:opacity-0 md:group-hover/msg:opacity-100"
                 )}
               />
             }

--- a/src/web/src/components/dashboard-navbar.tsx
+++ b/src/web/src/components/dashboard-navbar.tsx
@@ -297,7 +297,7 @@ export function DashboardNavbar() {
                                   <Button
                                     variant="ghost"
                                     size="sm"
-                                    className="text-[11px] text-muted-foreground h-6 px-2 hover:text-destructive opacity-0 group-hover:opacity-100 transition-opacity"
+                                    className="text-[11px] text-muted-foreground h-6 px-2 hover:text-destructive md:opacity-0 md:group-hover:opacity-100 transition-opacity"
                                     onClick={() => {
                                       openConfirm(
                                         "Remove machine",

--- a/src/web/src/components/dashboard-navbar.tsx
+++ b/src/web/src/components/dashboard-navbar.tsx
@@ -297,7 +297,7 @@ export function DashboardNavbar() {
                                   <Button
                                     variant="ghost"
                                     size="sm"
-                                    className="text-[11px] text-muted-foreground h-6 px-2 hover:text-destructive md:opacity-0 md:group-hover:opacity-100 transition-opacity"
+                                    className="text-[11px] text-muted-foreground h-6 px-2 hover:text-destructive opacity-0 group-hover:opacity-100 transition-opacity"
                                     onClick={() => {
                                       openConfirm(
                                         "Remove machine",


### PR DESCRIPTION
# Why we need this PR?

Mobile devices don't support hover interactions, so UI elements relying on `group-hover:opacity-100` are invisible/inaccessible on touch screens.

## What changed

- **Chat copy/flag buttons**: Changed from `opacity-0 group-hover/msg:opacity-100` to `md:opacity-0 md:group-hover/msg:opacity-100` so buttons are always visible on mobile, hover-revealed on desktop.
- **Studio/new page 1**: Added `pt-14` on mobile to prevent content from overlapping with the absolute-positioned navigation buttons (Workspaces / Sign out).

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)