### PR TITLE
feat(web): canvas layout presets and channel bar alignment

### DIFF
--- a/src/web/src/app/(app)/w/[slug]/home/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/home/page.tsx
@@ -22,11 +22,14 @@ import {
   ZoomIn,
   ZoomOut,
   Maximize2,
-  RotateCcw,
   Loader2,
   Plus,
+  Circle,
+  GitBranch,
+  ArrowRight,
 } from "lucide-react";
 import type { Agent, AgentLink } from "@alook/shared";
+import { cn } from "@/lib/utils";
 import { useAgentContext } from "@/contexts/agent-context";
 import { useWorkspace } from "@/contexts/workspace-context";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -47,13 +50,31 @@ import { LinkEdge } from "@/components/canvas/link-edge";
 import { LinkSidecar } from "@/components/canvas/link-sidecar";
 import { ActiveTasksFloat } from "@/components/canvas/active-tasks-float";
 import { UpcomingEventsFloat } from "@/components/canvas/upcoming-events-float";
-import { getAutoLayout } from "@/components/canvas/auto-layout";
+import { getAutoLayout, type LayoutType } from "@/components/canvas/auto-layout";
 
 const nodeTypes = { agent: AgentNode };
 const edgeTypes = { link: LinkEdge };
 
 function storageKey(workspaceId: string) {
   return `alook-canvas-positions-${workspaceId}`;
+}
+
+function layoutStorageKey(workspaceId: string) {
+  return `alook-canvas-layout-${workspaceId}`;
+}
+
+function loadLayoutType(workspaceId: string): LayoutType {
+  try {
+    const raw = localStorage.getItem(layoutStorageKey(workspaceId));
+    if (raw === "star" || raw === "tree" || raw === "flow") return raw;
+  } catch {}
+  return "star";
+}
+
+function saveLayoutType(workspaceId: string, layout: LayoutType) {
+  try {
+    localStorage.setItem(layoutStorageKey(workspaceId), layout);
+  } catch {}
 }
 
 function loadPositions(workspaceId: string): Record<string, { x: number; y: number }> {
@@ -89,6 +110,7 @@ function AgentCanvas({ onAgentClick }: { onAgentClick?: (agent: Agent) => void }
   const [sidecarLink, setSidecarLink] = useState<AgentLink | null>(null);
   const [sidecarOpen, setSidecarOpen] = useState(false);
   const [showHint, setShowHint] = useState(false);
+  const [layoutType, setLayoutType] = useState<LayoutType>(() => loadLayoutType(workspaceId));
   const initialLayoutDone = useRef(false);
   const handleMap = useRef<Record<string, { sourceHandle: string; targetHandle: string }>>({});
 
@@ -195,7 +217,7 @@ function AgentCanvas({ onAgentClick }: { onAgentClick?: (agent: Agent) => void }
           source: link.source_agent_id,
           target: link.target_agent_id,
         }));
-        newNodes = getAutoLayout(newNodes, currentEdges);
+        newNodes = getAutoLayout(newNodes, currentEdges, layoutType);
         if (!initialLayoutDone.current) {
           initialLayoutDone.current = true;
           setTimeout(() => fitView({ padding: 0.4, duration: 400 }), 50);
@@ -210,7 +232,7 @@ function AgentCanvas({ onAgentClick }: { onAgentClick?: (agent: Agent) => void }
         source: link.source_agent_id,
         target: link.target_agent_id,
       }));
-      const allLaid = getAutoLayout([...fixedNodes, ...floatingNodes], currentEdges);
+      const allLaid = getAutoLayout([...fixedNodes, ...floatingNodes], currentEdges, layoutType);
       newNodes = newNodes.map((n) => {
         if (validPositions[n.id]) return n;
         const laid = allLaid.find((l) => l.id === n.id);
@@ -293,29 +315,32 @@ function AgentCanvas({ onAgentClick }: { onAgentClick?: (agent: Agent) => void }
     [workspaceId],
   );
 
-  const handleResetLayout = useCallback(() => {
+  const handleLayoutChange = useCallback((newLayout: LayoutType) => {
+    setLayoutType(newLayout);
+    saveLayoutType(workspaceId, newLayout);
     try {
       localStorage.removeItem(storageKey(workspaceId));
-    } catch { }
+    } catch {}
     const currentEdges: Edge[] = links.map((link) => ({
       id: link.id,
       source: link.source_agent_id,
       target: link.target_agent_id,
     }));
     setNodes((prev) => {
-      const laid = getAutoLayout(prev, currentEdges);
-      // Animate by adding a transition style
+      const laid = getAutoLayout(prev, currentEdges, newLayout);
       const animated = laid.map((n) => ({
         ...n,
         style: { ...n.style, transition: "transform 300ms ease-out" },
       }));
       setTimeout(() => {
-        setNodes((nds) =>
-          nds.map((n) => ({
+        setNodes((nds) => {
+          const final = nds.map((n) => ({
             ...n,
             style: { ...n.style, transition: undefined },
-          })),
-        );
+          }));
+          savePositions(workspaceId, final);
+          return final;
+        });
         fitView({ padding: 0.4, duration: 400 });
       }, 350);
       return animated;
@@ -395,13 +420,66 @@ function AgentCanvas({ onAgentClick }: { onAgentClick?: (agent: Agent) => void }
         >
           <Maximize2 className="size-4" />
         </button>
-        <button
-          type="button"
-          className="size-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-          onClick={handleResetLayout}
-        >
-          <RotateCcw className="size-4" />
-        </button>
+
+        <div className="w-px h-5 bg-foreground/10 mx-0.5 self-center" />
+
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                className={cn(
+                  "size-7 rounded-md flex items-center justify-center transition-colors",
+                  layoutType === "star"
+                    ? "text-foreground bg-accent"
+                    : "text-muted-foreground hover:text-foreground hover:bg-accent",
+                )}
+                onClick={() => handleLayoutChange("star")}
+              />
+            }
+          >
+            <Circle className="size-3.5" />
+          </TooltipTrigger>
+          <TooltipContent side="top">Star Layout</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                className={cn(
+                  "size-7 rounded-md flex items-center justify-center transition-colors",
+                  layoutType === "tree"
+                    ? "text-foreground bg-accent"
+                    : "text-muted-foreground hover:text-foreground hover:bg-accent",
+                )}
+                onClick={() => handleLayoutChange("tree")}
+              />
+            }
+          >
+            <GitBranch className="size-3.5" />
+          </TooltipTrigger>
+          <TooltipContent side="top">Tree Layout</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                className={cn(
+                  "size-7 rounded-md flex items-center justify-center transition-colors",
+                  layoutType === "flow"
+                    ? "text-foreground bg-accent"
+                    : "text-muted-foreground hover:text-foreground hover:bg-accent",
+                )}
+                onClick={() => handleLayoutChange("flow")}
+              />
+            }
+          >
+            <ArrowRight className="size-3.5" />
+          </TooltipTrigger>
+          <TooltipContent side="top">Flow Layout</TooltipContent>
+        </Tooltip>
       </div>
 
       {/* No-links hint */}

--- a/src/web/src/app/(app)/w/[slug]/home/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/home/page.tsx
@@ -24,9 +24,11 @@ import {
   Maximize2,
   Loader2,
   Plus,
+  LayoutGrid,
   Circle,
   GitBranch,
   ArrowRight,
+  Check,
 } from "lucide-react";
 import type { Agent, AgentLink } from "@alook/shared";
 import { cn } from "@/lib/utils";
@@ -36,6 +38,11 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { useAgentChatSheet } from "@/contexts/agent-chat-sheet-context";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { AgentPreviewCard } from "@/components/agent-preview-card";
 import { AnimatedAvatar, parseAvatarUrl } from "@/components/avatar";
 import {
@@ -68,7 +75,7 @@ function loadLayoutType(workspaceId: string): LayoutType {
     const raw = localStorage.getItem(layoutStorageKey(workspaceId));
     if (raw === "star" || raw === "tree" || raw === "flow") return raw;
   } catch {}
-  return "star";
+  return "tree";
 }
 
 function saveLayoutType(workspaceId: string, layout: LayoutType) {
@@ -423,63 +430,48 @@ function AgentCanvas({ onAgentClick }: { onAgentClick?: (agent: Agent) => void }
 
         <div className="w-px h-5 bg-foreground/10 mx-0.5 self-center" />
 
-        <Tooltip>
-          <TooltipTrigger
-            render={
+        <Popover>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <PopoverTrigger
+                  render={
+                    <button
+                      type="button"
+                      className="size-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                    />
+                  }
+                >
+                  <LayoutGrid className="size-3.5" />
+                </PopoverTrigger>
+              }
+            />
+            <TooltipContent side="top">Layout</TooltipContent>
+          </Tooltip>
+          <PopoverContent className="w-36 p-1" align="start" side="top" sideOffset={8}>
+            {([
+              { type: "star" as const, label: "Star", icon: Circle },
+              { type: "tree" as const, label: "Tree", icon: GitBranch },
+              { type: "flow" as const, label: "Flow", icon: ArrowRight },
+            ]).map(({ type, label, icon: Icon }) => (
               <button
+                key={type}
                 type="button"
                 className={cn(
-                  "size-7 rounded-md flex items-center justify-center transition-colors",
-                  layoutType === "star"
-                    ? "text-foreground bg-accent"
-                    : "text-muted-foreground hover:text-foreground hover:bg-accent",
+                  "w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors",
+                  layoutType === type
+                    ? "bg-accent text-foreground"
+                    : "text-muted-foreground hover:text-foreground hover:bg-accent/50",
                 )}
-                onClick={() => handleLayoutChange("star")}
-              />
-            }
-          >
-            <Circle className="size-3.5" />
-          </TooltipTrigger>
-          <TooltipContent side="top">Star Layout</TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <button
-                type="button"
-                className={cn(
-                  "size-7 rounded-md flex items-center justify-center transition-colors",
-                  layoutType === "tree"
-                    ? "text-foreground bg-accent"
-                    : "text-muted-foreground hover:text-foreground hover:bg-accent",
-                )}
-                onClick={() => handleLayoutChange("tree")}
-              />
-            }
-          >
-            <GitBranch className="size-3.5" />
-          </TooltipTrigger>
-          <TooltipContent side="top">Tree Layout</TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <button
-                type="button"
-                className={cn(
-                  "size-7 rounded-md flex items-center justify-center transition-colors",
-                  layoutType === "flow"
-                    ? "text-foreground bg-accent"
-                    : "text-muted-foreground hover:text-foreground hover:bg-accent",
-                )}
-                onClick={() => handleLayoutChange("flow")}
-              />
-            }
-          >
-            <ArrowRight className="size-3.5" />
-          </TooltipTrigger>
-          <TooltipContent side="top">Flow Layout</TooltipContent>
-        </Tooltip>
+                onClick={() => handleLayoutChange(type)}
+              >
+                <Icon className="size-3.5" />
+                <span className="flex-1 text-left">{label}</span>
+                {layoutType === type && <Check className="size-3.5" />}
+              </button>
+            ))}
+          </PopoverContent>
+        </Popover>
       </div>
 
       {/* No-links hint */}

--- a/src/web/src/components/canvas/auto-layout.ts
+++ b/src/web/src/components/canvas/auto-layout.ts
@@ -1,13 +1,32 @@
 import dagre from "@dagrejs/dagre";
 import type { Node, Edge } from "@xyflow/react";
 
+export type LayoutType = "star" | "tree" | "flow";
+
 const NODE_WIDTH = 280;
 const NODE_HEIGHT = 100;
 
 export function getAutoLayout(
   nodes: Node[],
   edges: Edge[],
-  direction: "LR" | "TB" = "LR",
+  layout: LayoutType = "star",
+): Node[] {
+  if (nodes.length === 0) return nodes;
+
+  switch (layout) {
+    case "star":
+      return getConcentricLayout(nodes, edges);
+    case "tree":
+      return getDagreLayout(nodes, edges, "TB");
+    case "flow":
+      return getDagreLayout(nodes, edges, "LR");
+  }
+}
+
+function getDagreLayout(
+  nodes: Node[],
+  edges: Edge[],
+  direction: "LR" | "TB",
 ): Node[] {
   const g = new dagre.graphlib.Graph();
   g.setDefaultEdgeLabel(() => ({}));
@@ -38,4 +57,80 @@ export function getAutoLayout(
       },
     };
   });
+}
+
+function getConcentricLayout(nodes: Node[], edges: Edge[]): Node[] {
+  if (nodes.length === 1) {
+    return [{ ...nodes[0], position: { x: -NODE_WIDTH / 2, y: -NODE_HEIGHT / 2 } }];
+  }
+
+  const degree: Record<string, number> = {};
+  const outDegree: Record<string, number> = {};
+  const adjacency: Record<string, Set<string>> = {};
+
+  for (const node of nodes) {
+    degree[node.id] = 0;
+    outDegree[node.id] = 0;
+    adjacency[node.id] = new Set();
+  }
+
+  for (const edge of edges) {
+    if (degree[edge.source] !== undefined && degree[edge.target] !== undefined) {
+      degree[edge.source]++;
+      degree[edge.target]++;
+      outDegree[edge.source]++;
+      adjacency[edge.source].add(edge.target);
+      adjacency[edge.target].add(edge.source);
+    }
+  }
+
+  const sortedNodes = [...nodes].sort((a, b) => {
+    const degDiff = (degree[b.id] ?? 0) - (degree[a.id] ?? 0);
+    if (degDiff !== 0) return degDiff;
+    const outDiff = (outDegree[b.id] ?? 0) - (outDegree[a.id] ?? 0);
+    if (outDiff !== 0) return outDiff;
+    return a.id.localeCompare(b.id);
+  });
+
+  const centerId = sortedNodes[0].id;
+  const centerNeighbors = adjacency[centerId] ?? new Set();
+
+  const firstRing: Node[] = [];
+  const outerRing: Node[] = [];
+
+  for (const node of nodes) {
+    if (node.id === centerId) continue;
+    if (centerNeighbors.has(node.id)) {
+      firstRing.push(node);
+    } else {
+      outerRing.push(node);
+    }
+  }
+
+  const FIRST_RADIUS = 250;
+  const OUTER_RADIUS = 450;
+
+  const positioned: Record<string, { x: number; y: number }> = {};
+  positioned[centerId] = { x: -NODE_WIDTH / 2, y: -NODE_HEIGHT / 2 };
+
+  for (let i = 0; i < firstRing.length; i++) {
+    const angle = (2 * Math.PI * i) / firstRing.length - Math.PI / 2;
+    positioned[firstRing[i].id] = {
+      x: Math.cos(angle) * FIRST_RADIUS - NODE_WIDTH / 2,
+      y: Math.sin(angle) * FIRST_RADIUS - NODE_HEIGHT / 2,
+    };
+  }
+
+  for (let i = 0; i < outerRing.length; i++) {
+    const angle = (2 * Math.PI * i) / outerRing.length - Math.PI / 2;
+    positioned[outerRing[i].id] = {
+      x: Math.cos(angle) * OUTER_RADIUS - NODE_WIDTH / 2,
+      y: Math.sin(angle) * OUTER_RADIUS - NODE_HEIGHT / 2,
+    };
+  }
+
+  return nodes.map((node) => ({
+    ...node,
+    position: positioned[node.id] ?? { x: 0, y: 0 },
+  }));
 }

--- a/src/web/src/components/canvas/auto-layout.ts
+++ b/src/web/src/components/canvas/auto-layout.ts
@@ -9,7 +9,7 @@ const NODE_HEIGHT = 100;
 export function getAutoLayout(
   nodes: Node[],
   edges: Edge[],
-  layout: LayoutType = "star",
+  layout: LayoutType = "tree",
 ): Node[] {
   if (nodes.length === 0) return nodes;
 

--- a/src/web/src/components/channel-bar.tsx
+++ b/src/web/src/components/channel-bar.tsx
@@ -85,7 +85,7 @@ export function ChannelBar() {
   }
 
   return (
-    <div className="h-8 flex items-center gap-1.5 px-2 mb-1 overflow-x-auto thin-scrollbar shrink-0">
+    <div className="h-8 flex items-center gap-1.5 px-3 md:px-5 mb-1 overflow-x-auto thin-scrollbar shrink-0">
       {defaultChannel && (
         <ChannelPill
           id={defaultChannel.id}

--- a/src/web/src/components/channel-bar.tsx
+++ b/src/web/src/components/channel-bar.tsx
@@ -220,6 +220,7 @@ function SortableChannelPill({
     <div
       ref={setNodeRef}
       style={style}
+      className="inline-flex items-center"
       {...attributes}
       {...listeners}
     >


### PR DESCRIPTION
# Why we need this PR?

The canvas home page's auto-layout (flat Dagre LR) lacked visual hierarchy for agent relationships. Additionally, the chat page's channel bar had alignment inconsistencies with the header.

## What changed

- **Canvas layout presets**: Added 3 layout algorithms — Star (concentric, coordinator at center), Tree (top-down hierarchy, new default), and Flow (left-to-right, original Dagre LR)
- **Layout picker UI**: Replaced the "Reset Layout" button with a single-button popover that lets users choose between layout presets
- **Channel bar vertical alignment**: Added `inline-flex items-center` to the sortable wrapper so all channel pills align vertically
- **Channel bar horizontal padding**: Changed from `px-2` to `px-3 md:px-5` to match the header padding

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)