### PR TITLE
feat: unify release tags and changelog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,3 +143,18 @@ jobs:
       - name: Lighthouse CI
         working-directory: src/web
         run: npx @lhci/cli autorun --config=lighthouserc.json && node scripts/print-lighthouse-scores.mjs
+
+  release:
+    name: GitHub Release
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [quality, test, build, coverage]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "${{ github.ref_name }}" --generate-notes --title "${{ github.ref_name }}"

--- a/.github/workflows/publish-app.yml
+++ b/.github/workflows/publish-app.yml
@@ -16,7 +16,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       id-token: write
-      contents: write
     steps:
       - uses: actions/checkout@v6
 
@@ -25,7 +24,6 @@ jobs:
         run: |
           VERSION=$(node -p "require('./src/app/package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=app/v$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Check if version already published
         id: check
@@ -75,12 +73,6 @@ jobs:
         if: steps.check.outputs.skip == 'false'
         working-directory: src/app
         run: npm publish --access public
-
-      - name: Create GitHub release
-        if: steps.check.outputs.skip == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "${{ steps.version.outputs.tag }}" --generate-notes --title "App v${{ steps.version.outputs.version }}"
 
       - name: Notify Discord
         if: steps.check.outputs.skip == 'false'

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -16,7 +16,6 @@ jobs:
     timeout-minutes: 10
     permissions:
       id-token: write
-      contents: write
     steps:
       - uses: actions/checkout@v6
 
@@ -25,7 +24,6 @@ jobs:
         run: |
           VERSION=$(node -p "require('./src/cli/package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=cli/v$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Check if version already published
         id: check
@@ -67,12 +65,6 @@ jobs:
         if: steps.check.outputs.skip == 'false'
         working-directory: src/cli
         run: npm publish --access public
-
-      - name: Create GitHub release
-        if: steps.check.outputs.skip == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "${{ steps.version.outputs.tag }}" --generate-notes --title "CLI v${{ steps.version.outputs.version }}"
 
       - name: Notify Discord
         if: steps.check.outputs.skip == 'false'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,10 +21,19 @@ pnpm bump 0.0.11      # explicit version (v prefix optional)
 pnpm bump patch        # auto-increment patch/minor/major
 pnpm bump patch --min-cli  # also update MIN_CLI_VERSION in src/web/wrangler.toml
 ```
-This updates every `src/*/package.json`, commits `release: vX.Y.Z`, but does NOT push.
+This updates every `src/*/package.json`, commits `release: vX.Y.Z`, and creates a local `vX.Y.Z` git tag.
 Add `--min-cli` when the release contains breaking changes that require users to update their CLI.
-After reviewing the commit, `git push origin main` to trigger CI:
+
+After reviewing the commit:
+```bash
+git push origin main --tags
+```
+
+This triggers:
+- **CI** — typecheck, lint, tests, coverage (uploaded to Codecov)
+- **Unified GitHub Release** — auto-created with generated changelog after all CI checks pass
 - **@alook/cli** → auto-published to npm via `publish-cli.yml` (watches `src/cli/package.json`)
+- **@alook/app** → auto-published to npm via `publish-app.yml` (watches `src/app/package.json`)
 - **CF Workers** → each module redeploys when its own `package.json` changes
 
 ## Plan-driven Development

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -77,8 +77,9 @@ if (updateMinCli) {
 const gitFiles = files.map((f) => f.replace(ROOT + "/", ""));
 execSync(`git add ${gitFiles.join(" ")}`, { cwd: ROOT, stdio: "inherit" });
 execSync(`git commit -m "release: v${version}"`, { cwd: ROOT, stdio: "inherit" });
+execSync(`git tag v${version}`, { cwd: ROOT, stdio: "inherit" });
 
-console.log(`\n✅ Committed: release: v${version}`);
+console.log(`\n✅ Committed and tagged: v${version}`);
 console.log(`\n👉 Next steps:`);
-console.log(`   git push origin main`);
+console.log(`   git push origin main --tags`);
 console.log(`   # CI will auto-publish @alook/cli and trigger CF deployments\n`);


### PR DESCRIPTION
## Summary
- Bump script (`scripts/bump-version.mjs`) now creates a local `v{version}` git tag after commit and instructs `git push origin main --tags`
- Removed per-package GitHub Release steps from `publish-cli.yml` and `publish-app.yml` (no more `cli/v*` / `app/v*` tags)
- Added a `release` job in `ci.yml` that creates a single unified GitHub Release with auto-generated changelog when a `v*` tag is pushed, gated on quality + test + build + coverage passing

Closes #204

## Test plan
- [ ] Run `pnpm bump patch` locally — verify it creates a commit AND a `v*` git tag
- [ ] Push with `--tags` — verify CI `release` job triggers after checks pass
- [ ] Verify `publish-cli.yml` and `publish-app.yml` no longer create GitHub Releases
- [ ] Verify the unified GitHub Release contains auto-generated changelog notes