### PR TITLE
fix(web): swap onboard.md step order — daemon start before workspace init

### DIFF
--- a/src/web/src/app/onboard.md/route.ts
+++ b/src/web/src/app/onboard.md/route.ts
@@ -28,7 +28,15 @@ Review your conversation history with this user. Summarize:
 
 Use this understanding to choose the best workspace setup.
 
-## 3. Explore Templates & Set Up Workspace
+## 3. Start Daemon
+
+\`\`\`bash
+${cliPrefix} daemon start
+\`\`\`
+
+The daemon must be running before initializing a workspace (workspace init requires active runtimes).
+
+## 4. Explore Templates & Set Up Workspace
 
 Visit ${baseUrl}/templates to explore available workspace templates.
 Each template has a JSON version at \`/templates/<slug>/json\` you can fetch for reference.
@@ -65,19 +73,13 @@ ${cliPrefix} workspace init --json-file <path_to_json>
 
 If the current workspace already has agents, a new workspace is created automatically.
 
-## 4. Start Daemon & Open Workspace
-
-\`\`\`bash
-${cliPrefix} daemon start
-\`\`\`
-
-Once the daemon starts successfully, tell the user their workspace is ready and provide the URL:
+Your workspace is ready. Open it at:
 
 \`\`\`
 ${baseUrl}/w/{slug}/home
 \`\`\`
 
-(Use the workspace slug from the \`workspace init\` output in Step 3.)
+(Use the workspace slug from the \`workspace init\` output above.)
 `;
 }
 


### PR DESCRIPTION
# Why we need this PR?

The onboard.md route tells users to run `workspace init` before `daemon start`, but `workspace init` requires a running daemon (it checks for runtimes and exits if none found). The welcome task also won't fire without an online daemon because it checks `isOnline(leaderRuntime.machineLastSeenAt)`.

## What changed

Swapped Step 3 and Step 4 in `buildOnboardMarkdown`:
- **Step 3** is now "Start Daemon" (`daemon start`)
- **Step 4** is now "Explore Templates & Set Up Workspace" (`workspace init`)
- Updated transitional text: removed "Once the daemon starts successfully" language (since daemon is already running), replaced with "Your workspace is ready"

This matches the self-hosted `onboard` command which already does daemon start before workspace creation.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)