### PR TITLE
fix: add loading state & double-click prevention to channel operations

### DIFF
--- a/src/web/src/components/channel-bar.tsx
+++ b/src/web/src/components/channel-bar.tsx
@@ -252,7 +252,7 @@ function ChannelPill({
   name: string;
   active: boolean;
   deleting: boolean;
-  isDeleting?: boolean;
+  isDeleting: boolean;
   onSelect: () => void;
   onRename: () => void;
   onDeleteRequest: () => void;

--- a/src/web/src/components/channel-bar.tsx
+++ b/src/web/src/components/channel-bar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
-import { Plus, Pencil, Trash2 } from "lucide-react";
+import { Plus, Pencil, Trash2, Loader2 } from "lucide-react";
 import {
   DndContext,
   closestCenter,
@@ -41,6 +41,9 @@ export function ChannelBar() {
     channels,
     activeChannel,
     loading,
+    creating: channelCreating,
+    deleting: channelDeleting,
+    renaming: channelRenaming,
     setActiveChannel,
     createChannel,
     renameChannel,
@@ -92,6 +95,7 @@ export function ChannelBar() {
           name={defaultChannel.name}
           active={defaultChannel.name === activeChannel}
           deleting={false}
+          isDeleting={false}
           onSelect={() => setActiveChannel(defaultChannel.name)}
           onRename={() => {}}
           onDeleteRequest={() => {}}
@@ -115,6 +119,7 @@ export function ChannelBar() {
               <RenameInput
                 key={ch.id}
                 currentName={ch.name}
+                loading={channelRenaming === ch.id}
                 onSave={async (name) => {
                   try {
                     await renameChannel(ch.id, name);
@@ -132,6 +137,7 @@ export function ChannelBar() {
                 name={ch.name}
                 active={ch.name === activeChannel}
                 deleting={deletingId === ch.id}
+                isDeleting={channelDeleting === ch.id}
                 disabled={renamingId !== null}
                 onSelect={() => setActiveChannel(ch.name)}
                 onRename={() => setRenamingId(ch.id)}
@@ -153,6 +159,7 @@ export function ChannelBar() {
 
       {creating ? (
         <CreateInput
+          loading={channelCreating}
           onSave={async (name) => {
             try {
               await createChannel(name);
@@ -194,6 +201,7 @@ function SortableChannelPill({
   name: string;
   active: boolean;
   deleting: boolean;
+  isDeleting: boolean;
   disabled: boolean;
   onSelect: () => void;
   onRename: () => void;
@@ -233,6 +241,7 @@ function ChannelPill({
   name,
   active,
   deleting,
+  isDeleting,
   onSelect,
   onRename,
   onDeleteRequest,
@@ -243,6 +252,7 @@ function ChannelPill({
   name: string;
   active: boolean;
   deleting: boolean;
+  isDeleting?: boolean;
   onSelect: () => void;
   onRename: () => void;
   onDeleteRequest: () => void;
@@ -304,10 +314,11 @@ function ChannelPill({
             Delete &ldquo;{name}&rdquo;? Its conversations will be removed.
           </p>
           <div className="flex gap-2 justify-end">
-            <Button variant="ghost" size="sm" onClick={onDeleteCancel}>
+            <Button variant="ghost" size="sm" onClick={onDeleteCancel} disabled={isDeleting}>
               Cancel
             </Button>
-            <Button variant="destructive" size="sm" onClick={onDeleteConfirm}>
+            <Button variant="destructive" size="sm" onClick={onDeleteConfirm} disabled={isDeleting}>
+              {isDeleting && <Loader2 className="size-3 animate-spin mr-1" />}
               Delete
             </Button>
           </div>
@@ -319,9 +330,11 @@ function ChannelPill({
 }
 
 function CreateInput({
+  loading,
   onSave,
   onCancel,
 }: {
+  loading?: boolean;
   onSave: (name: string) => void;
   onCancel: () => void;
 }) {
@@ -344,27 +357,33 @@ function CreateInput({
   }, [value, onSave, onCancel]);
 
   return (
-    <input
-      ref={ref}
-      value={value}
-      onChange={(e) => setValue(e.target.value)}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") handleSubmit();
-        if (e.key === "Escape") onCancel();
-      }}
-      onBlur={() => { if (!savedRef.current) onCancel(); }}
-      placeholder="name..."
-      className="h-5 w-24 px-1.5 rounded-md text-[11px] bg-transparent border border-input focus:border-ring focus:ring-2 focus:ring-ring/50 placeholder:text-muted-foreground/50 outline-none shrink-0"
-    />
+    <span className="inline-flex items-center gap-1 shrink-0">
+      <input
+        ref={ref}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") handleSubmit();
+          if (e.key === "Escape") onCancel();
+        }}
+        onBlur={() => { if (!savedRef.current) onCancel(); }}
+        disabled={loading}
+        placeholder="name..."
+        className="h-5 w-24 px-1.5 rounded-md text-[11px] bg-transparent border border-input focus:border-ring focus:ring-2 focus:ring-ring/50 placeholder:text-muted-foreground/50 outline-none shrink-0 disabled:opacity-50"
+      />
+      {loading && <Loader2 className="size-3 animate-spin text-muted-foreground" />}
+    </span>
   );
 }
 
 function RenameInput({
   currentName,
+  loading,
   onSave,
   onCancel,
 }: {
   currentName: string;
+  loading?: boolean;
   onSave: (name: string) => void;
   onCancel: () => void;
 }) {
@@ -402,7 +421,8 @@ function RenameInput({
         if (e.key === "Escape") onCancel();
       }}
       onBlur={() => { if (readyRef.current && !savedRef.current) onCancel(); }}
-      className="h-5 w-24 px-1.5 rounded-md text-[11px] bg-transparent border border-input focus:border-ring focus:ring-2 focus:ring-ring/50 outline-none shrink-0"
+      disabled={loading}
+      className="h-5 w-24 px-1.5 rounded-md text-[11px] bg-transparent border border-input focus:border-ring focus:ring-2 focus:ring-ring/50 outline-none shrink-0 disabled:opacity-50"
     />
   );
 }

--- a/src/web/src/contexts/channel-context.tsx
+++ b/src/web/src/contexts/channel-context.tsx
@@ -22,6 +22,9 @@ interface ChannelContextValue {
   channels: Channel[];
   activeChannel: string;
   loading: boolean;
+  creating: boolean;
+  deleting: string | null;
+  renaming: string | null;
   setActiveChannel: (name: string) => void;
   setAgentId: (id: string | null) => void;
   createChannel: (name: string) => Promise<Channel>;
@@ -50,6 +53,9 @@ export function ChannelProvider({
   const [activeChannel, setActiveChannelState] = useState<string>("default");
   const [loading, setLoading] = useState(true);
   const [agentId, setAgentId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [deleting, setDeleting] = useState<string | null>(null);
+  const [renaming, setRenaming] = useState<string | null>(null);
 
   const fetchChannels = useCallback(async () => {
     try {
@@ -88,35 +94,53 @@ export function ChannelProvider({
 
   const createChannel = useCallback(
     async (name: string) => {
-      const created = await createChannelApi(workspaceId, name);
-      await fetchChannels();
-      return created;
+      if (creating) return undefined as unknown as Channel;
+      setCreating(true);
+      try {
+        const created = await createChannelApi(workspaceId, name);
+        await fetchChannels();
+        return created;
+      } finally {
+        setCreating(false);
+      }
     },
-    [workspaceId, fetchChannels]
+    [workspaceId, fetchChannels, creating]
   );
 
   const renameChannel = useCallback(
     async (id: string, name: string) => {
-      const ch = channels.find((c) => c.id === id);
-      await renameChannelApi(id, workspaceId, name);
-      if (ch && ch.name === activeChannel) {
-        setActiveChannel(name);
+      if (renaming) return;
+      setRenaming(id);
+      try {
+        const ch = channels.find((c) => c.id === id);
+        await renameChannelApi(id, workspaceId, name);
+        if (ch && ch.name === activeChannel) {
+          setActiveChannel(name);
+        }
+        await fetchChannels();
+      } finally {
+        setRenaming(null);
       }
-      await fetchChannels();
     },
-    [workspaceId, channels, activeChannel, setActiveChannel, fetchChannels]
+    [workspaceId, channels, activeChannel, setActiveChannel, fetchChannels, renaming]
   );
 
   const deleteChannel = useCallback(
     async (id: string) => {
-      const ch = channels.find((c) => c.id === id);
-      await deleteChannelApi(id, workspaceId);
-      if (ch && ch.name === activeChannel) {
-        setActiveChannel("default");
+      if (deleting) return;
+      setDeleting(id);
+      try {
+        const ch = channels.find((c) => c.id === id);
+        await deleteChannelApi(id, workspaceId);
+        if (ch && ch.name === activeChannel) {
+          setActiveChannel("default");
+        }
+        await fetchChannels();
+      } finally {
+        setDeleting(null);
       }
-      await fetchChannels();
     },
-    [workspaceId, channels, activeChannel, setActiveChannel, fetchChannels]
+    [workspaceId, channels, activeChannel, setActiveChannel, fetchChannels, deleting]
   );
 
   const reorderChannels = useCallback(
@@ -146,6 +170,9 @@ export function ChannelProvider({
         channels,
         activeChannel,
         loading,
+        creating,
+        deleting,
+        renaming,
         setActiveChannel,
         setAgentId,
         createChannel,

--- a/src/web/src/contexts/channel-context.tsx
+++ b/src/web/src/contexts/channel-context.tsx
@@ -27,7 +27,7 @@ interface ChannelContextValue {
   renaming: string | null;
   setActiveChannel: (name: string) => void;
   setAgentId: (id: string | null) => void;
-  createChannel: (name: string) => Promise<Channel>;
+  createChannel: (name: string) => Promise<Channel | undefined>;
   renameChannel: (id: string, name: string) => Promise<void>;
   deleteChannel: (id: string) => Promise<void>;
   reorderChannels: (orderedIds: string[]) => Promise<void>;
@@ -94,7 +94,7 @@ export function ChannelProvider({
 
   const createChannel = useCallback(
     async (name: string) => {
-      if (creating) return undefined as unknown as Channel;
+      if (creating) return undefined;
       setCreating(true);
       try {
         const created = await createChannelApi(workspaceId, name);


### PR DESCRIPTION
# Why we need this PR?
> Closes #172

Channel create/delete/rename operations had no loading state or concurrent-call protection. Users could click multiple times causing duplicate channels, multiple API calls, and race conditions.

## What changed
- **`src/web/src/contexts/channel-context.tsx`** — Added per-operation loading state (`creating`, `deleting`, `renaming`) with guard + try/finally pattern to prevent re-entry while an operation is in flight. Exposed these states via the context value.
- **`src/web/src/components/channel-bar.tsx`** — Consumes loading state from context. Disables inputs/buttons and shows `Loader2` spinners during in-flight operations.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)