### PR TITLE
fix: scope email account lookups by workspace

### DIFF
--- a/src/email-worker/src/index.ts
+++ b/src/email-worker/src/index.ts
@@ -263,15 +263,16 @@ export default {
     }
 
     if (action === "test" && request.method === "POST") {
-      return this.handleTestConnection(accountId, env)
+      const workspaceId = url.searchParams.get("workspaceId") ?? undefined
+      return this.handleTestConnection(accountId, env, workspaceId)
     }
 
     return Response.json({ error: "not found" }, { status: 404 })
   },
 
-  async handleTestConnection(accountId: string, env: EmailEnv): Promise<Response> {
+  async handleTestConnection(accountId: string, env: EmailEnv, workspaceId?: string): Promise<Response> {
     const db = createDb(env.DB)
-    const account = await queries.emailAccount.getEmailAccountById(db, accountId)
+    const account = await queries.emailAccount.getEmailAccountById(db, accountId, workspaceId)
     if (!account) {
       return Response.json({ error: "account not found" }, { status: 404 })
     }

--- a/src/shared/src/db/queries/email-account.ts
+++ b/src/shared/src/db/queries/email-account.ts
@@ -46,11 +46,13 @@ export async function getEmailAccountScoped(db: Database, id: string, agentId: s
   return rows[0] ?? null;
 }
 
-export async function getEmailAccountById(db: Database, id: string) {
+export async function getEmailAccountById(db: Database, id: string, workspaceId?: string) {
+  const conditions = [eq(agentEmailAccount.id, id)];
+  if (workspaceId) conditions.push(eq(agentEmailAccount.workspaceId, workspaceId));
   const rows = await db
     .select()
     .from(agentEmailAccount)
-    .where(eq(agentEmailAccount.id, id));
+    .where(and(...conditions));
   return rows[0] ?? null;
 }
 

--- a/src/web/src/app/api/agents/[id]/email-accounts/[accountId]/test/route.ts
+++ b/src/web/src/app/api/agents/[id]/email-accounts/[accountId]/test/route.ts
@@ -22,11 +22,11 @@ export const POST = withAuth(async (req, ctx) => {
 
   let testRes: Response
   try {
-    testRes = await cfEnv.EMAIL_WORKER.fetch(`http://internal/imap/test?accountId=${accountId}`, {
+    testRes = await cfEnv.EMAIL_WORKER.fetch(`http://internal/imap/test?accountId=${accountId}&workspaceId=${ws.workspaceId}`, {
       method: "POST",
     })
   } catch {
-    testRes = await fetch(`${DEV_EMAIL_WORKER_URL}/imap/test?accountId=${accountId}`, {
+    testRes = await fetch(`${DEV_EMAIL_WORKER_URL}/imap/test?accountId=${accountId}&workspaceId=${ws.workspaceId}`, {
       method: "POST",
     })
   }


### PR DESCRIPTION
## Summary
- `getEmailAccountById()` now accepts optional `workspaceId` parameter for defense-in-depth filtering
- Email worker's test endpoint reads `workspaceId` from URL params and passes it to the lookup
- Web route now sends `workspaceId` when calling the email worker's test endpoint

## Changes
- `src/shared/src/db/queries/email-account.ts`: Added optional workspaceId filter to getEmailAccountById
- `src/email-worker/src/index.ts`: handleTestConnection accepts and uses workspaceId
- `src/web/src/app/api/agents/[id]/email-accounts/[accountId]/test/route.ts`: Passes workspaceId in URL

## Test plan
- [ ] Test email account connection with valid workspace → should work as before
- [ ] Verify that passing a mismatched workspaceId returns 404 (account not found)
- [ ] Existing callers without workspaceId still work (backwards compatible)

Closes #153