### PR TITLE
refactor: use resizable-panels ResizeHandle for chat sheet drag

### DIFF
--- a/src/web/src/components/canvas/agent-chat-sheet.tsx
+++ b/src/web/src/components/canvas/agent-chat-sheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useRef, useCallback } from "react";
+import React, { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import {
   Sheet,
@@ -17,6 +17,7 @@ import { ChannelBar } from "@/components/channel-bar";
 import { AgentChatView } from "@/components/agent-chat/agent-chat-view";
 import { ArrowUpRight, XIcon } from "lucide-react";
 import { Button, buttonVariants } from "@/components/ui/button";
+import { ResizeHandle } from "@/components/ui/resizable-panels";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
 interface AgentChatSheetProps {
@@ -37,22 +38,12 @@ export function AgentChatSheet({ open, onOpenChange, agent, targetConvId, scroll
   const { slug } = useWorkspace();
   const router = useRouter();
   const [width, setWidth] = useState(DEFAULT_WIDTH);
-  const dragging = useRef(false);
 
-  const onPointerDown = useCallback((e: React.PointerEvent) => {
-    e.preventDefault();
-    dragging.current = true;
-    (e.target as HTMLElement).setPointerCapture(e.pointerId);
-  }, []);
-
-  const onPointerMove = useCallback((e: React.PointerEvent) => {
-    if (!dragging.current) return;
-    const maxW = window.innerWidth * MAX_WIDTH_RATIO;
-    setWidth(Math.min(maxW, Math.max(MIN_WIDTH, window.innerWidth - e.clientX)));
-  }, []);
-
-  const onPointerUp = useCallback(() => {
-    dragging.current = false;
+  const handleResize = useCallback((delta: number) => {
+    setWidth((w) => {
+      const maxW = window.innerWidth * MAX_WIDTH_RATIO;
+      return Math.min(maxW, Math.max(MIN_WIDTH, w + delta));
+    });
   }, []);
 
   return (
@@ -64,10 +55,9 @@ export function AgentChatSheet({ open, onOpenChange, agent, targetConvId, scroll
         className="data-[side=right]:sm:inset-y-2 data-[side=right]:sm:right-2 data-[side=right]:sm:h-auto data-[side=right]:sm:rounded-xl data-[side=right]:sm:border flex flex-col"
       >
         {/* Resize handle */}
-        <div
-          onPointerDown={onPointerDown}
-          onPointerMove={onPointerMove}
-          onPointerUp={onPointerUp}
+        <ResizeHandle
+          onResize={handleResize}
+          direction="left"
           className="hidden sm:block absolute left-0 top-0 bottom-0 w-1.5 cursor-col-resize z-10 hover:bg-primary/20 active:bg-primary/30 transition-colors rounded-l-xl"
         />
 

--- a/src/web/src/components/ui/resizable-panels.tsx
+++ b/src/web/src/components/ui/resizable-panels.tsx
@@ -133,3 +133,47 @@ export function ResizablePanels({ panels, storageKey }: ResizablePanelsProps) {
     </div>
   );
 }
+
+export interface ResizeHandleProps {
+  onResize: (delta: number) => void;
+  className?: string;
+  direction?: "left" | "right";
+}
+
+export function ResizeHandle({ onResize, className, direction = "right" }: ResizeHandleProps) {
+  const dragging = useRef(false);
+  const startX = useRef(0);
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault();
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+      dragging.current = true;
+      startX.current = e.clientX;
+    },
+    []
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!dragging.current) return;
+      const delta = e.clientX - startX.current;
+      startX.current = e.clientX;
+      onResize(direction === "left" ? -delta : delta);
+    },
+    [onResize, direction]
+  );
+
+  const handlePointerUp = useCallback(() => {
+    dragging.current = false;
+  }, []);
+
+  return (
+    <div
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      className={className ?? "absolute left-0 top-0 bottom-0 w-1.5 cursor-col-resize z-10 hover:bg-primary/20 active:bg-primary/30 transition-colors"}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Extracts `ResizeHandle` component from `resizable-panels.tsx` as a reusable drag handle
- Replaces manual pointer-capture resize logic in `agent-chat-sheet.tsx` with `ResizeHandle`
- Min/max width constraints preserved (320px min, 80% viewport max)
- Touch/mobile resize continues to work via pointer events

Closes #164

## Test plan
- [ ] Drag-to-resize works smoothly on the chat sheet
- [ ] Min width (320px) and max width (80% viewport) constraints are enforced
- [ ] Touch resize works on mobile
- [ ] Manual pointer event code is removed from agent-chat-sheet
- [ ] Type check passes