### PR TITLE
fix(ci): resolve actionlint SC2129 shellcheck warning

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -58,10 +58,12 @@ jobs:
           gh release create "${{ steps.version.outputs.tag }}" --generate-notes --title "${{ steps.version.outputs.tag }}"
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${{ steps.version.outputs.tag }}"
           BODY=$(gh release view "${{ steps.version.outputs.tag }}" --json body -q .body)
-          echo "url=$RELEASE_URL" >> "$GITHUB_OUTPUT"
-          echo "body<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$BODY" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          {
+            echo "url=$RELEASE_URL"
+            echo "body<<EOF"
+            echo "$BODY"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Notify Discord
         if: steps.check.outputs.exists == 'false'


### PR DESCRIPTION
# Why we need this PR?
> Fixes the pre-existing actionlint CI failure (shellcheck SC2129) in `auto-tag-release.yml`.

## What changed
- Grouped individual `>> "$GITHUB_OUTPUT"` redirects into a single `{ } >> "$GITHUB_OUTPUT"` block (lines 61-64) per shellcheck best practice.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [ ] Other: ...