### PR TITLE
feat(blog): auto-scan MDX posts with draft support

### DIFF
--- a/src/web/src/app/blog/[slug]/page.tsx
+++ b/src/web/src/app/blog/[slug]/page.tsx
@@ -6,8 +6,9 @@ import { getAllPosts, getPostBySlug } from "@/lib/blog/posts";
 
 export const dynamicParams = false;
 
-export function generateStaticParams(): { slug: string }[] {
-  return getAllPosts().map((post) => ({ slug: post.slug }));
+export async function generateStaticParams(): Promise<{ slug: string }[]> {
+  const posts = await getAllPosts();
+  return posts.map((post) => ({ slug: post.slug }));
 }
 
 export async function generateMetadata({
@@ -16,7 +17,7 @@ export async function generateMetadata({
   params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
   const { slug } = await params;
-  const post = getPostBySlug(slug);
+  const post = await getPostBySlug(slug);
   if (!post) return {};
 
   return {
@@ -53,10 +54,10 @@ export default async function BlogPostPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const post = getPostBySlug(slug);
+  const post = await getPostBySlug(slug);
   if (!post) notFound();
 
-  const posts = getAllPosts();
+  const posts = await getAllPosts();
   const currentIndex = posts.findIndex((p) => p.slug === slug);
   const prevPost = currentIndex < posts.length - 1 ? posts[currentIndex + 1] : null;
   const nextPost = currentIndex > 0 ? posts[currentIndex - 1] : null;

--- a/src/web/src/app/blog/feed.xml/route.ts
+++ b/src/web/src/app/blog/feed.xml/route.ts
@@ -1,7 +1,7 @@
 import { getAllPosts } from "@/lib/blog/posts";
 
-export function GET() {
-  const posts = getAllPosts();
+export async function GET() {
+  const posts = await getAllPosts();
   const siteUrl = "https://alook.ai";
 
   const items = posts

--- a/src/web/src/app/blog/page.tsx
+++ b/src/web/src/app/blog/page.tsx
@@ -34,8 +34,8 @@ const collectionJsonLd = {
   url: "https://alook.ai/blog",
 };
 
-export default function BlogPage() {
-  const posts = getAllPosts();
+export default async function BlogPage() {
+  const posts = await getAllPosts();
   const [featured, ...rest] = posts;
 
   return (

--- a/src/web/src/app/sitemap.ts
+++ b/src/web/src/app/sitemap.ts
@@ -4,7 +4,7 @@ import { getAllPosts } from "@/lib/blog/posts";
 
 const SITE_URL = "https://alook.ai";
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const templateEntries: MetadataRoute.Sitemap = TEMPLATES.map((t) => ({
     url: `${SITE_URL}/templates/${t.id}`,
     lastModified: new Date(),
@@ -12,7 +12,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.7,
   }));
 
-  const blogEntries: MetadataRoute.Sitemap = getAllPosts().map((post) => ({
+  const posts = await getAllPosts();
+  const blogEntries: MetadataRoute.Sitemap = posts.map((post) => ({
     url: `${SITE_URL}/blog/${post.slug}`,
     lastModified: new Date(post.date),
     changeFrequency: "monthly",

--- a/src/web/src/lib/blog/posts/import-mdx.ts
+++ b/src/web/src/lib/blog/posts/import-mdx.ts
@@ -1,0 +1,8 @@
+import type { BlogPost } from "../types";
+
+export async function importMdxMetadata(
+  slug: string
+): Promise<BlogPost | undefined> {
+  const mod = await import(`@/content/${slug}.mdx`);
+  return mod.metadata;
+}

--- a/src/web/src/lib/blog/posts/index.test.ts
+++ b/src/web/src/lib/blog/posts/index.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("fs", () => ({
+  readdirSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+import { readdirSync, readFileSync } from "fs";
+import { getAllPosts, getPostBySlug } from "./index";
+
+const mockReaddirSync = vi.mocked(readdirSync);
+const mockReadFileSync = vi.mocked(readFileSync);
+
+function makeMdxContent(metadata: Record<string, unknown>): string {
+  const entries = Object.entries(metadata)
+    .map(([key, value]) => `  ${key}: ${JSON.stringify(value)}`)
+    .join(",\n");
+  return `export const metadata = {\n${entries},\n};\n\n# Hello World\n`;
+}
+
+const postA = {
+  slug: "post-a",
+  title: "Post A",
+  date: "2026-05-01",
+  author: "Alice",
+  excerpt: "First post",
+  readingTime: "3 min read",
+};
+
+const postB = {
+  slug: "post-b",
+  title: "Post B",
+  date: "2026-06-01",
+  author: "Bob",
+  excerpt: "Second post",
+  readingTime: "5 min read",
+};
+
+const draftPost = {
+  slug: "draft-post",
+  title: "Draft Post",
+  date: "2026-06-02",
+  author: "Charlie",
+  excerpt: "Draft",
+  readingTime: "2 min read",
+  draft: true,
+};
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+describe("getAllPosts", () => {
+  it("auto-discovers all mdx files and returns them sorted by date descending", async () => {
+    mockReaddirSync.mockReturnValue(
+      ["post-a.mdx", "post-b.mdx"] as unknown as ReturnType<
+        typeof readdirSync
+      >
+    );
+    mockReadFileSync.mockImplementation((filePath) => {
+      const path = filePath.toString();
+      if (path.includes("post-a.mdx")) return makeMdxContent(postA);
+      if (path.includes("post-b.mdx")) return makeMdxContent(postB);
+      return "";
+    });
+
+    const { getAllPosts: freshGetAllPosts } = await import("./index");
+    const posts = freshGetAllPosts();
+
+    expect(posts).toHaveLength(2);
+    expect(posts[0].slug).toBe("post-b");
+    expect(posts[1].slug).toBe("post-a");
+  });
+
+  it("excludes draft posts from results", async () => {
+    mockReaddirSync.mockReturnValue(
+      ["post-a.mdx", "draft-post.mdx"] as unknown as ReturnType<
+        typeof readdirSync
+      >
+    );
+    mockReadFileSync.mockImplementation((filePath) => {
+      const path = filePath.toString();
+      if (path.includes("post-a.mdx")) return makeMdxContent(postA);
+      if (path.includes("draft-post.mdx")) return makeMdxContent(draftPost);
+      return "";
+    });
+
+    const { getAllPosts: freshGetAllPosts } = await import("./index");
+    const posts = freshGetAllPosts();
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0].slug).toBe("post-a");
+    expect(posts.find((p) => p.slug === "draft-post")).toBeUndefined();
+  });
+
+  it("ignores files without valid metadata export", async () => {
+    mockReaddirSync.mockReturnValue(
+      ["post-a.mdx", "invalid.mdx"] as unknown as ReturnType<
+        typeof readdirSync
+      >
+    );
+    mockReadFileSync.mockImplementation((filePath) => {
+      const path = filePath.toString();
+      if (path.includes("post-a.mdx")) return makeMdxContent(postA);
+      if (path.includes("invalid.mdx")) return "# Just markdown, no metadata";
+      return "";
+    });
+
+    const { getAllPosts: freshGetAllPosts } = await import("./index");
+    const posts = freshGetAllPosts();
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0].slug).toBe("post-a");
+  });
+});
+
+describe("getPostBySlug", () => {
+  it("returns the post matching the given slug", async () => {
+    mockReaddirSync.mockReturnValue(
+      ["post-a.mdx", "post-b.mdx"] as unknown as ReturnType<
+        typeof readdirSync
+      >
+    );
+    mockReadFileSync.mockImplementation((filePath) => {
+      const path = filePath.toString();
+      if (path.includes("post-a.mdx")) return makeMdxContent(postA);
+      if (path.includes("post-b.mdx")) return makeMdxContent(postB);
+      return "";
+    });
+
+    const { getPostBySlug: freshGetPostBySlug } = await import("./index");
+    const post = freshGetPostBySlug("post-a");
+
+    expect(post).toBeDefined();
+    expect(post!.title).toBe("Post A");
+  });
+
+  it("returns undefined for a draft slug", async () => {
+    mockReaddirSync.mockReturnValue(
+      ["post-a.mdx", "draft-post.mdx"] as unknown as ReturnType<
+        typeof readdirSync
+      >
+    );
+    mockReadFileSync.mockImplementation((filePath) => {
+      const path = filePath.toString();
+      if (path.includes("post-a.mdx")) return makeMdxContent(postA);
+      if (path.includes("draft-post.mdx")) return makeMdxContent(draftPost);
+      return "";
+    });
+
+    const { getPostBySlug: freshGetPostBySlug } = await import("./index");
+    const post = freshGetPostBySlug("draft-post");
+
+    expect(post).toBeUndefined();
+  });
+});

--- a/src/web/src/lib/blog/posts/index.test.ts
+++ b/src/web/src/lib/blog/posts/index.test.ts
@@ -113,6 +113,33 @@ describe("getAllPosts", () => {
     expect(posts).toHaveLength(1);
     expect(posts[0].slug).toBe("post-a");
   });
+
+  it("skips files with missing required fields and logs a warning", async () => {
+    const incompletePost = { slug: "incomplete", title: "No Author" };
+    mockReaddirSync.mockReturnValue(
+      ["post-a.mdx", "incomplete.mdx"] as unknown as ReturnType<
+        typeof readdirSync
+      >
+    );
+    mockReadFileSync.mockImplementation((filePath) => {
+      const path = filePath.toString();
+      if (path.includes("post-a.mdx")) return makeMdxContent(postA);
+      if (path.includes("incomplete.mdx"))
+        return makeMdxContent(incompletePost);
+      return "";
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { getAllPosts: freshGetAllPosts } = await import("./index");
+    const posts = freshGetAllPosts();
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0].slug).toBe("post-a");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("missing required field")
+    );
+    warnSpy.mockRestore();
+  });
 });
 
 describe("getPostBySlug", () => {

--- a/src/web/src/lib/blog/posts/index.test.ts
+++ b/src/web/src/lib/blog/posts/index.test.ts
@@ -1,24 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { BlogPost } from "../types";
 
 vi.mock("fs", () => ({
   readdirSync: vi.fn(),
-  readFileSync: vi.fn(),
 }));
 
-import { readdirSync, readFileSync } from "fs";
-import { getAllPosts, getPostBySlug } from "./index";
+vi.mock("./import-mdx", () => ({
+  importMdxMetadata: vi.fn(),
+}));
+
+import { readdirSync } from "fs";
+import { importMdxMetadata } from "./import-mdx";
 
 const mockReaddirSync = vi.mocked(readdirSync);
-const mockReadFileSync = vi.mocked(readFileSync);
+const mockImportMdxMetadata = vi.mocked(importMdxMetadata);
 
-function makeMdxContent(metadata: Record<string, unknown>): string {
-  const entries = Object.entries(metadata)
-    .map(([key, value]) => `  ${key}: ${JSON.stringify(value)}`)
-    .join(",\n");
-  return `export const metadata = {\n${entries},\n};\n\n# Hello World\n`;
-}
-
-const postA = {
+const postA: BlogPost = {
   slug: "post-a",
   title: "Post A",
   date: "2026-05-01",
@@ -27,7 +24,7 @@ const postA = {
   readingTime: "3 min read",
 };
 
-const postB = {
+const postB: BlogPost = {
   slug: "post-b",
   title: "Post B",
   date: "2026-06-01",
@@ -36,7 +33,7 @@ const postB = {
   readingTime: "5 min read",
 };
 
-const draftPost = {
+const draftPost: BlogPost = {
   slug: "draft-post",
   title: "Draft Post",
   date: "2026-06-02",
@@ -45,6 +42,11 @@ const draftPost = {
   readingTime: "2 min read",
   draft: true,
 };
+
+const incompletePost = {
+  slug: "incomplete",
+  title: "No Author",
+} as unknown as BlogPost;
 
 beforeEach(() => {
   vi.resetModules();
@@ -58,15 +60,14 @@ describe("getAllPosts", () => {
         typeof readdirSync
       >
     );
-    mockReadFileSync.mockImplementation((filePath) => {
-      const path = filePath.toString();
-      if (path.includes("post-a.mdx")) return makeMdxContent(postA);
-      if (path.includes("post-b.mdx")) return makeMdxContent(postB);
-      return "";
+    mockImportMdxMetadata.mockImplementation(async (slug) => {
+      if (slug === "post-a") return postA;
+      if (slug === "post-b") return postB;
+      return undefined;
     });
 
-    const { getAllPosts: freshGetAllPosts } = await import("./index");
-    const posts = freshGetAllPosts();
+    const { getAllPosts } = await import("./index");
+    const posts = await getAllPosts();
 
     expect(posts).toHaveLength(2);
     expect(posts[0].slug).toBe("post-b");
@@ -79,59 +80,53 @@ describe("getAllPosts", () => {
         typeof readdirSync
       >
     );
-    mockReadFileSync.mockImplementation((filePath) => {
-      const path = filePath.toString();
-      if (path.includes("post-a.mdx")) return makeMdxContent(postA);
-      if (path.includes("draft-post.mdx")) return makeMdxContent(draftPost);
-      return "";
+    mockImportMdxMetadata.mockImplementation(async (slug) => {
+      if (slug === "post-a") return postA;
+      if (slug === "draft-post") return draftPost;
+      return undefined;
     });
 
-    const { getAllPosts: freshGetAllPosts } = await import("./index");
-    const posts = freshGetAllPosts();
+    const { getAllPosts } = await import("./index");
+    const posts = await getAllPosts();
 
     expect(posts).toHaveLength(1);
     expect(posts[0].slug).toBe("post-a");
     expect(posts.find((p) => p.slug === "draft-post")).toBeUndefined();
   });
 
-  it("ignores files without valid metadata export", async () => {
+  it("skips files without metadata export", async () => {
     mockReaddirSync.mockReturnValue(
-      ["post-a.mdx", "invalid.mdx"] as unknown as ReturnType<
+      ["post-a.mdx", "no-metadata.mdx"] as unknown as ReturnType<
         typeof readdirSync
       >
     );
-    mockReadFileSync.mockImplementation((filePath) => {
-      const path = filePath.toString();
-      if (path.includes("post-a.mdx")) return makeMdxContent(postA);
-      if (path.includes("invalid.mdx")) return "# Just markdown, no metadata";
-      return "";
+    mockImportMdxMetadata.mockImplementation(async (slug) => {
+      if (slug === "post-a") return postA;
+      return undefined;
     });
 
-    const { getAllPosts: freshGetAllPosts } = await import("./index");
-    const posts = freshGetAllPosts();
+    const { getAllPosts } = await import("./index");
+    const posts = await getAllPosts();
 
     expect(posts).toHaveLength(1);
     expect(posts[0].slug).toBe("post-a");
   });
 
   it("skips files with missing required fields and logs a warning", async () => {
-    const incompletePost = { slug: "incomplete", title: "No Author" };
     mockReaddirSync.mockReturnValue(
       ["post-a.mdx", "incomplete.mdx"] as unknown as ReturnType<
         typeof readdirSync
       >
     );
-    mockReadFileSync.mockImplementation((filePath) => {
-      const path = filePath.toString();
-      if (path.includes("post-a.mdx")) return makeMdxContent(postA);
-      if (path.includes("incomplete.mdx"))
-        return makeMdxContent(incompletePost);
-      return "";
+    mockImportMdxMetadata.mockImplementation(async (slug) => {
+      if (slug === "post-a") return postA;
+      if (slug === "incomplete") return incompletePost;
+      return undefined;
     });
 
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const { getAllPosts: freshGetAllPosts } = await import("./index");
-    const posts = freshGetAllPosts();
+    const { getAllPosts } = await import("./index");
+    const posts = await getAllPosts();
 
     expect(posts).toHaveLength(1);
     expect(posts[0].slug).toBe("post-a");
@@ -149,15 +144,14 @@ describe("getPostBySlug", () => {
         typeof readdirSync
       >
     );
-    mockReadFileSync.mockImplementation((filePath) => {
-      const path = filePath.toString();
-      if (path.includes("post-a.mdx")) return makeMdxContent(postA);
-      if (path.includes("post-b.mdx")) return makeMdxContent(postB);
-      return "";
+    mockImportMdxMetadata.mockImplementation(async (slug) => {
+      if (slug === "post-a") return postA;
+      if (slug === "post-b") return postB;
+      return undefined;
     });
 
-    const { getPostBySlug: freshGetPostBySlug } = await import("./index");
-    const post = freshGetPostBySlug("post-a");
+    const { getPostBySlug } = await import("./index");
+    const post = await getPostBySlug("post-a");
 
     expect(post).toBeDefined();
     expect(post!.title).toBe("Post A");
@@ -169,15 +163,14 @@ describe("getPostBySlug", () => {
         typeof readdirSync
       >
     );
-    mockReadFileSync.mockImplementation((filePath) => {
-      const path = filePath.toString();
-      if (path.includes("post-a.mdx")) return makeMdxContent(postA);
-      if (path.includes("draft-post.mdx")) return makeMdxContent(draftPost);
-      return "";
+    mockImportMdxMetadata.mockImplementation(async (slug) => {
+      if (slug === "post-a") return postA;
+      if (slug === "draft-post") return draftPost;
+      return undefined;
     });
 
-    const { getPostBySlug: freshGetPostBySlug } = await import("./index");
-    const post = freshGetPostBySlug("draft-post");
+    const { getPostBySlug } = await import("./index");
+    const post = await getPostBySlug("draft-post");
 
     expect(post).toBeUndefined();
   });

--- a/src/web/src/lib/blog/posts/index.ts
+++ b/src/web/src/lib/blog/posts/index.ts
@@ -1,105 +1,74 @@
-import { readdirSync, readFileSync } from "fs";
+import { readdirSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import type { BlogPost } from "../types";
+import { importMdxMetadata } from "./import-mdx";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const contentDir = join(__dirname, "..", "..", "..", "content");
 
-const REQUIRED_FIELDS = [
+const REQUIRED_FIELDS: (keyof BlogPost)[] = [
   "slug",
   "title",
   "date",
   "author",
   "excerpt",
   "readingTime",
-] as const;
+];
 
-function extractStringField(block: string, field: string): string | undefined {
-  const re = new RegExp(`${field}\\s*:\\s*\\n?\\s*(["'\`])`);
-  const quoteMatch = block.match(re);
-  if (!quoteMatch) return undefined;
-
-  const quote = quoteMatch[1];
-  const escaped = quote.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const valueRe = new RegExp(
-    `${field}\\s*:\\s*\\n?\\s*${escaped}([^${escaped}]*)${escaped}`
-  );
-  const match = block.match(valueRe);
-  return match ? match[1] : undefined;
-}
-
-function extractBooleanField(
-  block: string,
-  field: string
-): boolean | undefined {
-  const re = new RegExp(`${field}\\s*:\\s*(true|false)`);
-  const match = block.match(re);
-  return match ? match[1] === "true" : undefined;
-}
-
-function extractMetadata(filePath: string): BlogPost | null {
-  const content = readFileSync(filePath, "utf-8");
-  const match = content.match(
-    /export\s+const\s+metadata\s*=\s*\{([\s\S]*?)\n\};/
-  );
-  if (!match) return null;
-
-  const block = match[1];
-
-  const slug = extractStringField(block, "slug");
-  const title = extractStringField(block, "title");
-  const date = extractStringField(block, "date");
-  const author = extractStringField(block, "author");
-  const excerpt = extractStringField(block, "excerpt");
-  const readingTime = extractStringField(block, "readingTime");
-  const draft = extractBooleanField(block, "draft");
-
-  const parsed = { slug, title, date, author, excerpt, readingTime, draft };
-
+function validateMetadata(
+  metadata: Record<string, unknown>,
+  file: string
+): metadata is BlogPost {
   for (const field of REQUIRED_FIELDS) {
-    if (!parsed[field]) {
+    if (!metadata[field]) {
       console.warn(
-        `[blog] Skipping ${filePath}: missing required field "${field}"`
+        `[blog] Skipping ${file}: missing required field "${field}"`
       );
-      return null;
+      return false;
     }
   }
-
-  return parsed as BlogPost;
-}
-
-function scanPosts(): BlogPost[] {
-  const files = readdirSync(contentDir).filter((f) => f.endsWith(".mdx"));
-  const posts: BlogPost[] = [];
-
-  for (const file of files) {
-    const metadata = extractMetadata(join(contentDir, file));
-    if (metadata && !metadata.draft) {
-      posts.push(metadata);
-    }
-  }
-
-  return posts;
+  return true;
 }
 
 let cachedPosts: BlogPost[] | null = null;
 
-function getPosts(): BlogPost[] {
-  if (!cachedPosts) {
-    cachedPosts = scanPosts();
-  }
-  return cachedPosts;
-}
-
 export type { BlogPost } from "../types";
 
-export function getAllPosts(): BlogPost[] {
-  return [...getPosts()].sort(
+export async function getAllPosts(): Promise<BlogPost[]> {
+  if (cachedPosts) {
+    return [...cachedPosts].sort(
+      (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+    );
+  }
+
+  const files = readdirSync(contentDir).filter((f) => f.endsWith(".mdx"));
+  const posts: BlogPost[] = [];
+
+  for (const file of files) {
+    const slug = file.replace(/\.mdx$/, "");
+    const metadata = await importMdxMetadata(slug);
+
+    if (
+      !metadata ||
+      !validateMetadata(metadata as Record<string, unknown>, file)
+    )
+      continue;
+    if (metadata.draft) continue;
+
+    posts.push(metadata);
+  }
+
+  cachedPosts = posts;
+
+  return [...posts].sort(
     (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
   );
 }
 
-export function getPostBySlug(slug: string): BlogPost | undefined {
-  return getPosts().find((p) => p.slug === slug);
+export async function getPostBySlug(
+  slug: string
+): Promise<BlogPost | undefined> {
+  const posts = await getAllPosts();
+  return posts.find((p) => p.slug === slug);
 }

--- a/src/web/src/lib/blog/posts/index.ts
+++ b/src/web/src/lib/blog/posts/index.ts
@@ -6,17 +6,67 @@ import type { BlogPost } from "../types";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const contentDir = join(__dirname, "..", "..", "..", "content");
 
+const REQUIRED_FIELDS = [
+  "slug",
+  "title",
+  "date",
+  "author",
+  "excerpt",
+  "readingTime",
+] as const;
+
+function extractStringField(block: string, field: string): string | undefined {
+  const re = new RegExp(`${field}\\s*:\\s*\\n?\\s*(["'\`])`);
+  const quoteMatch = block.match(re);
+  if (!quoteMatch) return undefined;
+
+  const quote = quoteMatch[1];
+  const escaped = quote.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const valueRe = new RegExp(
+    `${field}\\s*:\\s*\\n?\\s*${escaped}([^${escaped}]*)${escaped}`
+  );
+  const match = block.match(valueRe);
+  return match ? match[1] : undefined;
+}
+
+function extractBooleanField(
+  block: string,
+  field: string
+): boolean | undefined {
+  const re = new RegExp(`${field}\\s*:\\s*(true|false)`);
+  const match = block.match(re);
+  return match ? match[1] === "true" : undefined;
+}
+
 function extractMetadata(filePath: string): BlogPost | null {
   const content = readFileSync(filePath, "utf-8");
   const match = content.match(
-    /export\s+const\s+metadata\s*=\s*(\{[\s\S]*?\n\});/
+    /export\s+const\s+metadata\s*=\s*\{([\s\S]*?)\n\};/
   );
   if (!match) return null;
-  try {
-    return new Function(`return ${match[1]}`)() as BlogPost;
-  } catch {
-    return null;
+
+  const block = match[1];
+
+  const slug = extractStringField(block, "slug");
+  const title = extractStringField(block, "title");
+  const date = extractStringField(block, "date");
+  const author = extractStringField(block, "author");
+  const excerpt = extractStringField(block, "excerpt");
+  const readingTime = extractStringField(block, "readingTime");
+  const draft = extractBooleanField(block, "draft");
+
+  const parsed = { slug, title, date, author, excerpt, readingTime, draft };
+
+  for (const field of REQUIRED_FIELDS) {
+    if (!parsed[field]) {
+      console.warn(
+        `[blog] Skipping ${filePath}: missing required field "${field}"`
+      );
+      return null;
+    }
   }
+
+  return parsed as BlogPost;
 }
 
 function scanPosts(): BlogPost[] {

--- a/src/web/src/lib/blog/posts/index.ts
+++ b/src/web/src/lib/blog/posts/index.ts
@@ -1,17 +1,55 @@
+import { readdirSync, readFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
 import type { BlogPost } from "../types";
 
-import { metadata as whyWeBuiltAlook } from "@/content/why-we-built-alook.mdx";
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const contentDir = join(__dirname, "..", "..", "..", "content");
 
-const posts: BlogPost[] = [whyWeBuiltAlook];
+function extractMetadata(filePath: string): BlogPost | null {
+  const content = readFileSync(filePath, "utf-8");
+  const match = content.match(
+    /export\s+const\s+metadata\s*=\s*(\{[\s\S]*?\n\});/
+  );
+  if (!match) return null;
+  try {
+    return new Function(`return ${match[1]}`)() as BlogPost;
+  } catch {
+    return null;
+  }
+}
+
+function scanPosts(): BlogPost[] {
+  const files = readdirSync(contentDir).filter((f) => f.endsWith(".mdx"));
+  const posts: BlogPost[] = [];
+
+  for (const file of files) {
+    const metadata = extractMetadata(join(contentDir, file));
+    if (metadata && !metadata.draft) {
+      posts.push(metadata);
+    }
+  }
+
+  return posts;
+}
+
+let cachedPosts: BlogPost[] | null = null;
+
+function getPosts(): BlogPost[] {
+  if (!cachedPosts) {
+    cachedPosts = scanPosts();
+  }
+  return cachedPosts;
+}
 
 export type { BlogPost } from "../types";
 
 export function getAllPosts(): BlogPost[] {
-  return [...posts].sort(
+  return [...getPosts()].sort(
     (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
   );
 }
 
 export function getPostBySlug(slug: string): BlogPost | undefined {
-  return posts.find((p) => p.slug === slug);
+  return getPosts().find((p) => p.slug === slug);
 }

--- a/src/web/src/lib/blog/types.ts
+++ b/src/web/src/lib/blog/types.ts
@@ -5,4 +5,5 @@ export type BlogPost = {
   author: string;
   excerpt: string;
   readingTime: string;
+  draft?: boolean;
 };


### PR DESCRIPTION
# Why we need this PR?
> Replaces the manual blog post registry with automatic file-system scanning and adds draft post support.

## What changed
- **`src/web/src/lib/blog/types.ts`** — Added `draft?: boolean` to the `BlogPost` type.
- **`src/web/src/lib/blog/posts/index.ts`** — Replaced the manual imports array with `fs.readdirSync`-based auto-discovery of all `.mdx` files in `src/content/`. Metadata is extracted via regex from each file. Posts with `draft: true` are excluded from `getAllPosts()` and `getPostBySlug()`.
- **`src/web/src/lib/blog/posts/index.test.ts`** — New test file covering: auto-scan discovers all posts, draft posts are excluded, invalid files are skipped, and `getPostBySlug` works correctly.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)