### PR TITLE
fix(ws-do): harden auth and disable public access

### DIFF
--- a/src/ws-do/src/ws-durable.test.ts
+++ b/src/ws-do/src/ws-durable.test.ts
@@ -223,6 +223,32 @@ describe("WebSocketDurableObject", () => {
       expect(ws.send).not.toHaveBeenCalled()
     })
 
+    it("closes with 1008 when auth message has no token", async () => {
+      const { durable } = createDO()
+
+      const ws = createMockWebSocket()
+      ws.serializeAttachment({ type: "user", userId: "", authenticated: false })
+
+      await durable.webSocketMessage(ws as any, JSON.stringify({ type: "auth" }))
+
+      expect(ws.close).toHaveBeenCalledWith(1008, "Unauthorized")
+      expect(ws.send).not.toHaveBeenCalled()
+      expect(mockGetValidSession).not.toHaveBeenCalled()
+    })
+
+    it("closes with 1008 when auth message has empty string token", async () => {
+      const { durable } = createDO()
+
+      const ws = createMockWebSocket()
+      ws.serializeAttachment({ type: "user", userId: "", authenticated: false })
+
+      await durable.webSocketMessage(ws as any, JSON.stringify({ type: "auth", token: "" }))
+
+      expect(ws.close).toHaveBeenCalledWith(1008, "Unauthorized")
+      expect(ws.send).not.toHaveBeenCalled()
+      expect(mockGetValidSession).not.toHaveBeenCalled()
+    })
+
     it("closes unauthenticated connection sending non-auth message", async () => {
       const { durable } = createDO()
 

--- a/src/ws-do/src/ws-durable.ts
+++ b/src/ws-do/src/ws-durable.ts
@@ -63,7 +63,11 @@ export class WebSocketDurableObject extends DurableObject<Env> {
         return
       }
 
-      const userId = await this.validateToken(msg.token!)
+      if (!msg.token) {
+        ws.close(1008, "Unauthorized")
+        return
+      }
+      const userId = await this.validateToken(msg.token)
       if (!userId) {
         log.warn("websocket auth failed")
         ws.close(1008, "Unauthorized")

--- a/src/ws-do/wrangler.toml
+++ b/src/ws-do/wrangler.toml
@@ -2,6 +2,7 @@ name = "alook-ws-do"
 main = "src/index.ts"
 compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
+workers_dev = false
 
 [observability]
 enabled = true


### PR DESCRIPTION
## Summary
- **Disable workers.dev subdomain**: Set `workers_dev = false` so ws-do is only accessible via service binding from `alook-web`. Prevents unauthenticated broadcast to arbitrary user/daemon channels.
- **Guard missing token**: Reject auth messages immediately when `token` field is missing/empty, avoiding an unnecessary DB query with undefined value.

## Test plan
- [x] All 18 ws-do tests pass (including 2 new tests for missing/empty token)
- [x] Lint passes
- [ ] Verify WebSocket connections still work after deploy (service binding path unchanged)