### PR TITLE
fix(email-worker): improve reliability and security

### DIFF
--- a/src/email-worker/src/imap-poller-do.test.ts
+++ b/src/email-worker/src/imap-poller-do.test.ts
@@ -123,6 +123,7 @@ function createMockCtx() {
       delete: vi.fn(async (key: string) => { storage.delete(key) }),
       deleteAll: vi.fn(async () => { storage.clear() }),
       setAlarm: vi.fn(async (time: number) => { alarm = time }),
+      getAlarm: vi.fn(async () => alarm),
       deleteAlarm: vi.fn(async () => { alarm = null }),
     },
     getWebSockets: vi.fn().mockReturnValue([]),
@@ -437,5 +438,43 @@ describe("lifecycle", () => {
     expect(ctx.storage.deleteAlarm).toHaveBeenCalled()
     expect(ctx.storage.deleteAll).toHaveBeenCalled()
     expect(mockConnect).not.toHaveBeenCalled()
+  })
+})
+
+// ─── Alarm resilience ───
+
+describe("alarm — resilience", () => {
+  it("reschedules alarm even when poll times out", async () => {
+    vi.useFakeTimers()
+    try {
+      const { durable, ctx } = createDO()
+      await ctx.storage.put("accountId", "aea_test1")
+      mockGetEmailAccount.mockResolvedValue({ ...ACCOUNT })
+      // Simulate a poll that never resolves (hangs forever)
+      mockConnect.mockImplementation(() => new Promise(() => {}))
+
+      const alarmPromise = durable.alarm()
+      await vi.advanceTimersByTimeAsync(30_000)
+      await alarmPromise
+
+      // Despite poll hanging, alarm must be rescheduled
+      expect(ctx.storage.getAlarm).toHaveBeenCalled()
+      expect(ctx.storage.setAlarm).toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("reschedules alarm when DB query throws in pollImap", async () => {
+    const { durable, ctx } = createDO()
+    await ctx.storage.put("accountId", "aea_test1")
+    // First call in alarm() succeeds, second call in pollImap() throws
+    mockGetEmailAccount
+      .mockResolvedValueOnce({ ...ACCOUNT })
+      .mockRejectedValueOnce(new Error("D1 unavailable"))
+
+    await durable.alarm()
+
+    expect(ctx.storage.setAlarm).toHaveBeenCalled()
   })
 })

--- a/src/email-worker/src/imap-poller-do.ts
+++ b/src/email-worker/src/imap-poller-do.ts
@@ -10,8 +10,10 @@ import type { EmailEnv } from "./types"
 const log = createLogger({ service: "imap-poller" })
 
 const MAX_BACKOFF_MS = 15 * 60 * 1000
+const DEFAULT_POLL_MS = 60_000
 const MAX_EMAILS_PER_POLL = 50
 const FIRST_SYNC_DAYS = 7
+const POLL_TIMEOUT_MS = 25_000
 
 export class ImapPollerDO extends DurableObject<EmailEnv> {
   private accountId: string | null = null
@@ -61,12 +63,38 @@ export class ImapPollerDO extends DurableObject<EmailEnv> {
   }
 
   async alarm(): Promise<void> {
-    await Promise.race([
-      this.pollImap(),
-      new Promise<void>((_, reject) => setTimeout(() => reject(new Error("poll timeout")), 25000)),
-    ]).catch((e) => {
+    const accountId = this.accountId ?? await this.ctx.storage.get<string>("accountId")
+    if (!accountId) return
+
+    let pollIntervalMs = DEFAULT_POLL_MS
+    try {
+      const db = this.db
+      const account = await queries.emailAccount.getEmailAccountById(db, accountId)
+      if (!account) {
+        await this.ctx.storage.deleteAlarm()
+        await this.ctx.storage.deleteAll()
+        return
+      }
+      pollIntervalMs = account.pollIntervalSeconds * 1000
+    } catch {
+      // DB read failed — use default interval, will retry next alarm
+    }
+
+    try {
+      await Promise.race([
+        this.pollImap(),
+        new Promise<void>((_, reject) => setTimeout(() => reject(new Error("poll timeout")), POLL_TIMEOUT_MS)),
+      ])
+    } catch (e) {
       log.warn("alarm: poll aborted", { err: String(e) })
-    })
+    } finally {
+      // Always ensure next alarm is scheduled so the chain never breaks
+      const existing = await this.ctx.storage.getAlarm()
+      if (!existing) {
+        const backoff = (await this.ctx.storage.get<number>("backoffMs")) ?? 0
+        await this.scheduleNext(backoff || pollIntervalMs)
+      }
+    }
   }
 
   private async pollImap(): Promise<void> {
@@ -238,10 +266,10 @@ export class ImapPollerDO extends DurableObject<EmailEnv> {
     const literalMatch = response.match(/\{(\d+)\}\r\n/)
     if (!literalMatch) return null
 
+    const literalLen = parseInt(literalMatch[1]!, 10)
     const contentStart = response.indexOf(literalMatch[0]) + literalMatch[0].length
-    const closingIdx = response.lastIndexOf("\r\n)")
-    if (closingIdx > contentStart) {
-      return response.substring(contentStart, closingIdx)
+    if (contentStart + literalLen <= response.length) {
+      return response.substring(contentStart, contentStart + literalLen)
     }
     return null
   }

--- a/src/email-worker/wrangler.toml
+++ b/src/email-worker/wrangler.toml
@@ -2,6 +2,7 @@ name = "alook-email-worker"
 main = "src/index.ts"
 compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
+workers_dev = false
 
 [observability]
 enabled = true


### PR DESCRIPTION
## Summary
- **Alarm chain resilience**: Rewrote `alarm()` with a `finally` block that always reschedules the next alarm. Previously, if `pollImap()` timed out (>25s) or threw an uncaught error, `scheduleNext()` never ran and the polling chain silently died forever (root cause of the 32h outage on May 22-23).
- **Disable public access**: Set `workers_dev = false` to prevent unauthenticated access to `/imap/*` management endpoints (start/stop/sync/status). Worker is only accessible via service binding from `alook-web`.
- **Fix FETCH parser**: Use IMAP literal byte count `{N}` to extract email content instead of `lastIndexOf("\r\n)")` which could match content within email bodies.

## Test plan
- [x] All 54 existing + new tests pass
- [x] TypeScript compiles without errors
- [x] New tests verify alarm rescheduling on timeout and DB failure
- [ ] Deploy and verify IMAP polling stays alive across multiple poll cycles
- [ ] Verify email sending still works via service binding after workers_dev disabled