### PR TITLE
feat: add codecov.yml with per-package coverage targets

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,31 @@
+coverage:
+  status:
+    project:
+      shared:
+        target: 50%
+        paths:
+          - src/shared/**
+      cli:
+        target: 60%
+        paths:
+          - src/cli/**
+      email-worker:
+        target: 70%
+        paths:
+          - src/email-worker/**
+      ws-do:
+        target: 70%
+        paths:
+          - src/ws-do/**
+      web:
+        target: 30%
+        paths:
+          - src/web/**
+    patch:
+      default:
+        target: 60%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true


### PR DESCRIPTION
# Why we need this PR?
> Closes #222

## What changed
- Created `codecov.yml` at project root with per-package coverage targets:
  - shared: 50%, cli: 60%, email-worker: 70%, ws-do: 70%, web: 30%
- Set global patch coverage target to 60%
- Configured codecov bot to post PR comments with coverage diff
- Validated config via `codecov.io/validate` endpoint (passes)

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [ ] Other: ...