### PR TITLE
fix: atomic position calculation in pin/channel creation

### DIFF
--- a/src/shared/src/db/queries/agent-pin.ts
+++ b/src/shared/src/db/queries/agent-pin.ts
@@ -11,14 +11,12 @@ export async function listPins(db: Database, workspaceId: string, userId: string
 }
 
 export async function pinAgent(db: Database, data: { agentId: string; workspaceId: string; userId: string }) {
-  const [maxRow] = await db
-    .select({ maxPos: sql<number>`COALESCE(MAX(${agentPin.position}), -1)` })
-    .from(agentPin)
-    .where(and(eq(agentPin.workspaceId, data.workspaceId), eq(agentPin.userId, data.userId)));
-  const nextPos = (maxRow?.maxPos ?? -1) + 1;
   const rows = await db
     .insert(agentPin)
-    .values({ ...data, position: nextPos })
+    .values({
+      ...data,
+      position: sql<number>`COALESCE((SELECT MAX(${agentPin.position}) FROM ${agentPin} WHERE ${agentPin.workspaceId} = ${data.workspaceId} AND ${agentPin.userId} = ${data.userId}), -1) + 1`,
+    })
     .onConflictDoNothing()
     .returning();
   return rows[0] ?? null;

--- a/src/shared/src/db/queries/channel.ts
+++ b/src/shared/src/db/queries/channel.ts
@@ -6,17 +6,12 @@ export async function createChannel(
   db: Database,
   data: { workspaceId: string; name: string }
 ) {
-  const [maxRow] = await db
-    .select({ maxPos: sql<number>`COALESCE(MAX(${channel.position}), -1)` })
-    .from(channel)
-    .where(eq(channel.workspaceId, data.workspaceId));
-  const nextPos = (maxRow?.maxPos ?? -1) + 1;
   const rows = await db
     .insert(channel)
     .values({
       workspaceId: data.workspaceId,
       name: data.name,
-      position: nextPos,
+      position: sql<number>`COALESCE((SELECT MAX(${channel.position}) FROM ${channel} WHERE ${channel.workspaceId} = ${data.workspaceId}), -1) + 1`,
     })
     .returning();
   return rows[0]!;


### PR DESCRIPTION
## Summary
- Replaces two-step read-then-write position calculation with atomic subquery INSERT
- Prevents race condition where concurrent calls could get duplicate positions

## Changes
- `src/shared/src/db/queries/agent-pin.ts`: pinAgent() now uses subquery for position
- `src/shared/src/db/queries/channel.ts`: createChannel() now uses subquery for position

## Test plan
- [ ] Create two pins simultaneously and verify no duplicate positions
- [ ] Create two channels simultaneously and verify no duplicate positions

Closes #149