### PR TITLE
fix(chat-composer): convert to plain-text mode, disable all rich text

### DIFF
--- a/src/web/src/components/agent-chat/chat-composer.tsx
+++ b/src/web/src/components/agent-chat/chat-composer.tsx
@@ -269,7 +269,6 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(
     const editor = useEditor({
       immediatelyRender: false,
       content: value || undefined,
-      contentType: "markdown",
       editable: !disabled,
       extensions: [
         StarterKit.configure({
@@ -280,7 +279,12 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(
           bold: false,
           italic: false,
           strike: false,
+          code: false,
           link: false,
+          bulletList: false,
+          orderedList: false,
+          listItem: false,
+          listKeymap: false,
         }),
         Placeholder.configure({ placeholder: placeholder ?? "" }),
         Markdown,
@@ -315,11 +319,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(
           }
 
           if (event.key === "Enter" && !event.shiftKey && !event.isComposing) {
-            const inList =
-              editor?.isActive("bulletList") ||
-              editor?.isActive("orderedList") ||
-              editor?.isActive("listItem");
-            if (!inList && !slashIsOpenRef.current) {
+            if (!slashIsOpenRef.current) {
               event.preventDefault();
               onSendRef.current();
               return true;
@@ -327,7 +327,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(
           }
           return false;
         },
-        handlePaste: (_view, event) => {
+        handlePaste: (view, event) => {
           const items = event.clipboardData?.items;
           if (!items) return false;
           const files: File[] = [];
@@ -337,10 +337,18 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(
               if (f) files.push(f);
             }
           }
-          if (files.length === 0) return false; // let plain text paste normally
-          event.preventDefault();
-          onFilesRef.current?.(files);
-          return true;
+          if (files.length > 0) {
+            event.preventDefault();
+            onFilesRef.current?.(files);
+            return true;
+          }
+          const text = event.clipboardData?.getData("text/plain");
+          if (text) {
+            event.preventDefault();
+            view.dispatch(view.state.tr.insertText(text));
+            return true;
+          }
+          return false;
         },
         handleDrop: () => false,
       },
@@ -358,9 +366,8 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(
       editor?.setEditable(!disabled);
     }, [editor, disabled]);
 
-    // Controlled value: push external markdown changes (draft restore /
+    // Controlled value: push external changes (draft restore /
     // conversation switch / clear-after-send) into the editor.
-    // contentType:"markdown" is required or lists silently break.
     // emitUpdate:false avoids a feedback loop.
     useEffect(() => {
       if (!editor) return;
@@ -370,16 +377,10 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(
       // content (and the caret) on every keystroke.
       const current = decodeChatEntities(editor.getMarkdown() || "").trim();
       if (incoming === current) return;
-      // Empty incoming → clearContent(). setContent("", {contentType:"markdown"})
-      // does NOT reliably empty the doc (parsing an empty markdown string can
-      // leave the prior content), which left the just-sent text in the input.
       if (!incoming) {
         editor.commands.clearContent();
       } else {
-        editor.commands.setContent(value || "", {
-          emitUpdate: false,
-          contentType: "markdown",
-        });
+        editor.commands.setContent(value || "", { emitUpdate: false });
       }
       onEditorStateRef.current(editor.getText(), editor.state.selection.from - 1);
     }, [value, editor]);

--- a/src/web/src/components/agent-chat/chat-composer.tsx
+++ b/src/web/src/components/agent-chat/chat-composer.tsx
@@ -268,7 +268,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(
 
     const editor = useEditor({
       immediatelyRender: false,
-      content: value || undefined,
+      content: value ? value.replaceAll("\n", "<br>") : undefined,
       editable: !disabled,
       extensions: [
         StarterKit.configure({
@@ -380,7 +380,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(
       if (!incoming) {
         editor.commands.clearContent();
       } else {
-        editor.commands.setContent(value || "", { emitUpdate: false });
+        editor.commands.setContent((value || "").replaceAll("\n", "<br>"), { emitUpdate: false });
       }
       onEditorStateRef.current(editor.getText(), editor.state.selection.from - 1);
     }, [value, editor]);


### PR DESCRIPTION
# Why we need this PR?
> Follow-up to PR #273. The chat input should behave as plain text — no rich text rendering, no markdown interpretation during editing.

## What changed

**`src/web/src/components/agent-chat/chat-composer.tsx`:**

1. **Disabled all remaining rich-text features** in StarterKit: `link`, `bulletList`, `orderedList`, `listItem`, `listKeymap` — prevents "1. " or "- " from creating lists, and pasted URLs from auto-linking.

2. **Simplified Enter handler** — removed the `inList` check since lists are impossible now. Enter always sends (except Shift+Enter, IME composing, mention/slash popup open).

3. **Forced plain-text paste** — instead of falling through to ProseMirror's default paste (which parses clipboard HTML), we explicitly insert `clipboardData.getData("text/plain")`. This prevents rich text from web pages being interpreted.

4. **Fixed draft restore** — removed `contentType: "markdown"` from both the initial editor config and the controlled-value `setContent()` call. Draft content is now treated as plain text, not parsed as markdown (which was stripping backticks, interpreting lists, etc.).

5. **File drop** — returns `false` to let the parent container handle everything (drag state reset + file staging).

6. **Kept Markdown extension** — still needed for `getMarkdown()` which serializes mention nodes to `@Name` format in the `onUpdate` callback.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)