### PR TITLE
feat: move daemon start to last onboard step and output workspace URL

### DIFF
--- a/src/cli/commands/workspace.test.ts
+++ b/src/cli/commands/workspace.test.ts
@@ -75,7 +75,7 @@ describe("workspace init", () => {
 
     postJSONMock.mockResolvedValueOnce({
       studio: { name: "Test WS" },
-      workspace: { id: "ws_test", name: "Test WS" },
+      workspace: { id: "ws_test", name: "Test WS", slug: "test-ws" },
       agents: [
         { id: "ag1", name: "Alice", email_handle: "alice" },
         { id: "ag2", name: "Bob", email_handle: "bob" },
@@ -93,6 +93,7 @@ describe("workspace init", () => {
     }));
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Workspace initialized"));
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("alice@alook.ai"));
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("https://alook.ai/w/test-ws"));
   });
 
   it("errors when JSON file does not exist", async () => {
@@ -141,7 +142,7 @@ describe("workspace init", () => {
       .mockResolvedValueOnce({ id: "ws_new", name: "New WS" }) // POST /api/workspaces
       .mockResolvedValueOnce({ // POST /api/studios
         studio: { name: "New WS" },
-        workspace: { id: "ws_new", name: "New WS" },
+        workspace: { id: "ws_new", name: "New WS", slug: "new-ws" },
         agents: [{ id: "ag1", name: "Charlie", email_handle: "charlie" }],
         links: [],
       });
@@ -173,7 +174,7 @@ describe("workspace init", () => {
       .mockResolvedValueOnce(undefined) // POST /api/runtimes (register)
       .mockResolvedValueOnce({ // POST /api/studios
         studio: { name: "Fresh WS" },
-        workspace: { id: "ws_fresh", name: "Fresh WS" },
+        workspace: { id: "ws_fresh", name: "Fresh WS", slug: "fresh-ws" },
         agents: [{ id: "ag1", name: "Dave", email_handle: "dave" }],
         links: [],
       });
@@ -203,7 +204,7 @@ describe("workspace init", () => {
       .mockResolvedValueOnce({ id: "ws_warn", name: "Warn WS" }) // POST /api/workspaces
       .mockResolvedValueOnce({ // POST /api/studios
         studio: { name: "Warn WS" },
-        workspace: { id: "ws_warn", name: "Warn WS" },
+        workspace: { id: "ws_warn", name: "Warn WS", slug: "warn-ws" },
         agents: [{ id: "ag1", name: "Eve", email_handle: "eve" }],
         links: [],
       });
@@ -229,7 +230,7 @@ describe("workspace init", () => {
 
     postJSONMock.mockResolvedValueOnce({
       studio: { name: "" },
-      workspace: { id: "ws_test", name: "Workspace" },
+      workspace: { id: "ws_test", name: "Workspace", slug: "workspace" },
       agents: [{ id: "ag1", name: "X", email_handle: "x" }],
       links: [],
     });
@@ -282,7 +283,7 @@ describe("workspace init", () => {
 
     postJSONMock.mockResolvedValueOnce({
       studio: { name: "" },
-      workspace: { id: "ws_test", name: "WS" },
+      workspace: { id: "ws_test", name: "WS", slug: "ws" },
       agents: [{ id: "ag1", name: "Y", email_handle: "y" }],
       links: [],
     });

--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -19,7 +19,7 @@ function slugify(name: string): string {
 
 interface StudioResponse {
   studio: { name: string };
-  workspace: { id: string; name: string };
+  workspace: { id: string; name: string; slug: string };
   agents: Array<{ id: string; name: string; email_handle: string | null }>;
 }
 
@@ -140,6 +140,7 @@ export function workspaceCommand(): Command {
           const email = agent.email_handle ? `${agent.email_handle}@alook.ai` : "no email";
           console.log(`  - ${agent.name} (${email})`);
         }
+        console.log(`\n  Open: https://alook.ai/w/${res.workspace.slug}`);
       } catch (err) {
         console.error(`Error: failed to create workspace: ${err instanceof Error ? err.message : err}`);
         process.exit(1);

--- a/src/web/src/app/onboard.md/route.test.ts
+++ b/src/web/src/app/onboard.md/route.test.ts
@@ -42,20 +42,6 @@ describe("GET /onboard.md", () => {
     expect(body).toContain("https://alook.ai/templates");
   });
 
-  it("orders steps correctly: Login → Reflect → Templates/Init → Daemon+URL", async () => {
-    const response = await GET();
-    const body = await response.text();
-    const loginIdx = body.indexOf("## 1. Login");
-    const reflectIdx = body.indexOf("## 2. Reflect on Your User");
-    const templatesIdx = body.indexOf("## 3. Explore Templates & Set Up Workspace");
-    const daemonIdx = body.indexOf("## 4. Start Daemon & Open Workspace");
-
-    expect(loginIdx).toBeGreaterThan(-1);
-    expect(reflectIdx).toBeGreaterThan(loginIdx);
-    expect(templatesIdx).toBeGreaterThan(reflectIdx);
-    expect(daemonIdx).toBeGreaterThan(templatesIdx);
-  });
-
   it("outputs workspace URL after daemon start", async () => {
     const response = await GET();
     const body = await response.text();

--- a/src/web/src/app/onboard.md/route.test.ts
+++ b/src/web/src/app/onboard.md/route.test.ts
@@ -41,4 +41,28 @@ describe("GET /onboard.md", () => {
     const body = await response.text();
     expect(body).toContain("https://alook.ai/templates");
   });
+
+  it("orders steps correctly: Login → Reflect → Templates/Init → Daemon+URL", async () => {
+    const response = await GET();
+    const body = await response.text();
+    const loginIdx = body.indexOf("## 1. Login");
+    const reflectIdx = body.indexOf("## 2. Reflect on Your User");
+    const templatesIdx = body.indexOf("## 3. Explore Templates & Set Up Workspace");
+    const daemonIdx = body.indexOf("## 4. Start Daemon & Open Workspace");
+
+    expect(loginIdx).toBeGreaterThan(-1);
+    expect(reflectIdx).toBeGreaterThan(loginIdx);
+    expect(templatesIdx).toBeGreaterThan(reflectIdx);
+    expect(daemonIdx).toBeGreaterThan(templatesIdx);
+  });
+
+  it("outputs workspace URL after daemon start", async () => {
+    const response = await GET();
+    const body = await response.text();
+    const daemonIdx = body.indexOf("## 4. Start Daemon & Open Workspace");
+    const urlIdx = body.indexOf("https://alook.ai/w/{slug}");
+
+    expect(daemonIdx).toBeGreaterThan(-1);
+    expect(urlIdx).toBeGreaterThan(daemonIdx);
+  });
 });

--- a/src/web/src/app/onboard.md/route.ts
+++ b/src/web/src/app/onboard.md/route.ts
@@ -16,13 +16,7 @@ npx @alook/cli login
 - Interactive terminal: attempts to open browser automatically
 - Verify success: \`npx @alook/cli status\`
 
-## 2. Start Daemon
-
-\`\`\`bash
-npx @alook/cli daemon start
-\`\`\`
-
-## 3. Reflect on Your User
+## 2. Reflect on Your User
 
 Review your conversation history with this user. Summarize:
 - Their role and domain
@@ -32,12 +26,12 @@ Review your conversation history with this user. Summarize:
 
 Use this understanding to choose the best workspace setup.
 
-## 4. Explore Templates & Set Up Workspace
+## 3. Explore Templates & Set Up Workspace
 
 Visit https://alook.ai/templates to explore available workspace templates.
 Each template has a JSON version at \`/templates/<slug>/json\` you can fetch for reference.
 
-Based on what you learned about the user in Step 3, customize the template or create your own configuration:
+Based on what you learned about the user in Step 2, customize the template or create your own configuration:
 
 \`\`\`json
 {
@@ -68,6 +62,20 @@ npx @alook/cli workspace init --json-file <path_to_json>
 \`\`\`
 
 If the current workspace already has agents, a new workspace is created automatically.
+
+## 4. Start Daemon & Open Workspace
+
+\`\`\`bash
+npx @alook/cli daemon start
+\`\`\`
+
+Once the daemon starts successfully, tell the user their workspace is ready and provide the URL:
+
+\`\`\`
+https://alook.ai/w/{slug}
+\`\`\`
+
+(Use the workspace slug from the \`workspace init\` output in Step 3.)
 `;
 
 export async function GET() {


### PR DESCRIPTION
# Why we need this PR?
> The "Start Daemon" step in onboard.md runs before the workspace is created. It should be the last step so the daemon starts after workspace init succeeds, and the user gets the workspace URL.

## What changed
- Reordered onboard.md steps: Login → Reflect → Templates/Init → Daemon+URL
- "Start Daemon" moved from step 2 to step 4 (last)
- Step 4 now instructs the AI to output `https://alook.ai/w/{slug}` after daemon starts
- Added two new tests verifying step ordering and workspace URL output

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)