### PR TITLE
chore(ci): remove Discord notification from publish-app workflow

### DIFF
--- a/.github/workflows/publish-app.yml
+++ b/.github/workflows/publish-app.yml
@@ -73,25 +73,3 @@ jobs:
         if: steps.check.outputs.skip == 'false'
         working-directory: src/app
         run: npm publish --access public
-
-      - name: Notify Discord
-        if: steps.check.outputs.skip == 'false'
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          BODY=$(python3 -c "
-          import json, os
-          version = os.environ['VERSION']
-          payload = {
-            'embeds': [{
-              'title': f'📦 @alook/app v{version} published to npm',
-              'description': 'Run Alook locally with one command:\n\n\`\`\`\nnpx @alook/app onboard\n\`\`\`',
-              'color': 5025616,
-              'url': f'https://www.npmjs.com/package/@alook/app/v/{version}',
-              'footer': {'text': 'npm registry'},
-            }]
-          }
-          print(json.dumps(payload))
-          ")
-          curl -sf -H "Content-Type: application/json" -d "$BODY" "$DISCORD_WEBHOOK"


### PR DESCRIPTION
# Why we need this PR?
> Follows up on #259 — that PR removed non-release Discord notifications from `discord-notify.yml` and `publish-cli.yml`, but missed `publish-app.yml`.

## What changed
- Removed the "Notify Discord" step from `.github/workflows/publish-app.yml` (lines 77-97)
- The `DISCORD_WEBHOOK_URL` secret remains available for the release-only notification in `discord-notify.yml`

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] CI/CD