### PR TITLE
test(web): add unit tests for flags, inbox, traces, and comments routes

### DIFF
--- a/src/shared/test/constants.test.ts
+++ b/src/shared/test/constants.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest"
 import {
   POLL_INTERVAL_MS, OFFLINE_THRESHOLD_MS, EVENT_POLL_INTERVAL_MS, AGENT_HANDLE_MIN_LENGTH,
   TaskStatus, TERMINAL_TASK_STATUSES, isTerminalTaskStatus,
+  IssueStatus, ACTIVE_ISSUE_STATUSES, TERMINAL_ISSUE_STATUSES, isTerminalIssueStatus,
+  MeetingStatus, TERMINAL_MEETING_STATUSES,
 } from "../src/constants"
 
 describe("constants", () => {
@@ -39,5 +41,61 @@ describe("TaskStatus", () => {
     expect(isTerminalTaskStatus("queued")).toBe(false)
     expect(isTerminalTaskStatus("dispatched")).toBe(false)
     expect(isTerminalTaskStatus("running")).toBe(false)
+  })
+})
+
+describe("IssueStatus", () => {
+  it("has all expected status values", () => {
+    expect(IssueStatus.TODO).toBe("todo")
+    expect(IssueStatus.IN_PROGRESS).toBe("in_progress")
+    expect(IssueStatus.REVIEW).toBe("review")
+    expect(IssueStatus.DONE).toBe("done")
+    expect(IssueStatus.CLOSED).toBe("closed")
+    expect(IssueStatus.CANCELED).toBe("canceled")
+    expect(IssueStatus.FAILED).toBe("failed")
+  })
+
+  it("ACTIVE_ISSUE_STATUSES contains non-terminal statuses", () => {
+    expect(ACTIVE_ISSUE_STATUSES).toContain("todo")
+    expect(ACTIVE_ISSUE_STATUSES).toContain("in_progress")
+    expect(ACTIVE_ISSUE_STATUSES).toContain("review")
+    expect(ACTIVE_ISSUE_STATUSES).not.toContain("done")
+  })
+
+  it("TERMINAL_ISSUE_STATUSES contains terminal statuses", () => {
+    expect(TERMINAL_ISSUE_STATUSES).toContain("done")
+    expect(TERMINAL_ISSUE_STATUSES).toContain("closed")
+    expect(TERMINAL_ISSUE_STATUSES).toContain("canceled")
+    expect(TERMINAL_ISSUE_STATUSES).toContain("failed")
+  })
+
+  it("isTerminalIssueStatus returns true for terminal statuses", () => {
+    expect(isTerminalIssueStatus("done")).toBe(true)
+    expect(isTerminalIssueStatus("closed")).toBe(true)
+    expect(isTerminalIssueStatus("canceled")).toBe(true)
+    expect(isTerminalIssueStatus("failed")).toBe(true)
+  })
+
+  it("isTerminalIssueStatus returns false for active statuses", () => {
+    expect(isTerminalIssueStatus("todo")).toBe(false)
+    expect(isTerminalIssueStatus("in_progress")).toBe(false)
+    expect(isTerminalIssueStatus("review")).toBe(false)
+  })
+})
+
+describe("MeetingStatus", () => {
+  it("has expected status values", () => {
+    expect(MeetingStatus.PENDING).toBe("pending")
+    expect(MeetingStatus.SCHEDULED).toBe("scheduled")
+    expect(MeetingStatus.JOINING).toBe("joining")
+    expect(MeetingStatus.RECORDING).toBe("recording")
+    expect(MeetingStatus.COMPLETED).toBe("completed")
+    expect(MeetingStatus.FAILED).toBe("failed")
+  })
+
+  it("TERMINAL_MEETING_STATUSES contains only completed and failed", () => {
+    expect(TERMINAL_MEETING_STATUSES).toHaveLength(2)
+    expect(TERMINAL_MEETING_STATUSES).toContain("completed")
+    expect(TERMINAL_MEETING_STATUSES).toContain("failed")
   })
 })

--- a/src/shared/test/lib/mime.test.ts
+++ b/src/shared/test/lib/mime.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractAttachmentMeta,
+  filterDownloadableAttachments,
+  buildMimeMessage,
+} from "../../src/lib/mime";
+
+describe("extractAttachmentMeta", () => {
+  it("returns empty array for no attachments", () => {
+    expect(extractAttachmentMeta([])).toEqual([]);
+  });
+
+  it("extracts meta for disposition=attachment", () => {
+    const result = extractAttachmentMeta([
+      {
+        disposition: "attachment",
+        filename: "report.pdf",
+        mimeType: "application/pdf",
+        content: "aGVsbG8=",
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        key: "inline:0",
+        filename: "report.pdf",
+        size: 8,
+        contentType: "application/pdf",
+      },
+    ]);
+  });
+
+  it("extracts meta when filename is present even without disposition", () => {
+    const result = extractAttachmentMeta([
+      {
+        disposition: null,
+        filename: "image.png",
+        mimeType: "image/png",
+        content: new ArrayBuffer(1024),
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        key: "inline:0",
+        filename: "image.png",
+        size: 1024,
+        contentType: "image/png",
+      },
+    ]);
+  });
+
+  it("filters out inline attachments without filename", () => {
+    const result = extractAttachmentMeta([
+      { disposition: "inline", filename: null, mimeType: "text/plain", content: "hello" },
+    ]);
+    expect(result).toEqual([]);
+  });
+
+  it("uses fallback filename when filename is null but disposition is attachment", () => {
+    const result = extractAttachmentMeta([
+      { disposition: "attachment", filename: null, mimeType: "text/plain", content: "data" },
+    ]);
+    expect(result[0].filename).toBe("attachment-0");
+  });
+
+  it("uses fallback contentType when mimeType is empty", () => {
+    const result = extractAttachmentMeta([
+      { disposition: "attachment", filename: "file.bin", mimeType: "", content: "x" },
+    ]);
+    expect(result[0].contentType).toBe("application/octet-stream");
+  });
+
+  it("handles Uint8Array content size as 0 (no byteLength on content check)", () => {
+    const content = new Uint8Array([1, 2, 3]);
+    const result = extractAttachmentMeta([
+      { disposition: "attachment", filename: "data.bin", mimeType: "application/octet-stream", content },
+    ]);
+    // Uint8Array is not ArrayBuffer and not string, so size = 0
+    expect(result[0].size).toBe(0);
+  });
+
+  it("handles multiple attachments with sequential indices after filtering", () => {
+    const result = extractAttachmentMeta([
+      { disposition: "attachment", filename: "a.txt", mimeType: "text/plain", content: "aaa" },
+      { disposition: "inline", filename: null, mimeType: "text/html", content: "<p>hi</p>" },
+      { disposition: "attachment", filename: "b.txt", mimeType: "text/plain", content: "bb" },
+    ]);
+    expect(result).toHaveLength(2);
+    // After filter, map uses post-filter indices
+    expect(result[0].key).toBe("inline:0");
+    expect(result[0].filename).toBe("a.txt");
+    expect(result[1].key).toBe("inline:1");
+    expect(result[1].filename).toBe("b.txt");
+  });
+});
+
+describe("filterDownloadableAttachments", () => {
+  it("returns empty array for empty input", () => {
+    expect(filterDownloadableAttachments([])).toEqual([]);
+  });
+
+  it("includes attachments with disposition=attachment", () => {
+    const atts = [
+      { disposition: "attachment", filename: null },
+      { disposition: "inline", filename: null },
+    ];
+    const result = filterDownloadableAttachments(atts);
+    expect(result).toHaveLength(1);
+    expect(result[0].disposition).toBe("attachment");
+  });
+
+  it("includes attachments with a filename regardless of disposition", () => {
+    const atts = [
+      { disposition: "inline", filename: "image.png" },
+      { disposition: null, filename: null },
+    ];
+    const result = filterDownloadableAttachments(atts);
+    expect(result).toHaveLength(1);
+    expect(result[0].filename).toBe("image.png");
+  });
+
+  it("preserves original object references", () => {
+    const original = { disposition: "attachment" as const, filename: "f.txt", extra: 42 };
+    const result = filterDownloadableAttachments([original]);
+    expect(result[0]).toBe(original);
+  });
+});
+
+describe("buildMimeMessage", () => {
+  it("builds a simple text/html message without attachments", () => {
+    const msg = buildMimeMessage({
+      from: "sender@example.com",
+      to: "recipient@example.com",
+      subject: "Hello",
+      date: "Mon, 01 Jan 2026 00:00:00 GMT",
+      body: "<p>Hi there</p>",
+    });
+    expect(msg).toContain("From: sender@example.com");
+    expect(msg).toContain("To: recipient@example.com");
+    expect(msg).toContain("Subject: Hello");
+    expect(msg).toContain("Date: Mon, 01 Jan 2026 00:00:00 GMT");
+    expect(msg).toContain("MIME-Version: 1.0");
+    expect(msg).toContain("Content-Type: text/html; charset=utf-8");
+    expect(msg).toContain("<p>Hi there</p>");
+    expect(msg).not.toContain("boundary");
+  });
+
+  it("builds a text/plain message when bodyType is specified", () => {
+    const msg = buildMimeMessage({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "Plain",
+      date: "Mon, 01 Jan 2026 00:00:00 GMT",
+      body: "Hello plain",
+      bodyType: "text/plain",
+    });
+    expect(msg).toContain("Content-Type: text/plain; charset=utf-8");
+  });
+
+  it("includes threading headers when provided", () => {
+    const msg = buildMimeMessage({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "Re: Thread",
+      date: "Mon, 01 Jan 2026 00:00:00 GMT",
+      body: "reply",
+      messageId: "<msg-123@example.com>",
+      inReplyTo: "<msg-122@example.com>",
+      references: "<msg-121@example.com> <msg-122@example.com>",
+    });
+    expect(msg).toContain("Message-ID: <msg-123@example.com>");
+    expect(msg).toContain("In-Reply-To: <msg-122@example.com>");
+    expect(msg).toContain("References: <msg-121@example.com> <msg-122@example.com>");
+  });
+
+  it("builds multipart/mixed message with attachments", () => {
+    const msg = buildMimeMessage({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "With attachment",
+      date: "Mon, 01 Jan 2026 00:00:00 GMT",
+      body: "<p>See attached</p>",
+      attachments: [
+        {
+          filename: "doc.pdf",
+          contentType: "application/pdf",
+          base64: "SGVsbG8gV29ybGQ=",
+        },
+      ],
+    });
+    expect(msg).toContain("Content-Type: multipart/mixed; boundary=");
+    expect(msg).toContain('Content-Disposition: attachment; filename="doc.pdf"');
+    expect(msg).toContain("Content-Transfer-Encoding: base64");
+    expect(msg).toContain("SGVsbG8gV29ybGQ=");
+  });
+
+  it("wraps long base64 content at 76 characters", () => {
+    const longBase64 = "A".repeat(200);
+    const msg = buildMimeMessage({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "Long",
+      date: "Mon, 01 Jan 2026 00:00:00 GMT",
+      body: "body",
+      attachments: [{ filename: "big.bin", contentType: "application/octet-stream", base64: longBase64 }],
+    });
+    const lines = msg.split("\r\n");
+    const base64Lines = lines.filter(l => /^A+$/.test(l));
+    expect(base64Lines.length).toBeGreaterThan(1);
+    expect(base64Lines[0].length).toBe(76);
+  });
+
+  it("includes multiple attachments", () => {
+    const msg = buildMimeMessage({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "Multi",
+      date: "Mon, 01 Jan 2026 00:00:00 GMT",
+      body: "body",
+      attachments: [
+        { filename: "a.txt", contentType: "text/plain", base64: "YQ==" },
+        { filename: "b.txt", contentType: "text/plain", base64: "Yg==" },
+      ],
+    });
+    expect(msg).toContain('filename="a.txt"');
+    expect(msg).toContain('filename="b.txt"');
+    // Should end with boundary terminator
+    expect(msg).toMatch(/--.*--$/);
+  });
+});

--- a/src/shared/test/queries/agent-access.test.ts
+++ b/src/shared/test/queries/agent-access.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import * as agentAccessQueries from "../../src/db/queries/agent-access";
+
+function createMockDb(rows: any[]) {
+  const chain: any = {};
+  chain.select = vi.fn(() => chain);
+  chain.from = vi.fn(() => chain);
+  chain.innerJoin = vi.fn(() => chain);
+  chain.where = vi.fn(() => Promise.resolve(rows));
+  chain.insert = vi.fn(() => chain);
+  chain.values = vi.fn(() => chain);
+  chain.returning = vi.fn(() => Promise.resolve(rows));
+  chain.delete = vi.fn(() => chain);
+  return chain;
+}
+
+describe("agent-access query module exports", () => {
+  it("exports listAgentAccess", () => {
+    expect(typeof agentAccessQueries.listAgentAccess).toBe("function");
+  });
+
+  it("exports grantAgentAccess", () => {
+    expect(typeof agentAccessQueries.grantAgentAccess).toBe("function");
+  });
+
+  it("exports revokeAgentAccess", () => {
+    expect(typeof agentAccessQueries.revokeAgentAccess).toBe("function");
+  });
+
+  it("exports hasAgentAccess", () => {
+    expect(typeof agentAccessQueries.hasAgentAccess).toBe("function");
+  });
+
+  it("exports getAllAgentAccessForWorkspace", () => {
+    expect(typeof agentAccessQueries.getAllAgentAccessForWorkspace).toBe("function");
+  });
+});
+
+describe("hasAgentAccess", () => {
+  it("returns true when access row exists", async () => {
+    const mockDb = createMockDb([{ id: "aa_1" }]);
+    const result = await agentAccessQueries.hasAgentAccess(mockDb, "ag_1", "ws_1", "usr_1");
+    expect(result).toBe(true);
+  });
+
+  it("returns false when no access row exists", async () => {
+    const mockDb = createMockDb([]);
+    const result = await agentAccessQueries.hasAgentAccess(mockDb, "ag_1", "ws_1", "usr_1");
+    expect(result).toBe(false);
+  });
+});
+
+describe("revokeAgentAccess", () => {
+  it("returns null when no row deleted", async () => {
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([]));
+    const result = await agentAccessQueries.revokeAgentAccess(chain, "ag_1", "ws_1", "usr_1");
+    expect(result).toBeNull();
+  });
+});

--- a/src/shared/test/queries/agent-skill.test.ts
+++ b/src/shared/test/queries/agent-skill.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import * as agentSkillQueries from "../../src/db/queries/agent-skill";
+
+function createMockDb(rows: any[]) {
+  const chain: any = {};
+  chain.select = vi.fn(() => chain);
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => Promise.resolve(rows));
+  return chain;
+}
 
 describe("agent-skill query module exports", () => {
   it("exports syncGlobalSkills", () => {
@@ -22,5 +30,37 @@ describe("agent-skill query function signatures", () => {
   });
   it("getSkills accepts (db, agentId, runtime, workspaceId)", () => {
     expect(agentSkillQueries.getSkills.length).toBe(4);
+  });
+});
+
+describe("getSkills", () => {
+  it("returns empty array when no skills found", async () => {
+    const mockDb = createMockDb([]);
+    const result = await agentSkillQueries.getSkills(mockDb, "ag_1", "local", "ws_1");
+    expect(result).toEqual([]);
+  });
+
+  it("returns skills and deduplicates global skills by name", async () => {
+    const rows = [
+      { name: "code-review", description: "Reviews code", isGlobal: true },
+      { name: "code-review", description: "Reviews code (dup)", isGlobal: true },
+      { name: "deploy", description: "Deploys apps", isGlobal: false },
+    ];
+    const mockDb = createMockDb(rows);
+    const result = await agentSkillQueries.getSkills(mockDb, "ag_1", "local", "ws_1");
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("code-review");
+    expect(result[0].description).toBe("Reviews code");
+    expect(result[1].name).toBe("deploy");
+  });
+
+  it("does not deduplicate across global and agent scopes", async () => {
+    const rows = [
+      { name: "review", description: "Global review", isGlobal: true },
+      { name: "review", description: "Agent review", isGlobal: false },
+    ];
+    const mockDb = createMockDb(rows);
+    const result = await agentSkillQueries.getSkills(mockDb, "ag_1", "local", "ws_1");
+    expect(result).toHaveLength(2);
   });
 });

--- a/src/shared/test/queries/artifact.test.ts
+++ b/src/shared/test/queries/artifact.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from "vitest";
+import * as artifactQueries from "../../src/db/queries/artifact";
+
+function createMockDb(rows: any[]) {
+  const chain: any = {};
+  chain.select = vi.fn(() => chain);
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.limit = vi.fn(() => Promise.resolve(rows));
+  chain.insert = vi.fn(() => chain);
+  chain.values = vi.fn(() => chain);
+  chain.returning = vi.fn(() => Promise.resolve(rows));
+  return chain;
+}
+
+describe("artifact query module exports", () => {
+  it("exports createArtifact", () => {
+    expect(typeof artifactQueries.createArtifact).toBe("function");
+  });
+
+  it("exports listArtifactsByConversation", () => {
+    expect(typeof artifactQueries.listArtifactsByConversation).toBe("function");
+  });
+
+  it("exports getArtifact", () => {
+    expect(typeof artifactQueries.getArtifact).toBe("function");
+  });
+
+  it("exports artifactToResponse", () => {
+    expect(typeof artifactQueries.artifactToResponse).toBe("function");
+  });
+});
+
+describe("artifactToResponse", () => {
+  it("maps DB row to API response shape", () => {
+    const row = {
+      id: "art_123",
+      conversationId: "conv_456",
+      agentId: "ag_789",
+      workspaceId: "ws_001",
+      filename: "report.pdf",
+      contentType: "application/pdf",
+      size: 2048,
+      r2Key: "uploads/report.pdf",
+      source: "upload",
+      createdAt: "2026-01-15T10:00:00.000Z",
+    };
+
+    const result = artifactQueries.artifactToResponse(row as any);
+
+    expect(result).toEqual({
+      id: "art_123",
+      conversation_id: "conv_456",
+      agent_id: "ag_789",
+      filename: "report.pdf",
+      content_type: "application/pdf",
+      size: 2048,
+      source: "upload",
+      created_at: "2026-01-15T10:00:00.000Z",
+    });
+  });
+
+  it("excludes internal fields like r2Key and workspaceId", () => {
+    const row = {
+      id: "art_1",
+      conversationId: "conv_1",
+      agentId: "ag_1",
+      workspaceId: "ws_1",
+      filename: "file.txt",
+      contentType: "text/plain",
+      size: 100,
+      r2Key: "secret/key",
+      source: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    };
+
+    const result = artifactQueries.artifactToResponse(row as any);
+
+    expect(result).not.toHaveProperty("r2Key");
+    expect(result).not.toHaveProperty("workspace_id");
+    expect(result).not.toHaveProperty("workspaceId");
+  });
+
+  it("handles null source", () => {
+    const row = {
+      id: "art_1",
+      conversationId: "conv_1",
+      agentId: "ag_1",
+      workspaceId: "ws_1",
+      filename: "file.txt",
+      contentType: "text/plain",
+      size: 0,
+      r2Key: "key",
+      source: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    };
+
+    const result = artifactQueries.artifactToResponse(row as any);
+    expect(result.source).toBeNull();
+  });
+});
+
+describe("getArtifact", () => {
+  it("returns null when no artifact found", async () => {
+    const mockDb = createMockDb([]);
+    mockDb.limit = vi.fn(() => Promise.resolve([]));
+    mockDb.where = vi.fn(() => Promise.resolve([]));
+    const result = await artifactQueries.getArtifact(mockDb, "art_missing", "ws_1");
+    expect(result).toBeNull();
+  });
+});

--- a/src/shared/test/queries/calendar-event.test.ts
+++ b/src/shared/test/queries/calendar-event.test.ts
@@ -219,6 +219,44 @@ describe("computeNextScheduledAt", () => {
   });
 });
 
+describe("getOccurrencesPerDay", () => {
+  it("returns 1 for daily interval", () => {
+    expect(calendarQueries.getOccurrencesPerDay("1day")).toBe(1);
+  });
+
+  it("returns 1 for weekly interval", () => {
+    expect(calendarQueries.getOccurrencesPerDay("1week")).toBe(1);
+  });
+
+  it("returns 1 for monthly interval", () => {
+    expect(calendarQueries.getOccurrencesPerDay("1month")).toBe(1);
+  });
+
+  it("returns 24 for hourly interval", () => {
+    expect(calendarQueries.getOccurrencesPerDay("1hour")).toBe(24);
+  });
+
+  it("returns 12 for 2-hour interval", () => {
+    expect(calendarQueries.getOccurrencesPerDay("2hour")).toBe(12);
+  });
+
+  it("returns 48 for 30-minute interval", () => {
+    expect(calendarQueries.getOccurrencesPerDay("30min")).toBe(48);
+  });
+
+  it("returns 96 for 15-minute interval", () => {
+    expect(calendarQueries.getOccurrencesPerDay("15min")).toBe(96);
+  });
+
+  it("returns 1 for invalid format", () => {
+    expect(calendarQueries.getOccurrencesPerDay("invalid")).toBe(1);
+  });
+
+  it("returns 1 for 0-amount (division guard)", () => {
+    expect(calendarQueries.getOccurrencesPerDay("0min")).toBe(1);
+  });
+});
+
 describe("expandOccurrences", () => {
   it("returns one entry per occurrence within [from, to] for a daily event", () => {
     const out = calendarQueries.expandOccurrences(

--- a/src/shared/test/queries/conversation-map.test.ts
+++ b/src/shared/test/queries/conversation-map.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+import * as conversationMapQueries from "../../src/db/queries/conversation-map";
+
+function createMockDb(rows: any[]) {
+  const chain: any = {};
+  chain.select = vi.fn(() => chain);
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => Promise.resolve(rows));
+  chain.insert = vi.fn(() => chain);
+  chain.values = vi.fn(() => chain);
+  chain.onConflictDoNothing = vi.fn(() => Promise.resolve());
+  return chain;
+}
+
+describe("conversation-map query module exports", () => {
+  it("exports findByKey", () => {
+    expect(typeof conversationMapQueries.findByKey).toBe("function");
+  });
+
+  it("exports createMapping", () => {
+    expect(typeof conversationMapQueries.createMapping).toBe("function");
+  });
+});
+
+describe("findByKey", () => {
+  it("returns conversationId when mapping exists", async () => {
+    const mockDb = createMockDb([{ conversationId: "conv_123" }]);
+    const result = await conversationMapQueries.findByKey(mockDb, "email:ag_1:thread", "ws_1");
+    expect(result).toBe("conv_123");
+    expect(mockDb.select).toHaveBeenCalledOnce();
+    expect(mockDb.from).toHaveBeenCalledOnce();
+    expect(mockDb.where).toHaveBeenCalledOnce();
+    expect(mockDb.limit).toHaveBeenCalledWith(1);
+  });
+
+  it("returns null when no mapping exists", async () => {
+    const mockDb = createMockDb([]);
+    const result = await conversationMapQueries.findByKey(mockDb, "email:ag_1:unknown", "ws_1");
+    expect(result).toBeNull();
+  });
+});

--- a/src/shared/test/queries/conversation.test.ts
+++ b/src/shared/test/queries/conversation.test.ts
@@ -1,5 +1,23 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import * as conversationQueries from "../../src/db/queries/conversation";
+
+function createMockDb(rows: any[]) {
+  const chain: any = {};
+  chain.select = vi.fn(() => chain);
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => Promise.resolve(rows));
+  chain.orderBy = vi.fn(() => chain);
+  chain.limit = vi.fn(() => Promise.resolve(rows));
+  chain.insert = vi.fn(() => chain);
+  chain.values = vi.fn(() => chain);
+  chain.returning = vi.fn(() => Promise.resolve(rows));
+  chain.update = vi.fn(() => chain);
+  chain.set = vi.fn(() => chain);
+  chain.delete = vi.fn(() => chain);
+  chain.leftJoin = vi.fn(() => chain);
+  chain.groupBy = vi.fn(() => chain);
+  return chain;
+}
 
 describe("conversation query module exports", () => {
   it("exports createConversation", () => {
@@ -10,12 +28,20 @@ describe("conversation query module exports", () => {
     expect(typeof conversationQueries.getConversation).toBe("function");
   });
 
+  it("exports getConversationsByIds", () => {
+    expect(typeof conversationQueries.getConversationsByIds).toBe("function");
+  });
+
   it("exports listConversations", () => {
     expect(typeof conversationQueries.listConversations).toBe("function");
   });
 
   it("exports listConversationsByAgent", () => {
     expect(typeof conversationQueries.listConversationsByAgent).toBe("function");
+  });
+
+  it("exports updateConversationTitle", () => {
+    expect(typeof conversationQueries.updateConversationTitle).toBe("function");
   });
 
   it("exports getOrCreateAgentConversation", () => {
@@ -28,6 +54,10 @@ describe("conversation query module exports", () => {
 
   it("exports listPreviousConversations", () => {
     expect(typeof conversationQueries.listPreviousConversations).toBe("function");
+  });
+
+  it("exports hasPreviousConversations", () => {
+    expect(typeof conversationQueries.hasPreviousConversations).toBe("function");
   });
 });
 
@@ -46,5 +76,72 @@ describe("conversation query function signatures (with optional channel param)",
 
   it("listPreviousConversations accepts at least 5 params (db, workspaceId, userId, agentId, excludeId)", () => {
     expect(conversationQueries.listPreviousConversations.length).toBeGreaterThanOrEqual(5);
+  });
+});
+
+describe("getConversationsByIds", () => {
+  it("returns empty array for empty ids without querying DB", async () => {
+    const result = await conversationQueries.getConversationsByIds(null as any, [], "ws_1");
+    expect(result).toEqual([]);
+  });
+});
+
+describe("getConversation", () => {
+  it("returns null when not found", async () => {
+    const mockDb = createMockDb([]);
+    const result = await conversationQueries.getConversation(mockDb, "conv_missing", "ws_1");
+    expect(result).toBeNull();
+  });
+
+  it("returns conversation when found", async () => {
+    const conv = { id: "conv_1", title: "Test" };
+    const mockDb = createMockDb([conv]);
+    const result = await conversationQueries.getConversation(mockDb, "conv_1", "ws_1");
+    expect(result).toEqual(conv);
+  });
+});
+
+describe("updateConversationTitle", () => {
+  it("returns null when no row updated", async () => {
+    const chain: any = {};
+    chain.update = vi.fn(() => chain);
+    chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([]));
+    const result = await conversationQueries.updateConversationTitle(chain, "conv_1", "New Title");
+    expect(result).toBeNull();
+  });
+});
+
+describe("deleteConversation", () => {
+  it("returns null when conversation does not exist", async () => {
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([]));
+    const result = await conversationQueries.deleteConversation(chain, "conv_missing", "ws_1");
+    expect(result).toBeNull();
+  });
+});
+
+describe("hasPreviousConversations", () => {
+  it("returns true when previous conversations exist", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain);
+    chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.limit = vi.fn(() => Promise.resolve([{ exists: 1 }]));
+    const result = await conversationQueries.hasPreviousConversations(chain, "ws_1", "usr_1", "ag_1", "conv_current");
+    expect(result).toBe(true);
+  });
+
+  it("returns false when no previous conversations exist", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain);
+    chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.limit = vi.fn(() => Promise.resolve([]));
+    const result = await conversationQueries.hasPreviousConversations(chain, "ws_1", "usr_1", "ag_1", "conv_current");
+    expect(result).toBe(false);
   });
 });

--- a/src/shared/test/queries/email.test.ts
+++ b/src/shared/test/queries/email.test.ts
@@ -1,5 +1,22 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import * as emailQueries from "../../src/db/queries/email";
+
+function createMockDb(rows: any[]) {
+  const chain: any = {};
+  chain.select = vi.fn(() => chain);
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => Promise.resolve(rows));
+  chain.orderBy = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.offset = vi.fn(() => Promise.resolve(rows));
+  chain.insert = vi.fn(() => chain);
+  chain.values = vi.fn(() => chain);
+  chain.returning = vi.fn(() => Promise.resolve(rows));
+  chain.update = vi.fn(() => chain);
+  chain.set = vi.fn(() => chain);
+  chain.delete = vi.fn(() => chain);
+  return chain;
+}
 
 describe("email query module exports", () => {
   it("exports getInboxEmails", () => {
@@ -61,5 +78,52 @@ describe("email query function signatures", () => {
   it("updateEmailStatus has correct arity", () => {
     // (db, id, workspaceId, status)
     expect(emailQueries.updateEmailStatus.length).toBe(4);
+  });
+});
+
+describe("getEmailById", () => {
+  it("returns null when email not found", async () => {
+    const mockDb = createMockDb([]);
+    const result = await emailQueries.getEmailById(mockDb, "em_missing", "ws_1");
+    expect(result).toBeNull();
+  });
+
+  it("returns email when found", async () => {
+    const email = { id: "em_1", subject: "Hello" };
+    const mockDb = createMockDb([email]);
+    const result = await emailQueries.getEmailById(mockDb, "em_1", "ws_1");
+    expect(result).toEqual(email);
+  });
+});
+
+describe("getEmailByMessageId", () => {
+  it("returns null for empty messageId without querying DB", async () => {
+    const result = await emailQueries.getEmailByMessageId(null as any, "", "ws_1");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no email matches", async () => {
+    const mockDb = createMockDb([]);
+    const result = await emailQueries.getEmailByMessageId(mockDb, "<msg@test.com>", "ws_1");
+    expect(result).toBeNull();
+  });
+
+  it("returns email when messageId matches", async () => {
+    const email = { id: "em_1", messageId: "<msg@test.com>" };
+    const mockDb = createMockDb([email]);
+    const result = await emailQueries.getEmailByMessageId(mockDb, "<msg@test.com>", "ws_1");
+    expect(result).toEqual(email);
+  });
+});
+
+describe("updateEmailStatus", () => {
+  it("returns null when email not found for update", async () => {
+    const chain: any = {};
+    chain.update = vi.fn(() => chain);
+    chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([]));
+    const result = await emailQueries.updateEmailStatus(chain, "em_missing", "ws_1", "read");
+    expect(result).toBeNull();
   });
 });

--- a/src/shared/test/queries/issue-comment.test.ts
+++ b/src/shared/test/queries/issue-comment.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import * as issueCommentQueries from "../../src/db/queries/issue-comment";
+
+describe("issue-comment query module exports", () => {
+  it("exports createComment", () => {
+    expect(typeof issueCommentQueries.createComment).toBe("function");
+  });
+
+  it("exports listComments", () => {
+    expect(typeof issueCommentQueries.listComments).toBe("function");
+  });
+
+  it("exports deleteComment", () => {
+    expect(typeof issueCommentQueries.deleteComment).toBe("function");
+  });
+
+  it("exports commentToResponse", () => {
+    expect(typeof issueCommentQueries.commentToResponse).toBe("function");
+  });
+});
+
+describe("commentToResponse", () => {
+  it("maps DB row to API response shape with snake_case keys", () => {
+    const row = {
+      id: "ic_001",
+      issueId: "iss_123",
+      workspaceId: "ws_456",
+      authorType: "agent",
+      authorId: "ag_789",
+      content: "This looks good!",
+      createdAt: "2026-03-10T14:30:00.000Z",
+    };
+
+    const result = issueCommentQueries.commentToResponse(row as any);
+
+    expect(result).toEqual({
+      id: "ic_001",
+      issue_id: "iss_123",
+      workspace_id: "ws_456",
+      author_type: "agent",
+      author_id: "ag_789",
+      content: "This looks good!",
+      created_at: "2026-03-10T14:30:00.000Z",
+    });
+  });
+
+  it("preserves user author type", () => {
+    const row = {
+      id: "ic_002",
+      issueId: "iss_100",
+      workspaceId: "ws_1",
+      authorType: "user",
+      authorId: "usr_1",
+      content: "Fixed in latest commit",
+      createdAt: "2026-04-01T09:00:00.000Z",
+    };
+
+    const result = issueCommentQueries.commentToResponse(row as any);
+    expect(result.author_type).toBe("user");
+  });
+});

--- a/src/shared/test/queries/meeting-session.test.ts
+++ b/src/shared/test/queries/meeting-session.test.ts
@@ -1,5 +1,19 @@
-import { describe, it, expect } from "vitest"
+import { describe, it, expect, vi } from "vitest"
 import * as meetingQueries from "../../src/db/queries/meeting-session"
+
+function createMockDb(rows: any[]) {
+  const chain: any = {}
+  chain.select = vi.fn(() => chain)
+  chain.from = vi.fn(() => chain)
+  chain.where = vi.fn(() => Promise.resolve(rows))
+  chain.orderBy = vi.fn(() => chain)
+  chain.update = vi.fn(() => chain)
+  chain.set = vi.fn(() => chain)
+  chain.returning = vi.fn(() => Promise.resolve(rows))
+  chain.delete = vi.fn(() => chain)
+  chain.leftJoin = vi.fn(() => chain)
+  return chain
+}
 
 describe("meeting-session query module exports", () => {
   it("exports createMeetingSession", () => {
@@ -54,5 +68,70 @@ describe("meeting-session query function signatures", () => {
 
   it("deleteMeetingSession accepts (db, id, workspaceId)", () => {
     expect(meetingQueries.deleteMeetingSession.length).toBe(3)
+  })
+})
+
+describe("getMeetingSession", () => {
+  it("returns null when meeting not found", async () => {
+    const mockDb = createMockDb([])
+    const result = await meetingQueries.getMeetingSession(mockDb, "ms_missing", "ws_1")
+    expect(result).toBeNull()
+  })
+
+  it("returns meeting when found", async () => {
+    const meeting = { id: "ms_1", title: "Standup", status: "scheduled" }
+    const mockDb = createMockDb([meeting])
+    const result = await meetingQueries.getMeetingSession(mockDb, "ms_1", "ws_1")
+    expect(result).toEqual(meeting)
+  })
+})
+
+describe("getMeetingSessionById", () => {
+  it("returns null when meeting not found", async () => {
+    const mockDb = createMockDb([])
+    const result = await meetingQueries.getMeetingSessionById(mockDb, "ms_missing")
+    expect(result).toBeNull()
+  })
+})
+
+describe("updateMeetingSession", () => {
+  it("returns null when no row updated", async () => {
+    const chain: any = {}
+    chain.update = vi.fn(() => chain)
+    chain.set = vi.fn(() => chain)
+    chain.where = vi.fn(() => chain)
+    chain.returning = vi.fn(() => Promise.resolve([]))
+    const result = await meetingQueries.updateMeetingSession(chain, "ms_1", "ws_1", { title: "New" })
+    expect(result).toBeNull()
+  })
+})
+
+describe("claimMeetingSession", () => {
+  it("returns null when session not in scheduled state", async () => {
+    const chain: any = {}
+    chain.update = vi.fn(() => chain)
+    chain.set = vi.fn(() => chain)
+    chain.where = vi.fn(() => chain)
+    chain.returning = vi.fn(() => Promise.resolve([]))
+    const result = await meetingQueries.claimMeetingSession(chain, "ms_1", "ws_1", "2026-01-01T00:00:00Z")
+    expect(result).toBeNull()
+  })
+})
+
+describe("claimMeetingSessions", () => {
+  it("returns empty array for empty ids", async () => {
+    const result = await meetingQueries.claimMeetingSessions(null as any, [], "ws_1", "2026-01-01T00:00:00Z")
+    expect(result).toEqual([])
+  })
+})
+
+describe("deleteMeetingSession", () => {
+  it("returns null when session not found", async () => {
+    const chain: any = {}
+    chain.delete = vi.fn(() => chain)
+    chain.where = vi.fn(() => chain)
+    chain.returning = vi.fn(() => Promise.resolve([]))
+    const result = await meetingQueries.deleteMeetingSession(chain, "ms_missing", "ws_1")
+    expect(result).toBeNull()
   })
 })

--- a/src/shared/test/queries/message.test.ts
+++ b/src/shared/test/queries/message.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi } from "vitest";
+import * as messageQueries from "../../src/db/queries/message";
+
+function createMockDb(rows: any[]) {
+  const chain: any = {};
+  chain.select = vi.fn(() => chain);
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.limit = vi.fn(() => Promise.resolve(rows));
+  chain.insert = vi.fn(() => chain);
+  chain.values = vi.fn(() => chain);
+  chain.returning = vi.fn(() => Promise.resolve(rows));
+  chain.update = vi.fn(() => chain);
+  chain.set = vi.fn(() => chain);
+  chain.delete = vi.fn(() => chain);
+  return chain;
+}
+
+describe("message query module exports", () => {
+  it("exports createMessage", () => {
+    expect(typeof messageQueries.createMessage).toBe("function");
+  });
+
+  it("exports getNewestMessageId", () => {
+    expect(typeof messageQueries.getNewestMessageId).toBe("function");
+  });
+
+  it("exports getActiveMessageCount", () => {
+    expect(typeof messageQueries.getActiveMessageCount).toBe("function");
+  });
+
+  it("exports listMessages", () => {
+    expect(typeof messageQueries.listMessages).toBe("function");
+  });
+
+  it("exports getMessage", () => {
+    expect(typeof messageQueries.getMessage).toBe("function");
+  });
+
+  it("exports createBufferedMessage", () => {
+    expect(typeof messageQueries.createBufferedMessage).toBe("function");
+  });
+
+  it("exports listBufferedMessages", () => {
+    expect(typeof messageQueries.listBufferedMessages).toBe("function");
+  });
+
+  it("exports activateNextBufferedMessage", () => {
+    expect(typeof messageQueries.activateNextBufferedMessage).toBe("function");
+  });
+
+  it("exports revertToBuffered", () => {
+    expect(typeof messageQueries.revertToBuffered).toBe("function");
+  });
+
+  it("exports deleteBufferedMessage", () => {
+    expect(typeof messageQueries.deleteBufferedMessage).toBe("function");
+  });
+
+  it("exports deleteAllBufferedMessages", () => {
+    expect(typeof messageQueries.deleteAllBufferedMessages).toBe("function");
+  });
+
+  it("exports countBufferedMessages", () => {
+    expect(typeof messageQueries.countBufferedMessages).toBe("function");
+  });
+
+  it("exports updateMessageTaskId", () => {
+    expect(typeof messageQueries.updateMessageTaskId).toBe("function");
+  });
+
+  it("exports listMessagesAroundTask", () => {
+    expect(typeof messageQueries.listMessagesAroundTask).toBe("function");
+  });
+});
+
+describe("getNewestMessageId", () => {
+  it("returns message id when messages exist", async () => {
+    const mockDb = createMockDb([{ id: "msg_latest" }]);
+    const result = await messageQueries.getNewestMessageId(mockDb, "conv_1");
+    expect(result).toBe("msg_latest");
+  });
+
+  it("returns null when no messages exist", async () => {
+    const mockDb = createMockDb([]);
+    const result = await messageQueries.getNewestMessageId(mockDb, "conv_empty");
+    expect(result).toBeNull();
+  });
+});
+
+describe("getActiveMessageCount", () => {
+  it("returns count from query result", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain);
+    chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([{ cnt: 42 }]));
+    const result = await messageQueries.getActiveMessageCount(chain, "conv_1");
+    expect(result).toBe(42);
+  });
+
+  it("returns 0 when no rows returned", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain);
+    chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([]));
+    const result = await messageQueries.getActiveMessageCount(chain, "conv_empty");
+    expect(result).toBe(0);
+  });
+});
+
+describe("getMessage", () => {
+  it("returns null when message not found", async () => {
+    const mockDb = createMockDb([]);
+    mockDb.where = vi.fn(() => Promise.resolve([]));
+    const result = await messageQueries.getMessage(mockDb, "msg_missing");
+    expect(result).toBeNull();
+  });
+
+  it("returns message when found", async () => {
+    const msg = { id: "msg_1", content: "hello", role: "user" };
+    const mockDb = createMockDb([msg]);
+    mockDb.where = vi.fn(() => Promise.resolve([msg]));
+    const result = await messageQueries.getMessage(mockDb, "msg_1");
+    expect(result).toEqual(msg);
+  });
+});
+
+describe("countBufferedMessages", () => {
+  it("returns count value", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain);
+    chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([{ count: 5 }]));
+    const result = await messageQueries.countBufferedMessages(chain, "conv_1");
+    expect(result).toBe(5);
+  });
+
+  it("returns 0 when no results", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain);
+    chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([]));
+    const result = await messageQueries.countBufferedMessages(chain, "conv_1");
+    expect(result).toBe(0);
+  });
+});

--- a/src/shared/test/queries/overview.test.ts
+++ b/src/shared/test/queries/overview.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import * as overviewQueries from "../../src/db/queries/overview";
+
+describe("overview query module exports", () => {
+  it("exports getEmailStatsByWorkspace", () => {
+    expect(typeof overviewQueries.getEmailStatsByWorkspace).toBe("function");
+  });
+
+  it("exports getEmailAccountsByWorkspace", () => {
+    expect(typeof overviewQueries.getEmailAccountsByWorkspace).toBe("function");
+  });
+
+  it("exports getTaskStatsByWorkspace", () => {
+    expect(typeof overviewQueries.getTaskStatsByWorkspace).toBe("function");
+  });
+
+  it("exports getRecentTerminalTasks", () => {
+    expect(typeof overviewQueries.getRecentTerminalTasks).toBe("function");
+  });
+
+  it("exports getConversationCountsByAgent", () => {
+    expect(typeof overviewQueries.getConversationCountsByAgent).toBe("function");
+  });
+});
+
+describe("getRecentTerminalTasks", () => {
+  it("returns empty array for empty visibleAgentIds without querying DB", async () => {
+    const result = await overviewQueries.getRecentTerminalTasks(null as any, "ws_1", []);
+    expect(result).toEqual([]);
+  });
+});
+
+describe("getConversationCountsByAgent", () => {
+  it("returns empty array for empty visibleAgentIds without querying DB", async () => {
+    const result = await overviewQueries.getConversationCountsByAgent(null as any, "ws_1", []);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/shared/test/queries/task.test.ts
+++ b/src/shared/test/queries/task.test.ts
@@ -1,5 +1,23 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import * as taskQueries from "../../src/db/queries/task";
+
+function createMockDb(rows: any[]) {
+  const chain: any = {};
+  chain.select = vi.fn(() => chain);
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.limit = vi.fn(() => Promise.resolve(rows));
+  chain.insert = vi.fn(() => chain);
+  chain.values = vi.fn(() => chain);
+  chain.returning = vi.fn(() => Promise.resolve(rows));
+  chain.update = vi.fn(() => chain);
+  chain.set = vi.fn(() => chain);
+  chain.delete = vi.fn(() => chain);
+  chain.groupBy = vi.fn(() => chain);
+  chain.leftJoin = vi.fn(() => chain);
+  return chain;
+}
 
 describe("task query module exports", () => {
   it("exports listActiveTaskCountsByWorkspace", () => {
@@ -30,5 +48,130 @@ describe("task query function signatures", () => {
 
   it("listActiveTasksByAgent accepts (db, agentId, workspaceId)", () => {
     expect(taskQueries.listActiveTasksByAgent.length).toBe(3);
+  });
+});
+
+describe("listPendingTasksByRuntimes", () => {
+  it("returns empty array for empty runtimeIds without querying DB", async () => {
+    const result = await taskQueries.listPendingTasksByRuntimes(null as any, [], "ws_1");
+    expect(result).toEqual([]);
+  });
+});
+
+describe("claimKillTasks", () => {
+  it("returns empty array for empty runtimeIds without querying DB", async () => {
+    const result = await taskQueries.claimKillTasks(null as any, [], "ws_1", 10);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array for zero limit without querying DB", async () => {
+    const result = await taskQueries.claimKillTasks(null as any, ["rt_1"], "ws_1", 0);
+    expect(result).toEqual([]);
+  });
+});
+
+describe("countTasksByTrace", () => {
+  it("returns count from query", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain);
+    chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([{ value: 7 }]));
+    const result = await taskQueries.countTasksByTrace(chain, "trace_1");
+    expect(result).toBe(7);
+  });
+
+  it("returns 0 when no results", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain);
+    chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([]));
+    const result = await taskQueries.countTasksByTrace(chain, "trace_empty");
+    expect(result).toBe(0);
+  });
+});
+
+describe("getLatestTaskForConversation", () => {
+  it("returns null when no tasks exist", async () => {
+    const mockDb = createMockDb([]);
+    const result = await taskQueries.getLatestTaskForConversation(mockDb, "conv_empty");
+    expect(result).toBeNull();
+  });
+
+  it("returns latest task when found", async () => {
+    const task = { id: "task_1", traceId: "trace_1" };
+    const mockDb = createMockDb([task]);
+    const result = await taskQueries.getLatestTaskForConversation(mockDb, "conv_1");
+    expect(result).toEqual(task);
+  });
+});
+
+describe("getTask", () => {
+  it("returns null when task not found", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain);
+    chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([]));
+    const result = await taskQueries.getTask(chain, "task_missing");
+    expect(result).toBeNull();
+  });
+
+  it("returns task when found", async () => {
+    const task = { id: "task_1", status: "running" };
+    const chain: any = {};
+    chain.select = vi.fn(() => chain);
+    chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([task]));
+    const result = await taskQueries.getTask(chain, "task_1");
+    expect(result).toEqual(task);
+  });
+});
+
+describe("getTaskStatus", () => {
+  it("returns null when task not found", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain);
+    chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([]));
+    const result = await taskQueries.getTaskStatus(chain, "task_missing");
+    expect(result).toBeNull();
+  });
+
+  it("returns status when found", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain);
+    chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([{ status: "completed" }]));
+    const result = await taskQueries.getTaskStatus(chain, "task_1");
+    expect(result).toBe("completed");
+  });
+});
+
+describe("hasPendingTaskForConversation", () => {
+  it("returns true when pending tasks exist", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain);
+    chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.limit = vi.fn(() => Promise.resolve([{ id: "task_1" }]));
+    const result = await taskQueries.hasPendingTaskForConversation(chain, "conv_1");
+    expect(result).toBe(true);
+  });
+
+  it("returns false when no pending tasks", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain);
+    chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.limit = vi.fn(() => Promise.resolve([]));
+    const result = await taskQueries.hasPendingTaskForConversation(chain, "conv_empty");
+    expect(result).toBe(false);
+  });
+});
+
+describe("getTraceAgentsByTaskIds", () => {
+  it("returns empty map for empty taskIds", async () => {
+    const result = await taskQueries.getTraceAgentsByTaskIds(null as any, [], "ws_1");
+    expect(result).toBeInstanceOf(Map);
+    expect(result.size).toBe(0);
   });
 });

--- a/src/shared/test/queries/whitelist.test.ts
+++ b/src/shared/test/queries/whitelist.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+import * as whitelistQueries from "../../src/db/queries/whitelist";
+
+function createMockDb(rows: any[]) {
+  const chain: any = {};
+  chain.select = vi.fn(() => chain);
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => Promise.resolve(rows));
+  chain.insert = vi.fn(() => chain);
+  chain.values = vi.fn(() => chain);
+  chain.onConflictDoNothing = vi.fn(() => chain);
+  chain.returning = vi.fn(() => Promise.resolve(rows));
+  chain.delete = vi.fn(() => chain);
+  return chain;
+}
+
+describe("whitelist query module exports", () => {
+  it("exports getWhitelist", () => {
+    expect(typeof whitelistQueries.getWhitelist).toBe("function");
+  });
+
+  it("exports addWhitelist", () => {
+    expect(typeof whitelistQueries.addWhitelist).toBe("function");
+  });
+
+  it("exports removeWhitelist", () => {
+    expect(typeof whitelistQueries.removeWhitelist).toBe("function");
+  });
+
+  it("exports removeWhitelistByEmail", () => {
+    expect(typeof whitelistQueries.removeWhitelistByEmail).toBe("function");
+  });
+
+  it("exports isWhitelisted", () => {
+    expect(typeof whitelistQueries.isWhitelisted).toBe("function");
+  });
+
+  it("exports buildWhitelistSet", () => {
+    expect(typeof whitelistQueries.buildWhitelistSet).toBe("function");
+  });
+});
+
+describe("addWhitelist", () => {
+  it("returns null when insert conflicts (no row returned)", async () => {
+    const mockDb = createMockDb([]);
+    mockDb.returning = vi.fn(() => Promise.resolve([]));
+    const result = await whitelistQueries.addWhitelist(mockDb, "ag_1", "ws_1", "user@example.com");
+    expect(result).toBeNull();
+  });
+});
+
+describe("removeWhitelist", () => {
+  it("returns null when no row deleted", async () => {
+    const mockDb = createMockDb([]);
+    mockDb.returning = vi.fn(() => Promise.resolve([]));
+    const result = await whitelistQueries.removeWhitelist(mockDb, "wl_1", "ag_1", "ws_1");
+    expect(result).toBeNull();
+  });
+});

--- a/src/shared/test/queries/workspace-file-request.test.ts
+++ b/src/shared/test/queries/workspace-file-request.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest";
+import * as wfrQueries from "../../src/db/queries/workspace-file-request";
+
+function createMockDb(rows: any[]) {
+  const chain: any = {};
+  chain.select = vi.fn(() => chain);
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => Promise.resolve(rows));
+  chain.insert = vi.fn(() => chain);
+  chain.values = vi.fn(() => chain);
+  chain.returning = vi.fn(() => Promise.resolve(rows));
+  chain.update = vi.fn(() => chain);
+  chain.set = vi.fn(() => chain);
+  chain.delete = vi.fn(() => chain);
+  return chain;
+}
+
+describe("workspace-file-request query module exports", () => {
+  it("exports createRequest", () => {
+    expect(typeof wfrQueries.createRequest).toBe("function");
+  });
+
+  it("exports getPendingByWorkspace", () => {
+    expect(typeof wfrQueries.getPendingByWorkspace).toBe("function");
+  });
+
+  it("exports markDispatched", () => {
+    expect(typeof wfrQueries.markDispatched).toBe("function");
+  });
+
+  it("exports completeRequest", () => {
+    expect(typeof wfrQueries.completeRequest).toBe("function");
+  });
+
+  it("exports getRequest", () => {
+    expect(typeof wfrQueries.getRequest).toBe("function");
+  });
+
+  it("exports expireStale", () => {
+    expect(typeof wfrQueries.expireStale).toBe("function");
+  });
+});
+
+describe("markDispatched", () => {
+  it("does nothing for empty ids array (early return)", async () => {
+    await wfrQueries.markDispatched(null as any, []);
+  });
+});
+
+describe("getRequest", () => {
+  it("returns null when request not found", async () => {
+    const mockDb = createMockDb([]);
+    const result = await wfrQueries.getRequest(mockDb, "wfr_missing");
+    expect(result).toBeNull();
+  });
+
+  it("returns request when found", async () => {
+    const row = { id: "wfr_1", status: "pending", path: "/test" };
+    const mockDb = createMockDb([row]);
+    const result = await wfrQueries.getRequest(mockDb, "wfr_1");
+    expect(result).toEqual(row);
+  });
+});
+
+describe("completeRequest", () => {
+  it("returns null when no row updated", async () => {
+    const chain: any = {};
+    chain.update = vi.fn(() => chain);
+    chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([]));
+    const result = await wfrQueries.completeRequest(chain, "wfr_missing", { ok: true });
+    expect(result).toBeNull();
+  });
+});

--- a/src/shared/test/utils/db-errors.test.ts
+++ b/src/shared/test/utils/db-errors.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { isUniqueConstraintError } from "../../src/utils/db-errors";
+
+describe("isUniqueConstraintError", () => {
+  it("returns true for error with SQLITE_CONSTRAINT_UNIQUE code", () => {
+    const err = Object.assign(new Error("constraint failed"), {
+      code: "SQLITE_CONSTRAINT_UNIQUE",
+    });
+    expect(isUniqueConstraintError(err)).toBe(true);
+  });
+
+  it("returns true for error with UNIQUE in message", () => {
+    const err = new Error("UNIQUE constraint failed: table.column");
+    expect(isUniqueConstraintError(err)).toBe(true);
+  });
+
+  it("returns true for DrizzleQueryError wrapping a UNIQUE error as cause", () => {
+    const inner = Object.assign(new Error("constraint"), {
+      code: "SQLITE_CONSTRAINT_UNIQUE",
+    });
+    const outer = Object.assign(new Error("Query failed"), { cause: inner });
+    expect(isUniqueConstraintError(outer)).toBe(true);
+  });
+
+  it("returns true for nested cause chain", () => {
+    const innermost = new Error("UNIQUE constraint failed");
+    const middle = Object.assign(new Error("wrapped"), { cause: innermost });
+    const outer = Object.assign(new Error("top level"), { cause: middle });
+    expect(isUniqueConstraintError(outer)).toBe(true);
+  });
+
+  it("returns false for non-Error values", () => {
+    expect(isUniqueConstraintError(null)).toBe(false);
+    expect(isUniqueConstraintError(undefined)).toBe(false);
+    expect(isUniqueConstraintError("some string")).toBe(false);
+    expect(isUniqueConstraintError(42)).toBe(false);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isUniqueConstraintError(new Error("connection timeout"))).toBe(false);
+    expect(isUniqueConstraintError(new Error("FOREIGN KEY constraint"))).toBe(false);
+  });
+});

--- a/src/shared/test/utils/slug.test.ts
+++ b/src/shared/test/utils/slug.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { generateWorkspaceSlug } from "../../src/utils/slug";
+
+describe("generateWorkspaceSlug", () => {
+  it("starts with 'studio-' prefix", () => {
+    const slug = generateWorkspaceSlug();
+    expect(slug.startsWith("studio-")).toBe(true);
+  });
+
+  it("has correct total length (studio- prefix + 8 char nanoid)", () => {
+    const slug = generateWorkspaceSlug();
+    expect(slug.length).toBe("studio-".length + 8);
+  });
+
+  it("generates unique slugs", () => {
+    const slugs = new Set(Array.from({ length: 100 }, () => generateWorkspaceSlug()));
+    expect(slugs.size).toBe(100);
+  });
+});

--- a/src/web/src/app/api/flags/[messageId]/route.test.ts
+++ b/src/web/src/app/api/flags/[messageId]/route.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
+}));
+
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
+const mockUnflagMessage = vi.fn();
+
+vi.mock("@alook/shared", () => ({
+  createDb: vi.fn(() => ({})),
+  queries: {
+    messageFlag: {
+      unflagMessage: (...args: unknown[]) => mockUnflagMessage(...args),
+    },
+  },
+}));
+
+vi.mock("@/lib/middleware/auth", () => ({
+  withAuth: vi.fn((handler: any) => async (req: any, ctx?: any) => {
+    const params = ctx?.params instanceof Promise ? await ctx.params : ctx?.params;
+    return handler(req, { userId: "u1", email: "u@t.com", params });
+  }),
+}));
+
+vi.mock("@/lib/middleware/workspace", () => ({
+  withWorkspaceMember: vi.fn(async () => ({ workspaceId: "w1", memberRole: "owner" })),
+}));
+
+vi.mock("@/lib/middleware/helpers", () => {
+  const { NextResponse } = require("next/server");
+  return {
+    writeJSON: (data: unknown, status = 200) => NextResponse.json(data, { status }),
+    writeError: (message: string, status: number) => NextResponse.json({ error: message }, { status }),
+  };
+});
+
+import { DELETE } from "./route";
+
+describe("DELETE /api/flags/[messageId]", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 400 when messageId param is missing", async () => {
+    const req = new NextRequest("http://localhost/api/flags/", { method: "DELETE" });
+    const res = await DELETE(req, { params: Promise.resolve({}) } as any);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("unflag message and returns 204", async () => {
+    mockUnflagMessage.mockResolvedValue(undefined);
+
+    const req = new NextRequest("http://localhost/api/flags/m1", { method: "DELETE" });
+    const res = await DELETE(req, { params: Promise.resolve({ messageId: "m1" }) } as any);
+
+    expect(res.status).toBe(204);
+    expect(mockUnflagMessage).toHaveBeenCalledWith({}, "m1", "u1", "w1");
+  });
+});

--- a/src/web/src/app/api/flags/count/route.test.ts
+++ b/src/web/src/app/api/flags/count/route.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
+}));
+
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
+const mockGetFlaggedCount = vi.fn();
+
+vi.mock("@alook/shared", () => ({
+  createDb: vi.fn(() => ({})),
+  queries: {
+    messageFlag: {
+      getFlaggedCount: (...args: unknown[]) => mockGetFlaggedCount(...args),
+    },
+  },
+}));
+
+vi.mock("@/lib/middleware/auth", () => ({
+  withAuth: vi.fn((handler: any) => async (req: any, ctx?: any) => {
+    const params = ctx?.params instanceof Promise ? await ctx.params : ctx?.params;
+    return handler(req, { userId: "u1", email: "u@t.com", params });
+  }),
+}));
+
+vi.mock("@/lib/middleware/workspace", () => ({
+  withWorkspaceMember: vi.fn(async () => ({ workspaceId: "w1", memberRole: "owner" })),
+}));
+
+vi.mock("@/lib/middleware/helpers", () => {
+  const { NextResponse } = require("next/server");
+  return {
+    writeJSON: (data: unknown, status = 200) => NextResponse.json(data, { status }),
+    writeError: (message: string, status: number) => NextResponse.json({ error: message }, { status }),
+  };
+});
+
+import { GET } from "./route";
+
+describe("GET /api/flags/count", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns the flagged message count", async () => {
+    mockGetFlaggedCount.mockResolvedValue(5);
+
+    const req = new NextRequest("http://localhost/api/flags/count");
+    const res = await GET(req, {} as any);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ count: 5 });
+    expect(mockGetFlaggedCount).toHaveBeenCalledWith({}, "u1", "w1");
+  });
+
+  it("returns zero when no flagged messages", async () => {
+    mockGetFlaggedCount.mockResolvedValue(0);
+
+    const req = new NextRequest("http://localhost/api/flags/count");
+    const res = await GET(req, {} as any);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ count: 0 });
+  });
+});

--- a/src/web/src/app/api/flags/route.test.ts
+++ b/src/web/src/app/api/flags/route.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
+}));
+
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
+const mockListFlaggedMessageIds = vi.fn();
+const mockListFlaggedMessages = vi.fn();
+const mockGetMessageWorkspaceId = vi.fn();
+const mockFlagMessage = vi.fn();
+
+vi.mock("@alook/shared", () => ({
+  createDb: vi.fn(() => ({})),
+  queries: {
+    messageFlag: {
+      listFlaggedMessageIds: (...args: unknown[]) => mockListFlaggedMessageIds(...args),
+      listFlaggedMessages: (...args: unknown[]) => mockListFlaggedMessages(...args),
+      getMessageWorkspaceId: (...args: unknown[]) => mockGetMessageWorkspaceId(...args),
+      flagMessage: (...args: unknown[]) => mockFlagMessage(...args),
+    },
+  },
+}));
+
+vi.mock("@/lib/middleware/auth", () => ({
+  withAuth: vi.fn((handler: any) => async (req: any, ctx?: any) => {
+    const params = ctx?.params instanceof Promise ? await ctx.params : ctx?.params;
+    return handler(req, { userId: "u1", email: "u@t.com", params });
+  }),
+}));
+
+vi.mock("@/lib/middleware/workspace", () => ({
+  withWorkspaceMember: vi.fn(async () => ({ workspaceId: "w1", memberRole: "owner" })),
+}));
+
+vi.mock("@/lib/middleware/helpers", () => {
+  const { NextResponse } = require("next/server");
+  return {
+    writeJSON: (data: unknown, status = 200) => NextResponse.json(data, { status }),
+    writeError: (message: string, status: number) => NextResponse.json({ error: message }, { status }),
+  };
+});
+
+import { GET, POST } from "./route";
+
+describe("GET /api/flags", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("ids_only=true", () => {
+    it("returns 400 when conversation_id is missing", async () => {
+      const req = new NextRequest("http://localhost/api/flags?ids_only=true");
+      const res = await GET(req, {} as any);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain("conversation_id");
+    });
+
+    it("returns message_ids when conversation_id is provided", async () => {
+      mockListFlaggedMessageIds.mockResolvedValue(["m1", "m2"]);
+
+      const req = new NextRequest("http://localhost/api/flags?ids_only=true&conversation_id=c1");
+      const res = await GET(req, {} as any);
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ message_ids: ["m1", "m2"] });
+      expect(mockListFlaggedMessageIds).toHaveBeenCalledWith({}, "u1", "w1", "c1");
+    });
+  });
+
+  describe("normal list", () => {
+    it("returns flagged messages with defaults (limit=30, no before)", async () => {
+      mockListFlaggedMessages.mockResolvedValue({ items: [{ id: "m1" }], hasMore: false });
+
+      const req = new NextRequest("http://localhost/api/flags");
+      const res = await GET(req, {} as any);
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ items: [{ id: "m1" }], has_more: false });
+      expect(mockListFlaggedMessages).toHaveBeenCalledWith({}, "u1", "w1", { limit: 30, before: undefined });
+    });
+
+    it("clamps limit to 1-100 range", async () => {
+      mockListFlaggedMessages.mockResolvedValue({ items: [], hasMore: false });
+
+      const req = new NextRequest("http://localhost/api/flags?limit=200");
+      const res = await GET(req, {} as any);
+
+      expect(res.status).toBe(200);
+      expect(mockListFlaggedMessages).toHaveBeenCalledWith({}, "u1", "w1", { limit: 100, before: undefined });
+    });
+
+    it("clamps limit minimum to 1", async () => {
+      mockListFlaggedMessages.mockResolvedValue({ items: [], hasMore: false });
+
+      const req = new NextRequest("http://localhost/api/flags?limit=-5");
+      const res = await GET(req, {} as any);
+
+      expect(res.status).toBe(200);
+      expect(mockListFlaggedMessages).toHaveBeenCalledWith({}, "u1", "w1", { limit: 1, before: undefined });
+    });
+
+    it("passes valid before timestamp", async () => {
+      mockListFlaggedMessages.mockResolvedValue({ items: [], hasMore: false });
+
+      const req = new NextRequest("http://localhost/api/flags?before=2024-01-01T00:00:00Z");
+      const res = await GET(req, {} as any);
+
+      expect(res.status).toBe(200);
+      expect(mockListFlaggedMessages).toHaveBeenCalledWith({}, "u1", "w1", { limit: 30, before: "2024-01-01T00:00:00Z" });
+    });
+
+    it("returns 400 for invalid before timestamp", async () => {
+      const req = new NextRequest("http://localhost/api/flags?before=not-a-date");
+      const res = await GET(req, {} as any);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain("invalid before timestamp");
+    });
+  });
+});
+
+describe("POST /api/flags", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 400 when messageId is missing", async () => {
+    const req = new NextRequest("http://localhost/api/flags", {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await POST(req, {} as any);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("messageId");
+  });
+
+  it("returns 400 when body is not valid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/flags", {
+      method: "POST",
+      body: "not json",
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await POST(req, {} as any);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when message workspace id is null", async () => {
+    mockGetMessageWorkspaceId.mockResolvedValue(null);
+
+    const req = new NextRequest("http://localhost/api/flags", {
+      method: "POST",
+      body: JSON.stringify({ messageId: "m1" }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await POST(req, {} as any);
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "message not found" });
+  });
+
+  it("returns 404 when message belongs to different workspace", async () => {
+    mockGetMessageWorkspaceId.mockResolvedValue("other-workspace");
+
+    const req = new NextRequest("http://localhost/api/flags", {
+      method: "POST",
+      body: JSON.stringify({ messageId: "m1" }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await POST(req, {} as any);
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "message not found" });
+  });
+
+  it("returns 201 when message is newly flagged", async () => {
+    mockGetMessageWorkspaceId.mockResolvedValue("w1");
+    mockFlagMessage.mockResolvedValue({ id: "flag1" });
+
+    const req = new NextRequest("http://localhost/api/flags", {
+      method: "POST",
+      body: JSON.stringify({ messageId: "m1" }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await POST(req, {} as any);
+
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual({ flagged: true });
+    expect(mockFlagMessage).toHaveBeenCalledWith({}, { messageId: "m1", userId: "u1", workspaceId: "w1" });
+  });
+
+  it("returns 200 when message is already flagged", async () => {
+    mockGetMessageWorkspaceId.mockResolvedValue("w1");
+    mockFlagMessage.mockResolvedValue(null);
+
+    const req = new NextRequest("http://localhost/api/flags", {
+      method: "POST",
+      body: JSON.stringify({ messageId: "m1" }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await POST(req, {} as any);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ flagged: true });
+  });
+});

--- a/src/web/src/app/api/inbox/count/route.test.ts
+++ b/src/web/src/app/api/inbox/count/route.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetUnreadCount = vi.fn();
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
+}));
+
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
+vi.mock("@alook/shared", () => ({
+  createDb: vi.fn(() => ({})),
+  queries: {
+    inbox: {
+      getUnreadCount: (...args: unknown[]) => mockGetUnreadCount(...args),
+    },
+  },
+}));
+
+vi.mock("@/lib/middleware/auth", () => ({
+  withAuth: vi.fn((handler: any) => async (req: any, ctx?: any) => {
+    const params = ctx?.params instanceof Promise ? await ctx.params : ctx?.params;
+    return handler(req, { userId: "u1", email: "u@t.com", params });
+  }),
+}));
+
+vi.mock("@/lib/middleware/workspace", () => ({
+  withWorkspaceMember: vi.fn(async () => ({ workspaceId: "w1", memberRole: "owner" })),
+}));
+
+vi.mock("@/lib/middleware/helpers", () => {
+  const { NextResponse } = require("next/server");
+  return {
+    writeJSON: (data: unknown, status = 200) => NextResponse.json(data, { status }),
+    writeError: (message: string, status: number) => NextResponse.json({ error: message }, { status }),
+  };
+});
+
+vi.mock("@/lib/cache", () => ({
+  cached: vi.fn((_key: string, _ttl: number, fn: () => any) => fn()),
+  cacheKeys: { inboxCount: vi.fn(() => "test-key") },
+}));
+
+import { GET } from "./route";
+
+describe("GET /api/inbox/count", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns unread count with default types", async () => {
+    mockGetUnreadCount.mockResolvedValue(5);
+
+    const res = await GET(new NextRequest("http://localhost/api/inbox/count"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ count: 5 });
+    expect(mockGetUnreadCount).toHaveBeenCalledWith({}, "u1", "w1", ["user_dm_message"]);
+  });
+
+  it("filters types param by valid types", async () => {
+    mockGetUnreadCount.mockResolvedValue(2);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/inbox/count?types=calendar_event,email_notification")
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ count: 2 });
+    expect(mockGetUnreadCount).toHaveBeenCalledWith(
+      {},
+      "u1",
+      "w1",
+      ["calendar_event", "email_notification"]
+    );
+  });
+
+  it("defaults to user_dm_message when all types are invalid", async () => {
+    mockGetUnreadCount.mockResolvedValue(0);
+
+    await GET(new NextRequest("http://localhost/api/inbox/count?types=bogus"));
+
+    expect(mockGetUnreadCount).toHaveBeenCalledWith({}, "u1", "w1", ["user_dm_message"]);
+  });
+
+  it("returns count 0 when no unread items", async () => {
+    mockGetUnreadCount.mockResolvedValue(0);
+
+    const res = await GET(new NextRequest("http://localhost/api/inbox/count"));
+    const body = await res.json();
+
+    expect(body).toEqual({ count: 0 });
+  });
+
+  it("uses cached wrapper with correct key and ttl", async () => {
+    mockGetUnreadCount.mockResolvedValue(3);
+    const { cached, cacheKeys } = await import("@/lib/cache");
+
+    await GET(new NextRequest("http://localhost/api/inbox/count"));
+
+    expect(cacheKeys.inboxCount).toHaveBeenCalledWith("u1", "w1", ["user_dm_message"]);
+    expect(cached).toHaveBeenCalledWith("test-key", 60, expect.any(Function));
+  });
+});

--- a/src/web/src/app/api/inbox/read-all/route.test.ts
+++ b/src/web/src/app/api/inbox/read-all/route.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockMarkAllConversationsRead = vi.fn();
+const mockInvalidateInboxCounts = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
+}));
+
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
+vi.mock("@alook/shared", () => ({
+  createDb: vi.fn(() => ({})),
+  queries: {
+    inbox: {
+      markAllConversationsRead: (...args: unknown[]) => mockMarkAllConversationsRead(...args),
+    },
+  },
+}));
+
+vi.mock("@/lib/middleware/auth", () => ({
+  withAuth: vi.fn((handler: any) => async (req: any, ctx?: any) => {
+    const params = ctx?.params instanceof Promise ? await ctx.params : ctx?.params;
+    return handler(req, { userId: "u1", email: "u@t.com", params });
+  }),
+}));
+
+vi.mock("@/lib/middleware/workspace", () => ({
+  withWorkspaceMember: vi.fn(async () => ({ workspaceId: "w1", memberRole: "owner" })),
+}));
+
+vi.mock("@/lib/cache", () => ({
+  invalidateInboxCounts: (...args: unknown[]) => mockInvalidateInboxCounts(...args),
+}));
+
+import { POST } from "./route";
+
+describe("POST /api/inbox/read-all", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("marks all conversations read and returns 204", async () => {
+    mockMarkAllConversationsRead.mockResolvedValue(undefined);
+
+    const res = await POST(
+      new NextRequest("http://localhost/api/inbox/read-all", { method: "POST" })
+    );
+
+    expect(res.status).toBe(204);
+    expect(mockMarkAllConversationsRead).toHaveBeenCalledWith({}, "u1", "w1");
+    expect(mockInvalidateInboxCounts).toHaveBeenCalledWith("u1", "w1");
+  });
+
+  it("does not fail if invalidateInboxCounts rejects", async () => {
+    mockMarkAllConversationsRead.mockResolvedValue(undefined);
+    mockInvalidateInboxCounts.mockRejectedValue(new Error("cache error"));
+
+    const res = await POST(
+      new NextRequest("http://localhost/api/inbox/read-all", { method: "POST" })
+    );
+
+    expect(res.status).toBe(204);
+    expect(mockMarkAllConversationsRead).toHaveBeenCalledWith({}, "u1", "w1");
+  });
+
+  it("calls markAllConversationsRead with correct workspace and user", async () => {
+    mockMarkAllConversationsRead.mockResolvedValue(undefined);
+
+    await POST(new NextRequest("http://localhost/api/inbox/read-all", { method: "POST" }));
+
+    expect(mockMarkAllConversationsRead).toHaveBeenCalledTimes(1);
+    expect(mockMarkAllConversationsRead).toHaveBeenCalledWith({}, "u1", "w1");
+  });
+});

--- a/src/web/src/app/api/inbox/read/route.test.ts
+++ b/src/web/src/app/api/inbox/read/route.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetConversation = vi.fn();
+const mockMarkConversationRead = vi.fn();
+const mockInvalidateInboxCounts = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
+}));
+
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
+vi.mock("@alook/shared", () => ({
+  createDb: vi.fn(() => ({})),
+  queries: {
+    conversation: {
+      getConversation: (...args: unknown[]) => mockGetConversation(...args),
+    },
+    inbox: {
+      markConversationRead: (...args: unknown[]) => mockMarkConversationRead(...args),
+    },
+  },
+}));
+
+vi.mock("@/lib/middleware/auth", () => ({
+  withAuth: vi.fn((handler: any) => async (req: any, ctx?: any) => {
+    const params = ctx?.params instanceof Promise ? await ctx.params : ctx?.params;
+    return handler(req, { userId: "u1", email: "u@t.com", params });
+  }),
+}));
+
+vi.mock("@/lib/middleware/workspace", () => ({
+  withWorkspaceMember: vi.fn(async () => ({ workspaceId: "w1", memberRole: "owner" })),
+}));
+
+vi.mock("@/lib/cache", () => ({
+  invalidateInboxCounts: (...args: unknown[]) => mockInvalidateInboxCounts(...args),
+}));
+
+import { POST } from "./route";
+
+describe("POST /api/inbox/read", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function makeRequest(body?: string) {
+    return new NextRequest("http://localhost/api/inbox/read", {
+      method: "POST",
+      body,
+      headers: body !== undefined ? { "Content-Type": "application/json" } : {},
+    });
+  }
+
+  it("returns 400 for invalid JSON body", async () => {
+    const res = await POST(makeRequest("not-json"));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("invalid JSON body");
+  });
+
+  it("returns 400 when conversationId is missing", async () => {
+    const res = await POST(makeRequest(JSON.stringify({})));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("conversationId is required");
+  });
+
+  it("returns 400 when conversationId is empty string", async () => {
+    const res = await POST(makeRequest(JSON.stringify({ conversationId: "" })));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("conversationId is required");
+  });
+
+  it("returns 404 when conversation not found", async () => {
+    mockGetConversation.mockResolvedValue(null);
+
+    const res = await POST(makeRequest(JSON.stringify({ conversationId: "c1" })));
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe("conversation not found");
+    expect(mockGetConversation).toHaveBeenCalledWith({}, "c1", "w1");
+  });
+
+  it("returns 404 when conversation belongs to different user", async () => {
+    mockGetConversation.mockResolvedValue({ id: "c1", userId: "other-user" });
+
+    const res = await POST(makeRequest(JSON.stringify({ conversationId: "c1" })));
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe("conversation not found");
+  });
+
+  it("marks conversation as read and returns 204", async () => {
+    mockGetConversation.mockResolvedValue({ id: "c1", userId: "u1" });
+    mockMarkConversationRead.mockResolvedValue(undefined);
+
+    const res = await POST(makeRequest(JSON.stringify({ conversationId: "c1" })));
+
+    expect(res.status).toBe(204);
+    expect(mockMarkConversationRead).toHaveBeenCalledWith({}, "u1", "c1");
+    expect(mockInvalidateInboxCounts).toHaveBeenCalledWith("u1", "w1");
+  });
+
+  it("does not fail if invalidateInboxCounts rejects", async () => {
+    mockGetConversation.mockResolvedValue({ id: "c1", userId: "u1" });
+    mockMarkConversationRead.mockResolvedValue(undefined);
+    mockInvalidateInboxCounts.mockRejectedValue(new Error("cache error"));
+
+    const res = await POST(makeRequest(JSON.stringify({ conversationId: "c1" })));
+
+    expect(res.status).toBe(204);
+  });
+});

--- a/src/web/src/app/api/inbox/route.test.ts
+++ b/src/web/src/app/api/inbox/route.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockListUnreadConversations = vi.fn();
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
+}));
+
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
+vi.mock("@alook/shared", () => ({
+  createDb: vi.fn(() => ({})),
+  queries: {
+    inbox: {
+      listUnreadConversations: (...args: unknown[]) => mockListUnreadConversations(...args),
+    },
+  },
+}));
+
+vi.mock("@/lib/middleware/auth", () => ({
+  withAuth: vi.fn((handler: any) => async (req: any, ctx?: any) => {
+    const params = ctx?.params instanceof Promise ? await ctx.params : ctx?.params;
+    return handler(req, { userId: "u1", email: "u@t.com", params });
+  }),
+}));
+
+vi.mock("@/lib/middleware/workspace", () => ({
+  withWorkspaceMember: vi.fn(async () => ({ workspaceId: "w1", memberRole: "owner" })),
+}));
+
+vi.mock("@/lib/middleware/helpers", () => {
+  const { NextResponse } = require("next/server");
+  return {
+    writeJSON: (data: unknown, status = 200) => NextResponse.json(data, { status }),
+    writeError: (message: string, status: number) => NextResponse.json({ error: message }, { status }),
+  };
+});
+
+import { GET } from "./route";
+
+describe("GET /api/inbox", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns items and has_more with default limit", async () => {
+    mockListUnreadConversations.mockResolvedValue({ items: [{ id: "c1" }], hasMore: false });
+
+    const res = await GET(new NextRequest("http://localhost/api/inbox"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ items: [{ id: "c1" }], has_more: false });
+    expect(mockListUnreadConversations).toHaveBeenCalledWith(
+      {},
+      "u1",
+      "w1",
+      { limit: 30, before: undefined, types: ["user_dm_message"] }
+    );
+  });
+
+  it("clamps limit to minimum 1", async () => {
+    mockListUnreadConversations.mockResolvedValue({ items: [], hasMore: false });
+
+    await GET(new NextRequest("http://localhost/api/inbox?limit=-5"));
+
+    expect(mockListUnreadConversations).toHaveBeenCalledWith(
+      {},
+      "u1",
+      "w1",
+      expect.objectContaining({ limit: 1 })
+    );
+  });
+
+  it("clamps limit to maximum 100", async () => {
+    mockListUnreadConversations.mockResolvedValue({ items: [], hasMore: false });
+
+    await GET(new NextRequest("http://localhost/api/inbox?limit=999"));
+
+    expect(mockListUnreadConversations).toHaveBeenCalledWith(
+      {},
+      "u1",
+      "w1",
+      expect.objectContaining({ limit: 100 })
+    );
+  });
+
+  it("passes valid before timestamp", async () => {
+    mockListUnreadConversations.mockResolvedValue({ items: [], hasMore: false });
+
+    await GET(new NextRequest("http://localhost/api/inbox?before=2026-01-01T00:00:00Z"));
+
+    expect(mockListUnreadConversations).toHaveBeenCalledWith(
+      {},
+      "u1",
+      "w1",
+      expect.objectContaining({ before: "2026-01-01T00:00:00Z" })
+    );
+  });
+
+  it("returns 400 for invalid before timestamp", async () => {
+    const res = await GET(new NextRequest("http://localhost/api/inbox?before=not-a-date"));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("invalid before timestamp");
+    expect(mockListUnreadConversations).not.toHaveBeenCalled();
+  });
+
+  it("filters types param by valid types", async () => {
+    mockListUnreadConversations.mockResolvedValue({ items: [], hasMore: false });
+
+    await GET(new NextRequest("http://localhost/api/inbox?types=calendar_event,email_notification"));
+
+    expect(mockListUnreadConversations).toHaveBeenCalledWith(
+      {},
+      "u1",
+      "w1",
+      expect.objectContaining({ types: ["calendar_event", "email_notification"] })
+    );
+  });
+
+  it("ignores invalid types and defaults to user_dm_message", async () => {
+    mockListUnreadConversations.mockResolvedValue({ items: [], hasMore: false });
+
+    await GET(new NextRequest("http://localhost/api/inbox?types=bogus,invalid"));
+
+    expect(mockListUnreadConversations).toHaveBeenCalledWith(
+      {},
+      "u1",
+      "w1",
+      expect.objectContaining({ types: ["user_dm_message"] })
+    );
+  });
+
+  it("defaults to user_dm_message when no types param", async () => {
+    mockListUnreadConversations.mockResolvedValue({ items: [], hasMore: false });
+
+    await GET(new NextRequest("http://localhost/api/inbox"));
+
+    expect(mockListUnreadConversations).toHaveBeenCalledWith(
+      {},
+      "u1",
+      "w1",
+      expect.objectContaining({ types: ["user_dm_message"] })
+    );
+  });
+
+  it("returns has_more true when there are more items", async () => {
+    mockListUnreadConversations.mockResolvedValue({ items: [{ id: "c1" }], hasMore: true });
+
+    const res = await GET(new NextRequest("http://localhost/api/inbox?limit=1"));
+    const body = await res.json();
+
+    expect(body.has_more).toBe(true);
+  });
+});

--- a/src/web/src/app/api/issues/[id]/comments/route.test.ts
+++ b/src/web/src/app/api/issues/[id]/comments/route.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetIssue = vi.fn();
+const mockUpdateIssue = vi.fn();
+const mockSetLatestTask = vi.fn();
+const mockListComments = vi.fn();
+const mockCreateComment = vi.fn();
+const mockCommentToResponse = vi.fn((c: any) => ({
+  id: c.id,
+  content: c.content,
+  author_type: c.authorType,
+  author_id: c.authorId,
+  created_at: c.createdAt ?? "2026-01-01T00:00:00Z",
+}));
+const mockGetActiveTaskByConversation = vi.fn();
+const mockGetTask = vi.fn();
+const mockCreateTask = vi.fn();
+const mockGetAgent = vi.fn();
+const mockEnqueueTask = vi.fn();
+const mockBroadcastToUser = vi.fn().mockResolvedValue(undefined);
+const mockInvalidate = vi.fn().mockResolvedValue(undefined);
+const mockIsTerminalIssueStatus = vi.fn(() => false);
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
+}));
+
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
+vi.mock("@alook/shared", () => ({
+  CreateIssueCommentBodySchema: { parse: vi.fn((data: any) => data) },
+  TASK_TYPES: { ISSUE_EVENT: "issue_event" },
+  isTerminalIssueStatus: (...args: unknown[]) => mockIsTerminalIssueStatus(...args),
+  queries: {
+    issue: {
+      getIssue: (...a: unknown[]) => mockGetIssue(...a),
+      updateIssue: (...a: unknown[]) => mockUpdateIssue(...a),
+      setLatestTask: (...a: unknown[]) => mockSetLatestTask(...a),
+    },
+    issueComment: {
+      listComments: (...a: unknown[]) => mockListComments(...a),
+      createComment: (...a: unknown[]) => mockCreateComment(...a),
+      commentToResponse: (...a: unknown[]) => mockCommentToResponse(...a),
+    },
+    task: {
+      getActiveTaskByConversation: (...a: unknown[]) => mockGetActiveTaskByConversation(...a),
+      getTask: (...a: unknown[]) => mockGetTask(...a),
+      createTask: (...a: unknown[]) => mockCreateTask(...a),
+    },
+    agent: {
+      getAgent: (...a: unknown[]) => mockGetAgent(...a),
+    },
+  },
+}));
+
+vi.mock("@/lib/middleware/auth", () => ({
+  withAuth: vi.fn((handler: any) => async (req: any, ctx?: any) => {
+    const params = ctx?.params instanceof Promise ? await ctx.params : ctx?.params;
+    return handler(req, { userId: "u1", email: "u@t.com", params });
+  }),
+}));
+
+vi.mock("@/lib/middleware/workspace", () => ({
+  withWorkspaceMember: vi.fn(async () => ({ workspaceId: "w1", memberRole: "owner" })),
+}));
+
+vi.mock("@/lib/middleware/helpers", () => {
+  const { NextResponse } = require("next/server");
+  return {
+    writeJSON: (data: unknown, status = 200) => NextResponse.json(data, { status }),
+    writeError: (message: string, status: number) => NextResponse.json({ error: message }, { status }),
+    parseBody: vi.fn(async (req: any) => {
+      const body = await req.json();
+      return [body, null];
+    }),
+  };
+});
+
+vi.mock("@/lib/broadcast", () => ({
+  broadcastToUser: (...a: unknown[]) => mockBroadcastToUser(...a),
+}));
+
+vi.mock("@/lib/services/task", () => ({
+  TaskService: class {
+    enqueueTask(...args: any[]) {
+      return mockEnqueueTask(...args);
+    }
+  },
+}));
+
+vi.mock("@/lib/cache", () => ({
+  invalidate: (...a: unknown[]) => mockInvalidate(...a),
+  cacheKeys: { overviewTaskStats: vi.fn(() => "test-key") },
+}));
+
+import { GET, POST } from "./route";
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("GET /api/issues/[id]/comments", () => {
+  it("returns 400 when id is missing", async () => {
+    const req = new NextRequest("http://localhost/api/issues//comments");
+    const res = await GET(req, { params: {} } as any);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "issue id is required" });
+  });
+
+  it("returns 404 when issue not found", async () => {
+    mockGetIssue.mockResolvedValue(null);
+    const req = new NextRequest("http://localhost/api/issues/iss_1/comments");
+    const res = await GET(req, { params: { id: "iss_1" } } as any);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "issue not found" });
+  });
+
+  it("returns comments for the issue", async () => {
+    mockGetIssue.mockResolvedValue({ id: "iss_1", status: "todo" });
+    mockListComments.mockResolvedValue([
+      { id: "c1", content: "Hello", authorType: "user", authorId: "u1", createdAt: "2026-01-01T00:00:00Z" },
+      { id: "c2", content: "World", authorType: "agent", authorId: "a1", createdAt: "2026-01-01T01:00:00Z" },
+    ]);
+
+    const req = new NextRequest("http://localhost/api/issues/iss_1/comments");
+    const res = await GET(req, { params: { id: "iss_1" } } as any);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.comments).toHaveLength(2);
+    expect(body.comments[0]).toEqual({ id: "c1", content: "Hello", author_type: "user", author_id: "u1", created_at: "2026-01-01T00:00:00Z" });
+    expect(mockListComments).toHaveBeenCalledWith({}, "iss_1", "w1");
+  });
+});
+
+describe("POST /api/issues/[id]/comments", () => {
+  it("returns 400 when id is missing", async () => {
+    const req = new NextRequest("http://localhost/api/issues//comments", {
+      method: "POST",
+      body: JSON.stringify({ content: "test" }),
+    });
+    const res = await POST(req, { params: {} } as any);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "issue id is required" });
+  });
+
+  it("returns 404 when issue not found", async () => {
+    mockGetIssue.mockResolvedValue(null);
+    const req = new NextRequest("http://localhost/api/issues/iss_1/comments", {
+      method: "POST",
+      body: JSON.stringify({ content: "test" }),
+    });
+    const res = await POST(req, { params: { id: "iss_1" } } as any);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "issue not found" });
+  });
+
+  it("returns 403 when agentId does not match issue", async () => {
+    mockGetIssue.mockResolvedValue({ id: "iss_1", agentId: "a1", status: "todo" });
+    const req = new NextRequest("http://localhost/api/issues/iss_1/comments?agentId=a_other", {
+      method: "POST",
+      body: JSON.stringify({ content: "test" }),
+    });
+    const res = await POST(req, { params: { id: "iss_1" } } as any);
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "issue does not belong to agent" });
+  });
+
+  it("creates a user comment without re-dispatch when status is terminal", async () => {
+    mockIsTerminalIssueStatus.mockReturnValue(true);
+    mockGetIssue.mockResolvedValue({
+      id: "iss_1", agentId: "a1", status: "done", conversationId: "conv_1", creatorUserId: "u1",
+    });
+    mockCreateComment.mockResolvedValue({
+      id: "ic_1", issueId: "iss_1", workspaceId: "w1", authorType: "user", authorId: "u1", content: "Nice", createdAt: "2026-01-01T00:00:00Z",
+    });
+    mockUpdateIssue.mockResolvedValue({ id: "iss_1" });
+
+    const req = new NextRequest("http://localhost/api/issues/iss_1/comments", {
+      method: "POST",
+      body: JSON.stringify({ content: "Nice" }),
+    });
+    const res = await POST(req, { params: { id: "iss_1" } } as any);
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.comment).toEqual({ id: "ic_1", content: "Nice", author_type: "user", author_id: "u1", created_at: "2026-01-01T00:00:00Z" });
+    expect(mockCreateComment).toHaveBeenCalledWith({}, expect.objectContaining({ issueId: "iss_1", authorType: "user", authorId: "u1", content: "Nice" }));
+    expect(mockUpdateIssue).toHaveBeenCalledWith({}, "iss_1", "w1", {});
+    expect(mockBroadcastToUser).toHaveBeenCalledWith("u1", expect.objectContaining({ type: "issue.comment", issueId: "iss_1" }));
+    // Should NOT trigger re-dispatch because status is terminal
+    expect(mockGetActiveTaskByConversation).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
+  });
+
+  it("creates a user comment and triggers re-dispatch when non-terminal and no active task", async () => {
+    mockIsTerminalIssueStatus.mockReturnValue(false);
+    mockGetIssue.mockResolvedValue({
+      id: "iss_1", agentId: "a1", status: "in_progress", conversationId: "conv_1", creatorUserId: "u1", latestTaskId: "t_prev", title: "Fix bug",
+    });
+    mockCreateComment.mockResolvedValue({
+      id: "ic_2", issueId: "iss_1", workspaceId: "w1", authorType: "user", authorId: "u1", content: "Please retry", createdAt: "2026-01-02T00:00:00Z",
+    });
+    mockUpdateIssue.mockResolvedValue({ id: "iss_1" });
+    mockGetActiveTaskByConversation.mockResolvedValue(null);
+    mockGetTask.mockResolvedValue({ id: "t_prev", traceId: "trace_1" });
+    mockEnqueueTask.mockResolvedValue({ id: "t_new" });
+    mockSetLatestTask.mockResolvedValue(undefined);
+
+    const req = new NextRequest("http://localhost/api/issues/iss_1/comments", {
+      method: "POST",
+      body: JSON.stringify({ content: "Please retry" }),
+    });
+    const res = await POST(req, { params: { id: "iss_1" } } as any);
+
+    expect(res.status).toBe(201);
+    expect(mockGetActiveTaskByConversation).toHaveBeenCalledWith({}, "conv_1", "w1");
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
+      "a1", "conv_1", "w1",
+      expect.stringContaining("Please retry"),
+      "issue_event",
+      expect.objectContaining({ contextKey: "conv_1", context: { issue_id: "iss_1" }, traceId: "trace_1" }),
+    );
+    expect(mockSetLatestTask).toHaveBeenCalledWith({}, "iss_1", "w1", "t_new");
+    expect(mockInvalidate).toHaveBeenCalled();
+  });
+
+  it("creates an agent comment without re-dispatch", async () => {
+    mockIsTerminalIssueStatus.mockReturnValue(false);
+    mockGetIssue.mockResolvedValue({
+      id: "iss_1", agentId: "a1", status: "in_progress", conversationId: "conv_1", creatorUserId: "u1",
+    });
+    mockCreateComment.mockResolvedValue({
+      id: "ic_3", issueId: "iss_1", workspaceId: "w1", authorType: "agent", authorId: "a1", content: "Working on it", createdAt: "2026-01-03T00:00:00Z",
+    });
+    mockUpdateIssue.mockResolvedValue({ id: "iss_1" });
+
+    const req = new NextRequest("http://localhost/api/issues/iss_1/comments?agentId=a1", {
+      method: "POST",
+      body: JSON.stringify({ content: "Working on it" }),
+    });
+    const res = await POST(req, { params: { id: "iss_1" } } as any);
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.comment.author_type).toBe("agent");
+    expect(body.comment.author_id).toBe("a1");
+    expect(mockCreateComment).toHaveBeenCalledWith({}, expect.objectContaining({ authorType: "agent", authorId: "a1" }));
+    // Agent comments should NOT trigger re-dispatch
+    expect(mockGetActiveTaskByConversation).not.toHaveBeenCalled();
+    expect(mockEnqueueTask).not.toHaveBeenCalled();
+  });
+});

--- a/src/web/src/app/api/traces/[traceId]/route.test.ts
+++ b/src/web/src/app/api/traces/[traceId]/route.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetTraceTree = vi.fn();
+const mockGetConversation = vi.fn();
+const mockGetAllAgentsForWorkspace = vi.fn();
+const mockGetAllAgentAccessForWorkspace = vi.fn();
+
+vi.mock("@/lib/middleware/helpers", () => ({
+  writeJSON: (data: any, status = 200) =>
+    new Response(JSON.stringify(data), {
+      status,
+      headers: { "content-type": "application/json" },
+    }),
+  writeError: (message: string, status: number) =>
+    new Response(JSON.stringify({ error: message }), {
+      status,
+      headers: { "content-type": "application/json" },
+    }),
+}));
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
+}));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+vi.mock("@alook/shared", () => ({
+  queries: {
+    task: {
+      getTraceTree: (...args: any[]) => mockGetTraceTree(...args),
+    },
+    conversation: {
+      getConversation: (...args: any[]) => mockGetConversation(...args),
+    },
+    agent: {
+      getAllAgentsForWorkspace: (...args: any[]) => mockGetAllAgentsForWorkspace(...args),
+    },
+    agentAccess: {
+      getAllAgentAccessForWorkspace: (...args: any[]) => mockGetAllAgentAccessForWorkspace(...args),
+    },
+  },
+}));
+vi.mock("@/lib/middleware/auth", () => ({
+  withAuth: vi.fn((handler: any) => async (req: any, ctx?: any) => {
+    const params = ctx?.params instanceof Promise ? await ctx.params : ctx?.params;
+    return handler(req, { userId: "u1", email: "u@t.com", params });
+  }),
+}));
+vi.mock("@/lib/middleware/workspace", () => ({
+  withWorkspaceMember: vi.fn(async () => ({ workspaceId: "w1", memberRole: "owner" })),
+}));
+vi.mock("@/lib/cache", () => ({
+  cached: vi.fn((_key: string, _ttl: number, fn: () => any) => fn()),
+  cacheKeys: {
+    allAgents: (ws: string) => `agents:${ws}`,
+    allAgentAccess: (ws: string) => `aa:${ws}`,
+  },
+}));
+vi.mock("@/lib/agent-visibility", () => ({
+  filterVisibleAgents: vi.fn((agents: any[]) => agents),
+}));
+
+import { GET } from "./route";
+
+describe("GET /api/traces/[traceId]", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 400 for traceId without tr_ prefix", async () => {
+    const res = await GET(
+      new NextRequest("http://localhost/api/traces/invalid123"),
+      { params: Promise.resolve({ traceId: "invalid123" }) },
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("invalid traceId");
+  });
+
+  it("returns 400 for traceId that is too long", async () => {
+    const longId = "tr_" + "a".repeat(28); // length 31 > 30
+    const res = await GET(
+      new NextRequest(`http://localhost/api/traces/${longId}`),
+      { params: Promise.resolve({ traceId: longId }) },
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("invalid traceId");
+  });
+
+  it("returns 400 for missing traceId", async () => {
+    const res = await GET(
+      new NextRequest("http://localhost/api/traces/"),
+      { params: Promise.resolve({}) },
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("invalid traceId");
+  });
+
+  it("returns 404 when trace not found (empty tasks)", async () => {
+    mockGetTraceTree.mockResolvedValue([]);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/traces/tr_abc123"),
+      { params: Promise.resolve({ traceId: "tr_abc123" }) },
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe("trace not found");
+  });
+
+  it("returns trace with tasks and agent mapping", async () => {
+    mockGetTraceTree.mockResolvedValue([
+      {
+        id: "task_1",
+        agentId: "a1",
+        parentTaskId: null,
+        prompt: "Root task",
+        status: "completed",
+        type: "user_dm_message",
+        conversationId: "conv_1",
+        createdAt: "2026-01-01T00:00:00Z",
+        completedAt: "2026-01-01T00:01:00Z",
+      },
+      {
+        id: "task_2",
+        agentId: "a2",
+        parentTaskId: "task_1",
+        prompt: "Sub task",
+        status: "completed",
+        type: "email_notification",
+        conversationId: "conv_1",
+        createdAt: "2026-01-01T00:00:10Z",
+        completedAt: "2026-01-01T00:00:50Z",
+      },
+    ]);
+    mockGetConversation.mockResolvedValue({ channel: "slack" });
+    mockGetAllAgentsForWorkspace.mockResolvedValue([
+      { id: "a1", name: "Agent 1", emailHandle: "agent1", avatarUrl: "https://img/a1.png" },
+      { id: "a2", name: "Agent 2", emailHandle: "agent2", avatarUrl: "https://img/a2.png" },
+    ]);
+    mockGetAllAgentAccessForWorkspace.mockResolvedValue([]);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/traces/tr_abc123"),
+      { params: Promise.resolve({ traceId: "tr_abc123" }) },
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.trace_id).toBe("tr_abc123");
+    expect(body.channel).toBe("slack");
+    expect(body.tasks).toHaveLength(2);
+    expect(body.tasks[0]).toEqual({
+      id: "task_1",
+      agent_id: "a1",
+      agent: { name: "Agent 1", email_handle: "agent1", avatarUrl: "https://img/a1.png" },
+      parent_task_id: null,
+      prompt: "Root task",
+      status: "completed",
+      type: "user_dm_message",
+      conversation_id: "conv_1",
+      created_at: "2026-01-01T00:00:00Z",
+      completed_at: "2026-01-01T00:01:00Z",
+    });
+    expect(body.tasks[1].agent).toEqual({
+      name: "Agent 2",
+      email_handle: "agent2",
+      avatarUrl: "https://img/a2.png",
+    });
+  });
+
+  it("returns default channel when no conversation found", async () => {
+    mockGetTraceTree.mockResolvedValue([
+      {
+        id: "task_1",
+        agentId: "a1",
+        parentTaskId: null,
+        prompt: "Root task",
+        status: "active",
+        type: "user_dm_message",
+        conversationId: "conv_1",
+        createdAt: "2026-01-01T00:00:00Z",
+        completedAt: null,
+      },
+    ]);
+    mockGetConversation.mockResolvedValue(null);
+    mockGetAllAgentsForWorkspace.mockResolvedValue([
+      { id: "a1", name: "Agent 1", emailHandle: "agent1", avatarUrl: null },
+    ]);
+    mockGetAllAgentAccessForWorkspace.mockResolvedValue([]);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/traces/tr_abc123"),
+      { params: Promise.resolve({ traceId: "tr_abc123" }) },
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.channel).toBe("default");
+  });
+
+  it("returns null agent for unknown agentId", async () => {
+    mockGetTraceTree.mockResolvedValue([
+      {
+        id: "task_1",
+        agentId: "unknown_agent",
+        parentTaskId: null,
+        prompt: "Root task",
+        status: "active",
+        type: "user_dm_message",
+        conversationId: "conv_1",
+        createdAt: "2026-01-01T00:00:00Z",
+        completedAt: null,
+      },
+    ]);
+    mockGetConversation.mockResolvedValue({ channel: "default" });
+    mockGetAllAgentsForWorkspace.mockResolvedValue([]);
+    mockGetAllAgentAccessForWorkspace.mockResolvedValue([]);
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/traces/tr_abc123"),
+      { params: Promise.resolve({ traceId: "tr_abc123" }) },
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.tasks[0].agent).toBeNull();
+  });
+});

--- a/src/web/src/app/api/traces/route.test.ts
+++ b/src/web/src/app/api/traces/route.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockListTraces = vi.fn();
+const mockGetAllAgentsForWorkspace = vi.fn();
+const mockGetAllAgentAccessForWorkspace = vi.fn();
+
+vi.mock("@/lib/middleware/helpers", () => ({
+  writeJSON: (data: any, status = 200) =>
+    new Response(JSON.stringify(data), {
+      status,
+      headers: { "content-type": "application/json" },
+    }),
+  writeError: (message: string, status: number) =>
+    new Response(JSON.stringify({ error: message }), {
+      status,
+      headers: { "content-type": "application/json" },
+    }),
+}));
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
+}));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+vi.mock("@alook/shared", () => ({
+  queries: {
+    task: {
+      listTraces: (...args: any[]) => mockListTraces(...args),
+    },
+    agent: {
+      getAllAgentsForWorkspace: (...args: any[]) => mockGetAllAgentsForWorkspace(...args),
+    },
+    agentAccess: {
+      getAllAgentAccessForWorkspace: (...args: any[]) => mockGetAllAgentAccessForWorkspace(...args),
+    },
+  },
+}));
+vi.mock("@/lib/middleware/auth", () => ({
+  withAuth: vi.fn((handler: any) => async (req: any, ctx?: any) => {
+    const params = ctx?.params instanceof Promise ? await ctx.params : ctx?.params;
+    return handler(req, { userId: "u1", email: "u@t.com", params });
+  }),
+}));
+vi.mock("@/lib/middleware/workspace", () => ({
+  withWorkspaceMember: vi.fn(async () => ({ workspaceId: "w1", memberRole: "owner" })),
+}));
+vi.mock("@/lib/cache", () => ({
+  cached: vi.fn((_key: string, _ttl: number, fn: () => any) => fn()),
+  cacheKeys: {
+    allAgents: (ws: string) => `agents:${ws}`,
+    allAgentAccess: (ws: string) => `aa:${ws}`,
+  },
+}));
+vi.mock("@/lib/agent-visibility", () => ({
+  filterVisibleAgents: vi.fn((agents: any[]) => agents),
+}));
+
+import { GET } from "./route";
+
+describe("GET /api/traces", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns traces with agent info mapped", async () => {
+    mockListTraces.mockResolvedValue({
+      traces: [
+        {
+          traceId: "tr_abc",
+          rootPrompt: "Hello",
+          rootAgentId: "a1",
+          helperAgentIds: ["a2"],
+          status: "completed",
+          taskCount: 2,
+          startedAt: "2026-01-01T00:00:00Z",
+          completedAt: "2026-01-01T00:01:00Z",
+          channel: "default",
+        },
+      ],
+      hasMore: false,
+    });
+    mockGetAllAgentsForWorkspace.mockResolvedValue([
+      { id: "a1", name: "Agent 1", avatarUrl: "https://img/a1.png" },
+      { id: "a2", name: "Agent 2", avatarUrl: "https://img/a2.png" },
+    ]);
+    mockGetAllAgentAccessForWorkspace.mockResolvedValue([]);
+
+    const res = await GET(new NextRequest("http://localhost/api/traces"), {});
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.traces).toHaveLength(1);
+    expect(body.traces[0]).toEqual({
+      trace_id: "tr_abc",
+      root_prompt: "Hello",
+      root_agent_id: "a1",
+      root_agent: { name: "Agent 1", avatarUrl: "https://img/a1.png" },
+      helper_agents: [{ id: "a2", name: "Agent 2", avatarUrl: "https://img/a2.png" }],
+      status: "completed",
+      task_count: 2,
+      started_at: "2026-01-01T00:00:00Z",
+      completed_at: "2026-01-01T00:01:00Z",
+      channel: "default",
+    });
+    expect(body.has_more).toBe(false);
+  });
+
+  it("handles unknown agent (returns null for root_agent)", async () => {
+    mockListTraces.mockResolvedValue({
+      traces: [
+        {
+          traceId: "tr_xyz",
+          rootPrompt: "Test",
+          rootAgentId: "unknown_agent",
+          helperAgentIds: [],
+          status: "active",
+          taskCount: 1,
+          startedAt: "2026-01-01T00:00:00Z",
+          completedAt: null,
+          channel: "email",
+        },
+      ],
+      hasMore: false,
+    });
+    mockGetAllAgentsForWorkspace.mockResolvedValue([]);
+    mockGetAllAgentAccessForWorkspace.mockResolvedValue([]);
+
+    const res = await GET(new NextRequest("http://localhost/api/traces"), {});
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.traces[0].root_agent).toBeNull();
+  });
+
+  it("respects status filter", async () => {
+    mockListTraces.mockResolvedValue({ traces: [], hasMore: false });
+    mockGetAllAgentsForWorkspace.mockResolvedValue([]);
+    mockGetAllAgentAccessForWorkspace.mockResolvedValue([]);
+
+    await GET(new NextRequest("http://localhost/api/traces?status=failed"), {});
+
+    expect(mockListTraces).toHaveBeenCalledWith(
+      {},
+      "w1",
+      expect.objectContaining({ status: "failed" }),
+    );
+  });
+
+  it("ignores invalid status filter", async () => {
+    mockListTraces.mockResolvedValue({ traces: [], hasMore: false });
+    mockGetAllAgentsForWorkspace.mockResolvedValue([]);
+    mockGetAllAgentAccessForWorkspace.mockResolvedValue([]);
+
+    await GET(new NextRequest("http://localhost/api/traces?status=invalid"), {});
+
+    expect(mockListTraces).toHaveBeenCalledWith(
+      {},
+      "w1",
+      expect.objectContaining({ status: undefined }),
+    );
+  });
+
+  it("default limit behavior", async () => {
+    mockListTraces.mockResolvedValue({ traces: [], hasMore: false });
+    mockGetAllAgentsForWorkspace.mockResolvedValue([]);
+    mockGetAllAgentAccessForWorkspace.mockResolvedValue([]);
+
+    await GET(new NextRequest("http://localhost/api/traces"), {});
+
+    expect(mockListTraces).toHaveBeenCalledWith(
+      {},
+      "w1",
+      expect.objectContaining({ limit: undefined }),
+    );
+  });
+
+  it("clamps limit to 1-100 range", async () => {
+    mockListTraces.mockResolvedValue({ traces: [], hasMore: false });
+    mockGetAllAgentsForWorkspace.mockResolvedValue([]);
+    mockGetAllAgentAccessForWorkspace.mockResolvedValue([]);
+
+    await GET(new NextRequest("http://localhost/api/traces?limit=200"), {});
+
+    expect(mockListTraces).toHaveBeenCalledWith(
+      {},
+      "w1",
+      expect.objectContaining({ limit: 100 }),
+    );
+  });
+
+  it("multiAgent filter", async () => {
+    mockListTraces.mockResolvedValue({ traces: [], hasMore: false });
+    mockGetAllAgentsForWorkspace.mockResolvedValue([]);
+    mockGetAllAgentAccessForWorkspace.mockResolvedValue([]);
+
+    await GET(new NextRequest("http://localhost/api/traces?multiAgent=true"), {});
+
+    expect(mockListTraces).toHaveBeenCalledWith(
+      {},
+      "w1",
+      expect.objectContaining({ multiAgent: true }),
+    );
+  });
+
+  it("passes agentId and channel filters", async () => {
+    mockListTraces.mockResolvedValue({ traces: [], hasMore: false });
+    mockGetAllAgentsForWorkspace.mockResolvedValue([]);
+    mockGetAllAgentAccessForWorkspace.mockResolvedValue([]);
+
+    await GET(new NextRequest("http://localhost/api/traces?agentId=a1&channel=email"), {});
+
+    expect(mockListTraces).toHaveBeenCalledWith(
+      {},
+      "w1",
+      expect.objectContaining({ agentId: "a1", channel: "email" }),
+    );
+  });
+});


### PR DESCRIPTION
# Why we need this PR?
> Add unit test coverage for 10 Web API routes that previously had 0% coverage.

## What changed
- Added service-level mock tests for `flags/` (GET, POST), `flags/[messageId]` (DELETE), `flags/count` (GET)
- Added service-level mock tests for `inbox/` (GET), `inbox/count` (GET), `inbox/read` (POST), `inbox/read-all` (POST)
- Added service-level mock tests for `traces/` (GET), `traces/[traceId]` (GET)
- Added service-level mock tests for `issues/[id]/comments` (GET, POST)
- 65 new tests across 10 test files covering auth, validation, happy paths, and error paths
- Follows existing patterns from `task.test.ts` / `calendar.test.ts`

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)