### PR TITLE
fix(daemon): add missing WS push for daemon.kill, daemon.meetings, daemon.evict

### DIFF
--- a/src/shared/src/db/queries/task.ts
+++ b/src/shared/src/db/queries/task.ts
@@ -616,7 +616,7 @@ export async function claimKillTasks(
   return rows.map(r => ClaimedTaskRowSchema.parse(r));
 }
 
-const KILL_TASK_STALE_SECONDS = 30;
+const KILL_TASK_STALE_SECONDS = 90;
 
 export async function failStaleKillTasks(db: Database, workspaceId: string) {
   const threshold = new Date(Date.now() - KILL_TASK_STALE_SECONDS * 1000).toISOString();

--- a/src/web/src/app/api/agents/[id]/meetings/route.ts
+++ b/src/web/src/app/api/agents/[id]/meetings/route.ts
@@ -6,6 +6,7 @@ import { withWorkspaceMember } from "@/lib/middleware/workspace"
 import { writeJSON, writeError } from "@/lib/middleware/helpers"
 import { meetingToResponse } from "@/lib/api/responses"
 import { getDb } from "@/lib/db"
+import { broadcastToDaemon } from "@/lib/broadcast"
 
 const MEET_URL_RE = /^https:\/\/meet\.google\.com\/[a-z]{3}-[a-z]{4}-[a-z]{3}$/
 
@@ -70,5 +71,28 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
 
   const created = await queries.meetingSession.getMeetingSession(db, meeting.id, ws.workspaceId)
   if (!created) return writeError("meeting not found", 404)
+
+  if (agent.runtimeId) {
+    const runtime = await queries.runtime.getAgentRuntime(db, agent.runtimeId)
+    if (runtime) {
+      const scheduledTime = body.scheduledAt ? new Date(body.scheduledAt) : new Date()
+      const fiveMinFromNow = new Date(Date.now() + 5 * 60 * 1000)
+      if (scheduledTime <= fiveMinFromNow) {
+        broadcastToDaemon(runtime.daemonId, {
+          type: "daemon.meetings",
+          meetings: [{
+            id: created.id,
+            meeting_url: created.meetingUrl,
+            participants: created.participants as string[],
+            workspace_id: ws.workspaceId,
+            agent_id: agentId,
+            agent_name: agent.name ?? "",
+            title: created.title || undefined,
+          }],
+        }).catch(() => {})
+      }
+    }
+  }
+
   return writeJSON(meetingToResponse(created), 201)
 })

--- a/src/web/src/app/api/runtimes/machine/route.test.ts
+++ b/src/web/src/app/api/runtimes/machine/route.test.ts
@@ -55,6 +55,7 @@ vi.mock("@/lib/logger", () => ({
 }));
 vi.mock("@/lib/broadcast", () => ({
   broadcastToUser: vi.fn().mockResolvedValue(undefined),
+  broadcastToDaemon: vi.fn().mockResolvedValue({ sent: 1 }),
 }));
 
 import { DELETE } from "./route";
@@ -146,5 +147,19 @@ describe("DELETE /api/runtimes/machine", () => {
 
     expect(res.status).toBe(500);
     expect(body.error).toContain("Failed to remove machine");
+  });
+
+  it("broadcasts daemon.evict on successful delete", async () => {
+    const { broadcastToDaemon } = await import("@/lib/broadcast");
+    mockGetMemberByUserAndWorkspace.mockResolvedValue({ id: "m1" });
+    mockDeleteRuntimesByDaemonId.mockResolvedValue(undefined);
+    mockDeleteMachine.mockResolvedValue(undefined);
+
+    await DELETE(makeReq({ daemon_id: "d1", workspace_id: "w1" }));
+
+    expect(broadcastToDaemon).toHaveBeenCalledWith("d1", {
+      type: "daemon.evict",
+      workspaceId: "w1",
+    });
   });
 });

--- a/src/web/src/app/api/runtimes/machine/route.ts
+++ b/src/web/src/app/api/runtimes/machine/route.ts
@@ -6,7 +6,7 @@ import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON } from "@/lib/middleware/helpers";
 import { log } from "@/lib/logger";
-import { broadcastToUser } from "@/lib/broadcast";
+import { broadcastToUser, broadcastToDaemon } from "@/lib/broadcast";
 import { invalidate, cacheKeys } from "@/lib/cache";
 
 export const DELETE = withAuth(async (req: NextRequest, ctx) => {
@@ -32,6 +32,11 @@ export const DELETE = withAuth(async (req: NextRequest, ctx) => {
     log.error("Failed to delete machine", { err: e });
     return writeJSON({ error: "Failed to remove machine" }, 500);
   }
+
+  broadcastToDaemon(daemonId, {
+    type: "daemon.evict",
+    workspaceId: ws.workspaceId,
+  }).catch(() => {});
 
   broadcastToUser(ctx.userId, {
     type: "runtime.deleted",

--- a/src/web/src/lib/services/task.test.ts
+++ b/src/web/src/lib/services/task.test.ts
@@ -49,6 +49,9 @@ vi.mock("@alook/shared", () => ({
       getIssueByConversation: vi.fn(),
       updateIssue: vi.fn(),
     },
+    runtime: {
+      getAgentRuntime: vi.fn(),
+    },
   },
 }));
 
@@ -58,6 +61,7 @@ vi.mock("@/lib/logger", () => ({
 
 vi.mock("@/lib/broadcast", () => ({
   broadcastToUser: vi.fn().mockResolvedValue(undefined),
+  broadcastToDaemon: vi.fn().mockResolvedValue({ sent: 1 }),
 }));
 
 vi.mock("@/lib/api/responses", () => ({
@@ -67,7 +71,7 @@ vi.mock("@/lib/api/responses", () => ({
 
 import { TaskService } from "./task";
 import { queries } from "@alook/shared";
-import { broadcastToUser } from "@/lib/broadcast";
+import { broadcastToUser, broadcastToDaemon } from "@/lib/broadcast";
 
 const taskQ = queries.task as {
   [K in keyof typeof queries.task]: ReturnType<typeof vi.fn>;
@@ -85,6 +89,9 @@ const issueQ = (queries as any).issue as {
   getIssue: ReturnType<typeof vi.fn>;
   getIssueByConversation: ReturnType<typeof vi.fn>;
   updateIssue: ReturnType<typeof vi.fn>;
+};
+const runtimeQ = (queries as any).runtime as {
+  getAgentRuntime: ReturnType<typeof vi.fn>;
 };
 
 const service = new TaskService({} as any);
@@ -800,7 +807,9 @@ describe("TaskService", () => {
       const task = { id: "t1", status: "running", agentId: "a1", runtimeId: "r1", conversationId: "c1" };
       taskQ.getActiveTaskByConversation.mockResolvedValue(task);
       taskQ.cancelTask.mockResolvedValue({ ...task, status: "cancelled" });
+      taskQ.createTask.mockResolvedValue({ id: "kt1" });
       taskQ.countRunningTasks.mockResolvedValue(0);
+      runtimeQ.getAgentRuntime.mockResolvedValue({ daemonId: "d1" });
 
       await service.cancelActiveTask("c1", "w1");
 
@@ -813,11 +822,58 @@ describe("TaskService", () => {
       }));
     });
 
+    it("pushes daemon.kill for running task", async () => {
+      const task = { id: "t1", status: "running", agentId: "a1", runtimeId: "r1", conversationId: "c1" };
+      taskQ.getActiveTaskByConversation.mockResolvedValue(task);
+      taskQ.cancelTask.mockResolvedValue({ ...task, status: "cancelled" });
+      taskQ.createTask.mockResolvedValue({ id: "kt1" });
+      taskQ.countRunningTasks.mockResolvedValue(0);
+      runtimeQ.getAgentRuntime.mockResolvedValue({ daemonId: "d1" });
+
+      await service.cancelActiveTask("c1", "w1");
+
+      expect(broadcastToDaemon).toHaveBeenCalledWith("d1", {
+        type: "daemon.kill",
+        workspaceId: "w1",
+        taskId: "kt1",
+        targetTaskId: "t1",
+      });
+    });
+
+    it("pushes daemon.kill for dispatched task", async () => {
+      const task = { id: "t1", status: "dispatched", agentId: "a1", runtimeId: "r1", conversationId: "c1" };
+      taskQ.getActiveTaskByConversation.mockResolvedValue(task);
+      taskQ.cancelTask.mockResolvedValue({ ...task, status: "cancelled" });
+      taskQ.createTask.mockResolvedValue({ id: "kt1" });
+      taskQ.countRunningTasks.mockResolvedValue(0);
+      runtimeQ.getAgentRuntime.mockResolvedValue({ daemonId: "d1" });
+
+      await service.cancelActiveTask("c1", "w1");
+
+      expect(broadcastToDaemon).toHaveBeenCalledWith("d1", expect.objectContaining({
+        type: "daemon.kill",
+        targetTaskId: "t1",
+      }));
+    });
+
+    it("does not push daemon.kill for queued task", async () => {
+      const task = { id: "t1", status: "queued", agentId: "a1", runtimeId: "r1", conversationId: "c1" };
+      taskQ.getActiveTaskByConversation.mockResolvedValue(task);
+      taskQ.cancelTask.mockResolvedValue({ ...task, status: "cancelled" });
+      taskQ.countRunningTasks.mockResolvedValue(0);
+
+      await service.cancelActiveTask("c1", "w1");
+
+      expect(broadcastToDaemon).not.toHaveBeenCalled();
+    });
+
     it("creates kill_task for dispatched task", async () => {
       const task = { id: "t1", status: "dispatched", agentId: "a1", runtimeId: "r1", conversationId: "c1" };
       taskQ.getActiveTaskByConversation.mockResolvedValue(task);
       taskQ.cancelTask.mockResolvedValue({ ...task, status: "cancelled" });
+      taskQ.createTask.mockResolvedValue({ id: "kt1" });
       taskQ.countRunningTasks.mockResolvedValue(0);
+      runtimeQ.getAgentRuntime.mockResolvedValue({ daemonId: "d1" });
 
       await service.cancelActiveTask("c1", "w1");
 
@@ -831,7 +887,9 @@ describe("TaskService", () => {
       const task = { id: "t1", status: "running", agentId: "a1", runtimeId: "r1", conversationId: "c1" };
       taskQ.getActiveTaskByConversation.mockResolvedValue(task);
       taskQ.cancelTask.mockResolvedValue({ ...task, status: "cancelled" });
+      taskQ.createTask.mockResolvedValue({ id: "kt1" });
       taskQ.countRunningTasks.mockResolvedValue(0);
+      runtimeQ.getAgentRuntime.mockResolvedValue({ daemonId: "d1" });
 
       await service.cancelActiveTask("c1", "w1");
 

--- a/src/web/src/lib/services/task.ts
+++ b/src/web/src/lib/services/task.ts
@@ -314,7 +314,7 @@ export class TaskService {
     if (!cancelled) return null;
 
     if (activeTask.status === "dispatched" || activeTask.status === "running") {
-      await taskQueries.createTask(this.db, {
+      const killTask = await taskQueries.createTask(this.db, {
         agentId: activeTask.agentId,
         runtimeId: activeTask.runtimeId,
         workspaceId,
@@ -323,6 +323,16 @@ export class TaskService {
         type: TASK_TYPES.KILL_TASK,
         context: { target_task_id: activeTask.id },
       });
+
+      const runtime = await queries.runtime.getAgentRuntime(this.db, activeTask.runtimeId);
+      if (runtime) {
+        broadcastToDaemon(runtime.daemonId, {
+          type: "daemon.kill",
+          workspaceId,
+          taskId: killTask.id,
+          targetTaskId: activeTask.id,
+        }).catch(() => {});
+      }
     }
 
     await messageQueries.createMessage(this.db, {


### PR DESCRIPTION
# Why we need this PR?

Cancel (Stop task) was completely broken — clicking Stop would update the UI but the agent process kept running indefinitely. Root cause: the `KILL_TASK` was written to the database but never pushed to the daemon via WebSocket.

## What changed

1. **`daemon.kill` push in `cancelActiveTask`** — After creating the kill task, we now look up the runtime's daemonId and immediately broadcast `daemon.kill` via WS. This ensures the daemon receives the kill signal in <100ms instead of waiting up to 60s for the next poll.

2. **`daemon.meetings` push on meeting creation** — When a meeting is scheduled within 5 minutes (or immediately), we push `daemon.meetings` to the daemon so it can join without waiting for the next poll cycle.

3. **`daemon.evict` push on machine DELETE** — When a machine is removed, we notify the daemon immediately so it can clean up.

4. **`KILL_TASK_STALE_SECONDS` bumped from 30 → 90** — Previously, the sweep would expire kill tasks after 30s, but the WS poll fallback interval is 60s. This meant if the WS push failed, the poll could never pick up the kill task in time. Now there's a safe margin.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...