### PR TITLE
fix: auto-generate avatar in POST /api/studios

### DIFF
--- a/src/web/src/app/api/studios/route.test.ts
+++ b/src/web/src/app/api/studios/route.test.ts
@@ -4,6 +4,11 @@ vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(() => ({ env: { DB: {} } })),
 }));
 
+vi.mock("@/components/avatar", () => ({
+  randomConfig: vi.fn(() => ({ shape: "circle", color: "#ff0000" })),
+  serializeAvatarConfig: vi.fn(() => "generated-avatar-config"),
+}));
+
 const mockCreateAgent = vi.fn();
 const mockGetAgentByHandle = vi.fn();
 const mockListAgents = vi.fn();
@@ -296,6 +301,36 @@ describe("POST /api/studios", () => {
     await POST(req, {});
 
     expect(mockAddWhitelist).toHaveBeenCalledTimes(2);
+  });
+
+  it("auto-generates avatar when avatar_url is not provided", async () => {
+    const req = new NextRequest("http://localhost/api/studios", {
+      method: "POST",
+      body: JSON.stringify({
+        members: [{ name: "Solo", role: "leader", runtime_id: "rt1" }],
+      }),
+    });
+
+    await POST(req, {});
+
+    expect(mockCreateAgent).toHaveBeenCalledTimes(1);
+    const agentData = mockCreateAgent.mock.calls[0][1];
+    expect(agentData.avatarUrl).toBe("generated-avatar-config");
+  });
+
+  it("uses provided avatar_url when explicitly set", async () => {
+    const req = new NextRequest("http://localhost/api/studios", {
+      method: "POST",
+      body: JSON.stringify({
+        members: [{ name: "Solo", role: "leader", runtime_id: "rt1", avatar_url: "custom-avatar" }],
+      }),
+    });
+
+    await POST(req, {});
+
+    expect(mockCreateAgent).toHaveBeenCalledTimes(1);
+    const agentData = mockCreateAgent.mock.calls[0][1];
+    expect(agentData.avatarUrl).toBe("custom-avatar");
   });
 
   it("creates agents with auto-generated names when name is omitted", async () => {

--- a/src/web/src/app/api/studios/route.ts
+++ b/src/web/src/app/api/studios/route.ts
@@ -8,6 +8,7 @@ import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
 import { agentToResponse, workspaceToResponse, agentLinkToResponse } from "@/lib/api/responses";
+import { randomConfig, serializeAvatarConfig } from "@/components/avatar";
 import { TaskService } from "@/lib/services/task";
 import { invalidate, cached, cacheKeys } from "@/lib/cache";
 
@@ -140,7 +141,7 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
       maxConcurrentTasks: 6,
       ownerId: ctx.userId,
       emailHandle: handle,
-      avatarUrl: member.avatar_url ?? null,
+      avatarUrl: member.avatar_url || serializeAvatarConfig(randomConfig()),
     });
 
     if (ctx.email) {


### PR DESCRIPTION
# Why we need this PR?

Agents created via CLI `workspace init` have no avatar because the CLI doesn't pass `avatar_url`, and the server stored null. The Web frontend generates avatars client-side before calling the API, but CLI doesn't.

## What changed

- `src/web/src/app/api/studios/route.ts`: Changed `avatarUrl: member.avatar_url ?? null` to `avatarUrl: member.avatar_url || serializeAvatarConfig(randomConfig())`, matching the behavior in `POST /api/agents/recruit`. Added the corresponding import.
- `src/web/src/app/api/studios/route.test.ts`: Added mock for `@/components/avatar` and two test cases: one verifying auto-generation when `avatar_url` is missing, one verifying explicit values are preserved.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)