### PR TITLE
test: add e2e coverage for missing API routes (#191)

### DIFF
--- a/src/web/src/test/e2e/agent-email-accounts.test.ts
+++ b/src/web/src/test/e2e/agent-email-accounts.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import { seedTestData, cleanupTestData, type TestSeed, tokenRequest, sql } from "@alook/test-utils"
+
+let seed: TestSeed
+let accountId: string
+
+beforeAll(() => {
+  seed = seedTestData()
+})
+
+afterAll(() => {
+  if (accountId) {
+    sql(`DELETE FROM agent_email_account WHERE id = '${accountId}'`)
+  }
+  cleanupTestData(seed)
+})
+
+describe("GET /api/agents/[id]/email-accounts", () => {
+  it("returns empty list when no accounts configured", async () => {
+    const res = await tokenRequest(
+      `/api/agents/${seed.agentId}/email-accounts?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+    )
+    expect(res.status).toBe(200)
+    const data = await res.json() as unknown[]
+    expect(Array.isArray(data)).toBe(true)
+    expect(data).toHaveLength(0)
+  })
+
+  it("returns 404 for non-existent agent", async () => {
+    const res = await tokenRequest(
+      `/api/agents/ag_nonexistent_xyz/email-accounts?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+    )
+    expect(res.status).toBe(404)
+  })
+})
+
+describe("POST /api/agents/[id]/email-accounts", () => {
+  it("creates an email account", async () => {
+    const res = await tokenRequest(
+      `/api/agents/${seed.agentId}/email-accounts?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          emailAddress: "test@example.com",
+          displayName: "Test Account",
+          imapHost: "imap.example.com",
+          imapPort: 993,
+          imapUsername: "test@example.com",
+          imapPassword: "password123",
+          imapTls: true,
+          smtpHost: "smtp.example.com",
+          smtpPort: 587,
+          smtpUsername: "test@example.com",
+          smtpPassword: "password123",
+          smtpTls: 1,
+          pollIntervalSeconds: 60,
+        }),
+      },
+    )
+    expect(res.status).toBe(201)
+    const data = await res.json() as Record<string, unknown>
+    expect(data.id).toBeTruthy()
+    expect(data.email_address).toBe("test@example.com")
+    expect(data.display_name).toBe("Test Account")
+    expect(data.imap_host).toBe("imap.example.com")
+    expect(data.smtp_host).toBe("smtp.example.com")
+    expect(data.status).toBeTruthy()
+    accountId = data.id as string
+  })
+
+  it("lists the created account", async () => {
+    const res = await tokenRequest(
+      `/api/agents/${seed.agentId}/email-accounts?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+    )
+    expect(res.status).toBe(200)
+    const data = await res.json() as Array<Record<string, unknown>>
+    expect(data.length).toBeGreaterThanOrEqual(1)
+    expect(data.some(a => a.id === accountId)).toBe(true)
+  })
+
+  it("returns 404 for non-existent agent on create", async () => {
+    const res = await tokenRequest(
+      `/api/agents/ag_nonexistent_xyz/email-accounts?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          emailAddress: "fail@example.com",
+          displayName: "Fail",
+          imapHost: "imap.example.com",
+          imapPort: 993,
+          imapUsername: "fail@example.com",
+          imapPassword: "pass",
+          imapTls: true,
+          smtpHost: "smtp.example.com",
+          smtpPort: 587,
+          smtpUsername: "fail@example.com",
+          smtpPassword: "pass",
+          smtpTls: 1,
+          pollIntervalSeconds: 60,
+        }),
+      },
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it("rejects unauthenticated request", async () => {
+    const res = await fetch(
+      `${process.env.APP_URL || "http://localhost:3000"}/api/agents/${seed.agentId}/email-accounts?workspace_id=${seed.workspaceId}`,
+    )
+    expect(res.status).toBe(401)
+  })
+})

--- a/src/web/src/test/e2e/agent-recruit.test.ts
+++ b/src/web/src/test/e2e/agent-recruit.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import { seedTestData, cleanupTestData, type TestSeed, tokenRequest, sql, sqlBatch } from "@alook/test-utils"
+
+let seed: TestSeed
+let recruitedAgentId: string
+
+beforeAll(() => {
+  seed = seedTestData()
+})
+
+afterAll(() => {
+  if (recruitedAgentId) {
+    sqlBatch([
+      `DELETE FROM agent_task_queue WHERE agent_id = '${recruitedAgentId}'`,
+      `DELETE FROM message WHERE conversation_id IN (SELECT id FROM conversation WHERE agent_id = '${recruitedAgentId}')`,
+      `DELETE FROM conversation WHERE agent_id = '${recruitedAgentId}'`,
+      `DELETE FROM agent_whitelist WHERE agent_id = '${recruitedAgentId}'`,
+      `DELETE FROM agent_link WHERE source_agent_id = '${seed.agentId}' AND target_agent_id = '${recruitedAgentId}'`,
+      `DELETE FROM agent WHERE id = '${recruitedAgentId}'`,
+    ])
+  }
+  cleanupTestData(seed)
+})
+
+describe("POST /api/agents/recruit", () => {
+  it("recruits a new agent and returns agent + link", async () => {
+    const res = await tokenRequest(
+      `/api/agents/recruit?workspace_id=${seed.workspaceId}&agentId=${seed.agentId}`,
+      seed.machineToken,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "RecruitedBot",
+          description: "A test recruited agent",
+          instructions: "You are a helper bot",
+          relationship: "Helps with testing",
+        }),
+      },
+    )
+    expect(res.status).toBe(201)
+    const data = await res.json() as { agent: Record<string, unknown>; link: Record<string, unknown> }
+    expect(data.agent).toBeTruthy()
+    expect(data.agent.name).toBe("RecruitedBot")
+    expect(data.agent.email).toBeTruthy()
+    expect(data.link).toBeTruthy()
+    expect(data.link.source_agent_id).toBeTruthy()
+    expect(data.link.target_agent_id).toBe(data.agent.id)
+    recruitedAgentId = data.agent.id as string
+  })
+
+  it("returns 400 without agentId query param", async () => {
+    const res = await tokenRequest(
+      `/api/agents/recruit?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "ShouldFail",
+          instructions: "test",
+          relationship: "test",
+        }),
+      },
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 404 for non-existent calling agent", async () => {
+    const res = await tokenRequest(
+      `/api/agents/recruit?workspace_id=${seed.workspaceId}&agentId=ag_nonexistent_xyz`,
+      seed.machineToken,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "ShouldFail",
+          instructions: "test",
+          relationship: "test",
+        }),
+      },
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it("rejects unauthenticated request", async () => {
+    const res = await fetch(
+      `${process.env.APP_URL || "http://localhost:3000"}/api/agents/recruit?workspace_id=${seed.workspaceId}&agentId=${seed.agentId}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "NoAuth", instructions: "x", relationship: "x" }),
+      },
+    )
+    expect(res.status).toBe(401)
+  })
+})

--- a/src/web/src/test/e2e/artifacts.test.ts
+++ b/src/web/src/test/e2e/artifacts.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import { seedTestData, cleanupTestData, type TestSeed, tokenRequest } from "@alook/test-utils"
+
+let seed: TestSeed
+let conversationId: string
+let artifactId: string
+
+beforeAll(async () => {
+  seed = seedTestData()
+
+  const convRes = await tokenRequest(
+    `/api/conversations?workspace_id=${seed.workspaceId}`,
+    seed.machineToken,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agent_id: seed.agentId }),
+    },
+  )
+  const convData = await convRes.json() as { id: string }
+  conversationId = convData.id
+})
+
+afterAll(() => cleanupTestData(seed))
+
+describe("POST /api/artifacts/upload", () => {
+  it("uploads a file and returns artifact metadata", async () => {
+    const fileContent = new Blob(["hello world"], { type: "text/plain" })
+    const formData = new FormData()
+    formData.append("file", new File([fileContent], "test.txt", { type: "text/plain" }))
+    formData.append("conversation_id", conversationId)
+
+    const res = await tokenRequest(
+      `/api/artifacts/upload?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+      {
+        method: "POST",
+        body: formData,
+      },
+    )
+    expect(res.status).toBe(200)
+    const data = await res.json() as Record<string, unknown>
+    expect(data.id).toBeTruthy()
+    expect(data.filename).toBe("test.txt")
+    expect(data.content_type).toBe("text/plain")
+    expect(data.size).toBe(11)
+    expect(data.conversation_id).toBe(conversationId)
+    artifactId = data.id as string
+  })
+
+  it("rejects upload without file", async () => {
+    const formData = new FormData()
+    formData.append("conversation_id", conversationId)
+
+    const res = await tokenRequest(
+      `/api/artifacts/upload?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+      {
+        method: "POST",
+        body: formData,
+      },
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it("rejects upload without conversation_id", async () => {
+    const fileContent = new Blob(["data"], { type: "text/plain" })
+    const formData = new FormData()
+    formData.append("file", new File([fileContent], "test2.txt", { type: "text/plain" }))
+
+    const res = await tokenRequest(
+      `/api/artifacts/upload?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+      {
+        method: "POST",
+        body: formData,
+      },
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it("rejects upload for non-existent conversation", async () => {
+    const fileContent = new Blob(["data"], { type: "text/plain" })
+    const formData = new FormData()
+    formData.append("file", new File([fileContent], "test3.txt", { type: "text/plain" }))
+    formData.append("conversation_id", "conv_nonexistent_xyz")
+
+    const res = await tokenRequest(
+      `/api/artifacts/upload?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+      {
+        method: "POST",
+        body: formData,
+      },
+    )
+    expect(res.status).toBe(404)
+  })
+})
+
+describe("GET /api/artifacts", () => {
+  it("lists artifacts for a conversation", async () => {
+    const res = await tokenRequest(
+      `/api/artifacts?workspace_id=${seed.workspaceId}&conversation_id=${conversationId}`,
+      seed.machineToken,
+    )
+    expect(res.status).toBe(200)
+    const data = await res.json() as Array<Record<string, unknown>>
+    expect(Array.isArray(data)).toBe(true)
+    expect(data.length).toBeGreaterThanOrEqual(1)
+    expect(data.some(a => a.id === artifactId)).toBe(true)
+  })
+
+  it("returns 400 without conversation_id", async () => {
+    const res = await tokenRequest(
+      `/api/artifacts?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it("rejects unauthenticated request", async () => {
+    const res = await fetch(
+      `${process.env.APP_URL || "http://localhost:3000"}/api/artifacts?workspace_id=${seed.workspaceId}&conversation_id=${conversationId}`,
+    )
+    expect(res.status).toBe(401)
+  })
+})

--- a/src/web/src/test/e2e/conversation-init.test.ts
+++ b/src/web/src/test/e2e/conversation-init.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import { seedTestData, cleanupTestData, type TestSeed, tokenRequest } from "@alook/test-utils"
+
+let seed: TestSeed
+let conversationId: string
+
+beforeAll(async () => {
+  seed = seedTestData()
+
+  const convRes = await tokenRequest(
+    `/api/conversations?workspace_id=${seed.workspaceId}`,
+    seed.machineToken,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agent_id: seed.agentId }),
+    },
+  )
+  const convData = await convRes.json() as { id: string }
+  conversationId = convData.id
+
+  // Send a message to populate conversation
+  await tokenRequest(
+    `/api/conversations/${conversationId}/messages?workspace_id=${seed.workspaceId}`,
+    seed.machineToken,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "Init test message" }),
+    },
+  )
+})
+
+afterAll(() => cleanupTestData(seed))
+
+describe("GET /api/conversations/[id]/init", () => {
+  it("returns full conversation initialization data", async () => {
+    const res = await tokenRequest(
+      `/api/conversations/${conversationId}/init?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+    )
+    expect(res.status).toBe(200)
+    const data = await res.json() as Record<string, unknown>
+    expect(data.conversation).toBeTruthy()
+    expect(data.messages).toBeTruthy()
+    expect(Array.isArray(data.messages)).toBe(true)
+    expect(typeof data.has_more_messages).toBe("boolean")
+    expect(typeof data.has_more_conversations).toBe("boolean")
+    expect(typeof data.has_more_artifacts).toBe("boolean")
+    expect(Array.isArray(data.artifacts)).toBe(true)
+    expect(Array.isArray(data.buffered_messages)).toBe(true)
+    expect(Array.isArray(data.flagged_message_ids)).toBe(true)
+    expect(typeof data.thinking_counts).toBe("object")
+    expect(typeof data.cache_valid).toBe("boolean")
+    expect(typeof data.message_count).toBe("number")
+  })
+
+  it("returns cache_valid=true when newest_message_id matches", async () => {
+    // First get the init data to find the newest message id
+    const firstRes = await tokenRequest(
+      `/api/conversations/${conversationId}/init?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+    )
+    const firstData = await firstRes.json() as { messages: Array<{ id: string }>; message_count: number }
+    const newestMsgId = firstData.messages[0]?.id
+    const msgCount = firstData.message_count
+
+    if (newestMsgId) {
+      const res = await tokenRequest(
+        `/api/conversations/${conversationId}/init?workspace_id=${seed.workspaceId}&newest_message_id=${newestMsgId}&message_count=${msgCount}`,
+        seed.machineToken,
+      )
+      expect(res.status).toBe(200)
+      const data = await res.json() as { cache_valid: boolean; messages: unknown }
+      expect(data.cache_valid).toBe(true)
+      expect(data.messages).toBeNull()
+    }
+  })
+
+  it("returns 404 for non-existent conversation", async () => {
+    const res = await tokenRequest(
+      `/api/conversations/conv_nonexistent_xyz/init?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it("rejects unauthenticated request", async () => {
+    const res = await fetch(
+      `${process.env.APP_URL || "http://localhost:3000"}/api/conversations/${conversationId}/init?workspace_id=${seed.workspaceId}`,
+    )
+    expect(res.status).toBe(401)
+  })
+})

--- a/src/web/src/test/e2e/inbox.test.ts
+++ b/src/web/src/test/e2e/inbox.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import { seedTestData, cleanupTestData, type TestSeed, tokenRequest, sql } from "@alook/test-utils"
+
+let seed: TestSeed
+let conversationId: string
+let taskId: string
+
+beforeAll(async () => {
+  seed = seedTestData()
+
+  const convRes = await tokenRequest(
+    `/api/conversations?workspace_id=${seed.workspaceId}`,
+    seed.machineToken,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agent_id: seed.agentId }),
+    },
+  )
+  const convData = await convRes.json() as { id: string }
+  conversationId = convData.id
+
+  const msgRes = await tokenRequest(
+    `/api/conversations/${conversationId}/messages?workspace_id=${seed.workspaceId}`,
+    seed.machineToken,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "Inbox test message" }),
+    },
+  )
+  const msgData = await msgRes.json() as { task?: { id: string } | null }
+  if (msgData.task) {
+    taskId = msgData.task.id
+  }
+
+  // Poll, start, and complete the task so it shows up in inbox
+  await tokenRequest(`/api/daemon/tasks/poll`, seed.machineToken, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ daemon_id: seed.daemonId, max_tasks: 1 }),
+  })
+  await tokenRequest(`/api/daemon/tasks/${taskId}/start`, seed.machineToken, { method: "POST" })
+
+  // Post an assistant message so the inbox query can find it
+  await tokenRequest(
+    `/api/daemon/tasks/${taskId}/messages`,
+    seed.machineToken,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        messages: [{ seq: 1, type: "text", content: "Task done" }],
+      }),
+    },
+  )
+
+  await tokenRequest(`/api/daemon/tasks/${taskId}/complete`, seed.machineToken, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ output: "done", session_id: "sess_inbox_1" }),
+  })
+})
+
+afterAll(() => {
+  sql(`DELETE FROM conversation_read_state WHERE user_id = '${seed.userId}'`)
+  cleanupTestData(seed)
+})
+
+describe("GET /api/inbox/count", () => {
+  it("returns unread count", async () => {
+    const res = await tokenRequest(
+      `/api/inbox/count?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+    )
+    expect(res.status).toBe(200)
+    const data = await res.json() as { count: number }
+    expect(typeof data.count).toBe("number")
+  })
+
+  it("rejects unauthenticated request", async () => {
+    const res = await fetch(
+      `${process.env.APP_URL || "http://localhost:3000"}/api/inbox/count?workspace_id=${seed.workspaceId}`,
+    )
+    expect(res.status).toBe(401)
+  })
+})
+
+describe("GET /api/inbox", () => {
+  it("returns inbox items list", async () => {
+    const res = await tokenRequest(
+      `/api/inbox?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+    )
+    expect(res.status).toBe(200)
+    const data = await res.json() as { items: unknown[]; has_more: boolean }
+    expect(Array.isArray(data.items)).toBe(true)
+    expect(typeof data.has_more).toBe("boolean")
+  })
+
+  it("respects limit parameter", async () => {
+    const res = await tokenRequest(
+      `/api/inbox?workspace_id=${seed.workspaceId}&limit=1`,
+      seed.machineToken,
+    )
+    expect(res.status).toBe(200)
+    const data = await res.json() as { items: unknown[] }
+    expect(data.items.length).toBeLessThanOrEqual(1)
+  })
+
+  it("rejects invalid before timestamp", async () => {
+    const res = await tokenRequest(
+      `/api/inbox?workspace_id=${seed.workspaceId}&before=not-a-date`,
+      seed.machineToken,
+    )
+    expect(res.status).toBe(400)
+  })
+})
+
+describe("POST /api/inbox/read", () => {
+  it("marks a conversation as read", async () => {
+    const res = await tokenRequest(
+      `/api/inbox/read?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ conversationId }),
+      },
+    )
+    expect(res.status).toBe(204)
+  })
+
+  it("returns 400 when conversationId is missing", async () => {
+    const res = await tokenRequest(
+      `/api/inbox/read?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      },
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 404 for non-existent conversation", async () => {
+    const res = await tokenRequest(
+      `/api/inbox/read?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ conversationId: "conv_nonexistent_xyz" }),
+      },
+    )
+    expect(res.status).toBe(404)
+  })
+})
+
+describe("POST /api/inbox/read-all", () => {
+  it("marks all conversations as read", async () => {
+    const res = await tokenRequest(
+      `/api/inbox/read-all?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+      { method: "POST" },
+    )
+    expect(res.status).toBe(204)
+  })
+
+  it("rejects unauthenticated request", async () => {
+    const res = await fetch(
+      `${process.env.APP_URL || "http://localhost:3000"}/api/inbox/read-all?workspace_id=${seed.workspaceId}`,
+      { method: "POST" },
+    )
+    expect(res.status).toBe(401)
+  })
+})

--- a/src/web/src/test/e2e/task-lifecycle.test.ts
+++ b/src/web/src/test/e2e/task-lifecycle.test.ts
@@ -457,3 +457,133 @@ describe("task failure and retry", () => {
     expect(data.error).toBe("only failed tasks can be retried")
   })
 })
+
+describe("task progress reporting", () => {
+  let progressTaskId: string
+
+  beforeAll(async () => {
+    const convRes = await tokenRequest(
+      `/api/conversations?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agent_id: seed.agentId }),
+      },
+    )
+    const { id: convId } = await convRes.json() as { id: string }
+
+    const msgRes = await tokenRequest(
+      `/api/conversations/${convId}/messages?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: "Progress test" }),
+      },
+    )
+    const msgData = await msgRes.json() as { task?: { id: string } | null }
+    if (msgData.task) {
+      progressTaskId = msgData.task.id
+    }
+
+    await tokenRequest(`/api/daemon/tasks/poll`, seed.machineToken, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ daemon_id: seed.daemonId, max_tasks: 1 }),
+    })
+    await tokenRequest(`/api/daemon/tasks/${progressTaskId}/start`, seed.machineToken, { method: "POST" })
+  })
+
+  it("POST /api/daemon/tasks/:id/progress returns ok", async () => {
+    const res = await tokenRequest(
+      `/api/daemon/tasks/${progressTaskId}/progress`,
+      seed.machineToken,
+      { method: "POST" },
+    )
+    expect(res.status).toBe(200)
+    const data = await res.json() as { status: string }
+    expect(data.status).toBe("ok")
+  })
+
+  it("rejects unauthenticated progress request", async () => {
+    const res = await fetch(
+      `${process.env.APP_URL || "http://localhost:3000"}/api/daemon/tasks/${progressTaskId}/progress`,
+      { method: "POST" },
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it("cleanup: complete progress task", async () => {
+    await tokenRequest(`/api/daemon/tasks/${progressTaskId}/complete`, seed.machineToken, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ output: "done", session_id: "sess_progress" }),
+    })
+  })
+})
+
+describe("task supersede", () => {
+  let supersedeTaskId: string
+
+  beforeAll(async () => {
+    const convRes = await tokenRequest(
+      `/api/conversations?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agent_id: seed.agentId }),
+      },
+    )
+    const { id: convId } = await convRes.json() as { id: string }
+
+    const msgRes = await tokenRequest(
+      `/api/conversations/${convId}/messages?workspace_id=${seed.workspaceId}`,
+      seed.machineToken,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: "Supersede test" }),
+      },
+    )
+    const msgData = await msgRes.json() as { task?: { id: string } | null }
+    if (msgData.task) {
+      supersedeTaskId = msgData.task.id
+    }
+
+    // Keep polling until our specific task is dispatched
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const pollRes = await tokenRequest(`/api/daemon/tasks/poll`, seed.machineToken, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ daemon_id: seed.daemonId, max_tasks: 10 }),
+      })
+      const pollData = await pollRes.json() as { tasks: Array<{ id: string }> }
+      if (pollData.tasks.some(t => t.id === supersedeTaskId)) break
+      await new Promise(r => setTimeout(r, 200))
+    }
+    await tokenRequest(`/api/daemon/tasks/${supersedeTaskId}/start`, seed.machineToken, { method: "POST" })
+  })
+
+  it("POST /api/daemon/tasks/:id/supersede marks task as superseded", async () => {
+    const res = await tokenRequest(
+      `/api/daemon/tasks/${supersedeTaskId}/supersede`,
+      seed.machineToken,
+      { method: "POST" },
+    )
+    expect(res.status).toBe(200)
+    const data = await res.json() as Record<string, unknown>
+    expect(data.status).toBe("superseded")
+    expect(data.id).toBe(supersedeTaskId)
+  })
+
+  it("superseding an already superseded task returns 400", async () => {
+    const res = await tokenRequest(
+      `/api/daemon/tasks/${supersedeTaskId}/supersede`,
+      seed.machineToken,
+      { method: "POST" },
+    )
+    expect(res.status).toBe(400)
+  })
+})


### PR DESCRIPTION
# Why we need this PR?
> Closes #191

## What changed
Add e2e test coverage for API routes that previously only had mocked unit tests:

**P1 (new test files):**
- `inbox.test.ts` — `/api/inbox/*` (count, read, read-all, list)
- `artifacts.test.ts` — `/api/artifacts/upload` + `/api/artifacts` (list)
- `agent-recruit.test.ts` — `/api/agents/recruit`
- `agent-email-accounts.test.ts` — `/api/agents/[id]/email-accounts/*`
- `conversation-init.test.ts` — `/api/conversations/[id]/init`

**P2 (added to existing files):**
- `task-lifecycle.test.ts` — `/api/daemon/tasks/[id]/progress` and `/api/daemon/tasks/[id]/supersede`

Each route has at minimum a happy-path test + error case (401/404/400).

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)