### PR TITLE
fix(web): resolve N+1 sequential I/O perf bugs (#207, #208, #209)

### DIFF
--- a/src/shared/src/db/queries/agent.ts
+++ b/src/shared/src/db/queries/agent.ts
@@ -148,6 +148,15 @@ export async function getAgentByHandle(db: Database, emailHandle: string) {
   return rows[0] ?? null;
 }
 
+export async function getExistingHandles(db: Database, handles: string[]) {
+  if (handles.length === 0) return [];
+  const rows = await db
+    .select({ emailHandle: agent.emailHandle })
+    .from(agent)
+    .where(inArray(agent.emailHandle, handles));
+  return rows.map((r) => r.emailHandle).filter(Boolean) as string[];
+}
+
 export async function getAgentsByIds(db: Database, ids: string[], workspaceId: string) {
   if (ids.length === 0) return [];
   return db

--- a/src/shared/src/db/queries/runtime.ts
+++ b/src/shared/src/db/queries/runtime.ts
@@ -109,6 +109,38 @@ export async function getAgentRuntimeForWorkspace(
   return rows[0] ?? null;
 }
 
+export async function getAgentRuntimesForWorkspace(
+  db: Database,
+  ids: string[],
+  workspaceId: string
+) {
+  if (ids.length === 0) return [];
+  return db
+    .select({
+      id: agentRuntime.id,
+      workspaceId: agentRuntime.workspaceId,
+      daemonId: agentRuntime.daemonId,
+      runtimeMode: agentRuntime.runtimeMode,
+      provider: agentRuntime.provider,
+      deviceInfo: agentRuntime.deviceInfo,
+      metadata: agentRuntime.metadata,
+      createdAt: agentRuntime.createdAt,
+      updatedAt: agentRuntime.updatedAt,
+      machineLastSeenAt: machine.lastSeenAt,
+    })
+    .from(agentRuntime)
+    .leftJoin(
+      machine,
+      and(
+        eq(machine.daemonId, agentRuntime.daemonId),
+        eq(machine.workspaceId, agentRuntime.workspaceId)
+      )
+    )
+    .where(
+      and(inArray(agentRuntime.id, ids), eq(agentRuntime.workspaceId, workspaceId))
+    );
+}
+
 export async function deleteRuntimesByDaemonId(
   db: Database,
   daemonId: string,

--- a/src/shared/test/queries/agent.test.ts
+++ b/src/shared/test/queries/agent.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import * as agentQueries from "../../src/db/queries/agent";
+
+function createMockDb(rows: any[]) {
+  const chain: any = {};
+  chain.select = vi.fn(() => chain);
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => Promise.resolve(rows));
+  return chain;
+}
 
 describe("agent query module exports", () => {
   it("exports getExistingHandles", () => {
@@ -15,13 +23,33 @@ describe("agent query module exports", () => {
   });
 });
 
-describe("agent query function signatures", () => {
-  it("getExistingHandles accepts (db, handles)", () => {
-    expect(agentQueries.getExistingHandles.length).toBe(2);
-  });
-
-  it("getExistingHandles returns empty array for empty input", async () => {
+describe("getExistingHandles", () => {
+  it("returns empty array for empty input without querying DB", async () => {
     const result = await agentQueries.getExistingHandles(null as any, []);
     expect(result).toEqual([]);
+  });
+
+  it("queries DB and returns existing handles when input is non-empty", async () => {
+    const mockDb = createMockDb([
+      { emailHandle: "alice" },
+      { emailHandle: "bob" },
+    ]);
+
+    const result = await agentQueries.getExistingHandles(mockDb, ["alice", "bob", "charlie"]);
+
+    expect(mockDb.select).toHaveBeenCalledOnce();
+    expect(mockDb.from).toHaveBeenCalledOnce();
+    expect(mockDb.where).toHaveBeenCalledOnce();
+    expect(result).toEqual(["alice", "bob"]);
+  });
+
+  it("filters out null emailHandle values from results", async () => {
+    const mockDb = createMockDb([
+      { emailHandle: "alice" },
+      { emailHandle: null },
+    ]);
+
+    const result = await agentQueries.getExistingHandles(mockDb, ["alice", "ghost"]);
+    expect(result).toEqual(["alice"]);
   });
 });

--- a/src/shared/test/queries/agent.test.ts
+++ b/src/shared/test/queries/agent.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import * as agentQueries from "../../src/db/queries/agent";
+
+describe("agent query module exports", () => {
+  it("exports getExistingHandles", () => {
+    expect(typeof agentQueries.getExistingHandles).toBe("function");
+  });
+
+  it("exports getAgentByHandle", () => {
+    expect(typeof agentQueries.getAgentByHandle).toBe("function");
+  });
+
+  it("exports getAgentsByIds", () => {
+    expect(typeof agentQueries.getAgentsByIds).toBe("function");
+  });
+});
+
+describe("agent query function signatures", () => {
+  it("getExistingHandles accepts (db, handles)", () => {
+    expect(agentQueries.getExistingHandles.length).toBe(2);
+  });
+
+  it("getExistingHandles returns empty array for empty input", async () => {
+    const result = await agentQueries.getExistingHandles(null as any, []);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/shared/test/queries/runtime.test.ts
+++ b/src/shared/test/queries/runtime.test.ts
@@ -1,5 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import * as runtimeQueries from "../../src/db/queries/runtime";
+
+function createMockDb(rows: any[]) {
+  const chain: any = {};
+  chain.select = vi.fn(() => chain);
+  chain.from = vi.fn(() => chain);
+  chain.leftJoin = vi.fn(() => chain);
+  chain.where = vi.fn(() => Promise.resolve(rows));
+  return chain;
+}
 
 describe("runtime query module exports", () => {
   it("exports getAgentRuntimesForWorkspace", () => {
@@ -23,17 +32,34 @@ describe("runtime query module exports", () => {
   });
 });
 
-describe("runtime query function signatures", () => {
-  it("getAgentRuntimesForWorkspace accepts (db, ids, workspaceId)", () => {
-    expect(runtimeQueries.getAgentRuntimesForWorkspace.length).toBe(3);
-  });
-
-  it("getAgentRuntimeForWorkspace accepts (db, id, workspaceId)", () => {
-    expect(runtimeQueries.getAgentRuntimeForWorkspace.length).toBe(3);
-  });
-
-  it("getAgentRuntimesForWorkspace returns empty array for empty ids", async () => {
+describe("getAgentRuntimesForWorkspace", () => {
+  it("returns empty array for empty ids without querying DB", async () => {
     const result = await runtimeQueries.getAgentRuntimesForWorkspace(null as any, [], "ws1");
     expect(result).toEqual([]);
+  });
+
+  it("queries DB and returns runtimes when ids is non-empty", async () => {
+    const mockRows = [
+      { id: "rt1", workspaceId: "ws1", runtimeMode: "local", machineLastSeenAt: null },
+      { id: "rt2", workspaceId: "ws1", runtimeMode: "cloud", machineLastSeenAt: "2026-01-01" },
+    ];
+    const mockDb = createMockDb(mockRows);
+
+    const result = await runtimeQueries.getAgentRuntimesForWorkspace(mockDb, ["rt1", "rt2"], "ws1");
+
+    expect(mockDb.select).toHaveBeenCalledOnce();
+    expect(mockDb.from).toHaveBeenCalledOnce();
+    expect(mockDb.leftJoin).toHaveBeenCalledOnce();
+    expect(mockDb.where).toHaveBeenCalledOnce();
+    expect(result).toEqual(mockRows);
+  });
+
+  it("returns single runtime for single id input", async () => {
+    const mockRows = [{ id: "rt1", workspaceId: "ws1", runtimeMode: "local", machineLastSeenAt: null }];
+    const mockDb = createMockDb(mockRows);
+
+    const result = await runtimeQueries.getAgentRuntimesForWorkspace(mockDb, ["rt1"], "ws1");
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("rt1");
   });
 });

--- a/src/shared/test/queries/runtime.test.ts
+++ b/src/shared/test/queries/runtime.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import * as runtimeQueries from "../../src/db/queries/runtime";
+
+describe("runtime query module exports", () => {
+  it("exports getAgentRuntimesForWorkspace", () => {
+    expect(typeof runtimeQueries.getAgentRuntimesForWorkspace).toBe("function");
+  });
+
+  it("exports getAgentRuntimeForWorkspace", () => {
+    expect(typeof runtimeQueries.getAgentRuntimeForWorkspace).toBe("function");
+  });
+
+  it("exports upsertAgentRuntime", () => {
+    expect(typeof runtimeQueries.upsertAgentRuntime).toBe("function");
+  });
+
+  it("exports listAgentRuntimes", () => {
+    expect(typeof runtimeQueries.listAgentRuntimes).toBe("function");
+  });
+
+  it("exports getAgentRuntime", () => {
+    expect(typeof runtimeQueries.getAgentRuntime).toBe("function");
+  });
+});
+
+describe("runtime query function signatures", () => {
+  it("getAgentRuntimesForWorkspace accepts (db, ids, workspaceId)", () => {
+    expect(runtimeQueries.getAgentRuntimesForWorkspace.length).toBe(3);
+  });
+
+  it("getAgentRuntimeForWorkspace accepts (db, id, workspaceId)", () => {
+    expect(runtimeQueries.getAgentRuntimeForWorkspace.length).toBe(3);
+  });
+
+  it("getAgentRuntimesForWorkspace returns empty array for empty ids", async () => {
+    const result = await runtimeQueries.getAgentRuntimesForWorkspace(null as any, [], "ws1");
+    expect(result).toEqual([]);
+  });
+});

--- a/src/web/src/app/api/email/send/route.test.ts
+++ b/src/web/src/app/api/email/send/route.test.ts
@@ -388,6 +388,85 @@ describe("POST /api/email/send", () => {
       expect(putOpts.httpMetadata.contentType).toBe("message/rfc822");
     });
 
+    it("fetches multiple attachments from R2 in parallel for local delivery", async () => {
+      mockGetAgent.mockResolvedValue({ id: "a1", emailHandle: "sender-agent", workspaceId: "ws1" });
+      mockGetAgentByHandle.mockResolvedValue({ id: "a2", emailHandle: "agent-b", workspaceId: "ws1" });
+      mockIsWhitelisted.mockResolvedValue(false);
+      mockWorkerSelfRefFetch.mockResolvedValue(Response.json({ ok: true }));
+      mockCreateEmail.mockResolvedValue({ id: "e1" });
+
+      const file1 = new TextEncoder().encode("file one");
+      const file2 = new TextEncoder().encode("file two");
+      const file3 = new TextEncoder().encode("file three");
+      mockEmailBucketGet
+        .mockResolvedValueOnce({ arrayBuffer: () => Promise.resolve(file1.buffer) })
+        .mockResolvedValueOnce({ arrayBuffer: () => Promise.resolve(file2.buffer) })
+        .mockResolvedValueOnce({ arrayBuffer: () => Promise.resolve(file3.buffer) });
+      mockEmailBucketPut.mockResolvedValue(undefined);
+
+      const attachments = [
+        { key: "emails/drafts/x/a.txt", filename: "a.txt", size: 8, contentType: "text/plain" },
+        { key: "emails/drafts/x/b.txt", filename: "b.txt", size: 8, contentType: "text/plain" },
+        { key: "emails/drafts/x/c.txt", filename: "c.txt", size: 10, contentType: "text/plain" },
+      ];
+
+      const req = makeReq({
+        agentId: "a1",
+        to: "agent-b@alook.ai",
+        subject: "Multi attach",
+        htmlBody: "<p>See files</p>",
+        attachments,
+      });
+
+      const res = await POST(req, {} as any);
+      expect(res.status).toBe(200);
+
+      expect(mockEmailBucketGet).toHaveBeenCalledTimes(3);
+      expect(mockEmailBucketGet).toHaveBeenCalledWith("emails/drafts/x/a.txt");
+      expect(mockEmailBucketGet).toHaveBeenCalledWith("emails/drafts/x/b.txt");
+      expect(mockEmailBucketGet).toHaveBeenCalledWith("emails/drafts/x/c.txt");
+
+      const putBody = mockEmailBucketPut.mock.calls[0][1] as string;
+      expect(putBody).toContain('filename="a.txt"');
+      expect(putBody).toContain('filename="b.txt"');
+      expect(putBody).toContain('filename="c.txt"');
+    });
+
+    it("skips attachments that return null from R2 in parallel fetch", async () => {
+      mockGetAgent.mockResolvedValue({ id: "a1", emailHandle: "sender-agent", workspaceId: "ws1" });
+      mockGetAgentByHandle.mockResolvedValue({ id: "a2", emailHandle: "agent-b", workspaceId: "ws1" });
+      mockIsWhitelisted.mockResolvedValue(false);
+      mockWorkerSelfRefFetch.mockResolvedValue(Response.json({ ok: true }));
+      mockCreateEmail.mockResolvedValue({ id: "e1" });
+
+      const file1 = new TextEncoder().encode("file one");
+      mockEmailBucketGet
+        .mockResolvedValueOnce({ arrayBuffer: () => Promise.resolve(file1.buffer) })
+        .mockResolvedValueOnce(null);
+      mockEmailBucketPut.mockResolvedValue(undefined);
+
+      const attachments = [
+        { key: "emails/drafts/x/exists.txt", filename: "exists.txt", size: 8, contentType: "text/plain" },
+        { key: "emails/drafts/x/missing.txt", filename: "missing.txt", size: 5, contentType: "text/plain" },
+      ];
+
+      const req = makeReq({
+        agentId: "a1",
+        to: "agent-b@alook.ai",
+        subject: "Partial attach",
+        htmlBody: "<p>Partial</p>",
+        attachments,
+      });
+
+      const res = await POST(req, {} as any);
+      expect(res.status).toBe(200);
+
+      expect(mockEmailBucketGet).toHaveBeenCalledTimes(2);
+      const putBody = mockEmailBucketPut.mock.calls[0][1] as string;
+      expect(putBody).toContain('filename="exists.txt"');
+      expect(putBody).not.toContain('filename="missing.txt"');
+    });
+
     it("checks whitelist and passes result in notify payload", async () => {
       mockGetAgent.mockResolvedValue({ id: "a1", emailHandle: "sender-agent", workspaceId: "ws1" });
       mockGetAgentByHandle.mockResolvedValue({ id: "a2", emailHandle: "agent-b", workspaceId: "ws1" });

--- a/src/web/src/app/api/email/send/route.ts
+++ b/src/web/src/app/api/email/send/route.ts
@@ -104,14 +104,15 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
       const messageId = `<${nanoid()}@alook.ai>`;
       const htmlBody = body.htmlBody || "";
 
-      const fetchedAttachments: { filename: string; contentType: string; base64: string }[] = [];
-      for (const att of attachments) {
-        const obj = await cfEnv.EMAIL_BUCKET.get(att.key);
-        if (!obj) continue;
-        const raw = await obj.arrayBuffer();
-        const base64 = btoa(String.fromCharCode(...new Uint8Array(raw)));
-        fetchedAttachments.push({ filename: att.filename, contentType: att.contentType, base64 });
-      }
+      const fetchedAttachments = (await Promise.all(
+        attachments.map(async (att) => {
+          const obj = await cfEnv.EMAIL_BUCKET.get(att.key);
+          if (!obj) return null;
+          const raw = await obj.arrayBuffer();
+          const base64 = btoa(String.fromCharCode(...new Uint8Array(raw)));
+          return { filename: att.filename, contentType: att.contentType, base64 };
+        })
+      )).filter((a): a is { filename: string; contentType: string; base64: string } => a !== null);
 
       const rawMime = buildMimeMessage({
         from: fromAddress,

--- a/src/web/src/app/api/studios/check-handles/route.test.ts
+++ b/src/web/src/app/api/studios/check-handles/route.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
+}));
+
+const mockGetExistingHandles = vi.fn();
+const mockGetAgentByHandle = vi.fn();
+
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
+vi.mock("@alook/shared", async () => {
+  const actual = await vi.importActual("@alook/shared");
+  return {
+    ...actual,
+    queries: {
+      agent: {
+        getExistingHandles: (...args: unknown[]) => mockGetExistingHandles(...args),
+        getAgentByHandle: (...args: unknown[]) => mockGetAgentByHandle(...args),
+      },
+    },
+  };
+});
+
+vi.mock("@/lib/middleware/auth", () => ({
+  withAuth: vi.fn((handler: any) => async (req: any, ctx?: any) => {
+    const params = ctx?.params instanceof Promise ? await ctx.params : ctx?.params;
+    return handler(req, { userId: "u1", email: "u@test.com", params });
+  }),
+}));
+
+import { POST } from "./route";
+
+function makeReq(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/studios/check-handles", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/studios/check-handles", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetExistingHandles.mockResolvedValue([]);
+  });
+
+  it("returns unique handles for each name when none exist", async () => {
+    const req = makeReq({ names: ["Alice", "Bob"] });
+    const res = await POST(req, {});
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toHaveLength(2);
+    expect(body[0].name).toBe("Alice");
+    expect(body[0].handle).toBeTruthy();
+    expect(body[1].name).toBe("Bob");
+    expect(body[1].handle).toBeTruthy();
+    expect(body[0].handle).not.toBe(body[1].handle);
+  });
+
+  it("skips handles that already exist in DB", async () => {
+    mockGetExistingHandles.mockResolvedValue(["alice"]);
+
+    const req = makeReq({ names: ["Alice"] });
+    const res = await POST(req, {});
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body[0].handle).not.toBe("alice");
+    expect(body[0].handle).toBeTruthy();
+  });
+
+  it("batch-fetches all candidates in a single call", async () => {
+    const req = makeReq({ names: ["Alice", "Bob", "Charlie"] });
+    await POST(req, {});
+
+    expect(mockGetExistingHandles).toHaveBeenCalledTimes(1);
+    const handles = mockGetExistingHandles.mock.calls[0][1] as string[];
+    expect(handles.length).toBeGreaterThan(3);
+  });
+
+  it("returns 400 if names array is empty", async () => {
+    const req = makeReq({ names: [] });
+    const res = await POST(req, {});
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 if names array exceeds 4", async () => {
+    const req = makeReq({ names: ["a", "b", "c", "d", "e"] });
+    const res = await POST(req, {});
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid request body", async () => {
+    const req = new NextRequest("http://localhost/api/studios/check-handles", {
+      method: "POST",
+      body: "not json",
+    });
+    const res = await POST(req, {});
+    expect(res.status).toBe(400);
+  });
+
+  it("falls back to nanoid suffix when all candidates are taken", async () => {
+    mockGetExistingHandles.mockImplementation((_db: any, handles: string[]) =>
+      Promise.resolve(handles)
+    );
+
+    const req = makeReq({ names: ["Alice"] });
+    const res = await POST(req, {});
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body[0].handle).toMatch(/^alice-.{6}$/);
+  });
+});

--- a/src/web/src/app/api/studios/check-handles/route.ts
+++ b/src/web/src/app/api/studios/check-handles/route.ts
@@ -22,41 +22,42 @@ export const POST = withAuth(async (req: NextRequest) => {
   const { env } = getCloudflareContext();
   const db = getDb((env as Env).DB);
 
-  const results: { name: string; handle: string }[] = [];
-  const usedHandles = new Set<string>();
-
+  // Generate all candidate handles upfront
+  const candidatesPerName: { name: string; candidates: string[] }[] = [];
   for (const name of body.names) {
     const base = name.toLowerCase().replace(/[^a-z0-9-]/g, "").slice(0, 30);
-    let handle = base;
-
-    // Try base handle first
-    if (isValidHandle(handle) && !usedHandles.has(handle)) {
-      const existing = await queries.agent.getAgentByHandle(db, handle);
-      if (!existing) {
-        usedHandles.add(handle);
-        results.push({ name, handle });
-        continue;
-      }
-    }
-
-    // Try with random name suffixes
-    let found = false;
+    const candidates: string[] = [];
+    if (isValidHandle(base)) candidates.push(base);
     for (let i = 0; i < 5; i++) {
       const suffix = uniqueNamesGenerator({ dictionaries: [names], length: 1, style: "lowerCase" });
       const candidate = `${base}-${suffix}`.slice(0, 30);
-      if (!isValidHandle(candidate) || usedHandles.has(candidate)) continue;
-      const existing = await queries.agent.getAgentByHandle(db, candidate);
-      if (!existing) {
+      if (isValidHandle(candidate)) candidates.push(candidate);
+    }
+    candidatesPerName.push({ name, candidates });
+  }
+
+  // Batch-fetch existence of all candidates in a single query
+  const allCandidates = candidatesPerName.flatMap((c) => c.candidates);
+  const existingHandles = new Set(
+    await queries.agent.getExistingHandles(db, allCandidates)
+  );
+
+  // Assign handles using in-memory Set lookups
+  const usedHandles = new Set<string>();
+  const results: { name: string; handle: string }[] = [];
+
+  for (const { name, candidates } of candidatesPerName) {
+    let handle: string | undefined;
+    for (const candidate of candidates) {
+      if (!existingHandles.has(candidate) && !usedHandles.has(candidate)) {
         handle = candidate;
-        found = true;
         break;
       }
     }
-
-    if (!found) {
+    if (!handle) {
+      const base = name.toLowerCase().replace(/[^a-z0-9-]/g, "").slice(0, 30);
       handle = `${base}-${nanoid(6)}`;
     }
-
     usedHandles.add(handle);
     results.push({ name, handle });
   }

--- a/src/web/src/app/api/studios/route.test.ts
+++ b/src/web/src/app/api/studios/route.test.ts
@@ -8,6 +8,7 @@ const mockCreateAgent = vi.fn();
 const mockGetAgentByHandle = vi.fn();
 const mockListAgents = vi.fn();
 const mockGetAgentRuntimeForWorkspace = vi.fn();
+const mockGetAgentRuntimesForWorkspace = vi.fn();
 const mockGetWorkspace = vi.fn();
 const mockGetWorkspaceBySlug = vi.fn();
 const mockUpdateWorkspace = vi.fn();
@@ -47,6 +48,7 @@ vi.mock("@alook/shared", async () => {
       },
       runtime: {
         getAgentRuntimeForWorkspace: (...args: unknown[]) => mockGetAgentRuntimeForWorkspace(...args),
+        getAgentRuntimesForWorkspace: (...args: unknown[]) => mockGetAgentRuntimesForWorkspace(...args),
       },
       workspace: {
         getWorkspace: (...args: unknown[]) => mockGetWorkspace(...args),
@@ -107,6 +109,11 @@ beforeEach(() => {
     runtimeMode: "local",
     machineLastSeenAt: new Date().toISOString(),
   });
+  mockGetAgentRuntimesForWorkspace.mockResolvedValue([{
+    id: "rt1",
+    runtimeMode: "local",
+    machineLastSeenAt: new Date().toISOString(),
+  }]);
   let agentIdx = 0;
   mockCreateAgent.mockImplementation((_db: any, data: any) => {
     agentIdx++;
@@ -200,6 +207,7 @@ describe("POST /api/studios", () => {
 
   it("returns 404 if runtime not in workspace", async () => {
     mockGetAgentRuntimeForWorkspace.mockResolvedValue(null);
+    mockGetAgentRuntimesForWorkspace.mockResolvedValue([]);
 
     const req = new NextRequest("http://localhost/api/studios", {
       method: "POST",

--- a/src/web/src/app/api/studios/route.ts
+++ b/src/web/src/app/api/studios/route.ts
@@ -54,13 +54,12 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
   if (valErr) return valErr;
 
   const runtimeIds = [...new Set(body.members.map((m) => m.runtime_id))];
-  const runtimeCache = new Map<string, { id: string; runtimeMode: string; machineLastSeenAt: string | null }>();
+  const runtimes = await queries.runtime.getAgentRuntimesForWorkspace(db, runtimeIds, ws.workspaceId);
+  const runtimeCache = new Map(runtimes.map((r) => [r.id, r]));
   for (const rid of runtimeIds) {
-    const runtime = await queries.runtime.getAgentRuntimeForWorkspace(db, rid, ws.workspaceId);
-    if (!runtime) {
+    if (!runtimeCache.has(rid)) {
       return writeError(`runtime ${rid} not found in workspace`, 404);
     }
-    runtimeCache.set(rid, runtime);
   }
 
   // Update workspace name/slug if a name is provided
@@ -154,9 +153,10 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
   const leaderAgent = createdAgents.find((a) => a.role === "leader")!;
   const specialists = createdAgents.filter((a) => a.role !== "leader");
   const createdLinks = [];
+  const memberPayloadMap = new Map(body.members.map((m) => [m.name, m]));
 
   for (const specialist of specialists) {
-    const memberPayload = body.members.find((m) => m.name === specialist.name);
+    const memberPayload = memberPayloadMap.get(specialist.name);
     if (!memberPayload?.relationship) continue;
 
     const leaderMention = `[@ id="${leaderAgent.id}" label="${leaderAgent.name}"]`;
@@ -267,7 +267,8 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
 
   // Fetch final agents for response
   const agents = await queries.agent.listAgents(db, ws.workspaceId, ctx.userId);
-  const studioAgents = agents.filter((a) => createdAgents.some((ca) => ca.id === a.id));
+  const createdIdSet = new Set(createdAgents.map((ca) => ca.id));
+  const studioAgents = agents.filter((a) => createdIdSet.has(a.id));
   const finalWorkspace = await queries.workspace.getWorkspace(db, ws.workspaceId, ctx.userId);
 
   return writeJSON({


### PR DESCRIPTION
## Summary
- **#209** — Email send route: R2 attachment fetches parallelized via `Promise.all()` instead of sequential awaits in a loop
- **#208** — Studio creation route: batch-fetch all runtimes in one DB query + use `Map`/`Set` for O(1) lookups instead of `.find()` in loops
- **#207** — Handle validation route: generate all candidates upfront, batch-check existence with a single DB query, assign from in-memory `Set`

## Changes
| File | Description |
|------|-------------|
| `src/shared/src/db/queries/runtime.ts` | Added `getAgentRuntimesForWorkspace()` batch query |
| `src/shared/src/db/queries/agent.ts` | Added `getExistingHandles()` batch query |
| `src/web/src/app/api/email/send/route.ts` | Wrapped R2 fetches in `Promise.all()` |
| `src/web/src/app/api/studios/route.ts` | Batch runtime fetch + Map/Set lookups |
| `src/web/src/app/api/studios/check-handles/route.ts` | Single batch query for all handle candidates |
| `src/web/src/app/api/studios/route.test.ts` | Updated mocks for new batch function |

## Test plan
- [x] All existing tests pass (turbo test — 8/8 task groups, 0 failures)
- [x] TypeScript compiles cleanly with no new type errors
- [x] Studio route test updated to mock new batch function
- [ ] Manual verification in staging with multi-member studio creation

Closes #207, #208, #209