### PR TITLE
feat(web): add fallback page for /w/[slug]/ route

### DIFF
--- a/src/web/src/app/(app)/w/[slug]/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/page.tsx
@@ -1,0 +1,10 @@
+import { redirect } from "next/navigation"
+
+export default async function WorkspaceRootPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  redirect(`/w/${slug}/home`)
+}


### PR DESCRIPTION
# Why we need this PR?

Navigating to `/w/{slug}` directly (without a sub-path like `/home`) causes an error because there's no `page.tsx` at that route level. This adds a server-side redirect to `/w/{slug}/home`.

## What changed

Added `src/web/src/app/(app)/w/[slug]/page.tsx` — a server component that redirects to `/w/{slug}/home` using Next.js `redirect()` from `next/navigation`.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)