### PR TITLE
fix(skill-scanner): write cache on 4xx to prevent infinite retry loop

### DIFF
--- a/src/cli/daemon/skill-scanner.test.ts
+++ b/src/cli/daemon/skill-scanner.test.ts
@@ -18,7 +18,7 @@ vi.mock("../lib/config.js", () => ({
   configDir: () => join(tmpdir(), "alook-skill-scanner-test-config-" + process.pid),
 }));
 
-import { startSkillScanner, stopSkillScanner, parseFrontmatter } from "./skill-scanner.js";
+import { startSkillScanner, stopSkillScanner, parseFrontmatter, isClientError } from "./skill-scanner.js";
 import type { DaemonClient } from "./client.js";
 
 describe("parseFrontmatter", () => {
@@ -29,6 +29,33 @@ describe("parseFrontmatter", () => {
 
   it("returns null without frontmatter", () => {
     expect(parseFrontmatter("Just text")).toBeNull();
+  });
+});
+
+describe("isClientError", () => {
+  it("returns true for 4xx HTTP errors", () => {
+    expect(isClientError(new Error("HTTP 400: Bad Request"))).toBe(true);
+    expect(isClientError(new Error("HTTP 401: Unauthorized"))).toBe(true);
+    expect(isClientError(new Error("HTTP 403: Forbidden"))).toBe(true);
+    expect(isClientError(new Error("HTTP 404: Not Found"))).toBe(true);
+    expect(isClientError(new Error("HTTP 422: Unprocessable Entity"))).toBe(true);
+  });
+
+  it("returns false for 5xx HTTP errors", () => {
+    expect(isClientError(new Error("HTTP 500: Internal Server Error"))).toBe(false);
+    expect(isClientError(new Error("HTTP 502: Bad Gateway"))).toBe(false);
+    expect(isClientError(new Error("HTTP 503: Service Unavailable"))).toBe(false);
+  });
+
+  it("returns false for network errors", () => {
+    expect(isClientError(new TypeError("fetch failed"))).toBe(false);
+    expect(isClientError(new Error("ECONNREFUSED"))).toBe(false);
+  });
+
+  it("returns false for non-Error values", () => {
+    expect(isClientError("string error")).toBe(false);
+    expect(isClientError(null)).toBe(false);
+    expect(isClientError(undefined)).toBe(false);
   });
 });
 
@@ -122,5 +149,97 @@ describe("runScan global skills syncs to all workspaces", () => {
       (args) => (args[1] as { scope: string }).scope === "global"
     );
     expect(globalCalls.length).toBe(2);
+  });
+
+  it("writes cache on 4xx error so next scan does not retry", async () => {
+    const home = join(tempDir, "home-4xx");
+    mockState.home = home;
+
+    const skillDir = join(home, ".claude", "skills", "my-skill");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "---\nname: my-skill\ndescription: Test 4xx\n---\nBody");
+
+    const wsDir = join(workspacesRoot, "ws1", "agent1");
+    mkdirSync(join(wsDir, "workdir"), { recursive: true });
+
+    mockClient.syncSkills.mockRejectedValue(new Error("HTTP 401: Unauthorized"));
+
+    startSkillScanner(mockClient as unknown as DaemonClient, {
+      workspacesRoot,
+      workspaces: [
+        { workspaceId: "ws1", token: "token-ws1", agentIds: ["agent1"] },
+      ],
+      runtimes: ["claude"],
+      daemonId: "test-daemon-4xx",
+    }, 999_999);
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    // First scan should have attempted the sync
+    expect(mockClient.syncSkills).toHaveBeenCalled();
+    const callCount = mockClient.syncSkills.mock.calls.length;
+
+    // Stop and restart to trigger a second scan — cache should prevent re-request
+    stopSkillScanner();
+    mockClient.syncSkills.mockClear();
+
+    startSkillScanner(mockClient as unknown as DaemonClient, {
+      workspacesRoot,
+      workspaces: [
+        { workspaceId: "ws1", token: "token-ws1", agentIds: ["agent1"] },
+      ],
+      runtimes: ["claude"],
+      daemonId: "test-daemon-4xx",
+    }, 999_999);
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Second scan should NOT call syncSkills because cache was written after 4xx
+    expect(mockClient.syncSkills).not.toHaveBeenCalled();
+  });
+
+  it("does not write cache on 5xx error so next scan retries", async () => {
+    const home = join(tempDir, "home-5xx");
+    mockState.home = home;
+
+    const skillDir = join(home, ".claude", "skills", "retry-skill");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "---\nname: retry-skill\ndescription: Test 5xx\n---\nBody");
+
+    const wsDir = join(workspacesRoot, "ws1", "agent1");
+    mkdirSync(join(wsDir, "workdir"), { recursive: true });
+
+    mockClient.syncSkills.mockRejectedValue(new Error("HTTP 500: Internal Server Error"));
+
+    startSkillScanner(mockClient as unknown as DaemonClient, {
+      workspacesRoot,
+      workspaces: [
+        { workspaceId: "ws1", token: "token-ws1", agentIds: ["agent1"] },
+      ],
+      runtimes: ["claude"],
+      daemonId: "test-daemon-5xx",
+    }, 999_999);
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(mockClient.syncSkills).toHaveBeenCalled();
+
+    // Stop and restart to trigger a second scan — no cache, so it should retry
+    stopSkillScanner();
+    mockClient.syncSkills.mockClear();
+
+    startSkillScanner(mockClient as unknown as DaemonClient, {
+      workspacesRoot,
+      workspaces: [
+        { workspaceId: "ws1", token: "token-ws1", agentIds: ["agent1"] },
+      ],
+      runtimes: ["claude"],
+      daemonId: "test-daemon-5xx",
+    }, 999_999);
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Second scan SHOULD call syncSkills because cache was NOT written after 5xx
+    expect(mockClient.syncSkills).toHaveBeenCalled();
   });
 });

--- a/src/cli/daemon/skill-scanner.ts
+++ b/src/cli/daemon/skill-scanner.ts
@@ -265,6 +265,17 @@ function writeCacheFile(filePath: string, hash: string, skills: SkillEntry[]) {
   writeFileSync(filePath, JSON.stringify(data, null, 2), "utf-8");
 }
 
+export function isClientError(err: unknown): boolean {
+  if (err instanceof Error) {
+    const match = err.message.match(/^HTTP (\d+):/);
+    if (match) {
+      const status = parseInt(match[1], 10);
+      return status >= 400 && status < 500;
+    }
+  }
+  return false;
+}
+
 let scanTimer: ReturnType<typeof setInterval> | null = null;
 let scannerConfig: SkillScannerConfig | null = null;
 let clientRef: DaemonClient | null = null;
@@ -346,7 +357,12 @@ function runScan() {
         );
         Promise.all(syncPromises).then(() => {
           writeCacheFile(globalCachePath(daemonId, runtime), hash, skills);
-        }).catch((e) => log.debug("Global skill sync failed", e));
+        }).catch((e) => {
+          if (isClientError(e)) {
+            writeCacheFile(globalCachePath(daemonId, runtime), hash, skills);
+          }
+          log.debug("Global skill sync failed", e);
+        });
       }
     } catch (e) {
       log.debug(`Global scan error for ${runtime}`, e);
@@ -373,7 +389,12 @@ function runScan() {
           skills: skillItems,
         }).then(() => {
           writeCacheFile(agentCachePath(target.agentId, target.runtime), hash, skills);
-        }).catch((e) => log.debug("Agent skill sync failed", e));
+        }).catch((e) => {
+          if (isClientError(e)) {
+            writeCacheFile(agentCachePath(target.agentId, target.runtime), hash, skills);
+          }
+          log.debug("Agent skill sync failed", e);
+        });
       }
     } catch (e) {
       log.debug(`Agent scan error for ${target.agentId}:${target.runtime}`, e);


### PR DESCRIPTION
# Why we need this PR?
> When the skill-scanner's `syncSkills()` API call returns a 4xx client error (e.g. 401 for deleted agents), the cache file is never written. This causes `prevHash !== hash` to always be true, triggering an infinite retry loop every 60 seconds.

## What changed
- Added `isClientError()` helper to detect 4xx HTTP errors from the error message format used by `DaemonClient.request()`
- Modified both global and agent skill sync `.catch()` handlers to write the cache file on 4xx errors, stopping the infinite retry
- 5xx and network errors preserve the existing retry behavior (no cache written)
- Added unit tests for `isClientError()` covering 4xx, 5xx, network errors, and non-Error values
- Added integration tests verifying that 4xx writes cache (no retry on next scan) and 5xx does not write cache (retries on next scan)

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] CLI (`@alook/cli`)