### PR TITLE
fix(ci): run coverage job on release commits to update Codecov badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
 
   coverage:
     name: Coverage
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'release:'))
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
# Why we need this PR?
The Coverage job only ran on PRs (`if: github.event_name == 'pull_request'`), so after PRs merge to main or release commits are pushed, Codecov never receives coverage data for the main branch — leaving the README badge stale.

## What changed
Updated the `coverage` job's `if` condition in `.github/workflows/ci.yml` to also trigger on push to main when the commit message starts with `release:`.

**Before:**
```yaml
if: github.event_name == 'pull_request'
```

**After:**
```yaml
if: github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'release:'))
```

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] CI/CD