### PR TITLE
fix: daemon bugs — flush race, readline leak, timeline lock, client retry, file-request scope

### DIFF
--- a/src/cli/daemon/agent/claude.ts
+++ b/src/cli/daemon/agent/claude.ts
@@ -198,6 +198,7 @@ export class ClaudeBackend implements AgentBackend {
 
       proc.on("close", (code: number | null) => {
         if (timeoutTimer) clearTimeout(timeoutTimer);
+        rl.close();
 
         if (timedOut) {
           resultStatus = "timeout";

--- a/src/cli/daemon/agent/codex.ts
+++ b/src/cli/daemon/agent/codex.ts
@@ -533,6 +533,7 @@ export class CodexBackend implements AgentBackend {
 
       proc.on("close", (code: number | null) => {
         if (timeoutTimer) clearTimeout(timeoutTimer);
+        rl.close();
 
         closeAllPending("process closed");
 

--- a/src/cli/daemon/agent/opencode.ts
+++ b/src/cli/daemon/agent/opencode.ts
@@ -229,6 +229,7 @@ export class OpenCodeBackend implements AgentBackend {
 
       proc.on("close", (code: number | null) => {
         if (timeoutTimer) clearTimeout(timeoutTimer);
+        rl.close();
 
         if (timedOut) {
           resultStatus = "timeout";

--- a/src/cli/daemon/client.ts
+++ b/src/cli/daemon/client.ts
@@ -28,7 +28,7 @@ export class DaemonClient {
     };
     const MAX_RETRIES = 3;
     const BASE_DELAY_MS = 500;
-    let lastError: unknown;
+    let lastError: unknown = new Error(`request failed: ${method} ${path}`);
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       try {
         const res = await fetch(this.baseURL + path, {
@@ -160,7 +160,7 @@ export class DaemonClient {
   ): Promise<ArrayBuffer> {
     const MAX_RETRIES = 3;
     const BASE_DELAY_MS = 500;
-    let lastError: unknown;
+    let lastError: unknown = new Error(`artifact download failed: ${artifactId}`);
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       try {
         const res = await fetch(

--- a/src/cli/daemon/execenv/timeline.ts
+++ b/src/cli/daemon/execenv/timeline.ts
@@ -151,7 +151,15 @@ export function updateEntry(
     const lockPath = lockPathFor(timelineDir, filename);
 
     try {
-      const acquired = acquireLock(lockPath);
+      let acquired = acquireLock(lockPath);
+      if (!acquired) {
+        // Retry up to 2 more times with short delays
+        for (let retry = 0; retry < 2 && !acquired; retry++) {
+          const start = Date.now();
+          while (Date.now() - start < 50 * (retry + 1)) { /* spin wait */ }
+          acquired = acquireLock(lockPath);
+        }
+      }
       if (!acquired) {
         log.debug(`Timeline updateEntry: lock held for ${filename}, skipping`);
         continue;

--- a/src/cli/daemon/session-runner.ts
+++ b/src/cli/daemon/session-runner.ts
@@ -301,13 +301,17 @@ export async function runSession(input: SessionRunnerInput): Promise<void> {
   const BATCH_SIZE = Number(process.env.ALOOK_MESSAGE_BATCH_SIZE) || 20;
   const FLUSH_INTERVAL_MS = Number(process.env.ALOOK_MESSAGE_FLUSH_INTERVAL_MS) || 100;
 
+  let isFlushing = false;
   const flushMessages = async () => {
-    if (pendingMessages.length === 0) return;
-    const batch = pendingMessages.splice(0);
+    if (isFlushing || pendingMessages.length === 0) return;
+    isFlushing = true;
     try {
+      const batch = pendingMessages.splice(0);
       await client.reportMessages(token, task.id, batch);
     } catch (e) {
       log.debug("message report failed", e);
+    } finally {
+      isFlushing = false;
     }
   };
 

--- a/src/shared/src/db/queries/workspace-file-request.ts
+++ b/src/shared/src/db/queries/workspace-file-request.ts
@@ -58,11 +58,13 @@ export async function completeRequest(
   return rows[0] ?? null;
 }
 
-export async function getRequest(db: Database, id: string) {
+export async function getRequest(db: Database, id: string, workspaceId?: string) {
+  const conditions = [eq(workspaceFileRequest.id, id)];
+  if (workspaceId) conditions.push(eq(workspaceFileRequest.workspaceId, workspaceId));
   const rows = await db
     .select()
     .from(workspaceFileRequest)
-    .where(eq(workspaceFileRequest.id, id));
+    .where(and(...conditions));
   return rows[0] ?? null;
 }
 

--- a/src/web/src/app/api/daemon/workspace/report/route.ts
+++ b/src/web/src/app/api/daemon/workspace/report/route.ts
@@ -17,7 +17,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
   const [body, err] = await parseBody(req, WorkspaceFileReportSchema);
   if (err) return err;
 
-  const row = await withD1Retry(() => queries.workspaceFileRequest.getRequest(db, body.request_id));
+  const row = await withD1Retry(() => queries.workspaceFileRequest.getRequest(db, body.request_id, ctx.workspaceId));
   if (!row) return writeError("request not found", 404);
 
   const result = {


### PR DESCRIPTION
## Summary
- **Flush race condition** (#108): Add `isFlushing` guard to prevent concurrent `flushMessages` calls from racing
- **Readline memory leak** (#109): Add `rl.close()` in process close handlers for all 3 agent backends (claude, codex, opencode)
- **Timeline lock drop** (#110): Add retry loop (2 retries with spin-wait) in `updateEntry` when lock acquisition fails
- **Client throw-undefined** (#115): Initialize `lastError` with a meaningful Error in both retry loops
- **File-request scope** (#107): Add optional `workspaceId` to `getRequest` query for defense-in-depth

## Test plan
- [x] All 662 CLI tests pass
- [x] All 241 shared tests pass
- [x] Lint passes (warnings only, pre-existing)
- [ ] Manual test: verify daemon handles concurrent message flush without loss
- [ ] Manual test: verify timeline entries are updated when lock contention occurs

Closes #107, #108, #109, #110, #115