### PR TITLE
test(cli,web): add tests for CLI utilities and web service helpers

### DIFF
--- a/src/cli/lib/runtimes.test.ts
+++ b/src/cli/lib/runtimes.test.ts
@@ -1,0 +1,85 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+
+vi.mock("child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+import { execSync } from "child_process";
+import { isCommandAvailable, detectRuntimes } from "./runtimes.js";
+
+const mockedExecSync = vi.mocked(execSync);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("isCommandAvailable", () => {
+  it("returns true when command exists", () => {
+    mockedExecSync.mockReturnValue("");
+    expect(isCommandAvailable("claude")).toBe(true);
+  });
+
+  it("returns false when command does not exist", () => {
+    mockedExecSync.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    expect(isCommandAvailable("nonexistent")).toBe(false);
+  });
+
+  it("uses 'which' on non-windows platforms", () => {
+    mockedExecSync.mockReturnValue("");
+    isCommandAvailable("claude");
+    expect(mockedExecSync).toHaveBeenCalledWith("which claude", { stdio: "ignore" });
+  });
+});
+
+describe("detectRuntimes", () => {
+  it("returns empty array when no runtimes found", () => {
+    mockedExecSync.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    expect(detectRuntimes()).toEqual([]);
+  });
+
+  it("detects available runtimes with versions", () => {
+    mockedExecSync.mockImplementation((cmd: string) => {
+      if (cmd === "which claude") return "";
+      if (cmd === "claude --version") return "1.0.0\n";
+      if (cmd === "which codex") return "";
+      if (cmd === "codex --version") return "2.0.0\n";
+      if (cmd === "which opencode") return "";
+      if (cmd === "opencode --version") return "3.0.0\n";
+      throw new Error("not found");
+    });
+
+    const result = detectRuntimes();
+    expect(result).toEqual([
+      { type: "claude", version: "1.0.0" },
+      { type: "codex", version: "2.0.0" },
+      { type: "opencode", version: "3.0.0" },
+    ]);
+  });
+
+  it("includes runtime with empty version when --version fails", () => {
+    mockedExecSync.mockImplementation((cmd: string) => {
+      if (cmd === "which claude") return "";
+      if (cmd === "claude --version") throw new Error("no version");
+      throw new Error("not found");
+    });
+
+    const result = detectRuntimes();
+    expect(result).toEqual([{ type: "claude", version: "" }]);
+  });
+
+  it("only checks claude, codex, opencode", () => {
+    mockedExecSync.mockImplementation((cmd: string) => {
+      if (cmd === "which claude") return "";
+      if (cmd === "claude --version") return "1.0.0\n";
+      throw new Error("not found");
+    });
+
+    const result = detectRuntimes();
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("claude");
+  });
+});

--- a/src/web/src/lib/errors.test.ts
+++ b/src/web/src/lib/errors.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { ApiError } from "./errors.js";
+
+describe("ApiError", () => {
+  it("creates an error with message and status", () => {
+    const err = new ApiError("not found", 404);
+    expect(err.message).toBe("not found");
+    expect(err.status).toBe(404);
+    expect(err.name).toBe("ApiError");
+  });
+
+  it("stores optional details array", () => {
+    const err = new ApiError("bad request", 400, ["field is required", "name too long"]);
+    expect(err.details).toEqual(["field is required", "name too long"]);
+  });
+
+  it("details is undefined when not provided", () => {
+    const err = new ApiError("server error", 500);
+    expect(err.details).toBeUndefined();
+  });
+
+  it("is an instance of Error", () => {
+    const err = new ApiError("test", 500);
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  describe("isNetworkError", () => {
+    it("returns true for status 0", () => {
+      const err = new ApiError("network", 0);
+      expect(err.isNetworkError).toBe(true);
+    });
+
+    it("returns false for other statuses", () => {
+      expect(new ApiError("", 500).isNetworkError).toBe(false);
+      expect(new ApiError("", 404).isNetworkError).toBe(false);
+    });
+  });
+
+  describe("isRateLimit", () => {
+    it("returns true for status 429", () => {
+      const err = new ApiError("rate limited", 429);
+      expect(err.isRateLimit).toBe(true);
+    });
+
+    it("returns false for other statuses", () => {
+      expect(new ApiError("", 500).isRateLimit).toBe(false);
+      expect(new ApiError("", 400).isRateLimit).toBe(false);
+    });
+  });
+
+  describe("isUnauthorized", () => {
+    it("returns true for status 401", () => {
+      const err = new ApiError("unauthorized", 401);
+      expect(err.isUnauthorized).toBe(true);
+    });
+
+    it("returns false for other statuses", () => {
+      expect(new ApiError("", 403).isUnauthorized).toBe(false);
+      expect(new ApiError("", 200).isUnauthorized).toBe(false);
+    });
+  });
+});

--- a/src/web/src/lib/inbox-filter.test.ts
+++ b/src/web/src/lib/inbox-filter.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  getInboxFilterTypes,
+  setInboxFilterTypes,
+  INBOX_FILTER_TYPES,
+  INBOX_FILTER_LABELS,
+  DEFAULT_INBOX_TYPES,
+  MANDATORY_INBOX_TYPES,
+} from "./inbox-filter.js";
+
+describe("inbox-filter constants", () => {
+  it("INBOX_FILTER_TYPES contains all expected types", () => {
+    expect(INBOX_FILTER_TYPES).toContain("user_dm_message");
+    expect(INBOX_FILTER_TYPES).toContain("calendar_event");
+    expect(INBOX_FILTER_TYPES).toContain("email_notification");
+    expect(INBOX_FILTER_TYPES).toHaveLength(3);
+  });
+
+  it("INBOX_FILTER_LABELS has labels for all types", () => {
+    expect(INBOX_FILTER_LABELS.user_dm_message).toBe("DM");
+    expect(INBOX_FILTER_LABELS.calendar_event).toBe("Calendar");
+    expect(INBOX_FILTER_LABELS.email_notification).toBe("Email");
+  });
+
+  it("DEFAULT_INBOX_TYPES includes user_dm_message", () => {
+    expect(DEFAULT_INBOX_TYPES).toContain("user_dm_message");
+  });
+
+  it("MANDATORY_INBOX_TYPES includes user_dm_message", () => {
+    expect(MANDATORY_INBOX_TYPES).toContain("user_dm_message");
+  });
+});
+
+describe("getInboxFilterTypes", () => {
+  let storage: Record<string, string>;
+
+  beforeEach(() => {
+    storage = {};
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn((key: string) => storage[key] ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        storage[key] = value;
+      }),
+    });
+  });
+
+  it("returns default types when no localStorage value", () => {
+    expect(getInboxFilterTypes()).toEqual(DEFAULT_INBOX_TYPES);
+  });
+
+  it("returns parsed types from localStorage", () => {
+    storage["inbox-filter-types"] = JSON.stringify(["user_dm_message", "calendar_event"]);
+    expect(getInboxFilterTypes()).toEqual(["user_dm_message", "calendar_event"]);
+  });
+
+  it("filters out invalid types", () => {
+    storage["inbox-filter-types"] = JSON.stringify(["user_dm_message", "invalid_type"]);
+    expect(getInboxFilterTypes()).toEqual(["user_dm_message"]);
+  });
+
+  it("returns default when all types invalid", () => {
+    storage["inbox-filter-types"] = JSON.stringify(["invalid1", "invalid2"]);
+    expect(getInboxFilterTypes()).toEqual(DEFAULT_INBOX_TYPES);
+  });
+
+  it("ensures mandatory types are included", () => {
+    storage["inbox-filter-types"] = JSON.stringify(["calendar_event"]);
+    const result = getInboxFilterTypes();
+    expect(result).toContain("user_dm_message");
+    expect(result).toContain("calendar_event");
+  });
+
+  it("returns default on JSON parse error", () => {
+    storage["inbox-filter-types"] = "not-json{{{";
+    expect(getInboxFilterTypes()).toEqual(DEFAULT_INBOX_TYPES);
+  });
+
+  it("returns default when window is undefined", () => {
+    vi.stubGlobal("window", undefined);
+    expect(getInboxFilterTypes()).toEqual(DEFAULT_INBOX_TYPES);
+  });
+});
+
+describe("setInboxFilterTypes", () => {
+  let storage: Record<string, string>;
+
+  beforeEach(() => {
+    storage = {};
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn((key: string) => storage[key] ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        storage[key] = value;
+      }),
+    });
+  });
+
+  it("saves types to localStorage", () => {
+    setInboxFilterTypes(["user_dm_message", "calendar_event"]);
+    const saved = JSON.parse(storage["inbox-filter-types"]);
+    expect(saved).toContain("user_dm_message");
+    expect(saved).toContain("calendar_event");
+  });
+
+  it("adds mandatory types if not included", () => {
+    setInboxFilterTypes(["calendar_event"]);
+    const saved = JSON.parse(storage["inbox-filter-types"]);
+    expect(saved).toContain("user_dm_message");
+    expect(saved).toContain("calendar_event");
+  });
+});

--- a/src/web/src/lib/time.test.ts
+++ b/src/web/src/lib/time.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { relativeTime } from "./time.js";
+
+describe("relativeTime", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns empty string for invalid date", () => {
+    expect(relativeTime("not-a-date")).toBe("");
+    expect(relativeTime("")).toBe("");
+  });
+
+  it("returns 'just now' for less than 1 minute ago", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-29T12:00:30Z"));
+    expect(relativeTime("2026-05-29T12:00:00Z")).toBe("just now");
+    vi.useRealTimers();
+  });
+
+  it("returns minutes ago for 1-59 minutes", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-29T12:05:00Z"));
+    expect(relativeTime("2026-05-29T12:00:00Z")).toBe("5m ago");
+    vi.useRealTimers();
+  });
+
+  it("returns hours ago for 1-23 hours", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-29T15:00:00Z"));
+    expect(relativeTime("2026-05-29T12:00:00Z")).toBe("3h ago");
+    vi.useRealTimers();
+  });
+
+  it("returns days ago for 1-6 days", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-31T12:00:00Z"));
+    expect(relativeTime("2026-05-29T12:00:00Z")).toBe("2d ago");
+    vi.useRealTimers();
+  });
+
+  it("returns formatted date for 7+ days", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-10T12:00:00Z"));
+    const result = relativeTime("2026-05-20T12:00:00Z");
+    expect(result).not.toContain("ago");
+    expect(result).not.toBe("just now");
+    expect(result).not.toBe("");
+    expect(result.length).toBeGreaterThan(0);
+    vi.useRealTimers();
+  });
+});

--- a/src/web/src/lib/token.test.ts
+++ b/src/web/src/lib/token.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { generateMachineToken } from "./token.js";
+
+describe("generateMachineToken", () => {
+  it("starts with 'al_' prefix", () => {
+    const token = generateMachineToken();
+    expect(token.startsWith("al_")).toBe(true);
+  });
+
+  it("has correct length (al_ + 48 hex chars = 51)", () => {
+    const token = generateMachineToken();
+    expect(token.length).toBe(51);
+  });
+
+  it("contains only valid hex characters after prefix", () => {
+    const token = generateMachineToken();
+    const hex = token.slice(3);
+    expect(hex).toMatch(/^[0-9a-f]{48}$/);
+  });
+
+  it("generates unique tokens", () => {
+    const tokens = new Set(Array.from({ length: 10 }, () => generateMachineToken()));
+    expect(tokens.size).toBe(10);
+  });
+});


### PR DESCRIPTION
# Why we need this PR?
> Improves test coverage for CLI lib utilities and web service helpers

## What changed
- Added tests for `src/cli/lib/runtimes.ts` (isCommandAvailable, detectRuntimes)
- Added tests for `src/web/src/lib/errors.ts` (ApiError class and getters)
- Added tests for `src/web/src/lib/time.ts` (relativeTime formatting)
- Added tests for `src/web/src/lib/token.ts` (generateMachineToken)
- Added tests for `src/web/src/lib/inbox-filter.ts` (filter type management with localStorage)

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] CLI (`@alook/cli`)
- [x] Web app (`@alook/web`)