### PR TITLE
fix: prevent duplicate chat message bubbles after send

### DIFF
--- a/src/web/src/components/agent-chat/agent-chat-view.tsx
+++ b/src/web/src/components/agent-chat/agent-chat-view.tsx
@@ -1554,7 +1554,7 @@ export function AgentChatView({
       });
       setMessages((prev) => {
         const without = prev.filter((m) => m.id !== optimistic.id && m.id !== message.id);
-        return sortMessages([...without, message]);
+        return mergeMessages(without, [message]);
       });
       appendCachedMessage(conversation.id, message, workspaceId).catch(() => {});
       if (message.attachment_ids && message.attachment_ids.length > 0) {

--- a/src/web/src/components/agent-chat/agent-chat-view.tsx
+++ b/src/web/src/components/agent-chat/agent-chat-view.tsx
@@ -443,6 +443,7 @@ export function AgentChatView({
   const prevConversationIdRef = useRef<string | undefined>(undefined);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const pendingOptimisticIdsRef = useRef<Set<string>>(new Set());
 
   const otherAgents = useMemo(() => agents.filter(a => a.id !== agentId), [agents, agentId]);
 
@@ -1227,7 +1228,13 @@ export function AgentChatView({
       if (msg.type === "conversation.message") {
         appendCachedMessage(msg.conversationId, msg.message, workspaceId).catch(() => {});
         if (msg.conversationId === conversation?.id) {
-          setMessages((prev) => mergeMessages(prev, [msg.message]));
+          setMessages((prev) => {
+            if (msg.message.role === "user" && pendingOptimisticIdsRef.current.size > 0) {
+              const without = prev.filter((m) => !pendingOptimisticIdsRef.current.has(m.id));
+              return mergeMessages(without, [msg.message]);
+            }
+            return mergeMessages(prev, [msg.message]);
+          });
         }
       }
       if (msg.type === "task.updated" && msg.taskId === activeTaskIdRef.current) {
@@ -1536,6 +1543,7 @@ export function AgentChatView({
     }
 
     setMessages((prev) => [...prev, optimistic]);
+    pendingOptimisticIdsRef.current.add(optimisticId);
     scrollToBottom();
 
     try {
@@ -1552,6 +1560,7 @@ export function AgentChatView({
         next.delete(optimisticId);
         return next;
       });
+      pendingOptimisticIdsRef.current.delete(optimisticId);
       setMessages((prev) => {
         const without = prev.filter((m) => m.id !== optimistic.id && m.id !== message.id);
         return mergeMessages(without, [message]);
@@ -1566,6 +1575,7 @@ export function AgentChatView({
       setTaskMessages([]);
       startPolling(task.id, conversation.id);
     } catch (err) {
+      pendingOptimisticIdsRef.current.delete(optimisticId);
       setPendingFilesByMessage((prev) => {
         if (!prev.has(optimisticId)) return prev;
         const next = new Map(prev);


### PR DESCRIPTION
# Why we need this PR?
> Fix duplicate message bubbles appearing briefly after sending a chat message.

## What changed
- Added `pendingOptimisticIdsRef` to track pending optimistic message IDs
- WebSocket `conversation.message` handler now replaces optimistic messages when the real message arrives (instead of adding alongside them)
- HTTP response handler clears the ref and still serves as a fallback
- Error handler also clears the ref to prevent leaks
- Used `mergeMessages` (Map-based dedup) instead of `sortMessages` in HTTP response handler for extra safety

**Root cause:** When a user sends a message, an optimistic message (`temp-xxx`) is rendered immediately. The WebSocket event arrives with the real message (`msg-xxx`) before the HTTP response. Since the IDs differ, both appeared briefly until the HTTP response cleaned up.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)