### PR TITLE
fix(web): onboarding Step 2 'Start the daemon' premature Done

### DIFF
--- a/src/web/src/app/(app)/studio/new/client.tsx
+++ b/src/web/src/app/(app)/studio/new/client.tsx
@@ -58,6 +58,7 @@ export function StudioOnboardingClient({
   const [generatedToken, setGeneratedToken] = useState("");
   const [generatingToken, setGeneratingToken] = useState(false);
   const [machineRegistered, setMachineRegistered] = useState(false);
+  const [daemonOnline, setDaemonOnline] = useState(false);
   const [showRegister, setShowRegister] = useState(false);
 
   const onlineRuntimes = runtimes.filter((r) => r.status === "online");
@@ -86,7 +87,7 @@ export function StudioOnboardingClient({
         listRuntimes(currentWsId).then(setRuntimes).catch(() => {});
       }
     } else if (msg.type === "runtime.status" && msg.status === "online") {
-      setMachineRegistered(true);
+      setDaemonOnline(true);
       const wsId = workspaceIdRef.current;
       if (wsId) {
         listRuntimes(wsId).then(setRuntimes).catch(() => {});
@@ -468,6 +469,7 @@ export function StudioOnboardingClient({
                         generatingToken={generatingToken}
                         onGenerateToken={handleGenerateToken}
                         registered={machineRegistered}
+                        daemonOnline={daemonOnline}
                       />
                     </div>
                   )}
@@ -483,6 +485,7 @@ export function StudioOnboardingClient({
                       generatingToken={generatingToken}
                       onGenerateToken={handleGenerateToken}
                       registered={machineRegistered}
+                      daemonOnline={daemonOnline}
                     />
                   </div>
                 </>

--- a/src/web/src/app/(app)/w/[slug]/runtimes/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/runtimes/page.tsx
@@ -45,6 +45,7 @@ export default function RuntimesPage() {
   const [generatedToken, setGeneratedToken] = useState("");
   const [generatingToken, setGeneratingToken] = useState(false);
   const [registeredDaemonId, setRegisteredDaemonId] = useState<string | null>(null);
+  const [daemonOnline, setDaemonOnline] = useState(false);
 
   const [latestCliVersion, setLatestCliVersion] = useState<string | null>(null);
   const [updatingDaemons, setUpdatingDaemons] = useState<Set<string>>(new Set());
@@ -95,6 +96,7 @@ export default function RuntimesPage() {
         setSheetOpen(false);
         setGeneratedToken("");
         setRegisteredDaemonId(null);
+        setDaemonOnline(false);
         toast.success("Machine connected");
         if (agentsRef.current.length === 0) {
           const slug = pathname.split("/")[2];
@@ -490,6 +492,7 @@ export default function RuntimesPage() {
               generatingToken={generatingToken}
               onGenerateToken={onGenerateToken}
               registered={!!registeredDaemonId}
+              daemonOnline={daemonOnline}
             />
           </SheetBody>
         </SheetContent>

--- a/src/web/src/app/api/daemon/register/route.test.ts
+++ b/src/web/src/app/api/daemon/register/route.test.ts
@@ -116,7 +116,7 @@ describe("POST /api/daemon/register", () => {
     expect(mockUpsertAgentRuntime).toHaveBeenCalledTimes(1);
   });
 
-  it("broadcasts runtime.registered and runtime.status after upserts", async () => {
+  it("broadcasts only runtime.registered after upserts (not runtime.status)", async () => {
     const POST = await loadRoute(authCtx);
 
     mockGetMember.mockResolvedValue({ userId: "u1", workspaceId: "w1" });
@@ -126,19 +126,30 @@ describe("POST /api/daemon/register", () => {
 
     await POST(makeReq(validBody));
 
-    expect(mockBroadcastToUser).toHaveBeenCalledTimes(2);
+    expect(mockBroadcastToUser).toHaveBeenCalledTimes(1);
     expect(mockBroadcastToUser).toHaveBeenCalledWith("u1", {
       type: "runtime.registered",
       daemonId: "d1",
       hostname: "MyMachine",
       workspaceId: "w1",
     });
-    expect(mockBroadcastToUser).toHaveBeenCalledWith("u1", {
-      type: "runtime.status",
-      daemonId: "d1",
-      workspaceId: "w1",
-      status: "online",
-    });
+  });
+
+  it("does NOT broadcast runtime.status from register endpoint", async () => {
+    const POST = await loadRoute(authCtx);
+
+    mockGetMember.mockResolvedValue({ userId: "u1", workspaceId: "w1" });
+    mockUpsertMachine.mockResolvedValue(undefined);
+    mockUpsertAgentRuntime.mockResolvedValue({ id: "r1" });
+    mockBroadcastToUser.mockResolvedValue(undefined);
+
+    await POST(makeReq(validBody));
+
+    const broadcastCalls = mockBroadcastToUser.mock.calls;
+    const statusBroadcasts = broadcastCalls.filter(
+      ([, msg]: [string, any]) => msg.type === "runtime.status"
+    );
+    expect(statusBroadcasts).toHaveLength(0);
   });
 
   it("returns 404 when membership is missing and does not broadcast", async () => {

--- a/src/web/src/app/api/daemon/register/route.ts
+++ b/src/web/src/app/api/daemon/register/route.ts
@@ -103,12 +103,5 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     workspaceId,
   }).catch(() => {});
 
-  broadcastToUser(ctx.userId, {
-    type: "runtime.status",
-    daemonId,
-    workspaceId,
-    status: "online",
-  }).catch(() => {});
-
   return writeJSON({ runtimes: results.map(runtimeToResponse), workspaceId });
 });

--- a/src/web/src/components/connect-machine-steps.tsx
+++ b/src/web/src/components/connect-machine-steps.tsx
@@ -27,11 +27,13 @@ export function ConnectMachineSteps({
   generatingToken,
   onGenerateToken,
   registered,
+  daemonOnline,
 }: {
   generatedToken: string;
   generatingToken: boolean;
   onGenerateToken: () => void;
   registered: boolean;
+  daemonOnline: boolean;
 }) {
   const hasTriggered = useRef(false);
 
@@ -108,9 +110,9 @@ export function ConnectMachineSteps({
         className={`space-y-2 transition-opacity duration-300 ${!registered ? "opacity-40 pointer-events-none" : ""}`}
       >
         <p className="text-sm font-medium flex items-center gap-2">
-          <StepIndicator step={2} completed={registered} />
+          <StepIndicator step={2} completed={daemonOnline} />
           Start the daemon
-          {registered && <span className="text-xs text-emerald-500 font-normal">Done</span>}
+          {daemonOnline && <span className="text-xs text-emerald-500 font-normal">Done</span>}
         </p>
         <p className="text-xs text-muted-foreground pl-7">
           The daemon connects your local agents to Alook.
@@ -128,7 +130,7 @@ export function ConnectMachineSteps({
           </TooltipTrigger>
           <TooltipContent>Click to copy</TooltipContent>
         </Tooltip>
-        {registered && (
+        {registered && !daemonOnline && (
           <div className="pl-7">
             <Button
               size="sm"


### PR DESCRIPTION
# Why we need this PR?
> Fixes onboarding bug where Step 2 "Start the daemon" showed Done immediately after CLI registration, even when the daemon wasn't actually running.

## What changed
- **Backend (`register/route.ts`)**: Removed premature `runtime.status: online` broadcast from the register endpoint. Only `runtime.registered` is broadcast now; daemon online status is the heartbeat endpoint's responsibility.
- **Frontend (`client.tsx`, `runtimes/page.tsx`)**: Added separate `daemonOnline` state. `runtime.registered` WS message → `machineRegistered` (Step 1); `runtime.status: online` → `daemonOnline` (Step 2).
- **Component (`connect-machine-steps.tsx`)**: Added `daemonOnline` prop. Step 2 indicator/label uses it instead of reusing `registered`.
- **Tests (`route.test.ts`)**: Updated to assert broadcast is called only once; added test verifying `runtime.status` is NOT broadcast from register.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)