### PR TITLE
feat: capture user registration source (UTM + referrer)

### DIFF
--- a/src/shared/src/db/queries/user.ts
+++ b/src/shared/src/db/queries/user.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, isNull, and } from "drizzle-orm";
 import { user } from "../schema";
 import type { Database } from "../index";
 
@@ -32,6 +32,38 @@ export async function updateUser(
     .update(user)
     .set({ name: data.name, image: data.image, updatedAt: new Date().toISOString() })
     .where(eq(user.id, id))
+    .returning();
+  return rows[0] ?? null;
+}
+
+export async function updateRegistrationSource(
+  db: Database,
+  id: string,
+  data: {
+    utmSource?: string | null;
+    utmMedium?: string | null;
+    utmCampaign?: string | null;
+    referrer?: string | null;
+  }
+) {
+  const rows = await db
+    .update(user)
+    .set({
+      utmSource: data.utmSource ?? null,
+      utmMedium: data.utmMedium ?? null,
+      utmCampaign: data.utmCampaign ?? null,
+      referrer: data.referrer ?? null,
+      updatedAt: new Date().toISOString(),
+    })
+    .where(
+      and(
+        eq(user.id, id),
+        isNull(user.utmSource),
+        isNull(user.utmMedium),
+        isNull(user.utmCampaign),
+        isNull(user.referrer),
+      )
+    )
     .returning();
   return rows[0] ?? null;
 }

--- a/src/shared/src/db/schema.ts
+++ b/src/shared/src/db/schema.ts
@@ -21,6 +21,10 @@ export const user = sqliteTable("user", {
   email: text("email").unique().notNull(),
   emailVerified: integer("emailVerified", { mode: "boolean" }),
   image: text("image"),
+  utmSource: text("utm_source"),
+  utmMedium: text("utm_medium"),
+  utmCampaign: text("utm_campaign"),
+  referrer: text("referrer"),
   createdAt: text("createdAt").notNull().$defaultFn(() => new Date().toISOString()),
   updatedAt: text("updatedAt").notNull().$defaultFn(() => new Date().toISOString()),
 });

--- a/src/shared/src/index.ts
+++ b/src/shared/src/index.ts
@@ -166,6 +166,7 @@ export {
   CreateStudioRequestSchema,
   RecruitAgentRequestSchema,
   DaemonPushMessageSchema,
+  RegistrationSourceSchema,
 } from "./schemas";
 
 export type {

--- a/src/shared/src/schemas.ts
+++ b/src/shared/src/schemas.ts
@@ -788,3 +788,15 @@ export const RecruitAgentRequestSchema = z.object({
   context_key: z.string().optional(),
 });
 export type RecruitAgentRequest = z.infer<typeof RecruitAgentRequestSchema>;
+
+// ---------------------------------------------------------------------------
+// Registration source
+// ---------------------------------------------------------------------------
+
+export const RegistrationSourceSchema = z.object({
+  utm_source: z.string().max(500).nullable().optional(),
+  utm_medium: z.string().max(500).nullable().optional(),
+  utm_campaign: z.string().max(500).nullable().optional(),
+  referrer: z.string().max(2000).nullable().optional(),
+});
+export type RegistrationSource = z.infer<typeof RegistrationSourceSchema>;

--- a/src/web/migrations/0037_user_registration_source.sql
+++ b/src/web/migrations/0037_user_registration_source.sql
@@ -1,0 +1,7 @@
+-- Add registration source tracking columns to the user table.
+-- Captures where the user came from (UTM params + referrer) at signup time.
+
+ALTER TABLE user ADD COLUMN utm_source TEXT;
+ALTER TABLE user ADD COLUMN utm_medium TEXT;
+ALTER TABLE user ADD COLUMN utm_campaign TEXT;
+ALTER TABLE user ADD COLUMN referrer TEXT;

--- a/src/web/src/app/(app)/workspaces/client.tsx
+++ b/src/web/src/app/(app)/workspaces/client.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
@@ -8,6 +9,7 @@ import { Logo } from "@/components/logo"
 import { Plus, ArrowRight, LogOut } from "lucide-react"
 import { signOut } from "@/lib/auth-client"
 import { clearAllCache } from "@/lib/chat-cache"
+import { sendRegistrationSource } from "@/lib/registration-source"
 
 interface WorkspaceItem {
   id: string
@@ -21,6 +23,10 @@ export function WorkspaceListClient({
   workspaces: WorkspaceItem[]
 }) {
   const router = useRouter()
+
+  useEffect(() => {
+    sendRegistrationSource()
+  }, [])
 
   return (
     <div className="relative flex min-h-dvh flex-col items-center justify-center p-6">

--- a/src/web/src/app/(auth)/sign-in/page.tsx
+++ b/src/web/src/app/(auth)/sign-in/page.tsx
@@ -23,6 +23,7 @@ import { SiGithub, SiGoogle } from "@icons-pack/react-simple-icons"
 import Image from "next/image"
 import { GradientBackground } from "@/components/gradient-background"
 import { resolveMode, DEV_PASSWORD } from "@alook/shared"
+import { captureRegistrationSource, sendRegistrationSource } from "@/lib/registration-source"
 
 const mode = resolveMode({
   nodeEnv: process.env.NODE_ENV,
@@ -48,6 +49,10 @@ function SignInForm({ postLoginUrl }: { postLoginUrl: string }) {
   const [code, setCode] = useState("")
   const [step, setStep] = useState<"email" | "code">("email")
   const [retryAfter, setRetryAfter] = useState<number | null>(null)
+
+  useEffect(() => {
+    captureRegistrationSource()
+  }, [])
 
   useEffect(() => {
     if (retryAfter == null) return
@@ -105,6 +110,7 @@ function SignInForm({ postLoginUrl }: { postLoginUrl: string }) {
         setError(error.message ?? "Invalid code")
         setCode("")
       } else {
+        sendRegistrationSource()
         window.location.href = postLoginUrl
         return
       }
@@ -135,6 +141,7 @@ function SignInForm({ postLoginUrl }: { postLoginUrl: string }) {
         return
       }
     }
+    sendRegistrationSource()
     window.location.href = postLoginUrl
   }
 

--- a/src/web/src/app/api/user/registration-source/route.test.ts
+++ b/src/web/src/app/api/user/registration-source/route.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
+}));
+
+const mockUpdateRegistrationSource = vi.fn();
+
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
+vi.mock("@alook/shared", async () => {
+  const actual = await vi.importActual("@alook/shared");
+  return {
+    ...actual,
+    queries: {
+      user: {
+        updateRegistrationSource: (...args: unknown[]) =>
+          mockUpdateRegistrationSource(...args),
+      },
+    },
+  };
+});
+
+vi.mock("@/lib/middleware/auth", () => ({
+  withAuth: vi.fn((handler: any) => async (req: any, ctx?: any) => {
+    const params = ctx?.params instanceof Promise ? await ctx.params : ctx?.params;
+    return handler(req, { userId: "u1", email: "u@t.com", params });
+  }),
+}));
+
+vi.mock("@/lib/middleware/helpers", async () => {
+  const { NextResponse } = require("next/server");
+  const actual = await vi.importActual("@/lib/middleware/helpers");
+  return {
+    ...actual,
+    writeJSON: (data: unknown, status = 200) =>
+      NextResponse.json(data, { status }),
+    writeError: (message: string, status: number) =>
+      NextResponse.json({ error: message }, { status }),
+  };
+});
+
+import { POST } from "./route";
+
+describe("POST /api/user/registration-source", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("updates user with utm params and referrer", async () => {
+    mockUpdateRegistrationSource.mockResolvedValue({ id: "u1" });
+
+    const req = new NextRequest("http://localhost/api/user/registration-source", {
+      method: "POST",
+      body: JSON.stringify({
+        utm_source: "google",
+        utm_medium: "cpc",
+        utm_campaign: "launch",
+        referrer: "https://google.com/search",
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await POST(req, {} as any);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ updated: true });
+    expect(mockUpdateRegistrationSource).toHaveBeenCalledWith({}, "u1", {
+      utmSource: "google",
+      utmMedium: "cpc",
+      utmCampaign: "launch",
+      referrer: "https://google.com/search",
+    });
+  });
+
+  it("returns updated:false when no values provided", async () => {
+    const req = new NextRequest("http://localhost/api/user/registration-source", {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await POST(req, {} as any);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ updated: false });
+    expect(mockUpdateRegistrationSource).not.toHaveBeenCalled();
+  });
+
+  it("returns updated:false when all values are null", async () => {
+    const req = new NextRequest("http://localhost/api/user/registration-source", {
+      method: "POST",
+      body: JSON.stringify({
+        utm_source: null,
+        utm_medium: null,
+        utm_campaign: null,
+        referrer: null,
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await POST(req, {} as any);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ updated: false });
+    expect(mockUpdateRegistrationSource).not.toHaveBeenCalled();
+  });
+
+  it("returns updated:false when source already set (first-write-wins)", async () => {
+    mockUpdateRegistrationSource.mockResolvedValue(null);
+
+    const req = new NextRequest("http://localhost/api/user/registration-source", {
+      method: "POST",
+      body: JSON.stringify({ utm_source: "twitter" }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await POST(req, {} as any);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ updated: false });
+  });
+
+  it("handles partial UTM params (only referrer)", async () => {
+    mockUpdateRegistrationSource.mockResolvedValue({ id: "u1" });
+
+    const req = new NextRequest("http://localhost/api/user/registration-source", {
+      method: "POST",
+      body: JSON.stringify({ referrer: "https://news.ycombinator.com" }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await POST(req, {} as any);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ updated: true });
+    expect(mockUpdateRegistrationSource).toHaveBeenCalledWith({}, "u1", {
+      utmSource: null,
+      utmMedium: null,
+      utmCampaign: null,
+      referrer: "https://news.ycombinator.com",
+    });
+  });
+
+  it("returns 400 for invalid body", async () => {
+    const req = new NextRequest("http://localhost/api/user/registration-source", {
+      method: "POST",
+      body: "not json",
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await POST(req, {} as any);
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/web/src/app/api/user/registration-source/route.ts
+++ b/src/web/src/app/api/user/registration-source/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { queries, RegistrationSourceSchema } from "@alook/shared";
+import { getDb } from "@/lib/db";
+import { withAuth } from "@/lib/middleware/auth";
+import { writeJSON, parseBody } from "@/lib/middleware/helpers";
+
+export const POST = withAuth(async (req: NextRequest, ctx) => {
+  const { env } = getCloudflareContext();
+  const db = getDb((env as Env).DB);
+
+  const [body, valErr] = await parseBody(req, RegistrationSourceSchema);
+  if (valErr) return valErr;
+
+  const hasAnyValue =
+    body.utm_source || body.utm_medium || body.utm_campaign || body.referrer;
+  if (!hasAnyValue) {
+    return writeJSON({ updated: false });
+  }
+
+  const updated = await queries.user.updateRegistrationSource(db, ctx.userId, {
+    utmSource: body.utm_source || null,
+    utmMedium: body.utm_medium || null,
+    utmCampaign: body.utm_campaign || null,
+    referrer: body.referrer || null,
+  });
+
+  return writeJSON({ updated: !!updated });
+});

--- a/src/web/src/lib/registration-source.test.ts
+++ b/src/web/src/lib/registration-source.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { captureRegistrationSource, sendRegistrationSource } from "./registration-source";
+
+describe("registration-source", () => {
+  const mockFetch = vi.fn();
+  const store: Record<string, string> = {};
+
+  function resetStore() {
+    for (const key of Object.keys(store)) delete store[key];
+  }
+
+  beforeEach(() => {
+    resetStore();
+    vi.clearAllMocks();
+
+    Object.defineProperty(globalThis, "window", {
+      value: { location: { search: "" } },
+      writable: true,
+      configurable: true,
+    });
+
+    Object.defineProperty(globalThis, "document", {
+      value: { referrer: "" },
+      writable: true,
+      configurable: true,
+    });
+
+    Object.defineProperty(globalThis, "sessionStorage", {
+      value: {
+        getItem: (key: string) => store[key] ?? null,
+        setItem: (key: string, value: string) => { store[key] = value; },
+        removeItem: (key: string) => { delete store[key]; },
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    globalThis.fetch = mockFetch as any;
+    mockFetch.mockResolvedValue(new Response("ok"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("captureRegistrationSource", () => {
+    it("captures UTM params from URL", () => {
+      (window as any).location.search =
+        "?utm_source=google&utm_medium=cpc&utm_campaign=launch";
+
+      captureRegistrationSource();
+
+      const stored = JSON.parse(
+        store["alook_registration_source"]
+      );
+      expect(stored).toEqual({
+        utm_source: "google",
+        utm_medium: "cpc",
+        utm_campaign: "launch",
+        referrer: null,
+      });
+    });
+
+    it("captures document.referrer", () => {
+      (document as any).referrer = "https://news.ycombinator.com";
+
+      captureRegistrationSource();
+
+      const stored = JSON.parse(
+        store["alook_registration_source"]
+      );
+      expect(stored.referrer).toBe("https://news.ycombinator.com");
+    });
+
+    it("captures both UTM and referrer", () => {
+      (window as any).location.search = "?utm_source=twitter";
+      (document as any).referrer = "https://t.co/abc";
+
+      captureRegistrationSource();
+
+      const stored = JSON.parse(
+        store["alook_registration_source"]
+      );
+      expect(stored.utm_source).toBe("twitter");
+      expect(stored.referrer).toBe("https://t.co/abc");
+    });
+
+    it("does not store when no UTM or referrer present", () => {
+      (window as any).location.search = "";
+      (document as any).referrer = "";
+
+      captureRegistrationSource();
+
+      expect(store["alook_registration_source"]).toBeUndefined();
+    });
+
+    it("stores null for absent UTM fields", () => {
+      (window as any).location.search = "?utm_source=google";
+
+      captureRegistrationSource();
+
+      const stored = JSON.parse(
+        store["alook_registration_source"]
+      );
+      expect(stored.utm_medium).toBeNull();
+      expect(stored.utm_campaign).toBeNull();
+    });
+  });
+
+  describe("sendRegistrationSource", () => {
+    it("sends stored data and removes from sessionStorage", () => {
+      store["alook_registration_source"] = JSON.stringify({
+        utm_source: "google",
+        utm_medium: null,
+        utm_campaign: null,
+        referrer: "https://google.com",
+      });
+
+      sendRegistrationSource();
+
+      expect(mockFetch).toHaveBeenCalledWith("/api/user/registration-source", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          utm_source: "google",
+          utm_medium: null,
+          utm_campaign: null,
+          referrer: "https://google.com",
+        }),
+        keepalive: true,
+      });
+      expect(store["alook_registration_source"]).toBeUndefined();
+    });
+
+    it("does nothing when no stored data", () => {
+      resetStore();
+
+      sendRegistrationSource();
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("does not throw on fetch failure", () => {
+      store["alook_registration_source"] = JSON.stringify({
+        utm_source: "test",
+      });
+      mockFetch.mockRejectedValue(new Error("network error"));
+
+      expect(() => sendRegistrationSource()).not.toThrow();
+    });
+  });
+});

--- a/src/web/src/lib/registration-source.ts
+++ b/src/web/src/lib/registration-source.ts
@@ -1,0 +1,43 @@
+const REG_SOURCE_KEY = "alook_registration_source"
+
+export function captureRegistrationSource() {
+  if (typeof window === "undefined") return
+  try {
+    const params = new URLSearchParams(window.location.search)
+    const utmSource = params.get("utm_source") || null
+    const utmMedium = params.get("utm_medium") || null
+    const utmCampaign = params.get("utm_campaign") || null
+    const referrer = document.referrer || null
+    if (utmSource || utmMedium || utmCampaign || referrer) {
+      sessionStorage.setItem(
+        REG_SOURCE_KEY,
+        JSON.stringify({
+          utm_source: utmSource,
+          utm_medium: utmMedium,
+          utm_campaign: utmCampaign,
+          referrer,
+        }),
+      )
+    }
+  } catch {
+    // sessionStorage unavailable (private browsing etc.)
+  }
+}
+
+export function sendRegistrationSource() {
+  if (typeof window === "undefined") return
+  try {
+    const raw = sessionStorage.getItem(REG_SOURCE_KEY)
+    if (!raw) return
+    sessionStorage.removeItem(REG_SOURCE_KEY)
+    const data = JSON.parse(raw)
+    fetch("/api/user/registration-source", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+      keepalive: true,
+    }).catch(() => {})
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
# Why we need this PR?
> Enables daily new-user report to show acquisition source (where each user came from)

## What changed
- Added D1 migration `0037_user_registration_source.sql` with 4 nullable columns on the `user` table: `utm_source`, `utm_medium`, `utm_campaign`, `referrer`
- Updated Drizzle schema to include the new columns
- Created `src/web/src/lib/registration-source.ts` utility that captures UTM params + `document.referrer` into sessionStorage on page load, and sends them to the server after auth
- Created `POST /api/user/registration-source` endpoint that persists the data (first-write-wins: only updates if columns are still NULL)
- Sign-in page captures source on load and sends after OTP/dev sign-in success
- Workspaces page client sends source on mount (catch-all for OAuth flows)
- Added `RegistrationSourceSchema` Zod validation in shared

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...