### PR TITLE
fix(web): reliable mobile keyboard offset and backdrop for chat input

### DIFF
--- a/src/cli/eslint.config.mjs
+++ b/src/cli/eslint.config.mjs
@@ -3,7 +3,7 @@ import tseslint from "typescript-eslint";
 
 const eslintConfig = defineConfig([
   ...tseslint.configs.recommended,
-  globalIgnores(["dist/**"]),
+  globalIgnores(["dist/**", "coverage/**"]),
   {
     files: ["**/*.test.ts"],
     rules: {

--- a/src/web/src/app/globals.css
+++ b/src/web/src/app/globals.css
@@ -1726,6 +1726,15 @@ html, body {
   will-change: transform;
 }
 
+[data-keyboard-offset][data-keyboard-active]::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  bottom: -100vh;
+  background: var(--background);
+  z-index: -1;
+}
+
 html, body {
   background-color: oklch(0.93 0.015 80);
   min-height: 100dvh;

--- a/src/web/src/components/agent-chat/agent-chat-view.tsx
+++ b/src/web/src/components/agent-chat/agent-chat-view.tsx
@@ -2060,6 +2060,7 @@ export function AgentChatView({
         toast.error(msg.error || "Failed to dispatch follow-up");
       }
     });
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- activeChannelRef is a stable ref read inside the callback, not a reactive dep
   }, [subscribeWs, conversation?.id, workspaceId, agentId]);
 
   useEffect(() => {

--- a/src/web/src/components/agent-chat/chat-composer.tsx
+++ b/src/web/src/components/agent-chat/chat-composer.tsx
@@ -153,6 +153,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(
     },
     ref,
   ) {
+    const [editorFocused, setEditorFocused] = useState(false);
     const [mentionPopup, setMentionPopup] = useState<MentionPopupState>(EMPTY_MENTION_STATE);
     const mentionPopupRef = useRef(mentionPopup);
     useEffect(() => {
@@ -353,6 +354,8 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(
         },
         handleDrop: () => false,
       },
+      onFocus: () => setEditorFocused(true),
+      onBlur: () => setEditorFocused(false),
       onUpdate: ({ editor }) => {
         onChangeRef.current(decodeChatEntities(editor.getMarkdown()));
         reportState(editor);
@@ -401,7 +404,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(
 
     // iOS Safari fallback: scroll composer into view when the virtual keyboard resizes
     // the visual viewport.
-    useKeyboardScroll(contentRef, !!editor?.isFocused);
+    useKeyboardScroll(contentRef, editorFocused);
 
     useImperativeHandle(
       ref,

--- a/src/web/src/hooks/__tests__/use-keyboard-scroll.test.ts
+++ b/src/web/src/hooks/__tests__/use-keyboard-scroll.test.ts
@@ -20,6 +20,8 @@ function createMockContainer(bottom = 800) {
   return {
     style: { transform: "" },
     getBoundingClientRect: () => ({ top: 0, left: 0, right: 0, bottom, width: 0, height: 0 }),
+    setAttribute: vi.fn(),
+    removeAttribute: vi.fn(),
   } as unknown as HTMLElement;
 }
 

--- a/src/web/src/hooks/use-keyboard-scroll.ts
+++ b/src/web/src/hooks/use-keyboard-scroll.ts
@@ -39,10 +39,16 @@ export function createKeyboardScrollController(
         // Only shift enough to keep it visible, not the full keyboard height.
         const rect = inputContainer.getBoundingClientRect();
         const overflow = rect.bottom - vv.height - vv.offsetTop;
-        inputContainer.style.transform =
-          overflow > 0 ? `translateY(-${overflow}px)` : "";
+        if (overflow > 0) {
+          inputContainer.style.transform = `translateY(-${overflow}px)`;
+          inputContainer.setAttribute("data-keyboard-active", "");
+        } else {
+          inputContainer.style.transform = "";
+          inputContainer.removeAttribute("data-keyboard-active");
+        }
       } else if (inputContainer) {
         inputContainer.style.transform = "";
+        inputContainer.removeAttribute("data-keyboard-active");
       } else {
         el.scrollIntoView({ block: "end", behavior: "smooth" });
       }
@@ -57,6 +63,7 @@ export function createKeyboardScrollController(
     ) as HTMLElement | null;
     if (inputContainer) {
       inputContainer.style.transform = "";
+      inputContainer.removeAttribute("data-keyboard-active");
     }
   };
   return { handler, cleanup };
@@ -114,17 +121,24 @@ function attachVirtualKeyboardAPI(
   const onGeometryChange = () => {
     if (!isFocused) {
       inputContainer.style.transform = "";
+      inputContainer.removeAttribute("data-keyboard-active");
       return;
     }
     const { height } = vk.boundingRect;
-    inputContainer.style.transform =
-      height > 0 ? `translateY(-${height}px)` : "";
+    if (height > 0) {
+      inputContainer.style.transform = `translateY(-${height}px)`;
+      inputContainer.setAttribute("data-keyboard-active", "");
+    } else {
+      inputContainer.style.transform = "";
+      inputContainer.removeAttribute("data-keyboard-active");
+    }
   };
 
   vk.addEventListener("geometrychange", onGeometryChange);
   return () => {
     vk.removeEventListener("geometrychange", onGeometryChange);
     inputContainer.style.transform = "";
+    inputContainer.removeAttribute("data-keyboard-active");
     vk.overlaysContent = false;
   };
 }

--- a/src/web/src/hooks/use-keyboard-scroll.ts
+++ b/src/web/src/hooks/use-keyboard-scroll.ts
@@ -2,6 +2,11 @@
 
 import { useEffect, type RefObject } from "react";
 
+interface VirtualKeyboard extends EventTarget {
+  overlaysContent: boolean;
+  boundingRect: DOMRect;
+}
+
 export interface KeyboardScrollController {
   handler: () => void;
   cleanup: () => void;
@@ -108,7 +113,7 @@ function attachVirtualKeyboardAPI(
   isFocused: boolean,
 ): (() => void) | null {
   if (typeof window === "undefined") return null;
-  const vk = (navigator as any).virtualKeyboard;
+  const vk = (navigator as unknown as { virtualKeyboard?: VirtualKeyboard }).virtualKeyboard;
   if (!vk) return null;
 
   vk.overlaysContent = true;


### PR DESCRIPTION
# Why we need this PR?

Mobile chat input has two issues:
1. Keyboard opens but input doesn't always follow — intermittent, depends on timing
2. When input does float up, the area behind it is transparent (no backdrop)

## What changed

**Bug 1 — unreliable keyboard tracking:**
- `editor?.isFocused` (tiptap getter) is not reactive — captured as stale `false` in the `useKeyboardScroll` effect closure
- Added `useState` + tiptap `onFocus`/`onBlur` callbacks to properly track focus and re-bind the viewport listener

**Bug 2 — missing backdrop:**
- Added `data-keyboard-active` attribute to the input container when transform is applied
- CSS `::before` pseudo-element fills from the container to the bottom of the screen with `var(--background)`

**Test fix:**
- Added `setAttribute`/`removeAttribute` mocks to the test container fixture

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)
- [ ] Shared library (`@alook/shared`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...