### PR TITLE
refactor: extract shared useCopyToClipboard hook

### DIFF
--- a/src/web/src/components/agent-chat/message-list.tsx
+++ b/src/web/src/components/agent-chat/message-list.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useState } from "react";
+import React, { memo } from "react";
 import type { Agent, Artifact, Message, TaskApi as Task, TaskMessage } from "@alook/shared";
 
 import { cn } from "@/lib/utils";
@@ -12,6 +12,7 @@ import { FileText, Calendar, CircleDot, Mail, Flag, Copy, Check } from "lucide-r
 
 import { getEventIconType } from "@/components/agent-chat/agent-chat-view";
 import { toast } from "sonner";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 
 const MENTION_ALLOWED_TAGS = { mention: ["data-agent-id"] };
 const MENTION_LITERAL_TAGS = ["mention"];
@@ -127,7 +128,7 @@ export const MessageItem = memo(function MessageItem({
   isFlagged,
   onToggleFlag,
 }: MessageItemProps) {
-  const [copied, setCopied] = useState(false);
+  const { copy, copied } = useCopyToClipboard();
 
   const hasTaskStream =
     activeTask &&
@@ -149,14 +150,9 @@ export const MessageItem = memo(function MessageItem({
               aria-label={copied ? "Copied" : "Copy message"}
               onClick={async (e) => {
                 e.stopPropagation();
-                try {
-                  await navigator.clipboard.writeText(msg.content);
-                  setCopied(true);
-                  toast.success("Copied to clipboard");
-                  setTimeout(() => setCopied(false), 2000);
-                } catch {
-                  toast.error("Failed to copy");
-                }
+                const ok = await copy(msg.content);
+                if (ok) toast.success("Copied to clipboard");
+                else toast.error("Failed to copy");
               }}
               className={cn(
                 "self-start mb-1",

--- a/src/web/src/components/dashboard-navbar.tsx
+++ b/src/web/src/components/dashboard-navbar.tsx
@@ -82,11 +82,11 @@ function OnboardingSteps({
                 render={
                   <div
                     className="rounded-md bg-muted p-2.5 font-mono text-xs text-muted-foreground cursor-pointer hover:bg-muted/80 transition-colors"
-                    onClick={() =>
-                      copy(
-                        `${cliCmd()} register --token ${generatedToken}`
-                      )
-                    }
+                    onClick={() => {
+                      copy(`${cliCmd()} register --token ${generatedToken}`).then(
+                        (ok) => { if (ok) toast.success("Copied to clipboard"); }
+                      );
+                    }}
                   />
                 }
               >
@@ -129,9 +129,11 @@ function OnboardingSteps({
             render={
               <div
                 className="ml-7 rounded-md bg-muted p-2.5 font-mono text-xs text-muted-foreground cursor-pointer hover:bg-muted/80 transition-colors"
-                onClick={() =>
-                  copy(daemonStartCmd())
-                }
+                onClick={() => {
+                  copy(daemonStartCmd()).then(
+                    (ok) => { if (ok) toast.success("Copied to clipboard"); }
+                  );
+                }}
               />
             }
           >

--- a/src/web/src/components/dashboard-navbar.tsx
+++ b/src/web/src/components/dashboard-navbar.tsx
@@ -26,6 +26,7 @@ import { signOut } from "@/lib/auth-client";
 import { clearAllCache } from "@/lib/chat-cache";
 import { cliCmd, daemonStartCmd } from "@/lib/utils";
 import { ProviderLogo } from "@/components/provider-logo";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 
 function OnboardingSteps({
   generatedToken,
@@ -37,17 +38,13 @@ function OnboardingSteps({
   onGenerateToken: () => void;
 }) {
   const hasTriggered = useRef(false);
+  const { copy } = useCopyToClipboard();
   useEffect(() => {
     if (!generatedToken && !generatingToken && !hasTriggered.current) {
       hasTriggered.current = true;
       onGenerateToken();
     }
   }, [generatedToken, generatingToken, onGenerateToken]);
-
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
-    toast.success("Copied to clipboard");
-  };
 
   return (
     <div className="space-y-6">
@@ -86,7 +83,7 @@ function OnboardingSteps({
                   <div
                     className="rounded-md bg-muted p-2.5 font-mono text-xs text-muted-foreground cursor-pointer hover:bg-muted/80 transition-colors"
                     onClick={() =>
-                      copyToClipboard(
+                      copy(
                         `${cliCmd()} register --token ${generatedToken}`
                       )
                     }
@@ -103,9 +100,7 @@ function OnboardingSteps({
             <Button
               size="sm"
               onClick={() => {
-                navigator.clipboard.writeText(
-                  `${cliCmd()} register --token ${generatedToken}`
-                );
+                copy(`${cliCmd()} register --token ${generatedToken}`);
                 toast.success("Copied to clipboard");
               }}
               className="w-full"
@@ -135,7 +130,7 @@ function OnboardingSteps({
               <div
                 className="ml-7 rounded-md bg-muted p-2.5 font-mono text-xs text-muted-foreground cursor-pointer hover:bg-muted/80 transition-colors"
                 onClick={() =>
-                  copyToClipboard(daemonStartCmd())
+                  copy(daemonStartCmd())
                 }
               />
             }
@@ -154,7 +149,7 @@ export function DashboardNavbar() {
   const [runtimeSheetOpen, setRuntimeSheetOpen] = useState(false);
   const [generatedToken, setGeneratedToken] = useState("");
   const [generatingToken, setGeneratingToken] = useState(false);
-  const [tokenCopied, setTokenCopied] = useState(false);
+  const { copy: copyToken, copied: tokenCopied } = useCopyToClipboard();
 
   // Confirm dialog state
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -205,7 +200,6 @@ export function DashboardNavbar() {
 
   const handleGenerateToken = async () => {
     setGeneratingToken(true);
-    setTokenCopied(false);
     try {
       const res = await createMachineToken("cli", workspaceId);
       setGeneratedToken(res.token);
@@ -219,8 +213,7 @@ export function DashboardNavbar() {
   };
 
   const handleCopyToken = async () => {
-    await navigator.clipboard.writeText(generatedToken);
-    setTokenCopied(true);
+    await copyToken(generatedToken);
     toast.success("Copied to clipboard");
   };
 
@@ -238,7 +231,6 @@ export function DashboardNavbar() {
                 if (open) loadRuntimes();
                 if (!open) {
                   setGeneratedToken("");
-                  setTokenCopied(false);
                 }
               }}
             >

--- a/src/web/src/hooks/use-copy-to-clipboard.ts
+++ b/src/web/src/hooks/use-copy-to-clipboard.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+
+export function useCopyToClipboard(resetDelay = 2000) {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const copy = useCallback(
+    async (text: string) => {
+      try {
+        await navigator.clipboard.writeText(text);
+        setCopied(true);
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = setTimeout(() => setCopied(false), resetDelay);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [resetDelay]
+  );
+
+  return { copy, copied };
+}

--- a/src/web/src/hooks/use-copy-to-clipboard.ts
+++ b/src/web/src/hooks/use-copy-to-clipboard.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 
 export function useCopyToClipboard(resetDelay = 2000) {
   const [copied, setCopied] = useState(false);
@@ -20,6 +20,10 @@ export function useCopyToClipboard(resetDelay = 2000) {
     },
     [resetDelay]
   );
+
+  useEffect(() => {
+    return () => clearTimeout(timeoutRef.current);
+  }, []);
 
   return { copy, copied };
 }


### PR DESCRIPTION
## Summary
- Creates `src/web/src/hooks/use-copy-to-clipboard.ts` with `{ copy, copied }` API and configurable reset delay (default 2000ms)
- Replaces clipboard logic in `message-list.tsx` and `dashboard-navbar.tsx`
- No direct `navigator.clipboard.writeText` calls remain in these files

Closes #167

## Test plan
- [ ] Copy message button works in chat (shows "Copied" feedback)
- [ ] Copy command/token buttons work in dashboard onboarding
- [ ] "Copied!" feedback resets after 2 seconds
- [ ] Type check passes