### PR TITLE
fix: suppress sidebar hover popover during drag-and-drop

### DIFF
--- a/src/web/src/components/app-sidebar.tsx
+++ b/src/web/src/components/app-sidebar.tsx
@@ -309,6 +309,7 @@ export function AppSidebar({ onNavigate }: { onNavigate?: () => void } = {}) {
         onPin={() => handlePinWithFolderCleanup(agent.id)}
         onUnpin={() => handleUnpinAgent(agent.id)}
         extraContextMenuItems={extraContextMenuItems}
+        isDragActive={!!dragActiveId}
       />
     </div>
   );

--- a/src/web/src/components/sidebar/agent-sidebar-button.tsx
+++ b/src/web/src/components/sidebar/agent-sidebar-button.tsx
@@ -26,6 +26,7 @@ export function AgentSidebarButton({
   onUnpin,
   extraContextMenuItems,
   hidePin,
+  isDragActive,
 }: {
   agent: Agent;
   isActive: boolean;
@@ -37,6 +38,7 @@ export function AgentSidebarButton({
   onUnpin: () => void;
   extraContextMenuItems?: React.ReactNode;
   hidePin?: boolean;
+  isDragActive?: boolean;
 }) {
   const [previewOpen, setPreviewOpen] = useState(false);
   return (
@@ -49,8 +51,8 @@ export function AgentSidebarButton({
     >
       <ContextMenu>
         <PopoverTrigger
-          openOnHover
-          delay={10}
+          openOnHover={!isDragActive}
+          delay={200}
           render={
             <ContextMenuTrigger
               render={


### PR DESCRIPTION
# Why we need this PR?
> Closes #141

## What changed
- Added `isDragActive` prop to `AgentSidebarButton` — disables `openOnHover` on the popover trigger while any drag operation is active
- Increased popover hover delay from `10ms` to `200ms` to prevent accidental triggers during drag initiation (pointer sensor uses 5px distance threshold which takes ~100-200ms)
- Threaded `!!dragActiveId` from `AppSidebar` through the `renderAgentButton` helper

## Checklist
- [ ] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)