### PR TITLE
chore(ci): clean up coverage config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm vitest run --coverage --coverage.reporter=json --coverage.reporter=text --coverage.include='src/**' --coverage.exclude='**/*.test.*' --coverage.exclude='**/*.spec.*'
+      - run: pnpm vitest run --coverage --coverage.reporter=json --coverage.reporter=text
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,17 @@ import { defineConfig } from "vitest/config"
 export default defineConfig({
   test: {
     projects: ["src/shared", "src/web", "src/email-worker", "src/app", "tests/utils"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.{ts,tsx,js,jsx}"],
+      exclude: [
+        "**/*.test.*",
+        "**/*.spec.*",
+        "**/node_modules/**",
+        "**/.next/**",
+        "**/dist/**",
+        "**/bundled/**",
+      ],
+    },
   },
 })


### PR DESCRIPTION
# Why we need this PR?
> Closes CI coverage noise and prepares for Node.js 24 forced migration (June 2, 2026)

## What changed
- Moved coverage include/exclude configuration from inline CI command flags into `vitest.config.ts` for centralized management
- Changed coverage `include` from broad `src/**` to targeted `src/**/*.{ts,tsx,js,jsx}` — prevents v8 from trying to parse non-code files (.md, .example, .dev.vars, LICENSE, .gitignore, .toml, config files)
- Added excludes for build artifact directories (.next, dist, bundled) that produced sourcemap warnings
- Simplified the CI coverage command to just `pnpm vitest run --coverage --coverage.reporter=json --coverage.reporter=text`

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [ ] Other: ...