### PR TITLE
fix: prevent double-activation of machine tokens via atomic CAS

### DIFF
--- a/src/shared/src/db/queries/machine-token.ts
+++ b/src/shared/src/db/queries/machine-token.ts
@@ -67,10 +67,12 @@ export async function getPendingMachineToken(
 }
 
 export async function activateMachineToken(db: Database, id: string, workspaceId?: string) {
-  await db
+  const rows = await db
     .update(machineToken)
     .set({ status: "active", ...(workspaceId ? { workspaceId } : {}) })
-    .where(eq(machineToken.id, id));
+    .where(and(eq(machineToken.id, id), eq(machineToken.status, "pending")))
+    .returning();
+  return rows.length > 0;
 }
 
 export async function listMachineTokens(

--- a/src/web/src/app/api/machine-tokens/activate/route.test.ts
+++ b/src/web/src/app/api/machine-tokens/activate/route.test.ts
@@ -100,7 +100,7 @@ describe("POST /api/machine-tokens/activate", () => {
     mockGetMachineTokenByToken.mockResolvedValue(pendingToken);
     mockUpsertMachine.mockResolvedValue(undefined);
     mockUpsertAgentRuntime.mockResolvedValue({ id: "r1", provider: "claude" });
-    mockActivateMachineToken.mockResolvedValue(undefined);
+    mockActivateMachineToken.mockResolvedValue(true);
     mockBroadcastToUser.mockResolvedValue(undefined);
 
     const res = await POST(makeReq(validBody));
@@ -144,7 +144,7 @@ describe("POST /api/machine-tokens/activate", () => {
     mockGetMachineTokenByToken.mockResolvedValue(pendingToken);
     mockUpsertMachine.mockResolvedValue(undefined);
     mockUpsertAgentRuntime.mockResolvedValue({ id: "r1", provider: "claude" });
-    mockActivateMachineToken.mockResolvedValue(undefined);
+    mockActivateMachineToken.mockResolvedValue(true);
     mockBroadcastToUser.mockResolvedValue(undefined);
 
     await POST(makeReq(validBody));
@@ -175,7 +175,7 @@ describe("POST /api/machine-tokens/activate", () => {
     mockCreateMember.mockResolvedValue(undefined);
     mockUpsertMachine.mockResolvedValue(undefined);
     mockUpsertAgentRuntime.mockResolvedValue({ id: "r1", provider: "claude" });
-    mockActivateMachineToken.mockResolvedValue(undefined);
+    mockActivateMachineToken.mockResolvedValue(true);
     mockBroadcastToUser.mockResolvedValue(undefined);
 
     const res = await POST(makeReq(validBody));

--- a/src/web/src/app/api/machine-tokens/activate/route.ts
+++ b/src/web/src/app/api/machine-tokens/activate/route.ts
@@ -77,7 +77,10 @@ export async function POST(req: NextRequest) {
     results.push({ ...result, machineLastSeenAt: null });
   }
 
-  await queries.machineToken.activateMachineToken(db, mt.id, workspaceId);
+  const activated = await queries.machineToken.activateMachineToken(db, mt.id, workspaceId);
+  if (!activated) {
+    return writeJSON({ error: "token already activated" }, 409);
+  }
   await Promise.all([
     invalidate(cacheKeys.machineToken(token)),
     invalidate(cacheKeys.runtimeIds(workspaceId, daemonId)),


### PR DESCRIPTION
## Summary
- Adds `status = 'pending'` condition to the UPDATE WHERE clause in `activateMachineToken()` so only one concurrent request can succeed
- Route handler now checks the return value and returns 409 if the token was already activated by another request

## Changes
- `src/shared/src/db/queries/machine-token.ts`: UPDATE now uses atomic compare-and-swap, returns success boolean
- `src/web/src/app/api/machine-tokens/activate/route.ts`: Checks activation result, returns 409 on race conflict

## Test plan
- [ ] Activate a pending token → should succeed (200)
- [ ] Activate same token again → should return 409
- [ ] Simulate concurrent activation (two requests) → only one should succeed

Closes #150