### PR TITLE
refactor: unify relationship field to plain string

### DIFF
--- a/src/cli/commands/workspace.test.ts
+++ b/src/cli/commands/workspace.test.ts
@@ -65,7 +65,7 @@ describe("workspace init", () => {
       name: "Test WS",
       members: [
         { role: "leader", instructions: "You lead" },
-        { role: "engineer", instructions: "You code", relationship: { leaderSees: "delegate", memberSees: "report" } },
+        { role: "engineer", instructions: "You code", relationship: "delegate\n\nreport" },
       ],
     });
 

--- a/src/shared/src/schemas.ts
+++ b/src/shared/src/schemas.ts
@@ -759,10 +759,7 @@ export const StudioMemberSchema = z.object({
   instructions: z.string().optional().default(""),
   avatar_url: z.string().max(2000).nullable().optional(),
   email_handle: z.string().max(30).optional(),
-  relationship: z.object({
-    leaderSees: z.string(),
-    memberSees: z.string(),
-  }).optional(),
+  relationship: z.string().optional(),
 });
 
 export const CreateStudioRequestSchema = z.object({

--- a/src/web/src/app/api/studios/route.test.ts
+++ b/src/web/src/app/api/studios/route.test.ts
@@ -151,8 +151,8 @@ describe("POST /api/studios", () => {
         scenario: "software-dev",
         members: [
           { name: "Jarvis", role: "leader", runtime_id: "rt1" },
-          { name: "Mira", role: "researcher", runtime_id: "rt1", relationship: { leaderSees: "Delegate research tasks", memberSees: "Report findings" } },
-          { name: "Linus", role: "engineer", runtime_id: "rt1", relationship: { leaderSees: "Delegate coding tasks", memberSees: "Report implementation" } },
+          { name: "Mira", role: "researcher", runtime_id: "rt1", relationship: "Delegate research tasks\n\nReport findings" },
+          { name: "Linus", role: "engineer", runtime_id: "rt1", relationship: "Delegate coding tasks\n\nReport implementation" },
         ],
       }),
     });
@@ -346,7 +346,7 @@ describe("POST /api/studios", () => {
       body: JSON.stringify({
         members: [
           { role: "leader", runtime_id: "rt1", instructions: "You lead" },
-          { role: "engineer", runtime_id: "rt1", instructions: "You code", relationship: { leaderSees: "delegate tasks", memberSees: "report results" } },
+          { role: "engineer", runtime_id: "rt1", instructions: "You code", relationship: "delegate tasks\n\nreport results" },
         ],
       }),
     });

--- a/src/web/src/app/api/studios/route.ts
+++ b/src/web/src/app/api/studios/route.ts
@@ -167,16 +167,12 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     const memberPayload = body.members[specIndex];
     if (!memberPayload?.relationship) continue;
 
-    const leaderMention = `[@ id="${leaderAgent.id}" label="${leaderAgent.name}"]`;
-    const specMention = `[@ id="${specialist.id}" label="${specialist.name}"]`;
-    const linkText = `${leaderMention} → ${specMention}: ${memberPayload.relationship.leaderSees}\n\n${specMention} → ${leaderMention}: ${memberPayload.relationship.memberSees}`;
-
     try {
       const link = await queries.agentLink.create(db, {
         workspaceId: ws.workspaceId,
         sourceAgentId: leaderAgent.id,
         targetAgentId: specialist.id,
-        instruction: linkText,
+        instruction: memberPayload.relationship,
       });
       createdLinks.push(link);
     } catch {

--- a/src/web/src/app/onboard.md/route.ts
+++ b/src/web/src/app/onboard.md/route.ts
@@ -56,10 +56,7 @@ Based on what you learned about the user in Step 3, customize the template or cr
       "role": "engineer",
       "description": "Implements features and fixes bugs",
       "instructions": "System prompt for this agent",
-      "relationship": {
-        "leaderSees": "When/how the leader delegates to this agent",
-        "memberSees": "How this agent reports back to the leader"
-      }
+      "relationship": "When/how to delegate to this agent and how they report back"
     }
   ]
 }

--- a/src/web/src/app/templates/[id]/json/route.test.ts
+++ b/src/web/src/app/templates/[id]/json/route.test.ts
@@ -50,8 +50,7 @@ describe("GET /templates/[id]/json", () => {
     expect(specialists.length).toBeGreaterThanOrEqual(1);
     for (const spec of specialists) {
       expect(spec.relationship).toBeTruthy();
-      expect(spec.relationship.leaderSees).toBeTruthy();
-      expect(spec.relationship.memberSees).toBeTruthy();
+      expect(typeof spec.relationship).toBe("string");
     }
   });
 

--- a/src/web/src/components/studio-onboarding/scenario-presets.ts
+++ b/src/web/src/components/studio-onboarding/scenario-presets.ts
@@ -6,10 +6,7 @@ export interface ScenarioMemberPreset {
   role: MemberRole;
   description: string;
   instructions: string;
-  relationship?: {
-    leaderSees: string;
-    memberSees: string;
-  };
+  relationship?: string;
 }
 
 export interface ScenarioPreset {
@@ -119,19 +116,13 @@ export const SCENARIO_PRESETS: ScenarioPreset[] = [
         role: "engineer",
         description: "Writes code, runs tests, and verifies implementations",
         instructions: ENGINEER_INSTRUCTIONS,
-        relationship: {
-          leaderSees: "Delegate coding tasks with: clear requirement description, acceptance criteria (3-5 specific testable items), relevant file paths, existing patterns to follow, and context from research findings if applicable.",
-          memberSees: "Report back with: implementation status, files changed, acceptance criteria checklist (pass/fail each), test results, and self-review concerns. After implementation, send work to the reviewer if one exists.",
-        },
+        relationship: "Delegate coding tasks with: clear requirement description, acceptance criteria (3-5 specific testable items), relevant file paths, existing patterns to follow, and context from research findings if applicable.\n\nReport back with: implementation status, files changed, acceptance criteria checklist (pass/fail each), test results, and self-review concerns. After implementation, send work to the reviewer if one exists.",
       },
       {
         role: "researcher",
         description: "Reads code, explores APIs, and gathers technical context",
         instructions: RESEARCHER_SOFTWARE_DEV,
-        relationship: {
-          leaderSees: "Delegate technical research with: what to investigate, what decision it informs, scope boundary, and relevant file paths or code pointers.",
-          memberSees: "Report back with: technical summary, evidence (file paths, doc URLs, code snippets), recommendation, and confidence level (High/Medium/Low). Flag anything unverified.",
-        },
+        relationship: "Delegate technical research with: what to investigate, what decision it informs, scope boundary, and relevant file paths or code pointers.\n\nReport back with: technical summary, evidence (file paths, doc URLs, code snippets), recommendation, and confidence level (High/Medium/Low). Flag anything unverified.",
       },
     ],
   },
@@ -146,19 +137,13 @@ export const SCENARIO_PRESETS: ScenarioPreset[] = [
         role: "researcher",
         description: "Finds sources, verifies facts, and organizes references",
         instructions: RESEARCHER_CONTENT,
-        relationship: {
-          leaderSees: "Delegate content research with: topic or claim to investigate, target content format (article, report, social), depth needed, and specific sources to check if any.",
-          memberSees: "Report back with: key facts for the writer, organized source list (URL, date, reliability), verification gaps, framing suggestion, and per-claim confidence.",
-        },
+        relationship: "Delegate content research with: topic or claim to investigate, target content format (article, report, social), depth needed, and specific sources to check if any.\n\nReport back with: key facts for the writer, organized source list (URL, date, reliability), verification gaps, framing suggestion, and per-claim confidence.",
       },
       {
         role: "assistant",
         description: "Handles formatting, publishing workflows, and follow-ups",
         instructions: ASSISTANT_CONTENT,
-        relationship: {
-          leaderSees: "Delegate content operations with: what content to format or publish, target platform, deadline, and style requirements.",
-          memberSees: "Report back with: what was done (formatted, published, submitted), next step (awaiting review, scheduled date), and blockers if any.",
-        },
+        relationship: "Delegate content operations with: what content to format or publish, target platform, deadline, and style requirements.\n\nReport back with: what was done (formatted, published, submitted), next step (awaiting review, scheduled date), and blockers if any.",
       },
     ],
   },
@@ -182,19 +167,13 @@ export const SCENARIO_PRESETS: ScenarioPreset[] = [
         role: "researcher",
         description: "Researches prospects, companies, and market intelligence",
         instructions: RESEARCHER_SALES,
-        relationship: {
-          leaderSees: "Delegate prospect research with: target criteria, market or industry focus, what intelligence is needed, and how it will be used (outreach, pitch, proposal).",
-          memberSees: "Report back with: prioritized prospect list (name, role, company, relevance, suggested angle), market signals, and confidence per finding.",
-        },
+        relationship: "Delegate prospect research with: target criteria, market or industry focus, what intelligence is needed, and how it will be used (outreach, pitch, proposal).\n\nReport back with: prioritized prospect list (name, role, company, relevance, suggested angle), market signals, and confidence per finding.",
       },
       {
         role: "assistant",
         description: "Handles outreach emails, follow-ups, and pipeline tracking",
         instructions: ASSISTANT_SALES,
-        relationship: {
-          leaderSees: "Delegate outreach with: who to contact, messaging angle, follow-up cadence, and desired outcome.",
-          memberSees: "Report back with: emails sent or scheduled, responses received, pipeline updates, and deals needing escalation.",
-        },
+        relationship: "Delegate outreach with: who to contact, messaging angle, follow-up cadence, and desired outcome.\n\nReport back with: emails sent or scheduled, responses received, pipeline updates, and deals needing escalation.",
       },
     ],
   },
@@ -209,10 +188,7 @@ export const SCENARIO_PRESETS: ScenarioPreset[] = [
         role: "assistant",
         description: "Drafts customer responses and tracks open issues",
         instructions: ASSISTANT_SUPPORT,
-        relationship: {
-          leaderSees: "Delegate support tasks with: customer issue summary, urgency level, prior interaction context, and resolution approach.",
-          memberSees: "Report back with: response drafted or sent, resolution status, follow-up schedule, and recurring patterns to flag.",
-        },
+        relationship: "Delegate support tasks with: customer issue summary, urgency level, prior interaction context, and resolution approach.\n\nReport back with: response drafted or sent, resolution status, follow-up schedule, and recurring patterns to flag.",
       },
     ],
   },

--- a/src/web/src/components/studio-onboarding/team-preview.tsx
+++ b/src/web/src/components/studio-onboarding/team-preview.tsx
@@ -24,10 +24,7 @@ export interface TeamMember {
   avatarUrl: string;
   runtimeId: string;
   emailHandle?: string;
-  relationship?: {
-    leaderSees: string;
-    memberSees: string;
-  };
+  relationship?: string;
 }
 
 const ROLE_LABELS: Record<MemberRole, string> = {

--- a/src/web/src/lib/templates/presets/client-ops.ts
+++ b/src/web/src/lib/templates/presets/client-ops.ts
@@ -47,10 +47,7 @@ export const clientOps: TemplatePreset = {
 - For follow-ups: be helpful, not pushy — "Checking in on X, let me know if you need anything."
 - For updates: lead with progress, then next steps, then blockers.
 - Set calendar reminders for all follow-up actions. Never let a commitment drop silently.`,
-      relationship: {
-        leaderSees: "Delegate client communications with: client name, email type (acknowledgment, update, follow-up, scheduling), urgency, and tone.",
-        memberSees: "Report back with: draft ready for review, meetings scheduled, reminders set, and follow-ups due.",
-      },
+      relationship: "Delegate client communications with: client name, email type (acknowledgment, update, follow-up, scheduling), urgency, and tone.\n\nReport back with: draft ready for review, meetings scheduled, reminders set, and follow-ups due.",
     },
   ],
 };

--- a/src/web/src/lib/templates/presets/daily-newsletter-operator.ts
+++ b/src/web/src/lib/templates/presets/daily-newsletter-operator.ts
@@ -47,10 +47,7 @@ export const dailyNewsletterOperator: TemplatePreset = {
 - For each story: summarize key facts, provide context, assess reader interest. Include compelling data points or quotes.
 - Scan broadly: news sites, social media, industry blogs, RSS feeds. Look for under-the-radar gems.
 - Flag emerging themes worth watching across multiple stories.`,
-      relationship: {
-        leaderSees: "Delegate curation with: today's theme or angle, audience focus, and number of stories needed.",
-        memberSees: "Report back with: ranked story candidates (headline, summary, source, reader-interest score) and emerging themes spotted.",
-      },
+      relationship: "Delegate curation with: today's theme or angle, audience focus, and number of stories needed.\n\nReport back with: ranked story candidates (headline, summary, source, reader-interest score) and emerging themes spotted.",
     },
     {
       role: "assistant",
@@ -63,10 +60,7 @@ export const dailyNewsletterOperator: TemplatePreset = {
 - Subject line: specific, curiosity-driving, under 50 characters. Provide 2-3 options for A/B testing.
 - Never publish without final review from the leader.
 - Flag production concerns (broken links, missing context) proactively.`,
-      relationship: {
-        leaderSees: "Delegate formatting with: approved stories, issue theme, intro angle, and delivery deadline.",
-        memberSees: "Report back with: formatted issue ready for review, subject line options, and any production concerns (broken links, missing context).",
-      },
+      relationship: "Delegate formatting with: approved stories, issue theme, intro angle, and delivery deadline.\n\nReport back with: formatted issue ready for review, subject line options, and any production concerns (broken links, missing context).",
     },
   ],
 };

--- a/src/web/src/lib/templates/presets/devops-monitor.ts
+++ b/src/web/src/lib/templates/presets/devops-monitor.ts
@@ -48,10 +48,7 @@ export const devopsMonitor: TemplatePreset = {
 - For known issues: execute the runbook (restart, clear cache, rollback). For unknown: investigate systematically — recent deploys, dependency status, resource utilization.
 - Document what happened: root cause, action taken, verification method, and prevention recommendation.
 - If unsure about impact, ask before executing.`,
-      relationship: {
-        leaderSees: "Delegate investigation with: alert context, affected service, severity, and recent changes to check.",
-        memberSees: "Report back with: root cause, action taken, verification method, and prevention recommendation.",
-      },
+      relationship: "Delegate investigation with: alert context, affected service, severity, and recent changes to check.\n\nReport back with: root cause, action taken, verification method, and prevention recommendation.",
     },
   ],
 };

--- a/src/web/src/lib/templates/presets/executive-assistant.ts
+++ b/src/web/src/lib/templates/presets/executive-assistant.ts
@@ -49,10 +49,7 @@ export const executiveAssistant: TemplatePreset = {
 - Track follow-ups: flag items with no response after 48 hours. Maintain a running list of pending commitments.
 - Be concise and precise — respect everyone's time.
 - Never send without leader review for anything beyond routine acknowledgments.`,
-      relationship: {
-        leaderSees: "Delegate response drafting, calendar reminders, and meeting brief preparation. Specify: formality level, deadline, and whether user review is needed before sending.",
-        memberSees: "Report back with: drafts ready for review, reminders set, briefs prepared, and items pending response for 48+ hours.",
-      },
+      relationship: "Delegate response drafting, calendar reminders, and meeting brief preparation. Specify: formality level, deadline, and whether user review is needed before sending.\n\nReport back with: drafts ready for review, reminders set, briefs prepared, and items pending response for 48+ hours.",
     },
   ],
 };

--- a/src/web/src/lib/templates/presets/indie-hacker-ship-crew.ts
+++ b/src/web/src/lib/templates/presets/indie-hacker-ship-crew.ts
@@ -47,10 +47,7 @@ export const indieHackerShipCrew: TemplatePreset = {
 - Self-review before reporting: check for bugs, security issues, and performance problems.
 - Include basic tests for new features. Verify everything runs before calling it done.
 - If requirements are unclear, ask before coding.`,
-      relationship: {
-        leaderSees: "Delegate feature or bugfix with: requirement, affected files, user impact, and acceptance criteria.",
-        memberSees: "Report back with: files changed, tests passing, self-review findings, and any concerns about edge cases.",
-      },
+      relationship: "Delegate feature or bugfix with: requirement, affected files, user impact, and acceptance criteria.\n\nReport back with: files changed, tests passing, self-review findings, and any concerns about edge cases.",
     },
     {
       role: "assistant",
@@ -63,10 +60,7 @@ export const indieHackerShipCrew: TemplatePreset = {
 - For documentation: clear, concise, with code examples and common gotchas.
 - For announcements: highlight user-facing changes in plain language.
 - Track outstanding items and remind the leader when things are overdue.`,
-      relationship: {
-        leaderSees: "Delegate user reply, docs update, or announcement with: context, tone, and target audience.",
-        memberSees: "Report back with: draft ready for review, docs updated, or announcement prepared with publish timing.",
-      },
+      relationship: "Delegate user reply, docs update, or announcement with: context, tone, and target audience.\n\nReport back with: draft ready for review, docs updated, or announcement prepared with publish timing.",
     },
   ],
 };

--- a/src/web/src/lib/templates/presets/open-source-maintainer.ts
+++ b/src/web/src/lib/templates/presets/open-source-maintainer.ts
@@ -47,10 +47,7 @@ export const openSourceMaintainer: TemplatePreset = {
 - For releases: verify all changes, update version numbers, generate changelog entries.
 - Include specific file paths and line numbers in all findings.
 - Ship quality. If something looks off, flag it — don't let it slide.`,
-      relationship: {
-        leaderSees: "Delegate code review or fix with: PR/issue link, affected files, what to check or fix, and acceptance criteria.",
-        memberSees: "Report back with: review findings (approve/request changes), fix implemented with test results, or release checklist status.",
-      },
+      relationship: "Delegate code review or fix with: PR/issue link, affected files, what to check or fix, and acceptance criteria.\n\nReport back with: review findings (approve/request changes), fix implemented with test results, or release checklist status.",
     },
     {
       role: "researcher",
@@ -64,10 +61,7 @@ export const openSourceMaintainer: TemplatePreset = {
 - Always cite sources (file paths, issue numbers, doc URLs). Distinguish confirmed facts from hypotheses.
 - Include reproduction steps for bugs and flag confidence level for each finding.
 - Lead with your recommendation, then supporting evidence.`,
-      relationship: {
-        leaderSees: "Delegate investigation with: issue/PR link, what to research (bug repro, prior art, dependency compat), and scope boundary.",
-        memberSees: "Report back with: reproduction steps, root cause analysis, relevant prior issues, and confidence level per finding.",
-      },
+      relationship: "Delegate investigation with: issue/PR link, what to research (bug repro, prior art, dependency compat), and scope boundary.\n\nReport back with: reproduction steps, root cause analysis, relevant prior issues, and confidence level per finding.",
     },
   ],
 };

--- a/src/web/src/lib/templates/presets/research-analyst.ts
+++ b/src/web/src/lib/templates/presets/research-analyst.ts
@@ -47,10 +47,7 @@ export const researchAnalyst: TemplatePreset = {
 - Cross-reference important claims with multiple sources. Flag outdated or unreliable info.
 - Identify signals: unusual activity, pattern breaks, emerging trends.
 - Organize findings categorized for the leader to synthesize: discoveries, notable signals, sources, and confidence assessment.`,
-      relationship: {
-        leaderSees: "Delegate monitoring with: competitors to track, signals to watch for, sources to check, and reporting cadence.",
-        memberSees: "Report back with: categorized findings (discoveries, signals, sources), confidence per claim, and items flagged for urgency.",
-      },
+      relationship: "Delegate monitoring with: competitors to track, signals to watch for, sources to check, and reporting cadence.\n\nReport back with: categorized findings (discoveries, signals, sources), confidence per claim, and items flagged for urgency.",
     },
   ],
 };

--- a/src/web/src/lib/templates/presets/social-media-manager.ts
+++ b/src/web/src/lib/templates/presets/social-media-manager.ts
@@ -47,10 +47,7 @@ export const socialMediaManager: TemplatePreset = {
 - Track trending topics and identify newsjacking opportunities (industry news + your take). Flag viral formats worth adapting.
 - Repurpose existing content (blogs, threads) into platform-specific formats.
 - Set calendar reminders for optimal publishing times.`,
-      relationship: {
-        leaderSees: "Delegate post creation with: topic or content to repurpose, target platform, tone, and publish timing.",
-        memberSees: "Report back with: post drafts ready for review, trending topics spotted, and calendar reminders set for publishing.",
-      },
+      relationship: "Delegate post creation with: topic or content to repurpose, target platform, tone, and publish timing.\n\nReport back with: post drafts ready for review, trending topics spotted, and calendar reminders set for publishing.",
     },
   ],
 };

--- a/src/web/src/lib/templates/presets/technical-blog-pipeline.ts
+++ b/src/web/src/lib/templates/presets/technical-blog-pipeline.ts
@@ -47,10 +47,7 @@ export const technicalBlogPipeline: TemplatePreset = {
 - Verify technical accuracy of all claims. Flag areas of uncertainty or rapidly changing info.
 - Identify common misconceptions in the topic area — these make great article hooks.
 - Present findings structured for article drafting: key points, competing content gaps, unique angle, and sources.`,
-      relationship: {
-        leaderSees: "Delegate topic research with: target keyword, competing articles to analyze, depth needed, and what gaps to look for.",
-        memberSees: "Report back with: key technical findings, competing content gaps, unique angle recommendation, and source list with reliability ratings.",
-      },
+      relationship: "Delegate topic research with: target keyword, competing articles to analyze, depth needed, and what gaps to look for.\n\nReport back with: key technical findings, competing content gaps, unique angle recommendation, and source list with reliability ratings.",
     },
     {
       role: "engineer",
@@ -63,10 +60,7 @@ export const technicalBlogPipeline: TemplatePreset = {
 - Test each sample to verify it works. Provide setup instructions (dependencies, environment).
 - Use modern patterns and current best practices. Include error handling where relevant.
 - Note common pitfalls readers might encounter.`,
-      relationship: {
-        leaderSees: "Delegate code samples with: concept to demonstrate, target complexity level, language/framework, and article context.",
-        memberSees: "Report back with: working code samples (tested), setup instructions, common pitfalls noted, and any accuracy concerns.",
-      },
+      relationship: "Delegate code samples with: concept to demonstrate, target complexity level, language/framework, and article context.\n\nReport back with: working code samples (tested), setup instructions, common pitfalls noted, and any accuracy concerns.",
     },
   ],
 };

--- a/src/web/src/lib/templates/presets/weekly-report-bot.ts
+++ b/src/web/src/lib/templates/presets/weekly-report-bot.ts
@@ -47,10 +47,7 @@ export const weeklyReportBot: TemplatePreset = {
 - Calendar: note meeting purposes (not just titles), total meeting time, productive vs. overhead estimate.
 - Include: feature work, bug fixes, reviews, important decisions, client comms. Exclude: automated notifications, spam.
 - Flag data gaps (e.g., calendar empty on a day — PTO or just no meetings?). Highlight completed milestones.`,
-      relationship: {
-        leaderSees: "Delegate data gathering with: time range, sources to check (git, email, calendar), and focus areas or projects to highlight.",
-        memberSees: "Report back with: raw activity data organized by source, milestones completed, data gaps flagged, and items needing interpretation.",
-      },
+      relationship: "Delegate data gathering with: time range, sources to check (git, email, calendar), and focus areas or projects to highlight.\n\nReport back with: raw activity data organized by source, milestones completed, data gaps flagged, and items needing interpretation.",
     },
   ],
 };

--- a/src/web/src/test/e2e/workspace-init.test.ts
+++ b/src/web/src/test/e2e/workspace-init.test.ts
@@ -57,9 +57,7 @@ describe("workspace init flow", () => {
       const specialist = members.find(m => m.role !== "leader")
       expect(specialist).toBeTruthy()
       expect(specialist!.relationship).toBeTruthy()
-      const rel = specialist!.relationship as Record<string, string>
-      expect(rel.leaderSees).toBeTruthy()
-      expect(rel.memberSees).toBeTruthy()
+      expect(typeof specialist!.relationship).toBe("string")
     })
 
     it("GET /templates/nonexistent-slug/json returns 404", async () => {
@@ -88,10 +86,7 @@ describe("workspace init flow", () => {
             runtime_id: seed.runtimeId,
             description: "Test engineer agent",
             instructions: "You are the test engineer",
-            relationship: {
-              leaderSees: "Delegate code tasks to this engineer",
-              memberSees: "Report back with implementation results",
-            },
+            relationship: "Delegate code tasks to this engineer\n\nReport back with implementation results",
           },
         ],
       }


### PR DESCRIPTION
# Why we need this PR?

The `relationship` field had inconsistent types across the codebase:
- Studio creation used `{ leaderSees, memberSees }` object
- Recruit API used a plain string
- Both wrote to the same `agent_link.instruction` TEXT column

This caused the template JSON output to not be directly usable by the recruit API, and added unnecessary concat logic in the studio route.

## What changed

- `ScenarioMemberPreset.relationship` type: `{ leaderSees, memberSees }` → `string`
- `StudioMemberSchema.relationship` (zod): `z.object(...)` → `z.string()`
- Studio route: removed mention-based concat logic, writes relationship string directly to `agent_link.instruction`
- All 10 template presets + scenario-presets: merged object fields into `"delegation...\n\nreport..."` string format
- `team-preview.tsx`: type aligned
- `onboard.md` docs: updated example
- All related tests updated

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [x] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...