### PR TITLE
fix(app): resolve task dispatch timeout in self-hosted mode

### DIFF
--- a/src/app/src/lib/cli-env.ts
+++ b/src/app/src/lib/cli-env.ts
@@ -10,12 +10,15 @@ import { readPids } from "./pid.js";
  *   3. App mode (npx):       ~/.alook/self-hosted  (same as 1)
  */
 export function buildCliEnv(webPort?: number): Record<string, string> {
-  const port = webPort ?? (readPids().ports?.web ?? DEFAULT_PORTS.web);
+  const pids = readPids();
+  const port = webPort ?? (pids.ports?.web ?? DEFAULT_PORTS.web);
+  const wsDoPort = pids.ports?.wsDo ?? DEFAULT_PORTS.wsDo;
   return {
     ...(process.env as Record<string, string>),
     ALOOK_SERVER_URL: WEB_URL(port),
     ALOOK_PROJECT_ROOT: SELF_HOSTED_DIR,
     ALOOK_CMD_PREFIX: "npx @alook/app cli",
     ALOOK_HEALTH_PORT: "19515",
+    ALOOK_WS_DO_PORT: String(wsDoPort),
   };
 }

--- a/src/cli/daemon/ws-client.ts
+++ b/src/cli/daemon/ws-client.ts
@@ -8,7 +8,7 @@ const WS_RECONNECT_INIT = 1000;
 const WS_RECONNECT_MAX = 30_000;
 const WS_PING_INTERVAL = 25_000;
 const WS_LIVENESS_TIMEOUT = 50_000;
-const WS_DO_DEV_PORT = 8789;
+const WS_DO_DEV_PORT = Number(process.env.ALOOK_WS_DO_PORT) || 8789;
 
 export interface DaemonWsClientOptions {
   serverURL: string;

--- a/src/web/src/app/api/runtimes/[runtimeId]/rescan/route.test.ts
+++ b/src/web/src/app/api/runtimes/[runtimeId]/rescan/route.test.ts
@@ -57,7 +57,7 @@ vi.mock("@/lib/logger", () => ({
 }));
 
 vi.mock("@/lib/broadcast", () => ({
-  broadcastToDaemon: vi.fn(() => Promise.resolve()),
+  broadcastToDaemon: vi.fn(() => Promise.resolve({ sent: 1 })),
 }));
 
 import { POST } from "./route";

--- a/src/web/src/app/api/runtimes/[runtimeId]/update/route.test.ts
+++ b/src/web/src/app/api/runtimes/[runtimeId]/update/route.test.ts
@@ -60,7 +60,7 @@ vi.mock("@/lib/logger", () => ({
 }));
 
 vi.mock("@/lib/broadcast", () => ({
-  broadcastToDaemon: vi.fn(() => Promise.resolve()),
+  broadcastToDaemon: vi.fn(() => Promise.resolve({ sent: 1 })),
 }));
 
 // Mock global fetch for npm registry

--- a/src/web/src/lib/broadcast.ts
+++ b/src/web/src/lib/broadcast.ts
@@ -59,13 +59,19 @@ export function broadcastToAgent(agentId: string, message: WsMessage): Promise<v
   )
 }
 
-export async function broadcastToDaemon(daemonId: string, message: DaemonPushMessage): Promise<{ sent: number }> {
-  const result = await sendBroadcastWithResult(
+export function broadcastToDaemon(daemonId: string, message: DaemonPushMessage): Promise<{ sent: number }> {
+  const promise = sendBroadcastWithResult(
     `/broadcast/daemon/${daemonId}`,
     JSON.stringify(message),
     { daemonId, type: message.type },
   )
-  return result
+  try {
+    const { ctx } = getCloudflareContext()
+    ctx.waitUntil(promise.catch(() => {}))
+  } catch {
+    // Not in CF context — promise runs on its own
+  }
+  return promise
 }
 
 async function sendBroadcastWithResult(url: string, body: string, label: Record<string, string>): Promise<{ sent: number }> {

--- a/src/web/src/lib/broadcast.ts
+++ b/src/web/src/lib/broadcast.ts
@@ -59,10 +59,52 @@ export function broadcastToAgent(agentId: string, message: WsMessage): Promise<v
   )
 }
 
-export function broadcastToDaemon(daemonId: string, message: DaemonPushMessage): Promise<void> {
-  return sendBroadcast(
+export async function broadcastToDaemon(daemonId: string, message: DaemonPushMessage): Promise<{ sent: number }> {
+  const result = await sendBroadcastWithResult(
     `/broadcast/daemon/${daemonId}`,
     JSON.stringify(message),
     { daemonId, type: message.type },
   )
+  return result
+}
+
+async function sendBroadcastWithResult(url: string, body: string, label: Record<string, string>): Promise<{ sent: number }> {
+  let wsDoUrl: string | undefined
+  try {
+    const { env } = getCloudflareContext()
+    const wsEnv = env as Env
+    wsDoUrl = (wsEnv as unknown as Record<string, unknown>).DEV_WS_DO_URL as string | undefined
+
+    const res = await wsEnv.WS_DO_WORKER.fetch(`http://internal${url}`, {
+      method: "POST",
+      body,
+    })
+    if (res.ok) {
+      try {
+        const json = await res.json() as { sent?: number }
+        return { sent: json.sent ?? 0 }
+      } catch {
+        return { sent: 0 }
+      }
+    }
+    log.warn("broadcast service-binding non-ok", { ...label, status: res.status })
+  } catch {
+    // Service binding unavailable — fall through to HTTP
+  }
+
+  const fallbackUrl = wsDoUrl || DEV_WS_DO_URL
+  const res = await fetch(`${fallbackUrl}${url}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  })
+  if (!res.ok) {
+    throw new Error(`broadcast failed: ${res.status}`)
+  }
+  try {
+    const json = await res.json() as { sent?: number }
+    return { sent: json.sent ?? 0 }
+  } catch {
+    return { sent: 0 }
+  }
 }

--- a/src/web/src/lib/broadcast.ts
+++ b/src/web/src/lib/broadcast.ts
@@ -4,77 +4,7 @@ import { DEV_WS_DO_URL, createLogger } from "@alook/shared"
 
 const log = createLogger({ service: "broadcast" })
 
-async function doSend(url: string, body: string, label: Record<string, string>) {
-  let wsDoUrl: string | undefined
-  try {
-    const { env } = getCloudflareContext()
-    const wsEnv = env as Env
-    wsDoUrl = (wsEnv as unknown as Record<string, unknown>).DEV_WS_DO_URL as string | undefined
-
-    const res = await wsEnv.WS_DO_WORKER.fetch(`http://internal${url}`, {
-      method: "POST",
-      body,
-    })
-    if (res.ok) return
-    log.warn("broadcast service-binding non-ok", { ...label, status: res.status })
-  } catch {
-    // Service binding unavailable — fall through to HTTP
-  }
-
-  const fallbackUrl = wsDoUrl || DEV_WS_DO_URL
-  const res = await fetch(`${fallbackUrl}${url}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body,
-  })
-  if (!res.ok) {
-    throw new Error(`broadcast failed: ${res.status}`)
-  }
-}
-
-function sendBroadcast(url: string, body: string, label: Record<string, string>): Promise<void> {
-  const promise = doSend(url, body, label)
-  try {
-    const { ctx } = getCloudflareContext()
-    ctx.waitUntil(promise)
-  } catch {
-    // Not in CF context — promise runs on its own
-  }
-  return promise
-}
-
-export function broadcastToUser(userId: string, message: WsMessage): Promise<void> {
-  return sendBroadcast(
-    `/broadcast/user/${userId}`,
-    JSON.stringify(message),
-    { userId, type: message.type },
-  )
-}
-
-export function broadcastToAgent(agentId: string, message: WsMessage): Promise<void> {
-  return sendBroadcast(
-    `/broadcast/${agentId}`,
-    JSON.stringify(message),
-    { agentId, type: message.type },
-  )
-}
-
-export function broadcastToDaemon(daemonId: string, message: DaemonPushMessage): Promise<{ sent: number }> {
-  const promise = sendBroadcastWithResult(
-    `/broadcast/daemon/${daemonId}`,
-    JSON.stringify(message),
-    { daemonId, type: message.type },
-  )
-  try {
-    const { ctx } = getCloudflareContext()
-    ctx.waitUntil(promise.catch(() => {}))
-  } catch {
-    // Not in CF context — promise runs on its own
-  }
-  return promise
-}
-
-async function sendBroadcastWithResult(url: string, body: string, label: Record<string, string>): Promise<{ sent: number }> {
+async function doSend(url: string, body: string, label: Record<string, string>): Promise<{ sent: number }> {
   let wsDoUrl: string | undefined
   try {
     const { env } = getCloudflareContext()
@@ -113,4 +43,48 @@ async function sendBroadcastWithResult(url: string, body: string, label: Record<
   } catch {
     return { sent: 0 }
   }
+}
+
+function sendBroadcast(url: string, body: string, label: Record<string, string>): Promise<void> {
+  const promise = doSend(url, body, label)
+  try {
+    const { ctx } = getCloudflareContext()
+    ctx.waitUntil(promise.catch(() => {}))
+  } catch {
+    // Not in CF context — promise runs on its own
+  }
+  return promise.then(() => {})
+}
+
+export function broadcastToUser(userId: string, message: WsMessage): Promise<void> {
+  return sendBroadcast(
+    `/broadcast/user/${userId}`,
+    JSON.stringify(message),
+    { userId, type: message.type },
+  )
+}
+
+export function broadcastToAgent(agentId: string, message: WsMessage): Promise<void> {
+  return sendBroadcast(
+    `/broadcast/${agentId}`,
+    JSON.stringify(message),
+    { agentId, type: message.type },
+  )
+}
+
+export function broadcastToDaemon(daemonId: string, message: DaemonPushMessage): Promise<{ sent: number }> {
+  const promise = doSend(
+    `/broadcast/daemon/${daemonId}`,
+    JSON.stringify(message),
+    { daemonId, type: message.type },
+  )
+  try {
+    // CF worker may terminate before the fetch completes if the response is sent early;
+    // waitUntil keeps the isolate alive until the broadcast resolves.
+    const { ctx } = getCloudflareContext()
+    ctx.waitUntil(promise.catch(() => {}))
+  } catch {
+    // Not in CF context — promise runs on its own
+  }
+  return promise
 }

--- a/src/web/src/lib/services/task.ts
+++ b/src/web/src/lib/services/task.ts
@@ -439,10 +439,13 @@ export class TaskService {
     }
 
     try {
-      await broadcastToDaemon(runtime.daemonId, {
+      const { sent } = await broadcastToDaemon(runtime.daemonId, {
         type: "daemon.tasks",
         tasks: payloads,
       });
+      if (sent === 0) {
+        await taskQueries.revertDispatchedToQueued(this.db, task.id, workspaceId);
+      }
     } catch {
       await taskQueries.revertDispatchedToQueued(this.db, task.id, workspaceId);
     }

--- a/src/ws-do/src/ws-durable.test.ts
+++ b/src/ws-do/src/ws-durable.test.ts
@@ -152,10 +152,26 @@ describe("WebSocketDurableObject", () => {
       const res = await durable.fetch(req)
 
       expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ sent: 1 })
       expect(wsAuth.send).toHaveBeenCalledWith(
         JSON.stringify({ type: "runtime.status", daemonId: "d1", workspaceId: "w1", status: "online" })
       )
       expect(wsUnauth.send).not.toHaveBeenCalled()
+    })
+
+    it("returns sent: 0 when no connections exist", async () => {
+      const { durable, ctx } = createDO()
+      ;(ctx.getWebSockets as ReturnType<typeof vi.fn>).mockReturnValue([])
+
+      const req = new Request("http://internal/broadcast", {
+        method: "POST",
+        body: '{"type":"test"}',
+      })
+
+      const res = await durable.fetch(req)
+
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ sent: 0 })
     })
 
     it("skips connections that are not OPEN", async () => {

--- a/src/ws-do/src/ws-durable.ts
+++ b/src/ws-do/src/ws-durable.ts
@@ -13,8 +13,10 @@ export class WebSocketDurableObject extends DurableObject<Env> {
 
     if (url.pathname === "/broadcast" && request.method === "POST") {
       const body = await request.text()
-      this.broadcast(body)
-      return new Response("ok")
+      const sent = this.broadcast(body)
+      return new Response(JSON.stringify({ sent }), {
+        headers: { "Content-Type": "application/json" },
+      })
     }
 
     if (request.headers.get("Upgrade") !== "websocket") {
@@ -91,13 +93,16 @@ export class WebSocketDurableObject extends DurableObject<Env> {
     try { ws.close(1011, "Internal error") } catch {}
   }
 
-  private broadcast(message: string): void {
+  private broadcast(message: string): number {
+    let sent = 0
     for (const ws of this.ctx.getWebSockets()) {
       const state = ws.deserializeAttachment() as ConnectionState
       if (state.authenticated && ws.readyState === WebSocket.OPEN) {
         ws.send(message)
+        sent++
       }
     }
+    return sent
   }
 
   private async validateToken(token: string): Promise<string | null> {


### PR DESCRIPTION
# Why we need this PR?
> Self-hosted app users see "Failed: timed out in dispatched state" whenever they send a message to an agent after completing the onboard flow.

## What changed

**Root cause**: Daemon WS client hardcoded `WS_DO_DEV_PORT = 8789`, but the self-hosted app runs ws-do on port 15212. The daemon's WebSocket never connects to the correct ws-do instance, so WS push silently fails.

**Additionally**: The WS DO broadcast endpoint always returned HTTP 200 regardless of whether any daemon was connected. `pushTaskToDaemon` assumed success, leaving the task stuck in "dispatched" state until the 20s stale sweep failed it. The poll fallback couldn't recover it because `claimTask` only picks up "queued" tasks.

**Fixes**:
1. `src/app/src/lib/cli-env.ts` — Pass `ALOOK_WS_DO_PORT` env var from app to daemon
2. `src/cli/daemon/ws-client.ts` — Read ws-do port from `ALOOK_WS_DO_PORT` env (fallback 8789 for dev)
3. `src/ws-do/src/ws-durable.ts` — Broadcast returns `{ sent: N }` instead of plain "ok"
4. `src/web/src/lib/broadcast.ts` — `broadcastToDaemon` returns sent count to caller
5. `src/web/src/lib/services/task.ts` — Revert task to "queued" when `sent === 0` so poll can pick it up

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)
- [x] CLI (`@alook/cli`)
- [x] WebSocket DO (`@alook/ws-do`)
- [x] Other: `@alook/app` (self-hosted launcher)