### PR TITLE
fix: prioritize decoded subject over raw RFC 2047 header

### DIFF
--- a/src/email-worker/src/index.test.ts
+++ b/src/email-worker/src/index.test.ts
@@ -258,6 +258,119 @@ describe("whitelisted path", () => {
   })
 })
 
+// ─── Group 3b: RFC 2047 subject decoding ───
+
+describe("RFC 2047 subject decoding", () => {
+  it("uses parsed.subject (decoded) over raw RFC 2047 Q-encoded header", async () => {
+    const encodedSubject = "=?UTF-8?q?Re:_=E6=96=B0=E6=B3=A8=E5=86=8C=E7=94=A8=E6=88=B7?="
+    const { env, message, wsFetch } = setup({
+      isWhitelisted: true,
+      messageOpts: {
+        from: "owner@example.com",
+        to: "jarvis@alook.ai",
+        subject: encodedSubject,
+        body: "Test body",
+      },
+    })
+
+    await handler.email(message, env)
+
+    const notifyBody = JSON.parse(wsFetch.mock.calls[0][1].body)
+    expect(notifyBody.subject).toBe("Re: 新注册用户")
+  })
+
+  it("uses parsed.subject (decoded) over raw RFC 2047 B-encoded header", async () => {
+    const encodedSubject = "=?UTF-8?B?5rWL6K+V5Li76aKY?="
+    const { env, message, wsFetch } = setup({
+      isWhitelisted: true,
+      messageOpts: {
+        from: "owner@example.com",
+        to: "jarvis@alook.ai",
+        subject: encodedSubject,
+        body: "Test body",
+      },
+    })
+
+    await handler.email(message, env)
+
+    const notifyBody = JSON.parse(wsFetch.mock.calls[0][1].body)
+    expect(notifyBody.subject).toBe("测试主题")
+  })
+
+  it("uses plain ASCII subject as-is (no encoding)", async () => {
+    const { env, message, wsFetch } = setup({
+      isWhitelisted: true,
+      messageOpts: {
+        from: "owner@example.com",
+        to: "jarvis@alook.ai",
+        subject: "Plain subject",
+        body: "Test body",
+      },
+    })
+
+    await handler.email(message, env)
+
+    const notifyBody = JSON.parse(wsFetch.mock.calls[0][1].body)
+    expect(notifyBody.subject).toBe("Plain subject")
+  })
+
+  it("falls back to '(No Subject)' when both sources are empty", async () => {
+    const { env, message, wsFetch } = setup({
+      isWhitelisted: true,
+      messageOpts: {
+        from: "owner@example.com",
+        to: "jarvis@alook.ai",
+        subject: null,
+        body: "Test body",
+      },
+    })
+
+    await handler.email(message, env)
+
+    const notifyBody = JSON.parse(wsFetch.mock.calls[0][1].body)
+    expect(notifyBody.subject).toBe("(No Subject)")
+  })
+
+  it("falls back to raw header when parsed.subject is empty string", async () => {
+    const headers = new Headers()
+    headers.set("subject", "Fallback Subject")
+
+    const rawText = [
+      "From: owner@example.com",
+      "To: jarvis@alook.ai",
+      "Subject: ",
+      "",
+      "Test body",
+    ].join("\r\n")
+
+    const setReject = vi.fn()
+    const forward = vi.fn().mockResolvedValue(undefined)
+    const message = {
+      from: "owner@example.com",
+      to: "jarvis@alook.ai",
+      headers,
+      raw: new Response(rawText).body!,
+      rawSize: rawText.length,
+      setReject,
+      forward,
+      reply: vi.fn(),
+    } as unknown as ForwardableEmailMessage
+
+    mockGetAgentByHandle.mockResolvedValue(AGENT)
+    mockIsWhitelisted.mockResolvedValue(true)
+
+    const { bucket, put } = createMockR2()
+    const { fetcher, fetch: wsFetch } = createMockFetcher()
+    const { sendEmail } = createMockSendEmail()
+    const env = { DB: {} as D1Database, EMAIL_BUCKET: bucket, WEB_SERVICE: fetcher, SEND_EMAIL: sendEmail, IMAP_POLLER: {} as DurableObjectNamespace, ENCRYPTION_KEY: "test-secret" }
+
+    await handler.email(message, env)
+
+    const notifyBody = JSON.parse(wsFetch.mock.calls[0][1].body)
+    expect(notifyBody.subject).toBe("Fallback Subject")
+  })
+})
+
 // ─── Group 4: Non-whitelisted path (rejected) ───
 
 describe("non-whitelisted path", () => {

--- a/src/email-worker/src/index.ts
+++ b/src/email-worker/src/index.ts
@@ -355,7 +355,7 @@ export default {
     const parsed = await PostalMime.parse(rawBytes)
     const attachmentsMeta = extractAttachmentMeta(parsed.attachments || [])
 
-    const subject = message.headers.get("subject") || parsed.subject || "(No Subject)"
+    const subject = parsed.subject || message.headers.get("subject") || "(No Subject)"
     const messageId = message.headers.get("message-id") ?? ""
     const inReplyTo = message.headers.get("in-reply-to") ?? ""
     const references = message.headers.get("references") ?? ""

--- a/src/web/migrations/0036_decode_rfc2047_subjects.sql
+++ b/src/web/migrations/0036_decode_rfc2047_subjects.sql
@@ -1,0 +1,15 @@
+-- Migration for Issue #211: RFC 2047 encoded subjects
+--
+-- Problem: CF Email Routing path stored raw RFC 2047 encoded subjects
+-- (e.g. "=?UTF-8?q?Re:_=E6=96=B0...?=") instead of decoded Unicode.
+--
+-- Fix: The code now prioritizes parsed.subject (decoded by postal-mime)
+-- over the raw message header. New emails will be stored correctly.
+--
+-- Existing data: RFC 2047 decoding requires charset-aware hex/base64
+-- decoding which SQLite cannot perform in pure SQL. Affected rows are
+-- cosmetic-only and will self-correct as conversations continue.
+-- If bulk correction is needed, use an application-level script that
+-- re-parses from R2-stored raw emails.
+
+SELECT 1;


### PR DESCRIPTION
# Why we need this PR?
> Closes #211

## What changed

- **Primary fix**: Swapped priority in `src/email-worker/src/index.ts:358` so `parsed.subject` (decoded by postal-mime) is used over raw `message.headers.get("subject")` (RFC 2047 encoded)
- **Tests**: Added 5 test cases covering RFC 2047 Q-encoding, B-encoding, plain ASCII, missing subject fallback, and empty parsed.subject fallback
- **Migration**: Added `0036_decode_rfc2047_subjects.sql` documenting that existing encoded subjects cannot be fixed in pure SQL and will self-correct going forward

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Email Worker (`@alook/email-worker`)