### PR TITLE
test(shared): deepen db queries coverage to 50%

### DIFF
--- a/src/shared/test/queries/agent-deep.test.ts
+++ b/src/shared/test/queries/agent-deep.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi } from "vitest";
+import * as agentQueries from "../../src/db/queries/agent";
+
+describe("getAgent", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([]));
+    expect(await agentQueries.getAgent(chain, "x", "w")).toBeNull();
+  });
+  it("returns agent when found without userId", async () => {
+    const a = { id: "ag_1", visibility: "public" };
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([a]));
+    expect(await agentQueries.getAgent(chain, "ag_1", "w")).toEqual(a);
+  });
+  it("returns public agent for any user", async () => {
+    const a = { id: "ag_1", visibility: "public", ownerId: "other" };
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([a]));
+    expect(await agentQueries.getAgent(chain, "ag_1", "w", "usr_1")).toEqual(a);
+  });
+  it("returns agent when user is owner", async () => {
+    const a = { id: "ag_1", visibility: "private", ownerId: "usr_1" };
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([a]));
+    expect(await agentQueries.getAgent(chain, "ag_1", "w", "usr_1")).toEqual(a);
+  });
+  it("returns null for private agent without access", async () => {
+    const a = { id: "ag_1", visibility: "private", ownerId: "other" };
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    let callCount = 0;
+    chain.where = vi.fn(() => { callCount++; return Promise.resolve(callCount === 1 ? [a] : []); });
+    expect(await agentQueries.getAgent(chain, "ag_1", "w", "usr_1")).toBeNull();
+  });
+  it("returns private agent when user has access", async () => {
+    const a = { id: "ag_1", visibility: "private", ownerId: "other" };
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    let callCount = 0;
+    chain.where = vi.fn(() => { callCount++; return Promise.resolve(callCount === 1 ? [a] : [{ id: "access_1" }]); });
+    expect(await agentQueries.getAgent(chain, "ag_1", "w", "usr_1")).toEqual(a);
+  });
+});
+
+describe("createAgent", () => {
+  it("creates with defaults", async () => {
+    const a = { id: "ag_1" };
+    const chain: any = {};
+    chain.insert = vi.fn(() => chain); chain.values = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([a]));
+    const result = await agentQueries.createAgent(chain, { workspaceId: "w", name: "Bot" });
+    expect(chain.values).toHaveBeenCalledWith(expect.objectContaining({
+      name: "Bot", runtimeMode: "local", visibility: "private", maxConcurrentTasks: 6,
+    }));
+    expect(result).toEqual(a);
+  });
+});
+
+describe("deleteAgent", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain); chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await agentQueries.deleteAgent(chain, "x", "w")).toBeNull();
+  });
+  it("returns deleted agent", async () => {
+    const a = { id: "ag_1" };
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain); chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([a]));
+    expect(await agentQueries.deleteAgent(chain, "ag_1", "w")).toEqual(a);
+  });
+  it("filters by ownerId when provided", async () => {
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain); chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([]));
+    await agentQueries.deleteAgent(chain, "ag_1", "w", "usr_1");
+    expect(chain.where).toHaveBeenCalled();
+  });
+});
+
+describe("updateAgent", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await agentQueries.updateAgent(chain, "x", "w", { name: "N" })).toBeNull();
+  });
+  it("returns updated agent", async () => {
+    const a = { id: "ag_1" };
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.returning = vi.fn(() => Promise.resolve([a]));
+    expect(await agentQueries.updateAgent(chain, "ag_1", "w", { name: "N" })).toEqual(a);
+  });
+});
+
+describe("updateAgentStatus", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await agentQueries.updateAgentStatus(chain, "x", "w", "active")).toBeNull();
+  });
+  it("returns updated agent", async () => {
+    const a = { id: "ag_1" };
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.returning = vi.fn(() => Promise.resolve([a]));
+    expect(await agentQueries.updateAgentStatus(chain, "ag_1", "w", "active")).toEqual(a);
+  });
+});
+
+describe("getAgentByHandle", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([]));
+    expect(await agentQueries.getAgentByHandle(chain, "missing")).toBeNull();
+  });
+  it("returns agent", async () => {
+    const a = { id: "ag_1", emailHandle: "bot" };
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([a]));
+    expect(await agentQueries.getAgentByHandle(chain, "bot")).toEqual(a);
+  });
+});
+
+describe("getAgentsByIds", () => {
+  it("returns empty for empty ids", async () => {
+    expect(await agentQueries.getAgentsByIds(null as any, [], "w")).toEqual([]);
+  });
+});

--- a/src/shared/test/queries/agent-link.test.ts
+++ b/src/shared/test/queries/agent-link.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from "vitest";
+import * as agentLinkQueries from "../../src/db/queries/agent-link";
+
+describe("agent-link query module exports", () => {
+  it("exports listByWorkspace", () => { expect(typeof agentLinkQueries.listByWorkspace).toBe("function"); });
+  it("exports listByAgent", () => { expect(typeof agentLinkQueries.listByAgent).toBe("function"); });
+  it("exports create", () => { expect(typeof agentLinkQueries.create).toBe("function"); });
+  it("exports update", () => { expect(typeof agentLinkQueries.update).toBe("function"); });
+  it("exports remove", () => { expect(typeof agentLinkQueries.remove).toBe("function"); });
+  it("exports getColleaguesForAgent", () => { expect(typeof agentLinkQueries.getColleaguesForAgent).toBe("function"); });
+  it("exports getColleaguesForAgents", () => { expect(typeof agentLinkQueries.getColleaguesForAgents).toBe("function"); });
+  it("exports getAllColleaguesForWorkspace", () => { expect(typeof agentLinkQueries.getAllColleaguesForWorkspace).toBe("function"); });
+});
+
+describe("create", () => {
+  it("swaps source/target when source > target", async () => {
+    const link = { id: "link_1" };
+    const chain: any = {};
+    chain.insert = vi.fn(() => chain);
+    chain.values = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([link]));
+    await agentLinkQueries.create(chain, { workspaceId: "ws_1", sourceAgentId: "ag_z", targetAgentId: "ag_a" });
+    expect(chain.values).toHaveBeenCalledWith(expect.objectContaining({ sourceAgentId: "ag_a", targetAgentId: "ag_z" }));
+  });
+
+  it("keeps order when source < target", async () => {
+    const link = { id: "link_1" };
+    const chain: any = {};
+    chain.insert = vi.fn(() => chain);
+    chain.values = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([link]));
+    await agentLinkQueries.create(chain, { workspaceId: "ws_1", sourceAgentId: "ag_a", targetAgentId: "ag_z" });
+    expect(chain.values).toHaveBeenCalledWith(expect.objectContaining({ sourceAgentId: "ag_a", targetAgentId: "ag_z" }));
+  });
+});
+
+describe("update", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.update = vi.fn(() => chain);
+    chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await agentLinkQueries.update(chain, "x", "w", { instruction: "x" })).toBeNull();
+  });
+
+  it("returns updated link", async () => {
+    const link = { id: "link_1" };
+    const chain: any = {};
+    chain.update = vi.fn(() => chain);
+    chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([link]));
+    expect(await agentLinkQueries.update(chain, "link_1", "w", { instruction: "new" })).toEqual(link);
+  });
+});
+
+describe("remove", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await agentLinkQueries.remove(chain, "x", "w")).toBeNull();
+  });
+
+  it("returns removed link", async () => {
+    const link = { id: "link_1" };
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([link]));
+    expect(await agentLinkQueries.remove(chain, "link_1", "w")).toEqual(link);
+  });
+});
+
+describe("getColleaguesForAgents", () => {
+  it("returns empty array for empty agentIds", async () => {
+    expect(await agentLinkQueries.getColleaguesForAgents(null as any, [], "ws_1")).toEqual([]);
+  });
+});
+
+describe("getColleaguesForAgent", () => {
+  it("combines asSource and asTarget results", async () => {
+    const c1 = { name: "Alice" };
+    const c2 = { name: "Bob" };
+    const chain: any = {};
+    chain.select = vi.fn(() => chain);
+    chain.from = vi.fn(() => chain);
+    chain.innerJoin = vi.fn(() => chain);
+    let callCount = 0;
+    chain.where = vi.fn(() => { callCount++; return Promise.resolve(callCount === 1 ? [c1] : [c2]); });
+    const result = await agentLinkQueries.getColleaguesForAgent(chain, "ag_1", "ws_1");
+    expect(result).toEqual([c1, c2]);
+  });
+});
+
+describe("getAllColleaguesForWorkspace", () => {
+  it("combines asSource and asTarget results", async () => {
+    const c1 = { name: "Alice" };
+    const c2 = { name: "Bob" };
+    const chain: any = {};
+    chain.select = vi.fn(() => chain);
+    chain.from = vi.fn(() => chain);
+    chain.innerJoin = vi.fn(() => chain);
+    let callCount = 0;
+    chain.where = vi.fn(() => { callCount++; return Promise.resolve(callCount === 1 ? [c1] : [c2]); });
+    const result = await agentLinkQueries.getAllColleaguesForWorkspace(chain, "ws_1");
+    expect(result).toEqual([c1, c2]);
+  });
+});

--- a/src/shared/test/queries/agent-pin.test.ts
+++ b/src/shared/test/queries/agent-pin.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import * as pin from "../../src/db/queries/agent-pin";
+
+describe("agent-pin exports", () => {
+  it("exports listPins", () => { expect(typeof pin.listPins).toBe("function"); });
+  it("exports pinAgent", () => { expect(typeof pin.pinAgent).toBe("function"); });
+  it("exports unpinAgent", () => { expect(typeof pin.unpinAgent).toBe("function"); });
+  it("exports reorderPins", () => { expect(typeof pin.reorderPins).toBe("function"); });
+});
+
+describe("pinAgent", () => {
+  it("returns null on conflict", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([{ maxPos: 2 }]));
+    chain.insert = vi.fn(() => chain); chain.values = vi.fn(() => chain);
+    chain.onConflictDoNothing = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await pin.pinAgent(chain, { agentId: "a", workspaceId: "w", userId: "u" })).toBeNull();
+  });
+  it("creates at next position", async () => {
+    const p = { id: "pin_1", position: 3 };
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([{ maxPos: 2 }]));
+    chain.insert = vi.fn(() => chain); chain.values = vi.fn(() => chain);
+    chain.onConflictDoNothing = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([p]));
+    expect(await pin.pinAgent(chain, { agentId: "a", workspaceId: "w", userId: "u" })).toEqual(p);
+    expect(chain.values).toHaveBeenCalledWith(expect.objectContaining({ position: 3 }));
+  });
+});
+
+describe("unpinAgent", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await pin.unpinAgent(chain, "a", "w", "u")).toBeNull();
+  });
+  it("returns removed pin", async () => {
+    const p = { id: "pin_1" };
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([p]));
+    expect(await pin.unpinAgent(chain, "a", "w", "u")).toEqual(p);
+  });
+});
+
+describe("reorderPins", () => {
+  it("calls batch", async () => {
+    const chain: any = {};
+    chain.update = vi.fn(() => chain);
+    chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.batch = vi.fn(() => Promise.resolve());
+    await pin.reorderPins(chain, "w", "u", ["a", "b"]);
+    expect(chain.batch).toHaveBeenCalled();
+  });
+});

--- a/src/shared/test/queries/agent-sidebar-order.test.ts
+++ b/src/shared/test/queries/agent-sidebar-order.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from "vitest";
+import * as sidebar from "../../src/db/queries/agent-sidebar-order";
+
+describe("agent-sidebar-order exports", () => {
+  it("exports listOrder", () => { expect(typeof sidebar.listOrder).toBe("function"); });
+  it("exports reorder", () => { expect(typeof sidebar.reorder).toBe("function"); });
+});
+
+describe("listOrder", () => {
+  it("queries ordered items", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain);
+    chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.orderBy = vi.fn(() => Promise.resolve([]));
+    await sidebar.listOrder(chain, "w", "u");
+    expect(chain.orderBy).toHaveBeenCalled();
+  });
+});
+
+describe("reorder", () => {
+  it("calls batch", async () => {
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.insert = vi.fn(() => chain);
+    chain.values = vi.fn(() => chain);
+    chain.batch = vi.fn(() => Promise.resolve());
+    await sidebar.reorder(chain, "w", "u", ["a", "b"]);
+    expect(chain.batch).toHaveBeenCalled();
+  });
+});

--- a/src/shared/test/queries/channel-ops.test.ts
+++ b/src/shared/test/queries/channel-ops.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from "vitest";
+import * as channelQueries from "../../src/db/queries/channel";
+
+describe("getChannelByName", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([]));
+    expect(await channelQueries.getChannelByName(chain, "ws_1", "missing")).toBeNull();
+  });
+  it("returns channel when found", async () => {
+    const ch = { id: "ch_1", name: "general" };
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([ch]));
+    expect(await channelQueries.getChannelByName(chain, "ws_1", "general")).toEqual(ch);
+  });
+});
+
+describe("getChannelById", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([]));
+    expect(await channelQueries.getChannelById(chain, "x", "ws_1")).toBeNull();
+  });
+  it("returns channel when found", async () => {
+    const ch = { id: "ch_1", name: "general" };
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([ch]));
+    expect(await channelQueries.getChannelById(chain, "ch_1", "ws_1")).toEqual(ch);
+  });
+});
+
+describe("listChannels", () => {
+  it("returns channels ordered by position", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.orderBy = vi.fn(() => Promise.resolve([{ id: "ch_1" }]));
+    await channelQueries.listChannels(chain, "ws_1");
+    expect(chain.orderBy).toHaveBeenCalled();
+  });
+});
+
+describe("createChannel", () => {
+  it("creates channel at next position", async () => {
+    const ch = { id: "ch_1", name: "new", position: 2 };
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([{ maxPos: 1 }]));
+    chain.insert = vi.fn(() => chain); chain.values = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([ch]));
+    const result = await channelQueries.createChannel(chain, { workspaceId: "ws_1", name: "new" });
+    expect(chain.values).toHaveBeenCalledWith(expect.objectContaining({ name: "new", position: 2 }));
+    expect(result).toEqual(ch);
+  });
+});
+
+describe("deleteChannel", () => {
+  it("returns null when channel not found", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([]));
+    expect(await channelQueries.deleteChannel(chain, "x", "ws_1")).toBeNull();
+  });
+  it("deletes channel and conversations", async () => {
+    const ch = { id: "ch_1", name: "old" };
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([ch]));
+    chain.delete = vi.fn(() => chain);
+    chain.batch = vi.fn(() => Promise.resolve());
+    const result = await channelQueries.deleteChannel(chain, "ch_1", "ws_1");
+    expect(chain.batch).toHaveBeenCalled();
+    expect(result).toEqual(ch);
+  });
+});
+
+describe("renameChannel", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([]));
+    expect(await channelQueries.renameChannel(chain, "x", "ws_1", "new")).toBeNull();
+  });
+  it("renames and updates conversations", async () => {
+    const ch = { id: "ch_1", name: "old" };
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([ch]));
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.batch = vi.fn(() => Promise.resolve());
+    const result = await channelQueries.renameChannel(chain, "ch_1", "ws_1", "new");
+    expect(result).toEqual({ ...ch, name: "new" });
+  });
+});
+
+describe("reorderChannels", () => {
+  it("calls batch with updates", async () => {
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.batch = vi.fn(() => Promise.resolve());
+    await channelQueries.reorderChannels(chain, "ws_1", ["ch_a", "ch_b"]);
+    expect(chain.batch).toHaveBeenCalled();
+  });
+});

--- a/src/shared/test/queries/email-account.test.ts
+++ b/src/shared/test/queries/email-account.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import * as ea from "../../src/db/queries/email-account";
+
+function createSelectMock(rows: any[]) {
+  const chain: any = {};
+  chain.select = vi.fn(() => chain);
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => Promise.resolve(rows));
+  chain.insert = vi.fn(() => chain);
+  chain.values = vi.fn(() => chain);
+  chain.returning = vi.fn(() => Promise.resolve(rows));
+  return chain;
+}
+
+describe("email-account exports", () => {
+  it("exports createEmailAccount", () => { expect(typeof ea.createEmailAccount).toBe("function"); });
+  it("exports getEmailAccount", () => { expect(typeof ea.getEmailAccount).toBe("function"); });
+  it("exports getEmailAccountScoped", () => { expect(typeof ea.getEmailAccountScoped).toBe("function"); });
+  it("exports getEmailAccountById", () => { expect(typeof ea.getEmailAccountById).toBe("function"); });
+  it("exports getEmailAccountsByAgent", () => { expect(typeof ea.getEmailAccountsByAgent).toBe("function"); });
+  it("exports updateEmailAccount", () => { expect(typeof ea.updateEmailAccount).toBe("function"); });
+  it("exports deleteEmailAccount", () => { expect(typeof ea.deleteEmailAccount).toBe("function"); });
+  it("exports getEmailAccountsByAgents", () => { expect(typeof ea.getEmailAccountsByAgents).toBe("function"); });
+  it("exports getAllEmailAccountsForWorkspace", () => { expect(typeof ea.getAllEmailAccountsForWorkspace).toBe("function"); });
+});
+
+describe("createEmailAccount", () => {
+  it("creates and returns account", async () => {
+    const acc = { id: "ea_1" };
+    const mockDb = createSelectMock([acc]);
+    const result = await ea.createEmailAccount(mockDb, { agentId: "ag_1", workspaceId: "ws_1", emailAddress: "a@b.com", imapHost: "imap", imapUsername: "u", imapPassword: "p", smtpHost: "smtp", smtpUsername: "u", smtpPassword: "p" });
+    expect(result).toEqual(acc);
+  });
+});
+
+describe("getEmailAccount", () => {
+  it("returns null when not found", async () => { expect(await ea.getEmailAccount(createSelectMock([]), "x", "w")).toBeNull(); });
+  it("returns account", async () => { const a = { id: "ea_1" }; expect(await ea.getEmailAccount(createSelectMock([a]), "ea_1", "w")).toEqual(a); });
+});
+
+describe("getEmailAccountScoped", () => {
+  it("returns null when not found", async () => { expect(await ea.getEmailAccountScoped(createSelectMock([]), "x", "a", "w")).toBeNull(); });
+  it("returns account", async () => { const a = { id: "ea_1" }; expect(await ea.getEmailAccountScoped(createSelectMock([a]), "ea_1", "a", "w")).toEqual(a); });
+});
+
+describe("getEmailAccountById", () => {
+  it("returns null when not found", async () => { expect(await ea.getEmailAccountById(createSelectMock([]), "x")).toBeNull(); });
+  it("returns account", async () => { const a = { id: "ea_1" }; expect(await ea.getEmailAccountById(createSelectMock([a]), "ea_1")).toEqual(a); });
+});
+
+describe("updateEmailAccount", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await ea.updateEmailAccount(chain, "x", "w", { emailAddress: "a" })).toBeNull();
+  });
+  it("returns updated account", async () => {
+    const a = { id: "ea_1" };
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.returning = vi.fn(() => Promise.resolve([a]));
+    expect(await ea.updateEmailAccount(chain, "ea_1", "w", { emailAddress: "a" })).toEqual(a);
+  });
+});
+
+describe("deleteEmailAccount", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain); chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await ea.deleteEmailAccount(chain, "x", "w")).toBeNull();
+  });
+  it("returns deleted account", async () => {
+    const a = { id: "ea_1" };
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain); chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([a]));
+    expect(await ea.deleteEmailAccount(chain, "ea_1", "w")).toEqual(a);
+  });
+});
+
+describe("getEmailAccountsByAgents", () => {
+  it("returns empty for empty ids", async () => { expect(await ea.getEmailAccountsByAgents(null as any, [], "w")).toEqual([]); });
+  it("returns accounts for agents", async () => {
+    const mockDb = createSelectMock([{ id: "ea_1" }]);
+    await ea.getEmailAccountsByAgents(mockDb, ["ag_1"], "w");
+    expect(mockDb.where).toHaveBeenCalled();
+  });
+});

--- a/src/shared/test/queries/email-deep.test.ts
+++ b/src/shared/test/queries/email-deep.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import * as emailQueries from "../../src/db/queries/email";
+
+describe("createEmail", () => {
+  it("creates and returns email", async () => {
+    const email = { id: "em_1" };
+    const chain: any = {};
+    chain.insert = vi.fn(() => chain); chain.values = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([email]));
+    const result = await emailQueries.createEmail(chain, {
+      agentId: "ag_1", workspaceId: "w", fromEmail: "a@b.com", toEmail: "c@d.com",
+      subject: "Hi", r2Key: "key", isWhitelisted: true, forwarded: false, direction: "inbound",
+    });
+    expect(result).toEqual(email);
+  });
+});
+
+describe("getEmailsByAgent", () => {
+  it("returns emails without pagination", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.orderBy = vi.fn(() => Promise.resolve([{ id: "em_1" }]));
+    await emailQueries.getEmailsByAgent(chain, "ag_1", "w");
+    expect(chain.orderBy).toHaveBeenCalled();
+  });
+  it("applies pagination", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.orderBy = vi.fn(() => chain);
+    chain.limit = vi.fn(() => chain); chain.offset = vi.fn(() => Promise.resolve([]));
+    await emailQueries.getEmailsByAgent(chain, "ag_1", "w", undefined, { limit: 10, offset: 0 });
+    expect(chain.limit).toHaveBeenCalledWith(10);
+  });
+  it("applies status filter", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.orderBy = vi.fn(() => Promise.resolve([]));
+    await emailQueries.getEmailsByAgent(chain, "ag_1", "w", "read");
+    expect(chain.where).toHaveBeenCalled();
+  });
+});
+
+describe("getInboxEmails", () => {
+  it("returns inbound emails", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.orderBy = vi.fn(() => Promise.resolve([]));
+    await emailQueries.getInboxEmails(chain, "ag_1", "bot@test.com", "w");
+    expect(chain.orderBy).toHaveBeenCalled();
+  });
+});
+
+describe("getSentEmails", () => {
+  it("returns outbound emails", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.orderBy = vi.fn(() => Promise.resolve([]));
+    await emailQueries.getSentEmails(chain, "ag_1", "bot@test.com", "w");
+    expect(chain.orderBy).toHaveBeenCalled();
+  });
+});
+
+describe("getTrustedEmails", () => {
+  it("returns trusted inbound emails", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.orderBy = vi.fn(() => Promise.resolve([]));
+    await emailQueries.getTrustedEmails(chain, "ag_1", "bot@test.com", "w");
+    expect(chain.orderBy).toHaveBeenCalled();
+  });
+});
+
+describe("getRejectedEmails", () => {
+  it("returns rejected inbound emails", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.orderBy = vi.fn(() => Promise.resolve([]));
+    await emailQueries.getRejectedEmails(chain, "ag_1", "bot@test.com", "w");
+    expect(chain.orderBy).toHaveBeenCalled();
+  });
+});
+
+describe("deleteEmail", () => {
+  it("calls delete with correct params", async () => {
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain); chain.where = vi.fn(() => Promise.resolve());
+    await emailQueries.deleteEmail(chain, "em_1", "w");
+    expect(chain.delete).toHaveBeenCalled();
+  });
+});

--- a/src/shared/test/queries/inbox.test.ts
+++ b/src/shared/test/queries/inbox.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import * as inboxQueries from "../../src/db/queries/inbox";
+
+function createMockDb(rows: any[]) {
+  const chain: any = {};
+  chain.all = vi.fn(() => Promise.resolve(rows));
+  chain.run = vi.fn(() => Promise.resolve());
+  return chain;
+}
+
+describe("inbox exports", () => {
+  it("exports listUnreadConversations", () => { expect(typeof inboxQueries.listUnreadConversations).toBe("function"); });
+  it("exports getUnreadCount", () => { expect(typeof inboxQueries.getUnreadCount).toBe("function"); });
+  it("exports markConversationRead", () => { expect(typeof inboxQueries.markConversationRead).toBe("function"); });
+  it("exports markAllConversationsRead", () => { expect(typeof inboxQueries.markAllConversationsRead).toBe("function"); });
+});
+
+describe("listUnreadConversations", () => {
+  it("returns items and hasMore=false when rows <= limit", async () => {
+    const rows = [{ id: "c_1" }];
+    const mockDb = createMockDb(rows);
+    const result = await inboxQueries.listUnreadConversations(mockDb, "u", "w");
+    expect(result.items).toEqual(rows);
+    expect(result.hasMore).toBe(false);
+  });
+  it("returns hasMore=true when rows exceed limit", async () => {
+    const rows = Array.from({ length: 31 }, (_, i) => ({ id: `c_${i}` }));
+    const result = await inboxQueries.listUnreadConversations(createMockDb(rows), "u", "w");
+    expect(result.hasMore).toBe(true);
+    expect(result.items.length).toBe(30);
+  });
+  it("uses custom limit", async () => {
+    const rows = Array.from({ length: 6 }, (_, i) => ({ id: `c_${i}` }));
+    const result = await inboxQueries.listUnreadConversations(createMockDb(rows), "u", "w", { limit: 5 });
+    expect(result.hasMore).toBe(true);
+    expect(result.items.length).toBe(5);
+  });
+  it("handles before option", async () => {
+    const result = await inboxQueries.listUnreadConversations(createMockDb([]), "u", "w", { before: "2026-01-01" });
+    expect(result.items).toEqual([]);
+  });
+  it("handles types option", async () => {
+    const result = await inboxQueries.listUnreadConversations(createMockDb([]), "u", "w", { types: ["email_notification"] });
+    expect(result.items).toEqual([]);
+  });
+});
+
+describe("getUnreadCount", () => {
+  it("returns 0 when empty", async () => { expect(await inboxQueries.getUnreadCount(createMockDb([]), "u", "w")).toBe(0); });
+  it("returns count", async () => { expect(await inboxQueries.getUnreadCount(createMockDb([{ count: 5 }]), "u", "w")).toBe(5); });
+  it("handles custom types", async () => { expect(await inboxQueries.getUnreadCount(createMockDb([{ count: 2 }]), "u", "w", ["email_notification"])).toBe(2); });
+});
+
+describe("markConversationRead", () => {
+  it("calls db.run", async () => {
+    const mockDb = createMockDb([]);
+    await inboxQueries.markConversationRead(mockDb, "u", "c");
+    expect(mockDb.run).toHaveBeenCalled();
+  });
+});
+
+describe("markAllConversationsRead", () => {
+  it("calls db.run", async () => {
+    const mockDb = createMockDb([]);
+    await inboxQueries.markAllConversationsRead(mockDb, "u", "w");
+    expect(mockDb.run).toHaveBeenCalled();
+  });
+});

--- a/src/shared/test/queries/issue.test.ts
+++ b/src/shared/test/queries/issue.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from "vitest";
+import * as issueQueries from "../../src/db/queries/issue";
+
+function createSelectMock(rows: any[]) {
+  const chain: any = {};
+  chain.select = vi.fn(() => chain);
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => Promise.resolve(rows));
+  chain.orderBy = vi.fn(() => chain);
+  chain.insert = vi.fn(() => chain);
+  chain.values = vi.fn(() => chain);
+  chain.returning = vi.fn(() => Promise.resolve(rows));
+  return chain;
+}
+
+describe("issue exports", () => {
+  it("exports createIssue", () => { expect(typeof issueQueries.createIssue).toBe("function"); });
+  it("exports getIssue", () => { expect(typeof issueQueries.getIssue).toBe("function"); });
+  it("exports getIssueByConversation", () => { expect(typeof issueQueries.getIssueByConversation).toBe("function"); });
+  it("exports listIssues", () => { expect(typeof issueQueries.listIssues).toBe("function"); });
+  it("exports updateIssue", () => { expect(typeof issueQueries.updateIssue).toBe("function"); });
+  it("exports setLatestTask", () => { expect(typeof issueQueries.setLatestTask).toBe("function"); });
+  it("exports deleteIssue", () => { expect(typeof issueQueries.deleteIssue).toBe("function"); });
+  it("exports listIssueMessages", () => { expect(typeof issueQueries.listIssueMessages).toBe("function"); });
+});
+
+describe("createIssue", () => {
+  it("creates with default status todo", async () => {
+    const iss = { id: "iss_1" };
+    const mockDb = createSelectMock([iss]);
+    const result = await issueQueries.createIssue(mockDb, { workspaceId: "w", agentId: "a", creatorUserId: "u", conversationId: "c", title: "T", description: "D" });
+    expect(mockDb.values).toHaveBeenCalledWith(expect.objectContaining({ status: "todo" }));
+    expect(result).toEqual(iss);
+  });
+  it("uses custom status", async () => {
+    const mockDb = createSelectMock([{ id: "iss_1" }]);
+    await issueQueries.createIssue(mockDb, { workspaceId: "w", agentId: null, creatorUserId: "u", conversationId: null, title: "T", description: "D", status: "in_progress" });
+    expect(mockDb.values).toHaveBeenCalledWith(expect.objectContaining({ status: "in_progress" }));
+  });
+});
+
+describe("getIssue", () => {
+  it("returns null when not found", async () => { expect(await issueQueries.getIssue(createSelectMock([]), "x", "w")).toBeNull(); });
+  it("returns issue", async () => { const i = { id: "iss_1" }; expect(await issueQueries.getIssue(createSelectMock([i]), "iss_1", "w")).toEqual(i); });
+});
+
+describe("getIssueByConversation", () => {
+  it("returns null when not found", async () => { expect(await issueQueries.getIssueByConversation(createSelectMock([]), "x", "w")).toBeNull(); });
+  it("returns issue", async () => { const i = { id: "iss_1" }; expect(await issueQueries.getIssueByConversation(createSelectMock([i]), "c", "w")).toEqual(i); });
+});
+
+describe("listIssues", () => {
+  function createListMock() {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.orderBy = vi.fn(() => Promise.resolve([]));
+    return chain;
+  }
+  it("lists with default options", async () => {
+    const mockDb = createListMock();
+    await issueQueries.listIssues(mockDb, "w");
+    expect(mockDb.orderBy).toHaveBeenCalled();
+  });
+  it("filters by agentId", async () => { await issueQueries.listIssues(createListMock(), "w", { agentId: "a" }); });
+  it("filters by status", async () => { await issueQueries.listIssues(createListMock(), "w", { status: "todo" }); });
+  it("filters terminal=true", async () => { await issueQueries.listIssues(createListMock(), "w", { terminal: true }); });
+  it("filters terminal=false", async () => { await issueQueries.listIssues(createListMock(), "w", { terminal: false }); });
+});
+
+describe("updateIssue", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await issueQueries.updateIssue(chain, "x", "w", { title: "T" })).toBeNull();
+  });
+  it("returns updated issue", async () => {
+    const i = { id: "iss_1" };
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.returning = vi.fn(() => Promise.resolve([i]));
+    expect(await issueQueries.updateIssue(chain, "iss_1", "w", { title: "T" })).toEqual(i);
+  });
+  it("sets completedAt for terminal status", async () => {
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.returning = vi.fn(() => Promise.resolve([{ id: "iss_1" }]));
+    await issueQueries.updateIssue(chain, "iss_1", "w", { status: "done" });
+    expect(chain.set).toHaveBeenCalledWith(expect.objectContaining({ completedAt: expect.any(String) }));
+  });
+  it("sets completedAt null for active status", async () => {
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.returning = vi.fn(() => Promise.resolve([{ id: "iss_1" }]));
+    await issueQueries.updateIssue(chain, "iss_1", "w", { status: "todo" });
+    expect(chain.set).toHaveBeenCalledWith(expect.objectContaining({ completedAt: null }));
+  });
+});
+
+describe("deleteIssue", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain); chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await issueQueries.deleteIssue(chain, "x", "w")).toBeNull();
+  });
+  it("returns deleted issue", async () => {
+    const i = { id: "iss_1" };
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain); chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([i]));
+    expect(await issueQueries.deleteIssue(chain, "iss_1", "w")).toEqual(i);
+  });
+});
+
+describe("listIssueMessages", () => {
+  it("returns null when issue not found", async () => { expect(await issueQueries.listIssueMessages(createSelectMock([]), "x", "w")).toBeNull(); });
+  it("returns empty when no conversationId", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([{ id: "iss_1", conversationId: null }]));
+    expect(await issueQueries.listIssueMessages(chain, "iss_1", "w")).toEqual([]);
+  });
+});

--- a/src/shared/test/queries/machine-token.test.ts
+++ b/src/shared/test/queries/machine-token.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from "vitest";
+import * as mt from "../../src/db/queries/machine-token";
+
+function createSelectMock(rows: any[]) {
+  const chain: any = {};
+  chain.select = vi.fn(() => chain);
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => Promise.resolve(rows));
+  chain.innerJoin = vi.fn(() => chain);
+  chain.insert = vi.fn(() => chain);
+  chain.values = vi.fn(() => chain);
+  chain.returning = vi.fn(() => Promise.resolve(rows));
+  chain.orderBy = vi.fn(() => chain);
+  return chain;
+}
+
+describe("machine-token exports", () => {
+  it("exports createMachineToken", () => { expect(typeof mt.createMachineToken).toBe("function"); });
+  it("exports getMachineTokenByToken", () => { expect(typeof mt.getMachineTokenByToken).toBe("function"); });
+  it("exports getPendingMachineToken", () => { expect(typeof mt.getPendingMachineToken).toBe("function"); });
+  it("exports activateMachineToken", () => { expect(typeof mt.activateMachineToken).toBe("function"); });
+  it("exports listMachineTokens", () => { expect(typeof mt.listMachineTokens).toBe("function"); });
+  it("exports deleteMachineToken", () => { expect(typeof mt.deleteMachineToken).toBe("function"); });
+  it("exports updateMachineTokenLastUsed", () => { expect(typeof mt.updateMachineTokenLastUsed).toBe("function"); });
+});
+
+describe("createMachineToken", () => {
+  it("creates token with defaults", async () => {
+    const t = { id: "mt_1" };
+    const mockDb = createSelectMock([t]);
+    const result = await mt.createMachineToken(mockDb, { userId: "u", token: "tok", name: "T" });
+    expect(mockDb.values).toHaveBeenCalledWith(expect.objectContaining({ status: "active", workspaceId: null }));
+    expect(result).toEqual(t);
+  });
+  it("uses custom status", async () => {
+    const mockDb = createSelectMock([{ id: "mt_1" }]);
+    await mt.createMachineToken(mockDb, { userId: "u", token: "tok", name: "T", status: "pending" });
+    expect(mockDb.values).toHaveBeenCalledWith(expect.objectContaining({ status: "pending" }));
+  });
+});
+
+describe("getMachineTokenByToken", () => {
+  it("returns null when not found", async () => { expect(await mt.getMachineTokenByToken(createSelectMock([]), "x")).toBeNull(); });
+  it("returns token with join", async () => {
+    const t = { id: "mt_1" };
+    const mockDb = createSelectMock([t]);
+    expect(await mt.getMachineTokenByToken(mockDb, "tok")).toEqual(t);
+    expect(mockDb.innerJoin).toHaveBeenCalled();
+  });
+});
+
+describe("getPendingMachineToken", () => {
+  it("returns null when none", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.limit = vi.fn(() => Promise.resolve([]));
+    expect(await mt.getPendingMachineToken(chain, "u")).toBeNull();
+  });
+  it("returns pending token", async () => {
+    const t = { id: "mt_1" };
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.limit = vi.fn(() => Promise.resolve([t]));
+    expect(await mt.getPendingMachineToken(chain, "u")).toEqual(t);
+  });
+  it("handles workspaceId", async () => {
+    const t = { id: "mt_1" };
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.limit = vi.fn(() => Promise.resolve([t]));
+    expect(await mt.getPendingMachineToken(chain, "u", "ws_1")).toEqual(t);
+  });
+});
+
+describe("activateMachineToken", () => {
+  it("sets active", async () => {
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve());
+    await mt.activateMachineToken(chain, "mt_1");
+    expect(chain.set).toHaveBeenCalledWith(expect.objectContaining({ status: "active" }));
+  });
+  it("sets workspaceId when provided", async () => {
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve());
+    await mt.activateMachineToken(chain, "mt_1", "ws_1");
+    expect(chain.set).toHaveBeenCalledWith(expect.objectContaining({ workspaceId: "ws_1" }));
+  });
+});
+
+describe("deleteMachineToken", () => {
+  it("deletes by id and userId", async () => {
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve());
+    await mt.deleteMachineToken(chain, "mt_1", "u");
+    expect(chain.delete).toHaveBeenCalled();
+  });
+});
+
+describe("updateMachineTokenLastUsed", () => {
+  it("updates lastUsedAt", async () => {
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve());
+    await mt.updateMachineTokenLastUsed(chain, "mt_1");
+    expect(chain.set).toHaveBeenCalledWith(expect.objectContaining({ lastUsedAt: expect.any(String) }));
+  });
+});

--- a/src/shared/test/queries/machine.test.ts
+++ b/src/shared/test/queries/machine.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from "vitest";
+import * as machineQueries from "../../src/db/queries/machine";
+
+function createMockDb(rows: any[]) {
+  const chain: any = {};
+  chain.select = vi.fn(() => chain);
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => Promise.resolve(rows));
+  chain.insert = vi.fn(() => chain);
+  chain.values = vi.fn(() => chain);
+  chain.returning = vi.fn(() => Promise.resolve(rows));
+  chain.onConflictDoUpdate = vi.fn(() => chain);
+  chain.update = vi.fn(() => chain);
+  chain.set = vi.fn(() => chain);
+  chain.delete = vi.fn(() => chain);
+  return chain;
+}
+
+describe("machine query module exports", () => {
+  it("exports upsertMachine", () => { expect(typeof machineQueries.upsertMachine).toBe("function"); });
+  it("exports updateMachineLastSeen", () => { expect(typeof machineQueries.updateMachineLastSeen).toBe("function"); });
+  it("exports setMachineLastSeenNull", () => { expect(typeof machineQueries.setMachineLastSeenNull).toBe("function"); });
+  it("exports getMachineByDaemon", () => { expect(typeof machineQueries.getMachineByDaemon).toBe("function"); });
+  it("exports listMachinesForWorkspace", () => { expect(typeof machineQueries.listMachinesForWorkspace).toBe("function"); });
+  it("exports deleteMachine", () => { expect(typeof machineQueries.deleteMachine).toBe("function"); });
+  it("exports setPendingUpdateVersion", () => { expect(typeof machineQueries.setPendingUpdateVersion).toBe("function"); });
+  it("exports clearPendingUpdateVersion", () => { expect(typeof machineQueries.clearPendingUpdateVersion).toBe("function"); });
+  it("exports setPendingRescan", () => { expect(typeof machineQueries.setPendingRescan).toBe("function"); });
+  it("exports clearPendingRescan", () => { expect(typeof machineQueries.clearPendingRescan).toBe("function"); });
+});
+
+describe("upsertMachine", () => {
+  it("inserts and returns first row", async () => {
+    const m = { id: "m_1" };
+    const mockDb = createMockDb([m]);
+    const result = await machineQueries.upsertMachine(mockDb, { daemonId: "d_1", workspaceId: "ws_1", deviceInfo: "Mac" });
+    expect(mockDb.insert).toHaveBeenCalled();
+    expect(mockDb.onConflictDoUpdate).toHaveBeenCalled();
+    expect(result).toEqual(m);
+  });
+  it("uses null lastSeenAt when explicitly null", async () => {
+    const mockDb = createMockDb([{ id: "m_1" }]);
+    await machineQueries.upsertMachine(mockDb, { daemonId: "d_1", workspaceId: "ws_1", deviceInfo: "x", lastSeenAt: null });
+    expect(mockDb.values).toHaveBeenCalledWith(expect.objectContaining({ lastSeenAt: null }));
+  });
+});
+
+describe("getMachineByDaemon", () => {
+  it("returns null when not found", async () => {
+    const mockDb = createMockDb([]);
+    expect(await machineQueries.getMachineByDaemon(mockDb, "d_x", "ws_1")).toBeNull();
+  });
+  it("returns machine when found", async () => {
+    const m = { id: "m_1" };
+    const mockDb = createMockDb([m]);
+    expect(await machineQueries.getMachineByDaemon(mockDb, "d_1", "ws_1")).toEqual(m);
+  });
+});
+
+describe("updateMachineLastSeen", () => {
+  it("updates lastSeenAt", async () => {
+    const mockDb = createMockDb([]);
+    await machineQueries.updateMachineLastSeen(mockDb, "d_1", "ws_1");
+    expect(mockDb.set).toHaveBeenCalledWith(expect.objectContaining({ lastSeenAt: expect.any(String) }));
+  });
+});
+
+describe("setMachineLastSeenNull", () => {
+  it("sets lastSeenAt to null", async () => {
+    const mockDb = createMockDb([]);
+    await machineQueries.setMachineLastSeenNull(mockDb, "d_1", "ws_1");
+    expect(mockDb.set).toHaveBeenCalledWith(expect.objectContaining({ lastSeenAt: null }));
+  });
+});
+
+describe("deleteMachine", () => {
+  it("calls delete", async () => {
+    const mockDb = createMockDb([]);
+    await machineQueries.deleteMachine(mockDb, "d_1", "ws_1");
+    expect(mockDb.delete).toHaveBeenCalled();
+  });
+});
+
+describe("setPendingUpdateVersion", () => {
+  it("sets version", async () => {
+    const mockDb = createMockDb([]);
+    await machineQueries.setPendingUpdateVersion(mockDb, "d_1", "ws_1", "1.2.3");
+    expect(mockDb.set).toHaveBeenCalledWith(expect.objectContaining({ pendingUpdateVersion: "1.2.3" }));
+  });
+});
+
+describe("clearPendingUpdateVersion", () => {
+  it("clears to null", async () => {
+    const mockDb = createMockDb([]);
+    await machineQueries.clearPendingUpdateVersion(mockDb, "d_1", "ws_1");
+    expect(mockDb.set).toHaveBeenCalledWith(expect.objectContaining({ pendingUpdateVersion: null }));
+  });
+});
+
+describe("setPendingRescan", () => {
+  it("sets to true", async () => {
+    const mockDb = createMockDb([]);
+    await machineQueries.setPendingRescan(mockDb, "d_1", "ws_1");
+    expect(mockDb.set).toHaveBeenCalledWith(expect.objectContaining({ pendingRescan: true }));
+  });
+});
+
+describe("clearPendingRescan", () => {
+  it("sets to false", async () => {
+    const mockDb = createMockDb([]);
+    await machineQueries.clearPendingRescan(mockDb, "d_1", "ws_1");
+    expect(mockDb.set).toHaveBeenCalledWith(expect.objectContaining({ pendingRescan: false }));
+  });
+});

--- a/src/shared/test/queries/member.test.ts
+++ b/src/shared/test/queries/member.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest";
+import * as memberQueries from "../../src/db/queries/member";
+
+function createSelectMock(rows: any[]) {
+  const chain: any = {};
+  chain.select = vi.fn(() => chain);
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => Promise.resolve(rows));
+  chain.innerJoin = vi.fn(() => chain);
+  chain.insert = vi.fn(() => chain);
+  chain.values = vi.fn(() => chain);
+  chain.returning = vi.fn(() => Promise.resolve(rows));
+  return chain;
+}
+
+describe("member exports", () => {
+  it("exports getMemberByUserAndWorkspace", () => { expect(typeof memberQueries.getMemberByUserAndWorkspace).toBe("function"); });
+  it("exports listMembers", () => { expect(typeof memberQueries.listMembers).toBe("function"); });
+  it("exports updateMemberGlobalInstruction", () => { expect(typeof memberQueries.updateMemberGlobalInstruction).toBe("function"); });
+  it("exports createMember", () => { expect(typeof memberQueries.createMember).toBe("function"); });
+  it("exports getMember", () => { expect(typeof memberQueries.getMember).toBe("function"); });
+  it("exports deleteMember", () => { expect(typeof memberQueries.deleteMember).toBe("function"); });
+});
+
+describe("getMemberByUserAndWorkspace", () => {
+  it("returns null when not found", async () => { expect(await memberQueries.getMemberByUserAndWorkspace(createSelectMock([]), "u", "w")).toBeNull(); });
+  it("returns member", async () => { const m = { id: "mem_1" }; expect(await memberQueries.getMemberByUserAndWorkspace(createSelectMock([m]), "u", "w")).toEqual(m); });
+});
+
+describe("listMembers", () => {
+  it("joins user table", async () => {
+    const mockDb = createSelectMock([]);
+    await memberQueries.listMembers(mockDb, "ws_1");
+    expect(mockDb.innerJoin).toHaveBeenCalled();
+  });
+});
+
+describe("updateMemberGlobalInstruction", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await memberQueries.updateMemberGlobalInstruction(chain, "u", "w", "x")).toBeNull();
+  });
+  it("returns updated member", async () => {
+    const m = { id: "mem_1" };
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.returning = vi.fn(() => Promise.resolve([m]));
+    expect(await memberQueries.updateMemberGlobalInstruction(chain, "u", "w", "x")).toEqual(m);
+  });
+});
+
+describe("createMember", () => {
+  it("creates and returns member", async () => {
+    const m = { id: "mem_1" };
+    const mockDb = createSelectMock([m]);
+    expect(await memberQueries.createMember(mockDb, { workspaceId: "w", userId: "u", role: "admin" })).toEqual(m);
+  });
+});
+
+describe("getMember", () => {
+  it("returns null when not found", async () => { expect(await memberQueries.getMember(createSelectMock([]), "x", "w")).toBeNull(); });
+  it("returns member", async () => { const m = { id: "mem_1" }; expect(await memberQueries.getMember(createSelectMock([m]), "mem_1", "w")).toEqual(m); });
+});
+
+describe("deleteMember", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain); chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await memberQueries.deleteMember(chain, "x", "w")).toBeNull();
+  });
+  it("returns deleted member", async () => {
+    const m = { id: "mem_1" };
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain); chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([m]));
+    expect(await memberQueries.deleteMember(chain, "mem_1", "w")).toEqual(m);
+  });
+});

--- a/src/shared/test/queries/message-flag.test.ts
+++ b/src/shared/test/queries/message-flag.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from "vitest";
+import * as mf from "../../src/db/queries/message-flag";
+
+describe("message-flag exports", () => {
+  it("exports getMessageWorkspaceId", () => { expect(typeof mf.getMessageWorkspaceId).toBe("function"); });
+  it("exports flagMessage", () => { expect(typeof mf.flagMessage).toBe("function"); });
+  it("exports unflagMessage", () => { expect(typeof mf.unflagMessage).toBe("function"); });
+  it("exports listFlaggedMessages", () => { expect(typeof mf.listFlaggedMessages).toBe("function"); });
+  it("exports getFlaggedCount", () => { expect(typeof mf.getFlaggedCount).toBe("function"); });
+  it("exports listFlaggedMessageIds", () => { expect(typeof mf.listFlaggedMessageIds).toBe("function"); });
+});
+
+describe("getMessageWorkspaceId", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.innerJoin = vi.fn(() => chain); chain.where = vi.fn(() => chain);
+    chain.limit = vi.fn(() => Promise.resolve([]));
+    expect(await mf.getMessageWorkspaceId(chain, "x")).toBeNull();
+  });
+  it("returns workspaceId", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.innerJoin = vi.fn(() => chain); chain.where = vi.fn(() => chain);
+    chain.limit = vi.fn(() => Promise.resolve([{ workspaceId: "ws_1" }]));
+    expect(await mf.getMessageWorkspaceId(chain, "msg_1")).toBe("ws_1");
+  });
+});
+
+describe("flagMessage", () => {
+  it("returns null on conflict", async () => {
+    const chain: any = {};
+    chain.insert = vi.fn(() => chain); chain.values = vi.fn(() => chain);
+    chain.onConflictDoNothing = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await mf.flagMessage(chain, { messageId: "m", userId: "u", workspaceId: "w" })).toBeNull();
+  });
+  it("returns flag", async () => {
+    const f = { id: "mf_1" };
+    const chain: any = {};
+    chain.insert = vi.fn(() => chain); chain.values = vi.fn(() => chain);
+    chain.onConflictDoNothing = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([f]));
+    expect(await mf.flagMessage(chain, { messageId: "m", userId: "u", workspaceId: "w" })).toEqual(f);
+  });
+});
+
+describe("unflagMessage", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain); chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await mf.unflagMessage(chain, "m", "u", "w")).toBeNull();
+  });
+  it("returns removed flag", async () => {
+    const f = { id: "mf_1" };
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain); chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([f]));
+    expect(await mf.unflagMessage(chain, "m", "u", "w")).toEqual(f);
+  });
+});
+
+describe("listFlaggedMessages", () => {
+  it("returns items with hasMore=false", async () => {
+    const rows = [{ id: "mf_1" }];
+    const chain: any = {};
+    chain.all = vi.fn(() => Promise.resolve(rows));
+    const result = await mf.listFlaggedMessages(chain, "u", "w");
+    expect(result.items).toEqual(rows);
+    expect(result.hasMore).toBe(false);
+  });
+  it("returns hasMore=true when exceeding limit", async () => {
+    const rows = Array.from({ length: 31 }, (_, i) => ({ id: `mf_${i}` }));
+    const chain: any = {};
+    chain.all = vi.fn(() => Promise.resolve(rows));
+    const result = await mf.listFlaggedMessages(chain, "u", "w");
+    expect(result.hasMore).toBe(true);
+    expect(result.items.length).toBe(30);
+  });
+});
+
+describe("getFlaggedCount", () => {
+  it("returns 0 when empty", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([]));
+    expect(await mf.getFlaggedCount(chain, "u", "w")).toBe(0);
+  });
+  it("returns count", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([{ count: 7 }]));
+    expect(await mf.getFlaggedCount(chain, "u", "w")).toBe(7);
+  });
+});
+
+describe("listFlaggedMessageIds", () => {
+  it("returns message ids", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.innerJoin = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([{ messageId: "m1" }, { messageId: "m2" }]));
+    expect(await mf.listFlaggedMessageIds(chain, "u", "w", "c")).toEqual(["m1", "m2"]);
+  });
+});

--- a/src/shared/test/queries/session.test.ts
+++ b/src/shared/test/queries/session.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from "vitest";
+import * as sessionQueries from "../../src/db/queries/session";
+
+function createMockDb(rows: any[]) {
+  const chain: any = {};
+  chain.select = vi.fn(() => chain);
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => Promise.resolve(rows));
+  return chain;
+}
+
+describe("session exports", () => {
+  it("exports getValidSession", () => { expect(typeof sessionQueries.getValidSession).toBe("function"); });
+});
+
+describe("getValidSession", () => {
+  it("returns null when no valid session", async () => { expect(await sessionQueries.getValidSession(createMockDb([]), "tok")).toBeNull(); });
+  it("returns userId when valid", async () => { expect(await sessionQueries.getValidSession(createMockDb([{ userId: "u_1" }]), "tok")).toBe("u_1"); });
+});

--- a/src/shared/test/queries/user.test.ts
+++ b/src/shared/test/queries/user.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest";
+import * as userQueries from "../../src/db/queries/user";
+
+function createSelectMock(rows: any[]) {
+  const chain: any = {};
+  chain.select = vi.fn(() => chain);
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => Promise.resolve(rows));
+  chain.insert = vi.fn(() => chain);
+  chain.values = vi.fn(() => chain);
+  chain.returning = vi.fn(() => Promise.resolve(rows));
+  return chain;
+}
+
+describe("user exports", () => {
+  it("exports getUser", () => { expect(typeof userQueries.getUser).toBe("function"); });
+  it("exports getUserByEmail", () => { expect(typeof userQueries.getUserByEmail).toBe("function"); });
+  it("exports createUser", () => { expect(typeof userQueries.createUser).toBe("function"); });
+  it("exports updateUser", () => { expect(typeof userQueries.updateUser).toBe("function"); });
+});
+
+describe("getUser", () => {
+  it("returns null when not found", async () => { expect(await userQueries.getUser(createSelectMock([]), "x")).toBeNull(); });
+  it("returns user", async () => { const u = { id: "u_1" }; expect(await userQueries.getUser(createSelectMock([u]), "u_1")).toEqual(u); });
+});
+
+describe("getUserByEmail", () => {
+  it("returns null when not found", async () => { expect(await userQueries.getUserByEmail(createSelectMock([]), "x@x.com")).toBeNull(); });
+  it("returns user", async () => { const u = { id: "u_1" }; expect(await userQueries.getUserByEmail(createSelectMock([u]), "a@b.com")).toEqual(u); });
+});
+
+describe("createUser", () => {
+  it("creates user", async () => {
+    const u = { id: "u_1" };
+    expect(await userQueries.createUser(createSelectMock([u]), { name: "A", email: "a@b.com" })).toEqual(u);
+  });
+});
+
+describe("updateUser", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await userQueries.updateUser(chain, "x", { name: "B", image: null })).toBeNull();
+  });
+  it("returns updated user", async () => {
+    const u = { id: "u_1" };
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.returning = vi.fn(() => Promise.resolve([u]));
+    expect(await userQueries.updateUser(chain, "u_1", { name: "B", image: null })).toEqual(u);
+  });
+});

--- a/src/shared/test/queries/whitelist-deep.test.ts
+++ b/src/shared/test/queries/whitelist-deep.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+import * as wl from "../../src/db/queries/whitelist";
+
+describe("addWhitelist", () => {
+  it("returns null on conflict", async () => {
+    const chain: any = {};
+    chain.insert = vi.fn(() => chain); chain.values = vi.fn(() => chain);
+    chain.onConflictDoNothing = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await wl.addWhitelist(chain, "ag_1", "w", "test@test.com")).toBeNull();
+  });
+  it("returns entry when created", async () => {
+    const entry = { id: "wl_1", email: "test@test.com" };
+    const chain: any = {};
+    chain.insert = vi.fn(() => chain); chain.values = vi.fn(() => chain);
+    chain.onConflictDoNothing = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([entry]));
+    expect(await wl.addWhitelist(chain, "ag_1", "w", "test@test.com")).toEqual(entry);
+  });
+});
+
+describe("removeWhitelist", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain); chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await wl.removeWhitelist(chain, "x", "ag_1", "w")).toBeNull();
+  });
+  it("returns removed entry", async () => {
+    const entry = { id: "wl_1" };
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain); chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([entry]));
+    expect(await wl.removeWhitelist(chain, "wl_1", "ag_1", "w")).toEqual(entry);
+  });
+});
+
+describe("removeWhitelistByEmail", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain); chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await wl.removeWhitelistByEmail(chain, "ag_1", "w", "x@x.com")).toBeNull();
+  });
+  it("returns removed entry", async () => {
+    const entry = { id: "wl_1" };
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain); chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([entry]));
+    expect(await wl.removeWhitelistByEmail(chain, "ag_1", "w", "t@t.com")).toEqual(entry);
+  });
+});
+
+describe("isWhitelisted", () => {
+  it("returns true for whitelisted email", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.limit = vi.fn(() => Promise.resolve([{ id: "wl_1" }]));
+    expect(await wl.isWhitelisted(chain, "ag_1", "w", "test@test.com")).toBe(true);
+  });
+  it("returns false for non-whitelisted email", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.limit = vi.fn(() => Promise.resolve([]));
+    expect(await wl.isWhitelisted(chain, "ag_1", "w", "unknown@test.com")).toBe(false);
+  });
+});
+
+describe("buildWhitelistSet", () => {
+  it("builds a check function that matches whitelisted emails", async () => {
+    const chain: any = {};
+    chain.select = vi.fn(() => chain); chain.from = vi.fn(() => chain);
+    chain.where = vi.fn(() => Promise.resolve([{ email: "a@b.com" }]));
+    const result = await wl.buildWhitelistSet(chain, "ag_1", "w");
+    expect(result.check("a@b.com")).toBe(true);
+    expect(result.check("unknown@b.com")).toBe(false);
+  });
+});

--- a/src/shared/test/queries/workspace-invite.test.ts
+++ b/src/shared/test/queries/workspace-invite.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest";
+import * as wi from "../../src/db/queries/workspace-invite";
+
+function createSelectMock(rows: any[]) {
+  const chain: any = {};
+  chain.select = vi.fn(() => chain);
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => Promise.resolve(rows));
+  chain.innerJoin = vi.fn(() => chain);
+  chain.insert = vi.fn(() => chain);
+  chain.values = vi.fn(() => chain);
+  chain.returning = vi.fn(() => Promise.resolve(rows));
+  return chain;
+}
+
+describe("workspace-invite exports", () => {
+  it("exports createInvite", () => { expect(typeof wi.createInvite).toBe("function"); });
+  it("exports getInviteByToken", () => { expect(typeof wi.getInviteByToken).toBe("function"); });
+  it("exports listActiveInvites", () => { expect(typeof wi.listActiveInvites).toBe("function"); });
+  it("exports redeemInvite", () => { expect(typeof wi.redeemInvite).toBe("function"); });
+  it("exports deleteInvite", () => { expect(typeof wi.deleteInvite).toBe("function"); });
+});
+
+describe("createInvite", () => {
+  it("creates invite", async () => {
+    const inv = { id: "inv_1" };
+    expect(await wi.createInvite(createSelectMock([inv]), { workspaceId: "w", createdBy: "u", expiresAt: "2026-12-31" })).toEqual(inv);
+  });
+});
+
+describe("getInviteByToken", () => {
+  it("returns null when not found", async () => { expect(await wi.getInviteByToken(createSelectMock([]), "x")).toBeNull(); });
+  it("returns invite with joins", async () => {
+    const inv = { id: "inv_1" };
+    const mockDb = createSelectMock([inv]);
+    expect(await wi.getInviteByToken(mockDb, "tok")).toEqual(inv);
+    expect(mockDb.innerJoin).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("redeemInvite", () => {
+  it("returns null when expired", async () => {
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await wi.redeemInvite(chain, "x", "u")).toBeNull();
+  });
+  it("returns redeemed invite", async () => {
+    const inv = { id: "inv_1" };
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.returning = vi.fn(() => Promise.resolve([inv]));
+    expect(await wi.redeemInvite(chain, "tok", "u")).toEqual(inv);
+  });
+});
+
+describe("deleteInvite", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain); chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await wi.deleteInvite(chain, "x", "w")).toBeNull();
+  });
+  it("returns deleted invite", async () => {
+    const inv = { id: "inv_1" };
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain); chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([inv]));
+    expect(await wi.deleteInvite(chain, "inv_1", "w")).toEqual(inv);
+  });
+});

--- a/src/shared/test/queries/workspace.test.ts
+++ b/src/shared/test/queries/workspace.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import * as ws from "../../src/db/queries/workspace";
+
+function createSelectMock(rows: any[]) {
+  const chain: any = {};
+  chain.select = vi.fn(() => chain);
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => Promise.resolve(rows));
+  chain.innerJoin = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.insert = vi.fn(() => chain);
+  chain.values = vi.fn(() => chain);
+  chain.returning = vi.fn(() => Promise.resolve(rows));
+  return chain;
+}
+
+describe("workspace exports", () => {
+  it("exports getWorkspace", () => { expect(typeof ws.getWorkspace).toBe("function"); });
+  it("exports getWorkspaceBySlug", () => { expect(typeof ws.getWorkspaceBySlug).toBe("function"); });
+  it("exports listWorkspaces", () => { expect(typeof ws.listWorkspaces).toBe("function"); });
+  it("exports createWorkspace", () => { expect(typeof ws.createWorkspace).toBe("function"); });
+  it("exports updateWorkspace", () => { expect(typeof ws.updateWorkspace).toBe("function"); });
+  it("exports deleteWorkspace", () => { expect(typeof ws.deleteWorkspace).toBe("function"); });
+});
+
+describe("getWorkspace", () => {
+  it("returns null when not found", async () => { expect(await ws.getWorkspace(createSelectMock([]), "x", "u")).toBeNull(); });
+  it("returns workspace", async () => { const w = { id: "ws_1" }; expect(await ws.getWorkspace(createSelectMock([w]), "ws_1", "u")).toEqual(w); });
+});
+
+describe("getWorkspaceBySlug", () => {
+  it("returns null when not found", async () => { expect(await ws.getWorkspaceBySlug(createSelectMock([]), "x")).toBeNull(); });
+  it("returns workspace", async () => { const w = { id: "ws_1" }; expect(await ws.getWorkspaceBySlug(createSelectMock([w]), "slug")).toEqual(w); });
+});
+
+describe("createWorkspace", () => {
+  it("creates workspace", async () => {
+    const w = { id: "ws_1" };
+    expect(await ws.createWorkspace(createSelectMock([w]), { name: "N", slug: "s" })).toEqual(w);
+  });
+});
+
+describe("updateWorkspace", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await ws.updateWorkspace(chain, "x", { name: "N" })).toBeNull();
+  });
+  it("returns updated", async () => {
+    const w = { id: "ws_1" };
+    const chain: any = {};
+    chain.update = vi.fn(() => chain); chain.set = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain); chain.returning = vi.fn(() => Promise.resolve([w]));
+    expect(await ws.updateWorkspace(chain, "ws_1", { name: "N" })).toEqual(w);
+  });
+});
+
+describe("deleteWorkspace", () => {
+  it("returns null when not found", async () => {
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain); chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([]));
+    expect(await ws.deleteWorkspace(chain, "x")).toBeNull();
+  });
+  it("returns deleted", async () => {
+    const w = { id: "ws_1" };
+    const chain: any = {};
+    chain.delete = vi.fn(() => chain); chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => Promise.resolve([w]));
+    expect(await ws.deleteWorkspace(chain, "ws_1")).toEqual(w);
+  });
+});


### PR DESCRIPTION
# Why we need this PR?
> Coverage push PR #3: Deepen db/queries test coverage from ~25% to 50%+

## What changed
- Added 18 new test files for previously untested db/queries modules
- Deeper mock-based tests for agent, email, whitelist modules
- Tests cover CRUD operations, pagination logic, status transitions, batch operations
- Coverage: `src/db/queries` statements **19% → 51%**

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...