### PR TITLE
refactor: replace hand-rolled auto-resize textareas with shared component

### DIFF
--- a/src/web/src/components/agent-form-fields.tsx
+++ b/src/web/src/components/agent-form-fields.tsx
@@ -44,6 +44,7 @@ import {
 import { useAgentContext } from "@/contexts/agent-context";
 import { ApiError } from "@/lib/errors";
 import { toast } from "sonner";
+import { AutoResizeTextarea } from "@/components/ui/auto-resize-textarea";
 
 export function nameToHandle(name: string): string {
   return name
@@ -132,23 +133,13 @@ export function GeneralFields({
       </div>
 
       {/* Description — frameless, auto-growing */}
-      <textarea
+      <AutoResizeTextarea
         id="agent-description"
         value={description}
-        onChange={(e) => {
-          setDescription(e.target.value);
-          e.target.style.height = "auto";
-          e.target.style.height = `${e.target.scrollHeight}px`;
-        }}
-        ref={(el) => {
-          if (el) {
-            el.style.height = "auto";
-            el.style.height = `${el.scrollHeight}px`;
-          }
-        }}
+        onChange={(e) => setDescription(e.target.value)}
         placeholder="Add a description…"
         rows={1}
-        className="w-full resize-none overflow-hidden border-0 bg-transparent px-0 py-0.5 text-sm text-foreground shadow-none outline-none placeholder:text-muted-foreground/40 focus-visible:ring-0"
+        className="w-full border-0 bg-transparent px-0 py-0.5 text-sm text-foreground shadow-none outline-none placeholder:text-muted-foreground/40 focus-visible:ring-0"
       />
 
       {emailHandleSlot}
@@ -238,23 +229,13 @@ export function GeneralFields({
           {setInstructions && (
             <div className="space-y-1">
               <Label className="text-xs text-muted-foreground">Instructions</Label>
-              <textarea
+              <AutoResizeTextarea
                 id="agent-instructions"
                 value={instructions ?? ""}
-                onChange={(e) => {
-                  setInstructions(e.target.value);
-                  e.target.style.height = "auto";
-                  e.target.style.height = `${e.target.scrollHeight}px`;
-                }}
-                ref={(el) => {
-                  if (el) {
-                    el.style.height = "auto";
-                    el.style.height = `${el.scrollHeight}px`;
-                  }
-                }}
+                onChange={(e) => setInstructions(e.target.value)}
                 placeholder="System prompt or instructions..."
                 rows={3}
-                className="w-full resize-none overflow-hidden border-0 bg-transparent px-0 py-1 text-sm text-foreground shadow-none outline-none placeholder:text-muted-foreground/40 focus-visible:ring-0"
+                className="w-full border-0 bg-transparent px-0 py-1 text-sm text-foreground shadow-none outline-none placeholder:text-muted-foreground/40 focus-visible:ring-0"
               />
             </div>
           )}

--- a/src/web/src/components/calendar/calendar-event-sheet.tsx
+++ b/src/web/src/components/calendar/calendar-event-sheet.tsx
@@ -556,15 +556,12 @@ export function CalendarEventSheet({
     ? title.trim() || "Untitled event"
     : title.trim() || "New calendar event";
 
-  const titleRef = useRef<HTMLTextAreaElement | null>(null);
-
   const titleInput = readonly ? (
     <p className="w-full px-0 py-1 font-news text-xl sm:text-2xl md:text-3xl font-medium leading-[1.2] tracking-tight">
       {title || "Untitled event"}
     </p>
   ) : (
     <AutoResizeTextarea
-      ref={titleRef}
       aria-label="Event title"
       value={title}
       onChange={(e) => setTitle(e.target.value)}

--- a/src/web/src/components/calendar/calendar-event-sheet.tsx
+++ b/src/web/src/components/calendar/calendar-event-sheet.tsx
@@ -34,6 +34,7 @@ import type {
   CalendarEvent,
   UpdateCalendarEventRequest,
 } from "@alook/shared";
+import { AutoResizeTextarea } from "@/components/ui/auto-resize-textarea";
 import { CalendarDatePicker } from "./calendar-date-picker";
 import { CalendarTimePicker } from "./calendar-time-picker";
 import {
@@ -557,32 +558,16 @@ export function CalendarEventSheet({
 
   const titleRef = useRef<HTMLTextAreaElement | null>(null);
 
-  const resizeTitle = (el: HTMLTextAreaElement | null) => {
-    if (!el) return;
-    el.style.height = "auto";
-    el.style.height = `${el.scrollHeight}px`;
-  };
-
-  useEffect(() => {
-    resizeTitle(titleRef.current);
-  }, [title]);
-
   const titleInput = readonly ? (
     <p className="w-full px-0 py-1 font-news text-xl sm:text-2xl md:text-3xl font-medium leading-[1.2] tracking-tight">
       {title || "Untitled event"}
     </p>
   ) : (
-    <textarea
-      ref={(el) => {
-        titleRef.current = el;
-        resizeTitle(el);
-      }}
+    <AutoResizeTextarea
+      ref={titleRef}
       aria-label="Event title"
       value={title}
-      onChange={(e) => {
-        setTitle(e.target.value);
-        resizeTitle(e.target);
-      }}
+      onChange={(e) => setTitle(e.target.value)}
       onKeyDown={(e) => {
         if (e.key === "Enter" && !e.shiftKey) {
           e.preventDefault();
@@ -593,7 +578,7 @@ export function CalendarEventSheet({
       autoFocus={mode === "create"}
       rows={1}
       className={cn(
-        "w-full resize-none overflow-hidden rounded-none border-0 bg-transparent px-0 py-1 font-news text-xl sm:text-2xl md:text-3xl font-medium leading-[1.2] tracking-tight",
+        "w-full rounded-none border-0 bg-transparent px-0 py-1 font-news text-xl sm:text-2xl md:text-3xl font-medium leading-[1.2] tracking-tight",
         "shadow-none outline-none focus-visible:border-0 focus-visible:ring-0 focus-visible:ring-offset-0",
         "placeholder:text-muted-foreground/40 placeholder:font-normal"
       )}

--- a/src/web/src/components/issues/issue-sheet.tsx
+++ b/src/web/src/components/issues/issue-sheet.tsx
@@ -36,6 +36,7 @@ import type { TraceTask } from "@/lib/api";
 import { updateIssue } from "@/lib/api";
 import { AvatarRenderer, parseAvatarUrl } from "@/components/avatar";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { AutoResizeTextarea } from "@/components/ui/auto-resize-textarea";
 
 // --- Constants ---
 
@@ -325,18 +326,6 @@ export function IssueSheet({
     prevOpenRef.current = open;
   }, [open, mode, flushAutoSave]);
 
-  // --- Title auto-resize ---
-  const resizeTitle = useCallback((el?: HTMLTextAreaElement | null) => {
-    const target = el ?? titleRef.current;
-    if (!target) return;
-    target.style.height = "auto";
-    target.style.height = `${target.scrollHeight}px`;
-  }, []);
-
-  useEffect(() => {
-    requestAnimationFrame(() => resizeTitle());
-  }, [title, resizeTitle]);
-
   // --- Drag handle ---
   const onPointerDown = useCallback((e: React.PointerEvent) => {
     e.preventDefault();
@@ -523,21 +512,15 @@ export function IssueSheet({
     <>
       {/* Title */}
       <div className="shrink-0 px-2 sm:px-3 pt-5 pb-1">
-        <textarea
-          ref={(el) => {
-            titleRef.current = el;
-            resizeTitle(el);
-          }}
+        <AutoResizeTextarea
+          ref={titleRef}
           value={title}
-          onChange={(e) => {
-            setTitle(e.target.value);
-            resizeTitle(e.target);
-          }}
+          onChange={(e) => setTitle(e.target.value)}
           onKeyDown={onTitleKeyDown}
           placeholder={mode === "create" ? "New issue" : "Untitled"}
           autoFocus={mode === "create"}
           rows={1}
-          className="w-full resize-none overflow-hidden rounded-none border-0 bg-transparent px-0 py-1 font-news text-2xl md:text-3xl font-medium leading-[1.2] tracking-tight shadow-none outline-none focus-visible:border-0 focus-visible:ring-0 focus-visible:ring-offset-0 placeholder:text-muted-foreground/40 placeholder:font-normal"
+          className="w-full rounded-none border-0 bg-transparent px-0 py-1 font-news text-2xl md:text-3xl font-medium leading-[1.2] tracking-tight shadow-none outline-none focus-visible:border-0 focus-visible:ring-0 focus-visible:ring-offset-0 placeholder:text-muted-foreground/40 placeholder:font-normal"
         />
       </div>
 

--- a/src/web/src/components/issues/issue-sheet.tsx
+++ b/src/web/src/components/issues/issue-sheet.tsx
@@ -244,7 +244,6 @@ export function IssueSheet({
   const [confirmAgent, setConfirmAgent] = useState<Agent | null>(null);
   const [dispatching, setDispatching] = useState(false);
 
-  const titleRef = useRef<HTMLTextAreaElement>(null);
   const descriptionRef = useRef<HTMLDivElement>(null);
   const timelineRef = useRef<HTMLDivElement>(null);
   const dragging = useRef(false);
@@ -513,7 +512,6 @@ export function IssueSheet({
       {/* Title */}
       <div className="shrink-0 px-2 sm:px-3 pt-5 pb-1">
         <AutoResizeTextarea
-          ref={titleRef}
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           onKeyDown={onTitleKeyDown}

--- a/src/web/src/components/ui/auto-resize-textarea.tsx
+++ b/src/web/src/components/ui/auto-resize-textarea.tsx
@@ -1,0 +1,44 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+const resize = (el: HTMLTextAreaElement | null) => {
+  if (!el) return
+  el.style.height = "auto"
+  el.style.height = `${el.scrollHeight}px`
+}
+
+const AutoResizeTextarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<"textarea">
+>(({ className, onChange, ...props }, forwardedRef) => {
+  const innerRef = React.useRef<HTMLTextAreaElement | null>(null)
+
+  const setRef = React.useCallback(
+    (el: HTMLTextAreaElement | null) => {
+      innerRef.current = el
+      if (typeof forwardedRef === "function") forwardedRef(el)
+      else if (forwardedRef) forwardedRef.current = el
+      resize(el)
+    },
+    [forwardedRef]
+  )
+
+  React.useEffect(() => {
+    resize(innerRef.current)
+  }, [props.value])
+
+  return (
+    <textarea
+      ref={setRef}
+      className={cn("resize-none overflow-hidden", className)}
+      onChange={(e) => {
+        resize(e.target)
+        onChange?.(e)
+      }}
+      {...props}
+    />
+  )
+})
+AutoResizeTextarea.displayName = "AutoResizeTextarea"
+
+export { AutoResizeTextarea }


### PR DESCRIPTION
## Summary
Closes #161

- Created a shared `<AutoResizeTextarea />` component in `ui/auto-resize-textarea.tsx` that encapsulates scrollHeight-based auto-growing behavior
- Replaced 4 manual scrollHeight implementations across the codebase:
  - `agent-form-fields.tsx` — description and instructions textareas
  - `calendar-event-sheet.tsx` — event title textarea
  - `issue-sheet.tsx` — issue title textarea

## Details
The component:
- Uses `React.forwardRef` for ref forwarding
- Handles resize on mount, on value change, and on input
- Accepts all standard textarea props (className, placeholder, rows, etc.)
- Applies `resize-none overflow-hidden` by default, composable via `cn()`

The comment textarea in `issue-sheet.tsx` was intentionally left as-is since it uses `field-sizing-content` CSS with a max-height + scroll pattern (different use case).

## Test plan
- [x] `pnpm typecheck` passes (no new errors)
- [x] `pnpm test` — all 1025 tests pass
- [ ] Manual: verify agent form description auto-grows with content
- [ ] Manual: verify calendar event title auto-grows
- [ ] Manual: verify issue title auto-grows