### PR TITLE
refactor: replace hand-crafted kbd styling with shadcn Kbd component

### DIFF
--- a/src/web/src/components/avatar/avatar-generator.tsx
+++ b/src/web/src/components/avatar/avatar-generator.tsx
@@ -15,6 +15,7 @@ import {
   randomConfig,
 } from "./avatar-parts";
 import { cn } from "@/lib/utils";
+import { Kbd } from "@/components/ui/kbd";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
 // ─────────────────────────────────────────────────────────────
@@ -214,7 +215,7 @@ export function AvatarGenerator({ config, onChange, layout = "vertical", mobile 
         </svg>
         Random
         {isHorizontal && (
-          <kbd className="ml-1 rounded bg-background/20 px-1.5 py-0.5 text-[10px] font-mono">Space</kbd>
+          <Kbd className="ml-1 bg-background/20 text-[10px] text-inherit">Space</Kbd>
         )}
       </button>
     </div>

--- a/src/web/src/components/calendar/calendar-event-sheet.tsx
+++ b/src/web/src/components/calendar/calendar-event-sheet.tsx
@@ -35,7 +35,7 @@ import type {
   UpdateCalendarEventRequest,
 } from "@alook/shared";
 import { AutoResizeTextarea } from "@/components/ui/auto-resize-textarea";
-import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { Kbd } from "@/components/ui/kbd";
 import { CalendarDatePicker } from "./calendar-date-picker";
 import { CalendarTimePicker } from "./calendar-time-picker";
 import {
@@ -543,13 +543,7 @@ export function CalendarEventSheet({
   // foreground colour at reduced opacity so it reads on the primary fill in
   // both themes without needing a separate palette.
   const inlineSubmitHint = (
-    <KbdGroup
-      aria-hidden
-      className="mr-1 hidden sm:inline-flex opacity-60"
-    >
-      <Kbd className="bg-background/20 text-inherit">⇧</Kbd>
-      <Kbd className="bg-background/20 text-inherit">⏎</Kbd>
-    </KbdGroup>
+    <Kbd aria-hidden className="mr-1 hidden sm:inline-flex bg-background/20 text-inherit opacity-60">⇧ + ⏎</Kbd>
   );
 
   const a11yTitle = mode === "edit"

--- a/src/web/src/components/calendar/calendar-event-sheet.tsx
+++ b/src/web/src/components/calendar/calendar-event-sheet.tsx
@@ -35,6 +35,7 @@ import type {
   UpdateCalendarEventRequest,
 } from "@alook/shared";
 import { AutoResizeTextarea } from "@/components/ui/auto-resize-textarea";
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
 import { CalendarDatePicker } from "./calendar-date-picker";
 import { CalendarTimePicker } from "./calendar-time-picker";
 import {
@@ -542,14 +543,13 @@ export function CalendarEventSheet({
   // foreground colour at reduced opacity so it reads on the primary fill in
   // both themes without needing a separate palette.
   const inlineSubmitHint = (
-    <kbd
+    <KbdGroup
       aria-hidden
-      className="mr-1 hidden sm:inline-flex items-center gap-0.5 font-sans font-medium leading-none opacity-60"
+      className="mr-1 hidden sm:inline-flex opacity-60"
     >
-      <span>⇧</span>
-      <span>+</span>
-      <span>⏎</span>
-    </kbd>
+      <Kbd className="bg-background/20 text-inherit">⇧</Kbd>
+      <Kbd className="bg-background/20 text-inherit">⏎</Kbd>
+    </KbdGroup>
   );
 
   const a11yTitle = mode === "edit"

--- a/src/web/src/components/issues/issue-sheet.tsx
+++ b/src/web/src/components/issues/issue-sheet.tsx
@@ -36,6 +36,7 @@ import type { TraceTask } from "@/lib/api";
 import { updateIssue } from "@/lib/api";
 import { AvatarRenderer, parseAvatarUrl } from "@/components/avatar";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
 import { AutoResizeTextarea } from "@/components/ui/auto-resize-textarea";
 
 // --- Constants ---
@@ -494,7 +495,10 @@ export function IssueSheet({
         onKeyDown={(e) => { if (e.key === "Enter" && e.shiftKey) { e.preventDefault(); handleCommentSubmit(); } }}
       />
       <div className="flex items-center justify-between px-2.5 pb-2 pt-0.5">
-        <kbd className="text-[11px] text-muted-foreground/50 font-sans select-none">⇧↵</kbd>
+        <KbdGroup className="text-muted-foreground/50">
+          <Kbd className="text-[11px]">⇧</Kbd>
+          <Kbd className="text-[11px]">↵</Kbd>
+        </KbdGroup>
         <Button
           size="icon-sm"
           onClick={handleCommentSubmit}
@@ -768,9 +772,10 @@ export function IssueSheet({
                 disabled={!title.trim() || submitting}
               >
                 {submitting && <Loader2 className="mr-1.5 size-3.5 animate-spin" />}
-                <kbd className="mr-1 hidden sm:inline-flex items-center gap-0.5 font-sans font-medium leading-none opacity-60">
-                  <span>&#x21E7;</span><span>+</span><span>&#x23CE;</span>
-                </kbd>
+                <KbdGroup className="mr-1 hidden sm:inline-flex opacity-60">
+                  <Kbd className="bg-background/20 text-inherit">⇧</Kbd>
+                  <Kbd className="bg-background/20 text-inherit">⏎</Kbd>
+                </KbdGroup>
                 Create
               </Button>
             </SheetFooter>

--- a/src/web/src/components/issues/issue-sheet.tsx
+++ b/src/web/src/components/issues/issue-sheet.tsx
@@ -36,7 +36,7 @@ import type { TraceTask } from "@/lib/api";
 import { updateIssue } from "@/lib/api";
 import { AvatarRenderer, parseAvatarUrl } from "@/components/avatar";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
-import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { Kbd } from "@/components/ui/kbd";
 import { AutoResizeTextarea } from "@/components/ui/auto-resize-textarea";
 
 // --- Constants ---
@@ -495,10 +495,7 @@ export function IssueSheet({
         onKeyDown={(e) => { if (e.key === "Enter" && e.shiftKey) { e.preventDefault(); handleCommentSubmit(); } }}
       />
       <div className="flex items-center justify-between px-2.5 pb-2 pt-0.5">
-        <KbdGroup className="text-muted-foreground/50">
-          <Kbd className="text-[11px]">⇧</Kbd>
-          <Kbd className="text-[11px]">↵</Kbd>
-        </KbdGroup>
+        <Kbd className="text-[11px] text-muted-foreground/50">⇧↵</Kbd>
         <Button
           size="icon-sm"
           onClick={handleCommentSubmit}
@@ -772,10 +769,7 @@ export function IssueSheet({
                 disabled={!title.trim() || submitting}
               >
                 {submitting && <Loader2 className="mr-1.5 size-3.5 animate-spin" />}
-                <KbdGroup className="mr-1 hidden sm:inline-flex opacity-60">
-                  <Kbd className="bg-background/20 text-inherit">⇧</Kbd>
-                  <Kbd className="bg-background/20 text-inherit">⏎</Kbd>
-                </KbdGroup>
+                <Kbd className="mr-1 hidden sm:inline-flex bg-background/20 text-inherit opacity-60">⇧ + ⏎</Kbd>
                 Create
               </Button>
             </SheetFooter>

--- a/src/web/src/components/ui/kbd.tsx
+++ b/src/web/src/components/ui/kbd.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@/lib/utils"
+
+function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
+  return (
+    <kbd
+      data-slot="kbd"
+      className={cn(
+        "pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none in-data-[slot=tooltip-content]:bg-background/20 in-data-[slot=tooltip-content]:text-background dark:in-data-[slot=tooltip-content]:bg-background/10 [&_svg:not([class*='size-'])]:size-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <kbd
+      data-slot="kbd-group"
+      className={cn("inline-flex items-center gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+export { Kbd, KbdGroup }


### PR DESCRIPTION
# Why we need this PR?
> Closes #183

The codebase has 3 files with inconsistent, hand-crafted `<kbd>` styling for keyboard shortcut hints. This PR unifies them using shadcn's official `Kbd` component for consistency and maintainability.

## What changed

- **`src/web/src/components/ui/kbd.tsx`** — Added shadcn Kbd component (installed via `pnpm dlx shadcn@latest add kbd`)
- **`src/web/src/components/calendar/calendar-event-sheet.tsx`** — Replaced hand-crafted kbd with `<Kbd>` for ⇧ + ⏎ submit hint
- **`src/web/src/components/issues/issue-sheet.tsx`** — Replaced 2 hand-crafted kbd elements with `<Kbd>` for comment hint and create button hint
- **`src/web/src/components/avatar/avatar-generator.tsx`** — Replaced hand-crafted kbd with `<Kbd>` for Space key hint

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...