### PR TITLE
feat: CLI integration tests for daemon HTTP endpoints (#189)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
           pnpm --filter @alook/web dev &
           until curl -sf http://localhost:3000/api/health; do sleep 2; done
       - run: pnpm test:e2e
+      - run: pnpm --filter @alook/cli run test:integration
 
   build:
     name: Build

--- a/src/cli/package.json
+++ b/src/cli/package.json
@@ -41,6 +41,7 @@
     "build": "bun build src/index.ts --outdir dist --target node --format esm --external citty --external commander --external postal-mime --external playwright-core && bun build daemon/session-runner.ts --outdir dist --target node --format esm --external citty --external commander --external postal-mime && bun build daemon/meeting-runner.ts --outdir dist --target node --format esm --external playwright-core && node scripts/prepare-dist.mjs",
     "prepack": "pnpm run build",
     "test": "vitest run",
+    "test:integration": "vitest run --config ../../tests/integration/cli/vitest.config.ts",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit -p tsconfig.build.json"
   },

--- a/tests/integration/cli/register-poll-complete.test.ts
+++ b/tests/integration/cli/register-poll-complete.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import { randomUUID } from "crypto"
+import {
+  seedTestData,
+  cleanupTestData,
+  type TestSeed,
+  sql,
+  sqlQuery,
+} from "@alook/test-utils"
+import { DaemonClient } from "../../../src/cli/daemon/client"
+import {
+  RegisterResponseSchema,
+  PollResponseSchema,
+  TaskApiBaseSchema,
+} from "@alook/shared"
+
+const APP_URL = process.env.APP_URL ?? "http://localhost:3000"
+const client = new DaemonClient(APP_URL)
+
+let seed: TestSeed
+const daemonId = `daemon_integ_${randomUUID().slice(0, 8)}`
+let registeredRuntimeId: string
+let conversationId: string
+let taskId: string
+
+beforeAll(() => {
+  seed = seedTestData()
+})
+afterAll(() => cleanupTestData(seed))
+
+describe("register → poll → start → messages → complete lifecycle", () => {
+  it("register returns runtimes matching RegisterResponseSchema", async () => {
+    const result = await client.register(seed.machineToken, {
+      workspace_id: seed.workspaceId,
+      daemon_id: daemonId,
+      device_name: "integ-test-machine",
+      cli_version: "0.1.0-integ",
+      runtimes: [{ provider: "claude", runtime_mode: "local", version: "4.0" }],
+    })
+
+    const parsed = RegisterResponseSchema.safeParse(result)
+    expect(parsed.success).toBe(true)
+    expect(result.runtimes).toHaveLength(1)
+    expect(result.runtimes[0].id).toBeTruthy()
+    registeredRuntimeId = result.runtimes[0].id
+  })
+
+  it("poll with no queued tasks returns empty array matching PollResponseSchema", async () => {
+    const result = await client.poll(seed.machineToken, daemonId, 1, "0.1.0-integ")
+    const parsed = PollResponseSchema.safeParse({
+      tasks: result.tasks,
+      evicted: result.evicted,
+      pending_update: result.pending_update,
+      pending_rescan: result.pending_rescan,
+      file_requests: result.file_requests,
+      meetings: result.meetings,
+    })
+    expect(parsed.success).toBe(true)
+    expect(result.tasks).toEqual([])
+    expect(result.evicted).toBe(false)
+  })
+
+  it("poll claims a queued task", async () => {
+    const now = new Date().toISOString()
+    conversationId = `conv_${randomUUID().slice(0, 8)}`
+    taskId = `task_${randomUUID().slice(0, 8)}`
+
+    sql(`INSERT INTO conversation (id, workspace_id, agent_id, user_id, title, created_at) VALUES ('${conversationId}', '${seed.workspaceId}', '${seed.agentId}', '${seed.userId}', 'integ test', '${now}')`)
+    sql(`INSERT INTO agent_task_queue (id, agent_id, runtime_id, workspace_id, conversation_id, prompt, status, type, priority, created_at) VALUES ('${taskId}', '${seed.agentId}', '${registeredRuntimeId}', '${seed.workspaceId}', '${conversationId}', 'Hello integration test', 'queued', 'user_dm_message', 0, '${now}')`)
+
+    const result = await client.poll(seed.machineToken, daemonId, 1, "0.1.0-integ")
+    expect(result.tasks).toHaveLength(1)
+
+    const task = result.tasks[0]
+    expect(task.id).toBe(taskId)
+    expect(task.prompt).toBe("Hello integration test")
+    expect(task.status).toBe("dispatched")
+    expect(task.workspace_id).toBe(seed.workspaceId)
+  })
+
+  it("start task transitions status to running and returns TaskApiBase shape", async () => {
+    const result = await client.startTask(seed.machineToken, taskId) as Record<string, unknown>
+    const parsed = TaskApiBaseSchema.safeParse(result)
+    expect(parsed.success).toBe(true)
+    expect(result.status).toBe("running")
+    expect(result.started_at).toBeTruthy()
+  })
+
+  it("report messages stores them in DB", async () => {
+    await client.reportMessages(seed.machineToken, taskId, [
+      { seq: 1, type: "assistant", content: "Working on it..." },
+      { seq: 2, type: "assistant", content: "Done!" },
+    ])
+
+    const rows = sqlQuery<{ seq: number; type: string; content: string }>(
+      `SELECT seq, type, content FROM task_message WHERE task_id = '${taskId}' ORDER BY seq`
+    )
+    expect(rows).toHaveLength(2)
+    expect(rows[0].content).toBe("Working on it...")
+    expect(rows[1].content).toBe("Done!")
+  })
+
+  it("complete task transitions status and returns TaskApiBase shape", async () => {
+    const result = await client.completeTask(seed.machineToken, taskId, {
+      output: "Task completed successfully",
+      session_id: "sess_integ_test",
+    }) as Record<string, unknown>
+
+    const parsed = TaskApiBaseSchema.safeParse(result)
+    expect(parsed.success).toBe(true)
+    expect(result.status).toBe("completed")
+    expect(result.completed_at).toBeTruthy()
+  })
+
+  it("DB reflects final state after completion", () => {
+    const rows = sqlQuery<{ status: string; session_id: string | null; result: string | null }>(
+      `SELECT status, session_id, result FROM agent_task_queue WHERE id = '${taskId}'`
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].status).toBe("completed")
+    expect(rows[0].session_id).toBe("sess_integ_test")
+    expect(rows[0].result).toContain("Task completed successfully")
+  })
+
+  afterAll(() => {
+    try {
+      sql(`DELETE FROM task_message WHERE task_id = '${taskId}'`)
+      sql(`DELETE FROM agent_task_queue WHERE id = '${taskId}'`)
+      sql(`DELETE FROM conversation WHERE id = '${conversationId}'`)
+      sql(`DELETE FROM agent_runtime WHERE daemon_id = '${daemonId}'`)
+      sql(`DELETE FROM machine WHERE daemon_id = '${daemonId}'`)
+    } catch { /* ignore */ }
+  })
+})

--- a/tests/integration/cli/session-resume.test.ts
+++ b/tests/integration/cli/session-resume.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import { randomUUID } from "crypto"
+import {
+  seedTestData,
+  cleanupTestData,
+  type TestSeed,
+  sql,
+  sqlQuery,
+} from "@alook/test-utils"
+import { DaemonClient } from "../../../src/cli/daemon/client"
+
+const APP_URL = process.env.APP_URL ?? "http://localhost:3000"
+const client = new DaemonClient(APP_URL)
+
+let seed: TestSeed
+const daemonId = `daemon_sess_${randomUUID().slice(0, 8)}`
+let runtimeId: string
+
+beforeAll(async () => {
+  seed = seedTestData()
+
+  const reg = await client.register(seed.machineToken, {
+    workspace_id: seed.workspaceId,
+    daemon_id: daemonId,
+    device_name: "session-test-machine",
+    cli_version: "0.1.0-integ",
+    runtimes: [{ provider: "claude", runtime_mode: "local", version: "4.0" }],
+  })
+  runtimeId = reg.runtimes[0].id
+})
+afterAll(() => cleanupTestData(seed))
+
+describe("session resume via context_key", () => {
+  const contextKey = `ctx_${randomUUID().slice(0, 8)}`
+  const differentContextKey = `ctx_${randomUUID().slice(0, 8)}`
+  let firstConversationId: string
+  let firstTaskId: string
+  let secondTaskId: string
+  let thirdConversationId: string
+  let thirdTaskId: string
+
+  it("first task with context_key creates a new conversation", async () => {
+    const now = new Date().toISOString()
+    firstConversationId = `conv_${randomUUID().slice(0, 8)}`
+    firstTaskId = `task_${randomUUID().slice(0, 8)}`
+
+    sql(`INSERT INTO conversation (id, workspace_id, agent_id, user_id, title, created_at) VALUES ('${firstConversationId}', '${seed.workspaceId}', '${seed.agentId}', '${seed.userId}', 'session resume test', '${now}')`)
+    sql(`INSERT INTO agent_task_queue (id, agent_id, runtime_id, workspace_id, conversation_id, prompt, status, type, context_key, priority, created_at) VALUES ('${firstTaskId}', '${seed.agentId}', '${runtimeId}', '${seed.workspaceId}', '${firstConversationId}', 'First message', 'queued', 'user_dm_message', '${contextKey}', 0, '${now}')`)
+
+    const result = await client.poll(seed.machineToken, daemonId, 1)
+    expect(result.tasks).toHaveLength(1)
+    expect(result.tasks[0].id).toBe(firstTaskId)
+    expect(result.tasks[0].context_key).toBe(contextKey)
+    expect(result.tasks[0].conversation_id).toBe(firstConversationId)
+
+    // Complete the first task with a session_id
+    await client.startTask(seed.machineToken, firstTaskId)
+    await client.completeTask(seed.machineToken, firstTaskId, {
+      output: "First task done",
+      session_id: "sess_first",
+    })
+  })
+
+  it("second task with same context_key uses same conversation", async () => {
+    const now = new Date().toISOString()
+    secondTaskId = `task_${randomUUID().slice(0, 8)}`
+
+    sql(`INSERT INTO agent_task_queue (id, agent_id, runtime_id, workspace_id, conversation_id, prompt, status, type, context_key, priority, created_at) VALUES ('${secondTaskId}', '${seed.agentId}', '${runtimeId}', '${seed.workspaceId}', '${firstConversationId}', 'Second message same context', 'queued', 'user_dm_message', '${contextKey}', 0, '${now}')`)
+
+    const result = await client.poll(seed.machineToken, daemonId, 1)
+    expect(result.tasks).toHaveLength(1)
+    expect(result.tasks[0].id).toBe(secondTaskId)
+    expect(result.tasks[0].context_key).toBe(contextKey)
+    expect(result.tasks[0].conversation_id).toBe(firstConversationId)
+
+    await client.startTask(seed.machineToken, secondTaskId)
+    await client.completeTask(seed.machineToken, secondTaskId, {
+      output: "Second task done",
+      session_id: "sess_first",
+    })
+  })
+
+  it("task with different context_key uses a different conversation", async () => {
+    const now = new Date().toISOString()
+    thirdConversationId = `conv_${randomUUID().slice(0, 8)}`
+    thirdTaskId = `task_${randomUUID().slice(0, 8)}`
+
+    sql(`INSERT INTO conversation (id, workspace_id, agent_id, user_id, title, created_at) VALUES ('${thirdConversationId}', '${seed.workspaceId}', '${seed.agentId}', '${seed.userId}', 'different context', '${now}')`)
+    sql(`INSERT INTO agent_task_queue (id, agent_id, runtime_id, workspace_id, conversation_id, prompt, status, type, context_key, priority, created_at) VALUES ('${thirdTaskId}', '${seed.agentId}', '${runtimeId}', '${seed.workspaceId}', '${thirdConversationId}', 'Different context message', 'queued', 'user_dm_message', '${differentContextKey}', 0, '${now}')`)
+
+    const result = await client.poll(seed.machineToken, daemonId, 1)
+    expect(result.tasks).toHaveLength(1)
+    expect(result.tasks[0].id).toBe(thirdTaskId)
+    expect(result.tasks[0].context_key).toBe(differentContextKey)
+    expect(result.tasks[0].conversation_id).toBe(thirdConversationId)
+    expect(result.tasks[0].conversation_id).not.toBe(firstConversationId)
+  })
+
+  it("DB shows different session_ids for different context_keys", async () => {
+    await client.startTask(seed.machineToken, thirdTaskId)
+    await client.completeTask(seed.machineToken, thirdTaskId, {
+      output: "Third task done",
+      session_id: "sess_different",
+    })
+
+    const rows = sqlQuery<{ id: string; context_key: string | null; session_id: string | null; conversation_id: string }>(
+      `SELECT id, context_key, session_id, conversation_id FROM agent_task_queue WHERE id IN ('${firstTaskId}', '${secondTaskId}', '${thirdTaskId}') ORDER BY created_at`
+    )
+    expect(rows).toHaveLength(3)
+
+    // First two tasks share conversation and context_key
+    expect(rows[0].context_key).toBe(contextKey)
+    expect(rows[1].context_key).toBe(contextKey)
+    expect(rows[0].conversation_id).toBe(rows[1].conversation_id)
+    expect(rows[0].session_id).toBe("sess_first")
+    expect(rows[1].session_id).toBe("sess_first")
+
+    // Third task has different context_key and conversation
+    expect(rows[2].context_key).toBe(differentContextKey)
+    expect(rows[2].conversation_id).not.toBe(rows[0].conversation_id)
+    expect(rows[2].session_id).toBe("sess_different")
+  })
+
+  afterAll(() => {
+    try {
+      sql(`DELETE FROM agent_task_queue WHERE id IN ('${firstTaskId}', '${secondTaskId}', '${thirdTaskId}')`)
+      sql(`DELETE FROM conversation WHERE id IN ('${firstConversationId}', '${thirdConversationId}')`)
+      sql(`DELETE FROM agent_runtime WHERE daemon_id = '${daemonId}'`)
+      sql(`DELETE FROM machine WHERE daemon_id = '${daemonId}'`)
+    } catch { /* ignore */ }
+  })
+})

--- a/tests/integration/cli/session-resume.test.ts
+++ b/tests/integration/cli/session-resume.test.ts
@@ -47,7 +47,7 @@ describe("session resume via context_key", () => {
     sql(`INSERT INTO conversation (id, workspace_id, agent_id, user_id, title, created_at) VALUES ('${firstConversationId}', '${seed.workspaceId}', '${seed.agentId}', '${seed.userId}', 'session resume test', '${now}')`)
     sql(`INSERT INTO agent_task_queue (id, agent_id, runtime_id, workspace_id, conversation_id, prompt, status, type, context_key, priority, created_at) VALUES ('${firstTaskId}', '${seed.agentId}', '${runtimeId}', '${seed.workspaceId}', '${firstConversationId}', 'First message', 'queued', 'user_dm_message', '${contextKey}', 0, '${now}')`)
 
-    const result = await client.poll(seed.machineToken, daemonId, 1)
+    const result = await client.poll(seed.machineToken, daemonId, 1, "0.1.0-integ")
     expect(result.tasks).toHaveLength(1)
     expect(result.tasks[0].id).toBe(firstTaskId)
     expect(result.tasks[0].context_key).toBe(contextKey)
@@ -67,7 +67,7 @@ describe("session resume via context_key", () => {
 
     sql(`INSERT INTO agent_task_queue (id, agent_id, runtime_id, workspace_id, conversation_id, prompt, status, type, context_key, priority, created_at) VALUES ('${secondTaskId}', '${seed.agentId}', '${runtimeId}', '${seed.workspaceId}', '${firstConversationId}', 'Second message same context', 'queued', 'user_dm_message', '${contextKey}', 0, '${now}')`)
 
-    const result = await client.poll(seed.machineToken, daemonId, 1)
+    const result = await client.poll(seed.machineToken, daemonId, 1, "0.1.0-integ")
     expect(result.tasks).toHaveLength(1)
     expect(result.tasks[0].id).toBe(secondTaskId)
     expect(result.tasks[0].context_key).toBe(contextKey)
@@ -88,7 +88,7 @@ describe("session resume via context_key", () => {
     sql(`INSERT INTO conversation (id, workspace_id, agent_id, user_id, title, created_at) VALUES ('${thirdConversationId}', '${seed.workspaceId}', '${seed.agentId}', '${seed.userId}', 'different context', '${now}')`)
     sql(`INSERT INTO agent_task_queue (id, agent_id, runtime_id, workspace_id, conversation_id, prompt, status, type, context_key, priority, created_at) VALUES ('${thirdTaskId}', '${seed.agentId}', '${runtimeId}', '${seed.workspaceId}', '${thirdConversationId}', 'Different context message', 'queued', 'user_dm_message', '${differentContextKey}', 0, '${now}')`)
 
-    const result = await client.poll(seed.machineToken, daemonId, 1)
+    const result = await client.poll(seed.machineToken, daemonId, 1, "0.1.0-integ")
     expect(result.tasks).toHaveLength(1)
     expect(result.tasks[0].id).toBe(thirdTaskId)
     expect(result.tasks[0].context_key).toBe(differentContextKey)

--- a/tests/integration/cli/setup.ts
+++ b/tests/integration/cli/setup.ts
@@ -1,0 +1,3 @@
+if (!process.env.APP_URL) {
+  process.env.APP_URL = "http://localhost:3000"
+}

--- a/tests/integration/cli/skill-sync.test.ts
+++ b/tests/integration/cli/skill-sync.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import { randomUUID } from "crypto"
+import {
+  seedTestData,
+  cleanupTestData,
+  type TestSeed,
+  sqlQuery,
+} from "@alook/test-utils"
+import { DaemonClient } from "../../../src/cli/daemon/client"
+
+const APP_URL = process.env.APP_URL ?? "http://localhost:3000"
+const client = new DaemonClient(APP_URL)
+
+let seed: TestSeed
+const daemonId = `daemon_skill_${randomUUID().slice(0, 8)}`
+
+beforeAll(async () => {
+  seed = seedTestData()
+
+  await client.register(seed.machineToken, {
+    workspace_id: seed.workspaceId,
+    daemon_id: daemonId,
+    device_name: "skill-test-machine",
+    cli_version: "0.1.0-integ",
+    runtimes: [{ provider: "claude", runtime_mode: "local", version: "4.0" }],
+  })
+})
+afterAll(() => cleanupTestData(seed))
+
+describe("skill sync", () => {
+  const skills = [
+    { name: "test-skill-alpha", description: "Alpha skill for testing" },
+    { name: "test-skill-beta", description: "Beta skill for testing" },
+  ]
+
+  it("POST /api/daemon/skills/sync (global scope) stores skills in DB", async () => {
+    await client.syncSkills(seed.machineToken, {
+      scope: "global",
+      daemon_id: daemonId,
+      runtime: "claude",
+      skills,
+    })
+
+    const rows = sqlQuery<{ name: string; description: string; runtime: string; daemon_id: string | null }>(
+      `SELECT name, description, runtime, daemon_id FROM agent_skill WHERE workspace_id = '${seed.workspaceId}' AND runtime = 'claude' AND daemon_id = '${daemonId}' ORDER BY name`
+    )
+    expect(rows.length).toBeGreaterThanOrEqual(2)
+    const alpha = rows.find(r => r.name === "test-skill-alpha")
+    const beta = rows.find(r => r.name === "test-skill-beta")
+    expect(alpha).toBeDefined()
+    expect(alpha!.description).toBe("Alpha skill for testing")
+    expect(beta).toBeDefined()
+    expect(beta!.description).toBe("Beta skill for testing")
+  })
+
+  it("re-sync replaces old skills (stale removal)", async () => {
+    await client.syncSkills(seed.machineToken, {
+      scope: "global",
+      daemon_id: daemonId,
+      runtime: "claude",
+      skills: [{ name: "test-skill-gamma", description: "Gamma replaces all" }],
+    })
+
+    const rows = sqlQuery<{ name: string }>(
+      `SELECT name FROM agent_skill WHERE workspace_id = '${seed.workspaceId}' AND runtime = 'claude' AND daemon_id = '${daemonId}'`
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].name).toBe("test-skill-gamma")
+  })
+
+  it("POST /api/daemon/skills/sync (agent scope) scopes to agent", async () => {
+    await client.syncSkills(seed.machineToken, {
+      scope: "agent",
+      agent_id: seed.agentId,
+      runtime: "claude",
+      skills: [{ name: "agent-specific-skill", description: "Agent scoped" }],
+    })
+
+    const rows = sqlQuery<{ name: string; agent_id: string | null }>(
+      `SELECT name, agent_id FROM agent_skill WHERE workspace_id = '${seed.workspaceId}' AND agent_id = '${seed.agentId}' AND runtime = 'claude'`
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].name).toBe("agent-specific-skill")
+    expect(rows[0].agent_id).toBe(seed.agentId)
+  })
+
+})

--- a/tests/integration/cli/vitest.config.ts
+++ b/tests/integration/cli/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, mergeConfig } from "vitest/config"
+import { resolve } from "path"
+import shared from "../../../vitest.shared"
+
+const dir = resolve(import.meta.dirname)
+const root = resolve(dir, "../../../")
+
+export default mergeConfig(shared, defineConfig({
+  resolve: {
+    alias: {
+      "@alook/test-utils": resolve(root, "tests/utils/src/index.ts"),
+      "@alook/shared": resolve(root, "src/shared/src/index.ts"),
+    },
+  },
+  test: {
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+    include: [`${dir}/**/*.test.ts`],
+    setupFiles: [`${dir}/setup.ts`],
+    fileParallelism: false,
+  },
+}))

--- a/tests/integration/cli/ws-push-poll.test.ts
+++ b/tests/integration/cli/ws-push-poll.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import { randomUUID } from "crypto"
+import {
+  seedTestData,
+  cleanupTestData,
+  type TestSeed,
+  sql,
+} from "@alook/test-utils"
+import { DaemonClient } from "../../../src/cli/daemon/client"
+import { DaemonPushMessageSchema } from "@alook/shared"
+
+const APP_URL = process.env.APP_URL ?? "http://localhost:3000"
+const WS_DO_URL = process.env.WS_DO_URL ?? "http://localhost:8789"
+const client = new DaemonClient(APP_URL)
+
+let seed: TestSeed
+const daemonId = `daemon_ws_${randomUUID().slice(0, 8)}`
+let runtimeId: string
+let wsAvailable = false
+
+beforeAll(async () => {
+  seed = seedTestData()
+
+  // Check if WS-DO is available
+  try {
+    const res = await fetch(WS_DO_URL, { signal: AbortSignal.timeout(2000) })
+    wsAvailable = res.status !== 0
+  } catch {
+    wsAvailable = false
+  }
+
+  const reg = await client.register(seed.machineToken, {
+    workspace_id: seed.workspaceId,
+    daemon_id: daemonId,
+    device_name: "ws-test-machine",
+    cli_version: "0.1.0-integ",
+    runtimes: [{ provider: "claude", runtime_mode: "local", version: "4.0" }],
+  })
+  runtimeId = reg.runtimes[0].id
+})
+afterAll(() => cleanupTestData(seed))
+
+describe("WebSocket push → poll", () => {
+  it.skipIf(!wsAvailable)("daemon.tasks push triggers immediate poll with correct task", async () => {
+    const now = new Date().toISOString()
+    const conversationId = `conv_ws_${randomUUID().slice(0, 8)}`
+    const taskId = `task_ws_${randomUUID().slice(0, 8)}`
+
+    sql(`INSERT INTO conversation (id, workspace_id, agent_id, user_id, title, created_at) VALUES ('${conversationId}', '${seed.workspaceId}', '${seed.agentId}', '${seed.userId}', 'ws push test', '${now}')`)
+    sql(`INSERT INTO agent_task_queue (id, agent_id, runtime_id, workspace_id, conversation_id, prompt, status, type, priority, created_at) VALUES ('${taskId}', '${seed.agentId}', '${runtimeId}', '${seed.workspaceId}', '${conversationId}', 'WS push test prompt', 'queued', 'user_dm_message', 0, '${now}')`)
+
+    // Connect WebSocket and wait for push message
+    const wsUrl = `${WS_DO_URL.replace("http", "ws")}/ws/daemon?token=${seed.machineToken}&daemon_id=${daemonId}`
+    const ws = new WebSocket(wsUrl)
+
+    const pushMessage = await new Promise<unknown>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        ws.close()
+        reject(new Error("WebSocket push timeout — no daemon.tasks message received within 10s"))
+      }, 10_000)
+
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data as string)
+          if (data.type === "daemon.tasks") {
+            clearTimeout(timeout)
+            ws.close()
+            resolve(data)
+          }
+        } catch { /* ignore non-JSON frames */ }
+      }
+      ws.onerror = (err) => {
+        clearTimeout(timeout)
+        reject(err)
+      }
+    })
+
+    const parsed = DaemonPushMessageSchema.safeParse(pushMessage)
+    expect(parsed.success).toBe(true)
+    if (parsed.success && parsed.data.type === "daemon.tasks") {
+      expect(parsed.data.tasks.length).toBeGreaterThanOrEqual(1)
+      const pushed = parsed.data.tasks.find((t) => t.id === taskId)
+      expect(pushed).toBeDefined()
+    }
+
+    // Poll should also return the task
+    const pollResult = await client.poll(seed.machineToken, daemonId, 1)
+    expect(pollResult.tasks.length).toBeGreaterThanOrEqual(1)
+
+    // Cleanup
+    sql(`DELETE FROM agent_task_queue WHERE id = '${taskId}'`)
+    sql(`DELETE FROM conversation WHERE id = '${conversationId}'`)
+  })
+
+  it("skips WebSocket tests when WS-DO is not available", () => {
+    if (!wsAvailable) {
+      expect(true).toBe(true)
+    }
+  })
+
+  afterAll(() => {
+    try {
+      sql(`DELETE FROM agent_runtime WHERE daemon_id = '${daemonId}'`)
+      sql(`DELETE FROM machine WHERE daemon_id = '${daemonId}'`)
+    } catch { /* ignore */ }
+  })
+})

--- a/tests/integration/cli/ws-push-poll.test.ts
+++ b/tests/integration/cli/ws-push-poll.test.ts
@@ -92,12 +92,6 @@ describe("WebSocket push → poll", () => {
     sql(`DELETE FROM conversation WHERE id = '${conversationId}'`)
   })
 
-  it("skips WebSocket tests when WS-DO is not available", () => {
-    if (!wsAvailable) {
-      expect(true).toBe(true)
-    }
-  })
-
   afterAll(() => {
     try {
       sql(`DELETE FROM agent_runtime WHERE daemon_id = '${daemonId}'`)


### PR DESCRIPTION
# Why we need this PR?
> Closes #189

## What changed
- Added `tests/integration/cli/` directory with vitest config for integration tests
- Added `test:integration` script to `src/cli/package.json`
- Created 4 integration test files:
  - `register-poll-complete.test.ts` — Full lifecycle: register → poll → start → messages → complete with Zod schema validation
  - `skill-sync.test.ts` — Real skill sync with DB state verification (global + agent scope, stale removal)
  - `session-resume.test.ts` — Same context_key reuses conversation, different context_key starts new
  - `ws-push-poll.test.ts` — WebSocket push daemon.tasks (skips when WS-DO unavailable)
- Tests use `@alook/test-utils` for seeding via better-sqlite3 (no duplication)
- Response shapes validated against shared Zod schemas (RegisterResponseSchema, PollResponseSchema, TaskApiBaseSchema)

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] CLI (`@alook/cli`)
- [x] Shared library (`@alook/shared`)