### PR TITLE
test: add coverage for keyboard-active attribute

### DIFF
--- a/src/web/src/hooks/__tests__/use-keyboard-scroll.test.ts
+++ b/src/web/src/hooks/__tests__/use-keyboard-scroll.test.ts
@@ -75,6 +75,7 @@ describe("createKeyboardScrollController", () => {
     vi.advanceTimersByTime(150);
 
     expect(container.style.transform).toBe("translateY(-300px)");
+    expect(container.setAttribute).toHaveBeenCalledWith("data-keyboard-active", "");
 
     Object.defineProperty(globalThis, "window", {
       value: undefined,
@@ -101,6 +102,7 @@ describe("createKeyboardScrollController", () => {
     vi.advanceTimersByTime(150);
 
     expect(container.style.transform).toBe("");
+    expect(container.removeAttribute).toHaveBeenCalledWith("data-keyboard-active");
 
     Object.defineProperty(globalThis, "window", {
       value: undefined,
@@ -186,6 +188,7 @@ describe("createKeyboardScrollController", () => {
     vi.advanceTimersByTime(150);
 
     expect(container.style.transform).toBe("");
+    expect(container.removeAttribute).toHaveBeenCalledWith("data-keyboard-active");
 
     Object.defineProperty(globalThis, "window", {
       value: undefined,
@@ -322,6 +325,7 @@ describe("attachKeyboardScroll", () => {
     handler(new Event("resize"));
     vi.advanceTimersByTime(150);
     expect(container.style.transform).toBe("translateY(-300px)");
+    expect(container.setAttribute).toHaveBeenCalledWith("data-keyboard-active", "");
 
     detach();
 
@@ -330,6 +334,7 @@ describe("attachKeyboardScroll", () => {
       expect.any(Function),
     );
     expect(container.style.transform).toBe("");
+    expect(container.removeAttribute).toHaveBeenCalledWith("data-keyboard-active");
   });
 
   it("applies transform on resize when focused", () => {
@@ -342,6 +347,7 @@ describe("attachKeyboardScroll", () => {
     vi.advanceTimersByTime(300);
 
     expect(container.style.transform).toBe("translateY(-300px)");
+    expect(container.setAttribute).toHaveBeenCalledWith("data-keyboard-active", "");
   });
 
   it("does not fire when not focused", () => {


### PR DESCRIPTION
# Why we need this PR?

PR #281 introduced `data-keyboard-active` attribute toggling in `use-keyboard-scroll.ts` but the test only mocked `setAttribute`/`removeAttribute` without asserting they were called — causing codecov/patch to fail.

## What changed

Added `expect(container.setAttribute)` and `expect(container.removeAttribute)` assertions to the existing test cases that exercise transform apply/clear/cleanup/detach paths.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)
- [ ] Shared library (`@alook/shared`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...