### PR TITLE
fix(web): persist PET position and unread notifications

### DIFF
--- a/src/web/src/components/home-pet/cloud-code-monster-pet.test.ts
+++ b/src/web/src/components/home-pet/cloud-code-monster-pet.test.ts
@@ -312,6 +312,10 @@ describe("production workspace PET mounting", () => {
       path.join(root, "src/components/home-pet/workspace-pet-layer.tsx"),
       "utf8"
     );
+    const inboxCountContext = readFileSync(
+      path.join(root, "src/contexts/inbox-count-context.tsx"),
+      "utf8"
+    );
     const petComponent = readFileSync(
       path.join(root, "src/components/home-pet/cloud-code-monster-pet.tsx"),
       "utf8"
@@ -354,10 +358,6 @@ describe("production workspace PET mounting", () => {
     );
     const landingPage = readFileSync(
       path.join(root, "src/components/home/home-page.tsx"),
-      "utf8"
-    );
-    const inboxCountContext = readFileSync(
-      path.join(root, "src/contexts/inbox-count-context.tsx"),
       "utf8"
     );
     const agentContext = readFileSync(
@@ -415,10 +415,12 @@ describe("production workspace PET mounting", () => {
     expect(workspacePetLayer).not.toContain("isHome");
     expect(workspacePetLayer).toContain("petSettings.enabled");
     expect(workspacePetLayer).toContain("dynamic<CloudCodeMonsterPetProps>");
-    expect(workspaceHomePage).toContain("positionStorageKey");
     expect(workspacePetLayer).toContain("positionStorageKey");
-    expect(workspaceHomePage).toContain("alook-cloud-code-monster-pet-position-${slug}");
     expect(workspacePetLayer).toContain("alook-cloud-code-monster-pet-position-${slug}");
+    expect(inboxCountContext).toContain("notificationToken");
+    expect(inboxCountContext).toContain("setNotificationToken((token) => token + 1)");
+    expect(workspacePetLayer).toContain("useInboxCount");
+    expect(workspacePetLayer).toContain("notificationToken={notificationToken}");
     expect(petComponent).toContain("const EMPTY_PEEK_TARGETS");
     expect(petComponent).toContain("function readStoredPetPosition");
     expect(petComponent).toContain("function writeStoredPetPosition");

--- a/src/web/src/components/home-pet/cloud-code-monster-pet.test.ts
+++ b/src/web/src/components/home-pet/cloud-code-monster-pet.test.ts
@@ -18,14 +18,17 @@ import {
   getCloudCodeMonsterPreset,
   getMonsterFootstepIntervalMs,
   hasViolentMonsterDirectionChange,
+  isStoredPetPoint,
   isViolentMonsterDrag,
   pickCloudCodeMonsterActivity,
+  readStoredPetPosition,
   reflectCloudCodeMonsterWalk,
   resolveCloudCodeMonsterPeekPosition,
   resolveCloudCodeMonsterVisibleState,
   shouldCloudCodeMonsterAutoWalk,
   shouldFaintFromMonsterShake,
   shouldRefreshCloudCodeMonsterActivity,
+  writeStoredPetPosition,
 } from "./cloud-code-monster-pet";
 import { readHomePetSettings } from "../../lib/home-pet-settings";
 
@@ -101,6 +104,36 @@ describe("Cloud Code monster PET helpers", () => {
     expect(readHomePetSettings()).toMatchObject({
       enabled: false,
     });
+  });
+
+  it("persists the last PET position across remounts and rejects invalid stored data", () => {
+    const storageKey = "alook-cloud-code-monster-pet-position-test-workspace";
+    const store = new Map<string, string>();
+
+    vi.stubGlobal("localStorage", {
+      clear: () => store.clear(),
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        store.set(key, value);
+      },
+    });
+
+    localStorage.clear();
+
+    expect(readStoredPetPosition(storageKey)).toBeNull();
+    expect(isStoredPetPoint({ x: 240, y: 180 })).toBe(true);
+    expect(isStoredPetPoint({ x: Number.NaN, y: 180 })).toBe(false);
+    expect(isStoredPetPoint({ x: 240 })).toBe(false);
+
+    writeStoredPetPosition(storageKey, { x: 240, y: 180 });
+
+    expect(readStoredPetPosition(storageKey)).toEqual({ x: 240, y: 180 });
+
+    localStorage.setItem(storageKey, JSON.stringify({ x: "240", y: 180 }));
+
+    expect(readStoredPetPosition(storageKey)).toBeNull();
+
+    vi.unstubAllGlobals();
   });
 
   it("refreshes visible activity only after the away threshold", () => {
@@ -382,7 +415,14 @@ describe("production workspace PET mounting", () => {
     expect(workspacePetLayer).not.toContain("isHome");
     expect(workspacePetLayer).toContain("petSettings.enabled");
     expect(workspacePetLayer).toContain("dynamic<CloudCodeMonsterPetProps>");
+    expect(workspaceHomePage).toContain("positionStorageKey");
+    expect(workspacePetLayer).toContain("positionStorageKey");
+    expect(workspaceHomePage).toContain("alook-cloud-code-monster-pet-position-${slug}");
+    expect(workspacePetLayer).toContain("alook-cloud-code-monster-pet-position-${slug}");
     expect(petComponent).toContain("const EMPTY_PEEK_TARGETS");
+    expect(petComponent).toContain("function readStoredPetPosition");
+    expect(petComponent).toContain("function writeStoredPetPosition");
+    expect(petComponent).toContain("storedPosition ?? initialPosition");
     expect(petComponent).toContain("peekTargets = EMPTY_PEEK_TARGETS");
     expect(petComponent).toContain("peekTargetsRef.current = peekTargets");
     expect(petComponent).toContain("const hasPeekTargets = peekTargets.length > 0");

--- a/src/web/src/components/home-pet/cloud-code-monster-pet.tsx
+++ b/src/web/src/components/home-pet/cloud-code-monster-pet.tsx
@@ -112,12 +112,56 @@ export type {
 export type CloudCodeMonsterPetProps = {
   boundaryRef: RefObject<HTMLElement | null>;
   initialPosition?: PetPoint;
+  positionStorageKey?: string;
   previewComebackToken?: number;
   notificationToken?: number;
   peekTargets?: CloudCodeMonsterPeekTarget[];
 };
 
 const EMPTY_PEEK_TARGETS: CloudCodeMonsterPeekTarget[] = [];
+
+export function isStoredPetPoint(value: unknown): value is PetPoint {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const point = value as PetPoint;
+  return Number.isFinite(point.x) && Number.isFinite(point.y);
+}
+
+export function readStoredPetPosition(storageKey?: string): PetPoint | null {
+  if (!storageKey || typeof localStorage === "undefined") {
+    return null;
+  }
+
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed: unknown = JSON.parse(raw);
+    return isStoredPetPoint(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredPetPosition(
+  storageKey: string | undefined,
+  position: PetPoint
+) {
+  if (!storageKey || typeof localStorage === "undefined") {
+    return;
+  }
+
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(position));
+  } catch {
+    // Ignore quota/private-mode failures; the PET can still use in-memory state.
+  }
+}
+
 type PetTimerKey =
   | "reaction"
   | "shake"
@@ -179,6 +223,7 @@ function usePetTimers() {
 export function CloudCodeMonsterPet({
   boundaryRef,
   initialPosition,
+  positionStorageKey,
   previewComebackToken = 0,
   notificationToken = 0,
   peekTargets = EMPTY_PEEK_TARGETS,
@@ -284,12 +329,13 @@ export function CloudCodeMonsterPet({
   useEffect(() => {
     const syncPosition = () => {
       const bounds = getBounds(boundaryRef.current);
+      const storedPosition = readStoredPetPosition(positionStorageKey);
 
       setPosition((currentPosition) =>
         currentPosition
           ? clampPetPosition(currentPosition, bounds, CLOUD_CODE_MONSTER_SIZE)
           : clampPetPosition(
-              initialPosition ?? {
+              storedPosition ?? initialPosition ?? {
                 x: bounds.width - CLOUD_CODE_MONSTER_SIZE.width - 112,
                 y: Math.min(
                   bounds.height * 0.48,
@@ -314,7 +360,15 @@ export function CloudCodeMonsterPet({
       resizeObserverRef.current?.disconnect();
       resizeObserverRef.current = null;
     };
-  }, [boundaryRef, initialPosition]);
+  }, [boundaryRef, initialPosition, positionStorageKey]);
+
+  useEffect(() => {
+    if (!position || isDragging || isAutoWalking || isPeeking) {
+      return;
+    }
+
+    writeStoredPetPosition(positionStorageKey, position);
+  }, [isAutoWalking, isDragging, isPeeking, position, positionStorageKey]);
 
   useEffect(() => {
     return clearAllPetTimers;

--- a/src/web/src/components/home-pet/workspace-pet-layer.tsx
+++ b/src/web/src/components/home-pet/workspace-pet-layer.tsx
@@ -3,6 +3,7 @@
 import { type RefObject } from "react";
 import dynamic from "next/dynamic";
 
+import { useInboxCount } from "@/contexts/inbox-count-context";
 import { useHomePetSettings } from "@/lib/home-pet-settings";
 import type { CloudCodeMonsterPetProps } from "./cloud-code-monster-pet";
 
@@ -21,6 +22,7 @@ type WorkspacePetLayerProps = {
 
 export function WorkspacePetLayer({ boundaryRef, slug }: WorkspacePetLayerProps) {
   const petSettings = useHomePetSettings();
+  const { notificationToken } = useInboxCount();
 
   if (!petSettings.enabled) {
     return null;
@@ -30,6 +32,7 @@ export function WorkspacePetLayer({ boundaryRef, slug }: WorkspacePetLayerProps)
     <CloudCodeMonsterPet
       boundaryRef={boundaryRef}
       positionStorageKey={`alook-cloud-code-monster-pet-position-${slug}`}
+      notificationToken={notificationToken}
     />
   );
 }

--- a/src/web/src/components/home-pet/workspace-pet-layer.tsx
+++ b/src/web/src/components/home-pet/workspace-pet-layer.tsx
@@ -16,15 +16,20 @@ const CloudCodeMonsterPet = dynamic<CloudCodeMonsterPetProps>(
 
 type WorkspacePetLayerProps = {
   boundaryRef: RefObject<HTMLElement | null>;
-  slug?: string;
+  slug: string;
 };
 
-export function WorkspacePetLayer({ boundaryRef }: WorkspacePetLayerProps) {
+export function WorkspacePetLayer({ boundaryRef, slug }: WorkspacePetLayerProps) {
   const petSettings = useHomePetSettings();
 
   if (!petSettings.enabled) {
     return null;
   }
 
-  return <CloudCodeMonsterPet boundaryRef={boundaryRef} />;
+  return (
+    <CloudCodeMonsterPet
+      boundaryRef={boundaryRef}
+      positionStorageKey={`alook-cloud-code-monster-pet-position-${slug}`}
+    />
+  );
 }

--- a/src/web/src/contexts/inbox-count-context.tsx
+++ b/src/web/src/contexts/inbox-count-context.tsx
@@ -18,13 +18,19 @@ import type { WsMessage } from "@alook/shared";
 
 interface InboxCountContextValue {
   count: number;
+  notificationToken: number;
   refresh: () => void;
   decrement: () => void;
 }
 
 const InboxCountContext = createContext<InboxCountContextValue | null>(null);
 
-const FALLBACK_INBOX_COUNT: InboxCountContextValue = { count: 0, refresh: () => {}, decrement: () => {} };
+const FALLBACK_INBOX_COUNT: InboxCountContextValue = {
+  count: 0,
+  notificationToken: 0,
+  refresh: () => {},
+  decrement: () => {},
+};
 
 export function useInboxCount() {
   const ctx = useContext(InboxCountContext);
@@ -35,6 +41,7 @@ export function InboxCountProvider({ children }: { children: ReactNode }) {
   const { workspaceId } = useWorkspace();
   const { subscribeWs, agents } = useAgentContext();
   const [count, setCount] = useState(0);
+  const [notificationToken, setNotificationToken] = useState(0);
   const prevCountRef = useRef<number | null>(null);
   const pendingAgentIdRef = useRef<string | null>(null);
 
@@ -48,6 +55,7 @@ export function InboxCountProvider({ children }: { children: ReactNode }) {
       prevCountRef.current = r.count;
       setCount(r.count);
       if (prev !== null && r.count > prev) {
+        setNotificationToken((token) => token + 1);
         const agent = pendingAgentIdRef.current
           ? agentsRef.current.find((a) => a.id === pendingAgentIdRef.current)
           : undefined;
@@ -82,7 +90,7 @@ export function InboxCountProvider({ children }: { children: ReactNode }) {
   }, [refresh]);
 
   return (
-    <InboxCountContext.Provider value={{ count, refresh, decrement }}>
+    <InboxCountContext.Provider value={{ count, notificationToken, refresh, decrement }}>
       {children}
     </InboxCountContext.Provider>
   );


### PR DESCRIPTION
## Summary
- Persist PET position across workspace page switches with a slug-scoped localStorage key
- Trigger the PET bell reaction when unread inbox count increases
- Wire the unread notification token into both Home and global PET mounts

## Tests
- pnpm --filter @alook/web test src/components/home-pet/cloud-code-monster-pet.test.ts
- pnpm typecheck
- pnpm --filter @alook/web lint

Note: root pre-commit test is blocked locally by the existing @alook/shared browser Meet test requiring Chrome; focused PET tests, web lint, and typecheck pass.