### PR TITLE
fix: sync runtime button state with daemon via WS broadcast

### DIFF
--- a/src/shared/src/db/queries/runtime.ts
+++ b/src/shared/src/db/queries/runtime.ts
@@ -56,6 +56,7 @@ export async function listAgentRuntimes(db: Database, workspaceId: string) {
       updatedAt: agentRuntime.updatedAt,
       machineLastSeenAt: machine.lastSeenAt,
       pendingUpdateVersion: machine.pendingUpdateVersion,
+      pendingRescan: machine.pendingRescan,
     })
     .from(agentRuntime)
     .leftJoin(
@@ -94,6 +95,8 @@ export async function getAgentRuntimeForWorkspace(
       createdAt: agentRuntime.createdAt,
       updatedAt: agentRuntime.updatedAt,
       machineLastSeenAt: machine.lastSeenAt,
+      pendingUpdateVersion: machine.pendingUpdateVersion,
+      pendingRescan: machine.pendingRescan,
     })
     .from(agentRuntime)
     .leftJoin(
@@ -127,6 +130,8 @@ export async function getAgentRuntimesForWorkspace(
       createdAt: agentRuntime.createdAt,
       updatedAt: agentRuntime.updatedAt,
       machineLastSeenAt: machine.lastSeenAt,
+      pendingUpdateVersion: machine.pendingUpdateVersion,
+      pendingRescan: machine.pendingRescan,
     })
     .from(agentRuntime)
     .leftJoin(

--- a/src/web/src/app/api/daemon/register/route.test.ts
+++ b/src/web/src/app/api/daemon/register/route.test.ts
@@ -4,6 +4,8 @@ import { NextRequest } from "next/server";
 const mockGetMember = vi.fn();
 const mockUpsertMachine = vi.fn();
 const mockUpsertAgentRuntime = vi.fn();
+const mockGetMachineByDaemon = vi.fn();
+const mockClearPendingUpdateVersion = vi.fn();
 const mockBroadcastToUser = vi.fn();
 
 function sharedMocks() {
@@ -11,22 +13,28 @@ function sharedMocks() {
     "@opennextjs/cloudflare": {
       getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
     },
-    "@alook/shared": async () => ({
-      createDb: vi.fn(() => ({})),
-      queries: {
-        member: {
-          getMemberByUserAndWorkspace: (...a: any[]) => mockGetMember(...a),
+    "@alook/shared": async () => {
+      const real = await import("@alook/shared");
+      return {
+        createDb: vi.fn(() => ({})),
+        semverGte: real.semverGte,
+        queries: {
+          member: {
+            getMemberByUserAndWorkspace: (...a: any[]) => mockGetMember(...a),
+          },
+          machine: {
+            upsertMachine: (...a: any[]) => mockUpsertMachine(...a),
+            getMachineByDaemon: (...a: any[]) => mockGetMachineByDaemon(...a),
+            clearPendingUpdateVersion: (...a: any[]) => mockClearPendingUpdateVersion(...a),
+          },
+          runtime: {
+            upsertAgentRuntime: (...a: any[]) => mockUpsertAgentRuntime(...a),
+          },
         },
-        machine: {
-          upsertMachine: (...a: any[]) => mockUpsertMachine(...a),
-        },
-        runtime: {
-          upsertAgentRuntime: (...a: any[]) => mockUpsertAgentRuntime(...a),
-        },
-      },
-      RegisterDaemonRequestSchema: (await import("@alook/shared"))
-        .RegisterDaemonRequestSchema,
-    }),
+        RegisterDaemonRequestSchema: real.RegisterDaemonRequestSchema,
+        generateWorkspaceSlug: real.generateWorkspaceSlug,
+      };
+    },
     "@/lib/broadcast": {
       broadcastToUser: (...a: any[]) => mockBroadcastToUser(...a),
     },
@@ -116,12 +124,13 @@ describe("POST /api/daemon/register", () => {
     expect(mockUpsertAgentRuntime).toHaveBeenCalledTimes(1);
   });
 
-  it("broadcasts only runtime.registered after upserts (not runtime.status)", async () => {
+  it("broadcasts only runtime.registered after upserts when no pending update", async () => {
     const POST = await loadRoute(authCtx);
 
     mockGetMember.mockResolvedValue({ userId: "u1", workspaceId: "w1" });
     mockUpsertMachine.mockResolvedValue(undefined);
     mockUpsertAgentRuntime.mockResolvedValue({ id: "r1" });
+    mockGetMachineByDaemon.mockResolvedValue(null);
     mockBroadcastToUser.mockResolvedValue(undefined);
 
     await POST(makeReq(validBody));
@@ -135,12 +144,13 @@ describe("POST /api/daemon/register", () => {
     });
   });
 
-  it("does NOT broadcast runtime.status from register endpoint", async () => {
+  it("does NOT broadcast runtime.status when no pending update version", async () => {
     const POST = await loadRoute(authCtx);
 
     mockGetMember.mockResolvedValue({ userId: "u1", workspaceId: "w1" });
     mockUpsertMachine.mockResolvedValue(undefined);
     mockUpsertAgentRuntime.mockResolvedValue({ id: "r1" });
+    mockGetMachineByDaemon.mockResolvedValue(null);
     mockBroadcastToUser.mockResolvedValue(undefined);
 
     await POST(makeReq(validBody));
@@ -212,6 +222,7 @@ describe("POST /api/daemon/register", () => {
     mockUpsertMachine.mockRejectedValue(new Error("D1 timeout"));
     mockUpsertAgentRuntime.mockResolvedValue({ id: "r1" });
     mockBroadcastToUser.mockResolvedValue(undefined);
+    mockGetMachineByDaemon.mockResolvedValue(null);
 
     const res = await POST(makeReq(validBody));
     const body = await res.json();
@@ -219,5 +230,57 @@ describe("POST /api/daemon/register", () => {
     expect(res.status).toBe(200);
     expect(body.runtimes).toEqual([{ id: "r1" }]);
     expect(mockUpsertAgentRuntime).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears pendingUpdateVersion when cli_version satisfies pending version on register", async () => {
+    const POST = await loadRoute(authCtx);
+
+    mockGetMember.mockResolvedValue({ userId: "u1", workspaceId: "w1" });
+    mockUpsertMachine.mockResolvedValue(undefined);
+    mockUpsertAgentRuntime.mockResolvedValue({ id: "r1" });
+    mockGetMachineByDaemon.mockResolvedValue({ pendingUpdateVersion: "0.0.2" });
+    mockClearPendingUpdateVersion.mockResolvedValue(undefined);
+    mockBroadcastToUser.mockResolvedValue(undefined);
+
+    const res = await POST(makeReq(validBody));
+
+    expect(res.status).toBe(200);
+    expect(mockClearPendingUpdateVersion).toHaveBeenCalledWith({}, "d1", "w1");
+    expect(mockBroadcastToUser).toHaveBeenCalledWith("u1", {
+      type: "runtime.status",
+      daemonId: "d1",
+      workspaceId: "w1",
+      status: "online",
+    });
+  });
+
+  it("does not clear pendingUpdateVersion when cli_version is older", async () => {
+    const POST = await loadRoute(authCtx);
+
+    mockGetMember.mockResolvedValue({ userId: "u1", workspaceId: "w1" });
+    mockUpsertMachine.mockResolvedValue(undefined);
+    mockUpsertAgentRuntime.mockResolvedValue({ id: "r1" });
+    mockGetMachineByDaemon.mockResolvedValue({ pendingUpdateVersion: "2.0.0" });
+    mockBroadcastToUser.mockResolvedValue(undefined);
+
+    const res = await POST(makeReq(validBody));
+
+    expect(res.status).toBe(200);
+    expect(mockClearPendingUpdateVersion).not.toHaveBeenCalled();
+  });
+
+  it("does not check pendingUpdateVersion when cli_version is missing", async () => {
+    const POST = await loadRoute(authCtx);
+
+    mockGetMember.mockResolvedValue({ userId: "u1", workspaceId: "w1" });
+    mockUpsertMachine.mockResolvedValue(undefined);
+    mockUpsertAgentRuntime.mockResolvedValue({ id: "r1" });
+    mockBroadcastToUser.mockResolvedValue(undefined);
+
+    const bodyWithoutVersion = { ...validBody, cli_version: undefined };
+    const res = await POST(makeReq(bodyWithoutVersion));
+
+    expect(res.status).toBe(200);
+    expect(mockGetMachineByDaemon).not.toHaveBeenCalled();
   });
 });

--- a/src/web/src/app/api/daemon/register/route.ts
+++ b/src/web/src/app/api/daemon/register/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { queries } from "@alook/shared"
+import { queries, semverGte } from "@alook/shared"
 import { getDb, withD1Retry } from "@/lib/db"
 import { withAuth } from "@/lib/middleware/auth";
 import { writeJSON, parseBody } from "@/lib/middleware/helpers";
@@ -67,6 +67,24 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     });
   } catch (e) {
     log.warn("register: machine upsert failed", { daemonId, err: String(e) });
+  }
+
+  // Clear pendingUpdateVersion if daemon re-registered with a satisfying version
+  if (cliVersion) {
+    try {
+      const machineRow = await queries.machine.getMachineByDaemon(db, daemonId, workspaceId);
+      if (machineRow?.pendingUpdateVersion && semverGte(cliVersion, machineRow.pendingUpdateVersion)) {
+        await queries.machine.clearPendingUpdateVersion(db, daemonId, workspaceId);
+        broadcastToUser(ctx.userId, {
+          type: "runtime.status",
+          daemonId,
+          workspaceId,
+          status: "online",
+        }).catch(() => {});
+      }
+    } catch (e) {
+      log.warn("register: pending version check failed", { daemonId, err: String(e) });
+    }
   }
 
   const results = [];

--- a/src/web/src/app/api/daemon/tasks/poll/route.test.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.test.ts
@@ -806,4 +806,19 @@ describe("POST /api/daemon/tasks/poll", () => {
       status: "online",
     });
   });
+
+  it("does not fail poll when rescan broadcast rejects", async () => {
+    mockGetRuntimeIdsByDaemon.mockResolvedValue(["r1"]);
+    mockSweepStaleState.mockResolvedValue(undefined);
+    mockBroadcastToUser.mockRejectedValue(new Error("WS unavailable"));
+    mockClaimTasksForRuntimes.mockResolvedValue([]);
+    mockGetMachineByDaemon.mockResolvedValue({ pendingRescan: true });
+    mockClearPendingRescan.mockResolvedValue(undefined);
+
+    const res = await POST(postReq({ daemon_id: "d1" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.pending_rescan).toBe(true);
+  });
 });

--- a/src/web/src/app/api/daemon/tasks/poll/route.test.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.test.ts
@@ -784,4 +784,26 @@ describe("POST /api/daemon/tasks/poll", () => {
       expect.anything(),
     );
   });
+
+  it("broadcasts runtime.status after clearing pendingRescan", async () => {
+    mockGetRuntimeIdsByDaemon.mockResolvedValue(["r1"]);
+    mockSweepStaleState.mockResolvedValue(undefined);
+    mockBroadcastToUser.mockResolvedValue(undefined);
+    mockClaimTasksForRuntimes.mockResolvedValue([]);
+    mockGetMachineByDaemon.mockResolvedValue({ pendingRescan: true });
+    mockClearPendingRescan.mockResolvedValue(undefined);
+
+    const res = await POST(postReq({ daemon_id: "d1" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.pending_rescan).toBe(true);
+    expect(mockClearPendingRescan).toHaveBeenCalledWith({}, "d1", "w1");
+    expect(mockBroadcastToUser).toHaveBeenCalledWith("u1", {
+      type: "runtime.status",
+      daemonId: "d1",
+      workspaceId: "w1",
+      status: "online",
+    });
+  });
 });

--- a/src/web/src/app/api/daemon/tasks/poll/route.test.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.test.ts
@@ -279,7 +279,7 @@ describe("POST /api/daemon/tasks/poll", () => {
     expect(mockClaimTasksForRuntimes).toHaveBeenCalledWith(["r1"], 1, "w1");
   });
 
-  it("returns pending_update when pendingUpdateVersion is set and cli_version is older", async () => {
+  it("returns pending_update when pendingUpdateVersion is set and cli_version is older, without clearing flag", async () => {
     mockUpsertMachine.mockResolvedValue({});
     mockGetRuntimeIdsByDaemon.mockResolvedValue(["r1"]);
     mockSweepStaleState.mockResolvedValue(undefined);
@@ -292,6 +292,8 @@ describe("POST /api/daemon/tasks/poll", () => {
 
     expect(res.status).toBe(200);
     expect(body.pending_update).toEqual({ version: "1.0.0" });
+    expect(mockClearPendingUpdateVersion).not.toHaveBeenCalled();
+    expect(mockBroadcastToUser).not.toHaveBeenCalled();
   });
 
   it("does not return pending_update when pendingUpdateVersion is not set", async () => {
@@ -309,7 +311,7 @@ describe("POST /api/daemon/tasks/poll", () => {
     expect(body.pending_update).toBeUndefined();
   });
 
-  it("auto-clears pendingUpdateVersion when cli_version >= pending version", async () => {
+  it("auto-clears pendingUpdateVersion and broadcasts when cli_version >= pending version", async () => {
     mockUpsertMachine.mockResolvedValue({});
     mockGetRuntimeIdsByDaemon.mockResolvedValue(["r1"]);
     mockSweepStaleState.mockResolvedValue(undefined);
@@ -324,6 +326,12 @@ describe("POST /api/daemon/tasks/poll", () => {
     expect(res.status).toBe(200);
     expect(body.pending_update).toBeUndefined();
     expect(mockClearPendingUpdateVersion).toHaveBeenCalledWith({}, "d1", "w1");
+    expect(mockBroadcastToUser).toHaveBeenCalledWith("u1", {
+      type: "runtime.status",
+      daemonId: "d1",
+      workspaceId: "w1",
+      status: "online",
+    });
   });
 
   it("does not attach pending_update when cli_version is missing (backward compat)", async () => {

--- a/src/web/src/app/api/daemon/tasks/poll/route.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.ts
@@ -72,16 +72,17 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
       const machineRow = machineResult.value;
       try {
         if (machineRow?.pendingUpdateVersion && body.cli_version) {
-          pendingUpdate = semverGte(body.cli_version, machineRow.pendingUpdateVersion)
-            ? undefined
-            : { version: machineRow.pendingUpdateVersion };
-          await queries.machine.clearPendingUpdateVersion(db, body.daemon_id, ctx.workspaceId);
-          broadcastToUser(ctx.userId, {
-            type: "runtime.status",
-            daemonId: body.daemon_id,
-            workspaceId: ctx.workspaceId,
-            status: "online",
-          }).catch(() => {});
+          if (semverGte(body.cli_version, machineRow.pendingUpdateVersion)) {
+            await queries.machine.clearPendingUpdateVersion(db, body.daemon_id, ctx.workspaceId);
+            broadcastToUser(ctx.userId, {
+              type: "runtime.status",
+              daemonId: body.daemon_id,
+              workspaceId: ctx.workspaceId,
+              status: "online",
+            }).catch(() => {});
+          } else {
+            pendingUpdate = { version: machineRow.pendingUpdateVersion };
+          }
         }
 
         if (machineRow?.pendingRescan) {

--- a/src/web/src/app/api/daemon/tasks/poll/route.ts
+++ b/src/web/src/app/api/daemon/tasks/poll/route.ts
@@ -87,6 +87,12 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
         if (machineRow?.pendingRescan) {
           pendingRescan = true;
           await queries.machine.clearPendingRescan(db, body.daemon_id, ctx.workspaceId);
+          broadcastToUser(ctx.userId, {
+            type: "runtime.status",
+            daemonId: body.daemon_id,
+            workspaceId: ctx.workspaceId,
+            status: "online",
+          }).catch(() => {});
         }
       } catch (e) {
         log.warn("pending check failed", { daemonId: body.daemon_id, err: String(e) });

--- a/src/web/src/app/api/runtimes/[runtimeId]/update/route.test.ts
+++ b/src/web/src/app/api/runtimes/[runtimeId]/update/route.test.ts
@@ -59,8 +59,11 @@ vi.mock("@/lib/logger", () => ({
   log: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
+const mockBroadcastToUser = vi.fn(() => Promise.resolve());
+
 vi.mock("@/lib/broadcast", () => ({
   broadcastToDaemon: vi.fn(() => Promise.resolve({ sent: 1 })),
+  broadcastToUser: (...args: any[]) => mockBroadcastToUser(...args),
 }));
 
 // Mock global fetch for npm registry
@@ -140,7 +143,7 @@ describe("DELETE /api/runtimes/[runtimeId]/update", () => {
     mockGetMemberByUserAndWorkspace.mockResolvedValue({ id: "m1" });
   });
 
-  it("returns 204 when cancelling update", async () => {
+  it("returns 204 when cancelling update and broadcasts runtime.status", async () => {
     mockGetAgentRuntimeForWorkspace.mockResolvedValue({
       id: "rt1",
       daemonId: "d1",
@@ -151,6 +154,12 @@ describe("DELETE /api/runtimes/[runtimeId]/update", () => {
 
     expect(res.status).toBe(204);
     expect(mockClearPendingUpdateVersion).toHaveBeenCalledWith({}, "d1", "w1");
+    expect(mockBroadcastToUser).toHaveBeenCalledWith("u1", {
+      type: "runtime.status",
+      daemonId: "d1",
+      workspaceId: "w1",
+      status: "online",
+    });
   });
 
   it("returns 404 for non-existent runtime", async () => {

--- a/src/web/src/app/api/runtimes/[runtimeId]/update/route.test.ts
+++ b/src/web/src/app/api/runtimes/[runtimeId]/update/route.test.ts
@@ -162,6 +162,19 @@ describe("DELETE /api/runtimes/[runtimeId]/update", () => {
     });
   });
 
+  it("returns 204 even when broadcast fails", async () => {
+    mockGetAgentRuntimeForWorkspace.mockResolvedValue({
+      id: "rt1",
+      daemonId: "d1",
+    });
+    mockClearPendingUpdateVersion.mockResolvedValue(undefined);
+    mockBroadcastToUser.mockRejectedValue(new Error("WS unavailable"));
+
+    const res = await DELETE(makeReq("DELETE", "rt1", "w1"));
+
+    expect(res.status).toBe(204);
+  });
+
   it("returns 404 for non-existent runtime", async () => {
     mockGetAgentRuntimeForWorkspace.mockResolvedValue(null);
 

--- a/src/web/src/app/api/runtimes/[runtimeId]/update/route.ts
+++ b/src/web/src/app/api/runtimes/[runtimeId]/update/route.ts
@@ -6,7 +6,7 @@ import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError } from "@/lib/middleware/helpers";
 import { fetchLatestCliVersion } from "@/lib/npm";
-import { broadcastToDaemon } from "@/lib/broadcast";
+import { broadcastToDaemon, broadcastToUser } from "@/lib/broadcast";
 
 export const POST = withAuth(async (req: NextRequest, ctx) => {
   const ws = await withWorkspaceMember(req, ctx);
@@ -53,6 +53,13 @@ export const DELETE = withAuth(async (req: NextRequest, ctx) => {
   if (!runtime) return writeError("runtime not found", 404);
 
   await queries.machine.clearPendingUpdateVersion(db, runtime.daemonId, ws.workspaceId);
+
+  broadcastToUser(ctx.userId, {
+    type: "runtime.status",
+    daemonId: runtime.daemonId,
+    workspaceId: ws.workspaceId,
+    status: "online",
+  }).catch(() => {});
 
   return new Response(null, { status: 204 });
 });


### PR DESCRIPTION
# Why we need this PR?
> Fixes runtime update/rescan button state being out of sync with daemon — buttons stayed in "pending" state for up to 30s after the daemon completed the operation.

## What changed

1. **Added `pendingRescan` to runtime queries** (`listAgentRuntimes`, `getAgentRuntimeForWorkspace`, `getAgentRuntimesForWorkspace`) — the response transformer already expected `rt.pendingRescan` but the query never selected it, so the field was always `false` regardless of DB state.

2. **Added `runtime.status` broadcast in `DELETE /api/runtimes/:id/update`** — when the daemon calls DELETE to clear `pendingUpdateVersion`, we now broadcast to the user so the frontend updates immediately via WebSocket instead of waiting for the next 30s polling cycle.

3. **Added `runtime.status` broadcast after `clearPendingRescan` in the poll route** — same pattern: when the daemon picks up and clears the rescan flag, broadcast so the UI knows immediately.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...