### PR TITLE
fix(cli): re-fetch runtimes after creating new workspace in workspace init

### DIFF
--- a/src/cli/commands/workspace.test.ts
+++ b/src/cli/commands/workspace.test.ts
@@ -126,15 +126,16 @@ describe("workspace init", () => {
     expect(consoleErrSpy).toHaveBeenCalledWith(expect.stringContaining("No daemon registered"));
   });
 
-  it("creates new workspace when agents already exist", async () => {
+  it("creates new workspace and re-fetches runtimes from it", async () => {
     const jsonPath = writeJson("valid.json", {
       name: "New WS",
       members: [{ role: "leader", instructions: "x" }],
     });
 
     getJSONMock
-      .mockResolvedValueOnce([{ id: "rt1", machineLastSeenAt: new Date().toISOString() }]) // runtimes
-      .mockResolvedValueOnce([{ id: "existing-agent" }]); // existing agents
+      .mockResolvedValueOnce([{ id: "rt1", machineLastSeenAt: new Date().toISOString() }]) // runtimes (old ws)
+      .mockResolvedValueOnce([{ id: "existing-agent" }]) // existing agents
+      .mockResolvedValueOnce([{ id: "rt_new", machineLastSeenAt: new Date().toISOString() }]); // runtimes (new ws)
 
     postJSONMock
       .mockResolvedValueOnce({ id: "ws_new", name: "New WS" }) // POST /api/workspaces
@@ -149,6 +150,72 @@ describe("workspace init", () => {
 
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("existing agents"));
     expect(postJSONMock).toHaveBeenCalledWith("/api/workspaces", expect.objectContaining({ name: "New WS" }));
+    expect(postJSONMock).toHaveBeenCalledWith("/api/studios", expect.objectContaining({
+      members: expect.arrayContaining([
+        expect.objectContaining({ runtime_id: "rt_new" }),
+      ]),
+    }));
+  });
+
+  it("registers runtime in new workspace when none exist there", async () => {
+    const jsonPath = writeJson("valid.json", {
+      name: "Fresh WS",
+      members: [{ role: "leader", instructions: "x" }],
+    });
+
+    getJSONMock
+      .mockResolvedValueOnce([{ id: "rt_orig", machineLastSeenAt: new Date().toISOString() }]) // runtimes (old ws)
+      .mockResolvedValueOnce([{ id: "existing-agent" }]) // existing agents
+      .mockResolvedValueOnce([]); // runtimes (new ws) — empty
+
+    postJSONMock
+      .mockResolvedValueOnce({ id: "ws_fresh", name: "Fresh WS" }) // POST /api/workspaces
+      .mockResolvedValueOnce(undefined) // POST /api/runtimes (register)
+      .mockResolvedValueOnce({ // POST /api/studios
+        studio: { name: "Fresh WS" },
+        workspace: { id: "ws_fresh", name: "Fresh WS" },
+        agents: [{ id: "ag1", name: "Dave", email_handle: "dave" }],
+        links: [],
+      });
+
+    await runInit(["--json-file", jsonPath]);
+
+    expect(postJSONMock).toHaveBeenCalledWith("/api/runtimes", { id: "rt_orig" });
+    expect(postJSONMock).toHaveBeenCalledWith("/api/studios", expect.objectContaining({
+      members: expect.arrayContaining([
+        expect.objectContaining({ runtime_id: "rt_orig" }),
+      ]),
+    }));
+  });
+
+  it("warns but continues when runtime re-fetch fails in new workspace", async () => {
+    const jsonPath = writeJson("valid.json", {
+      name: "Warn WS",
+      members: [{ role: "leader", instructions: "x" }],
+    });
+
+    getJSONMock
+      .mockResolvedValueOnce([{ id: "rt1", machineLastSeenAt: new Date().toISOString() }]) // runtimes (old ws)
+      .mockResolvedValueOnce([{ id: "existing-agent" }]) // existing agents
+      .mockRejectedValueOnce(new Error("timeout")); // runtimes (new ws) fails
+
+    postJSONMock
+      .mockResolvedValueOnce({ id: "ws_warn", name: "Warn WS" }) // POST /api/workspaces
+      .mockResolvedValueOnce({ // POST /api/studios
+        studio: { name: "Warn WS" },
+        workspace: { id: "ws_warn", name: "Warn WS" },
+        agents: [{ id: "ag1", name: "Eve", email_handle: "eve" }],
+        links: [],
+      });
+
+    await runInit(["--json-file", jsonPath]);
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("could not refresh runtimes"));
+    expect(postJSONMock).toHaveBeenCalledWith("/api/studios", expect.objectContaining({
+      members: expect.arrayContaining([
+        expect.objectContaining({ runtime_id: "rt1" }),
+      ]),
+    }));
   });
 
   it("warns when agent existence check fails", async () => {

--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -80,7 +80,7 @@ export function workspaceCommand(): Command {
         const lastSeen = new Date(r.machineLastSeenAt.includes("Z") ? r.machineLastSeenAt : r.machineLastSeenAt + "Z").getTime();
         return now - lastSeen < OFFLINE_THRESHOLD_MS;
       });
-      const runtime = onlineRuntime || runtimes[0];
+      let runtime = onlineRuntime || runtimes[0];
 
       // Check if workspace already has agents — if so, create a new workspace
       let targetWorkspaceId = workspaceId;
@@ -94,6 +94,23 @@ export function workspaceCommand(): Command {
           targetWorkspaceId = newWs.id;
           targetClient = new APIClient(serverUrl, token, targetWorkspaceId);
           console.log(`Created workspace: ${newWs.name} (${newWs.id})`);
+
+          // Re-fetch runtimes scoped to the new workspace
+          try {
+            const newRuntimes = await targetClient.getJSON<RuntimeResponse[]>("/api/runtimes");
+            if (newRuntimes.length > 0) {
+              const newOnlineRuntime = newRuntimes.find((r) => {
+                if (!r.machineLastSeenAt) return false;
+                const lastSeen = new Date(r.machineLastSeenAt.includes("Z") ? r.machineLastSeenAt : r.machineLastSeenAt + "Z").getTime();
+                return now - lastSeen < OFFLINE_THRESHOLD_MS;
+              });
+              runtime = newOnlineRuntime || newRuntimes[0];
+            } else {
+              await targetClient.postJSON("/api/runtimes", { id: runtime.id });
+            }
+          } catch (err) {
+            console.warn(`Warning: could not refresh runtimes for new workspace: ${err instanceof Error ? err.message : err}`);
+          }
         }
       } catch (err) {
         console.warn(`Warning: could not check existing agents: ${err instanceof Error ? err.message : err}`);


### PR DESCRIPTION
# Why we need this PR?
> Fixes runtime_id scoping bug in `workspace init` — when a new workspace is created (because existing agents are detected), the runtime fetched from the old workspace was injected into the new workspace's studio call, causing a 404.

## What changed
- Changed `runtime` from `const` to `let` so it can be reassigned after workspace creation
- After creating a new workspace, re-fetch runtimes scoped to the new workspace via `targetClient`
- If no runtimes exist in the new workspace, register the current daemon's runtime there
- Gracefully warns and falls back to old runtime if re-fetch fails
- Replaced 1 existing test, added 2 new test cases covering: runtime registration when new workspace has no runtimes, and graceful fallback on re-fetch failure

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] CLI (`@alook/cli`)