### PR TITLE
feat: add daemon_id isolation to global skill sync

### DIFF
--- a/src/cli/daemon/daemon.ts
+++ b/src/cli/daemon/daemon.ts
@@ -653,6 +653,7 @@ export async function startDaemon(
       agentIds: ws.agent_ids ?? [],
     })),
     runtimes: providers.map((p) => p.type as "claude" | "codex" | "opencode"),
+    daemonId: config.daemonId,
   }, 60_000);
 
   let shuttingDown = false;

--- a/src/cli/daemon/skill-scanner.test.ts
+++ b/src/cli/daemon/skill-scanner.test.ts
@@ -71,6 +71,7 @@ describe("runScan global skills syncs to all workspaces", () => {
         { workspaceId: "ws2", token: "token-ws2", agentIds: ["agent2"] },
       ],
       runtimes: ["claude"],
+      daemonId: "test-daemon",
     }, 999_999);
 
     await new Promise((r) => setTimeout(r, 100));
@@ -90,6 +91,7 @@ describe("runScan global skills syncs to all workspaces", () => {
       workspacesRoot,
       workspaces: [],
       runtimes: ["claude"],
+      daemonId: "test-daemon",
     }, 999_999);
 
     expect(mockClient.syncSkills).not.toHaveBeenCalled();

--- a/src/cli/daemon/skill-scanner.ts
+++ b/src/cli/daemon/skill-scanner.ts
@@ -227,6 +227,7 @@ export interface SkillScannerConfig {
   workspacesRoot: string;
   workspaces: { workspaceId: string; token: string; agentIds: string[] }[];
   runtimes: Runtime[];
+  daemonId: string;
 }
 
 
@@ -334,11 +335,13 @@ function runScan() {
       if (prevHash !== hash) {
         const skillItems = skills.map((s) => ({ name: s.name, description: s.description }));
         log.info(`Syncing global ${runtime} — ${skills.length} skills`);
+        const daemonId = scannerConfig.daemonId;
         const syncPromises = scannerConfig.workspaces.map((ws) =>
           clientRef!.syncSkills(ws.token, {
             scope: "global",
             runtime,
             skills: skillItems,
+            daemon_id: daemonId,
           })
         );
         Promise.all(syncPromises).then(() => {

--- a/src/cli/daemon/skill-scanner.ts
+++ b/src/cli/daemon/skill-scanner.ts
@@ -240,8 +240,8 @@ function computeHash(skills: SkillEntry[]): string {
   return createHash("md5").update(JSON.stringify(skills)).digest("hex");
 }
 
-function globalCachePath(runtime: Runtime): string {
-  return join(getCacheDir(), "global", `${runtime}.json`);
+function globalCachePath(daemonId: string, runtime: Runtime): string {
+  return join(getCacheDir(), "global", daemonId, `${runtime}.json`);
 }
 
 function agentCachePath(agentId: string, runtime: Runtime): string {
@@ -330,7 +330,7 @@ function runScan() {
     try {
       const skills = getGlobalScanner(runtime)();
       const hash = computeHash(skills);
-      const prevHash = readCacheHash(globalCachePath(runtime));
+      const prevHash = readCacheHash(globalCachePath(scannerConfig.daemonId, runtime));
 
       if (prevHash !== hash) {
         const skillItems = skills.map((s) => ({ name: s.name, description: s.description }));
@@ -345,7 +345,7 @@ function runScan() {
           })
         );
         Promise.all(syncPromises).then(() => {
-          writeCacheFile(globalCachePath(runtime), hash, skills);
+          writeCacheFile(globalCachePath(daemonId, runtime), hash, skills);
         }).catch((e) => log.debug("Global skill sync failed", e));
       }
     } catch (e) {

--- a/src/shared/src/db/queries/agent-skill.ts
+++ b/src/shared/src/db/queries/agent-skill.ts
@@ -12,23 +12,27 @@ export async function syncGlobalSkills(
   workspaceId: string,
   runtime: string,
   skills: SkillRow[],
+  daemonId?: string,
 ) {
   const now = new Date().toISOString();
   const rows = skills.map((s) => ({
     workspaceId,
     agentId: null,
+    daemonId: daemonId ?? null,
     runtime,
     name: s.name,
     description: s.description,
     syncedAt: now,
   }));
 
+  const deleteCondition = daemonId
+    ? and(eq(agentSkill.workspaceId, workspaceId), eq(agentSkill.runtime, runtime), isNull(agentSkill.agentId), eq(agentSkill.daemonId, daemonId))
+    : and(eq(agentSkill.workspaceId, workspaceId), eq(agentSkill.runtime, runtime), isNull(agentSkill.agentId), isNull(agentSkill.daemonId));
+
   const BATCH_SIZE = 10;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const statements: any[] = [
-    db.delete(agentSkill).where(
-      and(eq(agentSkill.workspaceId, workspaceId), eq(agentSkill.runtime, runtime), isNull(agentSkill.agentId))
-    ),
+    db.delete(agentSkill).where(deleteCondition),
   ];
   for (let i = 0; i < rows.length; i += BATCH_SIZE) {
     statements.push(db.insert(agentSkill).values(rows.slice(i, i + BATCH_SIZE)));
@@ -72,7 +76,7 @@ export async function getSkills(
   runtime: string,
   workspaceId: string,
 ) {
-  return db
+  const rows = await db
     .select({
       name: agentSkill.name,
       description: agentSkill.description,
@@ -86,4 +90,16 @@ export async function getSkills(
         or(isNull(agentSkill.agentId), eq(agentSkill.agentId, agentId))
       )
     );
+
+  // Deduplicate global skills by name (multiple daemons may sync the same skill)
+  const seen = new Set<string>();
+  const deduped: typeof rows = [];
+  for (const row of rows) {
+    const key = row.isGlobal ? `global:${row.name}` : `agent:${row.name}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      deduped.push(row);
+    }
+  }
+  return deduped;
 }

--- a/src/shared/src/db/schema.ts
+++ b/src/shared/src/db/schema.ts
@@ -772,13 +772,14 @@ export const agentSkill = sqliteTable(
       .notNull()
       .references(() => workspace.id, { onDelete: "cascade" }),
     agentId: text("agent_id"),
+    daemonId: text("daemon_id"),
     runtime: text("runtime").notNull(),
     name: text("name").notNull(),
     description: text("description").notNull().default(""),
     syncedAt: text("synced_at").notNull().$defaultFn(() => new Date().toISOString()),
   },
   (t) => [
-    unique("agent_skill_ws_runtime_name_agent").on(t.workspaceId, t.runtime, t.name, t.agentId),
+    unique("agent_skill_ws_runtime_name_agent_daemon").on(t.workspaceId, t.runtime, t.name, t.agentId, t.daemonId),
     index("idx_as_workspace_runtime").on(t.workspaceId, t.runtime),
     index("idx_as_agent_runtime").on(t.agentId, t.runtime),
     foreignKey({

--- a/src/shared/src/schemas.ts
+++ b/src/shared/src/schemas.ts
@@ -740,6 +740,7 @@ const SkillItemSchema = z.object({
 export const SkillSyncRequestSchema = z.object({
   scope: z.enum(["global", "agent"]),
   agent_id: z.string().min(1).optional(),
+  daemon_id: z.string().min(1).optional(),
   runtime: z.enum(["claude", "codex", "opencode"]),
   skills: z.array(SkillItemSchema),
 });

--- a/src/shared/test/queries/agent-skill.test.ts
+++ b/src/shared/test/queries/agent-skill.test.ts
@@ -14,8 +14,8 @@ describe("agent-skill query module exports", () => {
 });
 
 describe("agent-skill query function signatures", () => {
-  it("syncGlobalSkills accepts (db, workspaceId, runtime, skills)", () => {
-    expect(agentSkillQueries.syncGlobalSkills.length).toBe(4);
+  it("syncGlobalSkills accepts (db, workspaceId, runtime, skills, daemonId?)", () => {
+    expect(agentSkillQueries.syncGlobalSkills.length).toBe(5);
   });
   it("syncAgentSkills accepts (db, agentId, runtime, workspaceId, skills)", () => {
     expect(agentSkillQueries.syncAgentSkills.length).toBe(5);

--- a/src/web/migrations/0034_agent_skill_daemon_id.sql
+++ b/src/web/migrations/0034_agent_skill_daemon_id.sql
@@ -1,0 +1,6 @@
+-- Add daemon_id column to agent_skill for multi-daemon isolation
+ALTER TABLE agent_skill ADD COLUMN daemon_id TEXT;
+
+-- Drop old unique constraint and add new one with daemon_id dimension
+DROP INDEX IF EXISTS agent_skill_ws_runtime_name_agent;
+CREATE UNIQUE INDEX agent_skill_ws_runtime_name_agent_daemon ON agent_skill(workspace_id, runtime, name, agent_id, daemon_id);

--- a/src/web/migrations/0034_agent_skill_daemon_id.sql
+++ b/src/web/migrations/0034_agent_skill_daemon_id.sql
@@ -1,6 +1,9 @@
 -- Add daemon_id column to agent_skill for multi-daemon isolation
 ALTER TABLE agent_skill ADD COLUMN daemon_id TEXT;
 
+-- Clean up existing global skills (daemon_id is NULL); daemons will re-sync within 60s
+DELETE FROM agent_skill WHERE agent_id IS NULL;
+
 -- Drop old unique constraint and add new one with daemon_id dimension
 DROP INDEX IF EXISTS agent_skill_ws_runtime_name_agent;
 CREATE UNIQUE INDEX agent_skill_ws_runtime_name_agent_daemon ON agent_skill(workspace_id, runtime, name, agent_id, daemon_id);

--- a/src/web/src/app/api/daemon/skills/sync/route.ts
+++ b/src/web/src/app/api/daemon/skills/sync/route.ts
@@ -23,6 +23,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
         ctx.workspaceId!,
         body.runtime,
         body.skills,
+        body.daemon_id,
       )
     );
   } else {


### PR DESCRIPTION
# Why we need this PR?

When multiple daemons run on different machines (e.g., dev laptop + cloud server), each daemon's skill sync deletes and re-inserts all global skills for its workspace. Without daemon-level isolation, daemon A's sync wipes skills registered by daemon B, causing skills to flicker or disappear.

## What changed

- **Schema**: Added `daemon_id` column to `agent_skill` table; updated the unique constraint to include `daemon_id` so each daemon owns its own rows.
- **Migration**: `0034_agent_skill_daemon_id.sql` adds the column and recreates the unique index.
- **Sync query** (`syncGlobalSkills`): Now accepts an optional `daemonId` param and scopes the delete to only rows matching that daemon.
- **API route** (`/api/daemon/skills/sync`): Passes `body.daemon_id` through to the query.
- **Skill scanner**: Reads `daemonId` from config and includes it in sync requests.
- **Daemon startup**: Passes `config.daemonId` to the scanner config.
- **Request schema**: Added optional `daemon_id` field to `SkillSyncRequestSchema`.
- **Read query** (`getSkills`): Deduplicates global skills by name at query time so multiple daemons syncing the same skill don't produce duplicates in the response.
- **Tests**: Updated signature test and scanner test fixtures.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [x] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...