### PR TITLE
fix: Windows agent tests timeout after kill-tree refactor

### DIFF
--- a/src/cli/daemon/agent/__tests__/claude.test.ts
+++ b/src/cli/daemon/agent/__tests__/claude.test.ts
@@ -32,6 +32,12 @@ vi.mock("child_process", () => ({
   }),
 }));
 
+vi.mock("../../kill-tree.js", () => ({
+  killProcessTree: vi.fn().mockResolvedValue(undefined),
+  killGraceMs: () => 2000,
+  isAlive: () => false,
+}));
+
 const tick = (ms = 15) => new Promise((r) => setTimeout(r, ms));
 
 async function collectMessages(
@@ -241,19 +247,17 @@ describe("ClaudeBackend", () => {
 
   it("sets status to timeout when process is killed by timeout", async () => {
     vi.useFakeTimers();
-    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const killTree = await vi.importMock<typeof import("../../kill-tree.js")>("../../kill-tree.js");
     const session = backend.execute("hello", { cwd: "/tmp", timeout: 1000 });
     const mock = getMock();
 
     vi.advanceTimersByTime(1000);
-    // Timeout now reaps the whole process group (negative pid), not just the leader.
-    expect(killSpy).toHaveBeenCalledWith(-12345, "SIGTERM");
+    expect(killTree.killProcessTree).toHaveBeenCalledWith(12345);
 
     mock.proc.emit("close", null);
 
     const result = await session.result;
     expect(result.status).toBe("timeout");
-    killSpy.mockRestore();
     vi.useRealTimers();
   });
 

--- a/src/cli/daemon/agent/__tests__/codex.test.ts
+++ b/src/cli/daemon/agent/__tests__/codex.test.ts
@@ -35,6 +35,12 @@ vi.mock("child_process", () => ({
   }),
 }));
 
+vi.mock("../../kill-tree.js", () => ({
+  killProcessTree: vi.fn().mockResolvedValue(undefined),
+  killGraceMs: () => 2000,
+  isAlive: () => false,
+}));
+
 async function collectMessages(
   messages: AsyncIterable<AgentMessage>,
   maxMessages = 100,
@@ -969,19 +975,17 @@ describe("CodexBackend", () => {
 
   it("timeout kills process and sets status to timeout", async () => {
     vi.useFakeTimers();
-    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const killTree = await vi.importMock<typeof import("../../kill-tree.js")>("../../kill-tree.js");
     const session = backend.execute("hello", { cwd: "/tmp", timeout: 5000 });
     const mock = getMock();
 
     vi.advanceTimersByTime(5000);
-    // Timeout now reaps the whole process group (negative pid), not just the leader.
-    expect(killSpy).toHaveBeenCalledWith(-12345, "SIGTERM");
+    expect(killTree.killProcessTree).toHaveBeenCalledWith(12345);
 
     mock.proc.emit("close", null);
 
     const result = await session.result;
     expect(result.status).toBe("timeout");
-    killSpy.mockRestore();
     vi.useRealTimers();
   });
 

--- a/src/cli/daemon/agent/__tests__/opencode.test.ts
+++ b/src/cli/daemon/agent/__tests__/opencode.test.ts
@@ -27,6 +27,12 @@ vi.mock("child_process", () => ({
   }),
 }));
 
+vi.mock("../../kill-tree.js", () => ({
+  killProcessTree: vi.fn().mockResolvedValue(undefined),
+  killGraceMs: () => 2000,
+  isAlive: () => false,
+}));
+
 const tick = (ms = 15) => new Promise((r) => setTimeout(r, ms));
 
 async function collectMessages(
@@ -231,19 +237,17 @@ describe("OpenCodeBackend", () => {
 
   it("sets status to timeout when process is killed by timeout", async () => {
     vi.useFakeTimers();
-    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const killTree = await vi.importMock<typeof import("../../kill-tree.js")>("../../kill-tree.js");
     const session = backend.execute("hello", { cwd: "/tmp", timeout: 3000 });
     const mock = getMock();
 
     vi.advanceTimersByTime(3000);
-    // Timeout now reaps the whole process group (negative pid), not just the leader.
-    expect(killSpy).toHaveBeenCalledWith(-12345, "SIGTERM");
+    expect(killTree.killProcessTree).toHaveBeenCalledWith(12345);
 
     mock.proc.emit("close", null);
 
     const result = await session.result;
     expect(result.status).toBe("timeout");
-    killSpy.mockRestore();
     vi.useRealTimers();
   });
 

--- a/src/cli/daemon/kill-tree-win32.test.ts
+++ b/src/cli/daemon/kill-tree-win32.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Mock process.platform to "win32" BEFORE kill-tree.ts evaluates isPosix.
+const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform")!;
+Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+
+const execSyncMock = vi.fn();
+vi.mock("child_process", () => ({
+  execSync: execSyncMock,
+}));
+
+const { killProcessTree, isAlive } = await import("./kill-tree.js");
+
+// Restore platform after import so Vitest internals aren't confused.
+Object.defineProperty(process, "platform", originalPlatform);
+
+describe("killProcessTree (Windows)", () => {
+  it("calls taskkill /PID <pid> /T /F on Windows", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation((_pid: number, signal?: string | number) => {
+      if (signal === 0) return true; // isAlive → true
+      return true;
+    });
+
+    await killProcessTree(9999);
+
+    expect(execSyncMock).toHaveBeenCalledWith("taskkill /PID 9999 /T /F", { stdio: "ignore" });
+    killSpy.mockRestore();
+  });
+
+  it("does not poll or escalate to SIGKILL on Windows", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation((_pid: number, signal?: string | number) => {
+      if (signal === 0) return true;
+      return true;
+    });
+
+    const start = Date.now();
+    await killProcessTree(8888);
+    const elapsed = Date.now() - start;
+
+    // Should return immediately — no POLL_MS loop on Windows
+    expect(elapsed).toBeLessThan(200);
+    expect(execSyncMock).toHaveBeenCalledWith("taskkill /PID 8888 /T /F", { stdio: "ignore" });
+    killSpy.mockRestore();
+  });
+
+  it("does not throw when taskkill fails (process already dead)", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation((_pid: number, signal?: string | number) => {
+      if (signal === 0) return true;
+      return true;
+    });
+    execSyncMock.mockImplementationOnce(() => { throw new Error("process not found"); });
+
+    await expect(killProcessTree(7777)).resolves.toBeUndefined();
+    killSpy.mockRestore();
+  });
+
+  it("skips if process is already dead (isAlive returns false)", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("ESRCH"), { code: "ESRCH" });
+    });
+    execSyncMock.mockClear();
+
+    await killProcessTree(6666);
+
+    expect(execSyncMock).not.toHaveBeenCalled();
+    killSpy.mockRestore();
+  });
+});

--- a/src/cli/daemon/kill-tree.test.ts
+++ b/src/cli/daemon/kill-tree.test.ts
@@ -114,3 +114,4 @@ describe("isAlive", () => {
     expect(isAlive(2_000_000_000)).toBe(false);
   });
 });
+

--- a/src/cli/daemon/kill-tree.ts
+++ b/src/cli/daemon/kill-tree.ts
@@ -12,6 +12,7 @@
  * running. So after a short grace window we escalate to SIGKILL.
  */
 
+import { execSync } from "child_process";
 import { createLogger } from "../lib/logger.js";
 
 const log = createLogger({ module: "kill-tree" });
@@ -47,6 +48,15 @@ function signalTree(pid: number, signal: NodeJS.Signals): void {
       // EPERM / no-group (legacy non-detached spawn): fall through to plain pid.
     }
   }
+  if (!isPosix) {
+    try {
+      execSync(`taskkill /PID ${pid} /T /F`, { stdio: "ignore" });
+      return;
+    } catch {
+      // process may already be dead
+    }
+    return;
+  }
   try {
     process.kill(pid, signal);
   } catch {
@@ -64,13 +74,18 @@ export async function killProcessTree(
   opts?: { graceMs?: number },
 ): Promise<void> {
   if (!pid || pid < 1) return;
-  const graceMs = opts?.graceMs ?? killGraceMs();
-
   if (!isAlive(pid)) return;
 
+  if (!isPosix) {
+    // Windows: taskkill /T /F kills the entire tree, no grace needed
+    signalTree(pid, "SIGTERM");
+    return;
+  }
+
+  // POSIX: SIGTERM + grace + SIGKILL escalation
+  const graceMs = opts?.graceMs ?? killGraceMs();
   signalTree(pid, "SIGTERM");
 
-  // Poll until dead or the grace window expires.
   const deadline = Date.now() + graceMs;
   while (Date.now() < deadline) {
     if (!isAlive(pid)) return;


### PR DESCRIPTION
## Summary

- **Code fix**: `killProcessTree` now uses `taskkill /PID <pid> /T /F` on Windows to kill the entire process tree (MCP servers, tool subprocesses). Previously it only called `process.kill(pid)` which left child processes orphaned.
- **Windows path skips polling loop**: Since `taskkill /T /F` is a forceful kill, no grace period or async polling is needed on Windows — avoids timer-related issues.
- **Test fix**: Agent tests (claude, codex, opencode) now mock `killProcessTree` instead of spying on `process.kill`, so they run reliably on all platforms without depending on real process signals.

## Test plan

- [x] `kill-tree.test.ts` passes on Linux/macOS (5 tests)
- [x] Agent tests (claude/codex/opencode) pass with mocked `killProcessTree` (110 tests)
- [x] `session-runner.test.ts` passes (57 tests)
- [x] TypeScript typecheck passes
- [x] ESLint passes