### PR TITLE
feat(web): add GTM sign_up event tracking via @next/third-parties

### DIFF
--- a/src/web/src/app/(app)/layout.tsx
+++ b/src/web/src/app/(app)/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/session";
+import { SignupTracker } from "@/components/signup-tracker";
 
 export const metadata: Metadata = {
   robots: { index: false, follow: false },
@@ -14,5 +15,10 @@ export default async function AppLayout({
   const session = await getSession();
   if (!session) redirect("/sign-in");
 
-  return <>{children}</>;
+  return (
+    <>
+      <SignupTracker />
+      {children}
+    </>
+  );
 }

--- a/src/web/src/components/signup-tracker.test.ts
+++ b/src/web/src/components/signup-tracker.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+const mockSendGTMEvent = vi.fn()
+vi.mock("@next/third-parties/google", () => ({
+  sendGTMEvent: (...args: unknown[]) => mockSendGTMEvent(...args),
+}))
+
+vi.mock("react", () => ({
+  useEffect: (fn: () => void) => fn(),
+}))
+
+describe("SignupTracker", () => {
+  let cookieValue = ""
+  let cookieSetValue = ""
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    cookieValue = ""
+    cookieSetValue = ""
+    // @ts-expect-error stub global document
+    globalThis.document = {
+      get cookie() { return cookieValue },
+      set cookie(val: string) { cookieSetValue = val },
+    }
+  })
+
+  afterEach(() => {
+    // @ts-expect-error cleanup
+    delete globalThis.document
+  })
+
+  it("fires sign_up event and clears cookie when is_new_signup is present", async () => {
+    cookieValue = "is_new_signup=email"
+    vi.resetModules()
+    const { SignupTracker } = await import("./signup-tracker")
+    SignupTracker()
+
+    expect(mockSendGTMEvent).toHaveBeenCalledWith({ event: "sign_up", method: "email" })
+    expect(cookieSetValue).toBe("is_new_signup=; max-age=0; path=/")
+  })
+
+  it("does nothing when is_new_signup cookie is absent", async () => {
+    cookieValue = "other_cookie=value"
+    vi.resetModules()
+    const { SignupTracker } = await import("./signup-tracker")
+    SignupTracker()
+
+    expect(mockSendGTMEvent).not.toHaveBeenCalled()
+  })
+
+  it("handles github method correctly", async () => {
+    cookieValue = "session=abc; is_new_signup=github; other=xyz"
+    vi.resetModules()
+    const { SignupTracker } = await import("./signup-tracker")
+    SignupTracker()
+
+    expect(mockSendGTMEvent).toHaveBeenCalledWith({ event: "sign_up", method: "github" })
+  })
+})

--- a/src/web/src/components/signup-tracker.tsx
+++ b/src/web/src/components/signup-tracker.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import { useEffect } from "react"
+import { sendGTMEvent } from "@next/third-parties/google"
+
+export function SignupTracker() {
+  useEffect(() => {
+    const match = document.cookie.match(/(?:^|; )is_new_signup=([^;]*)/)
+    if (!match) return
+    const method = decodeURIComponent(match[1])
+    sendGTMEvent({ event: "sign_up", method })
+    document.cookie = "is_new_signup=; max-age=0; path=/"
+  }, [])
+
+  return null
+}

--- a/src/web/src/lib/auth.test.ts
+++ b/src/web/src/lib/auth.test.ts
@@ -74,6 +74,13 @@ type AuthOptions = {
       maxAge?: number
     }
   }
+  databaseHooks?: {
+    user?: {
+      create?: {
+        after?: (user: unknown, ctx: unknown) => Promise<void>
+      }
+    }
+  }
 }
 
 async function loadCreateAuth() {
@@ -235,5 +242,63 @@ describe("createAuth device authorization plugin", () => {
     const devicePlugin = opts.plugins.find((p: any) => p.__plugin === "deviceAuthorization")
     const { validateClient } = devicePlugin.cfg
     expect(validateClient("")).toBe(false)
+  })
+})
+
+describe("createAuth databaseHooks — user.create.after", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  function makeCtx(url: string) {
+    const cookies: Record<string, { value: string; opts: unknown }> = {}
+    return {
+      request: { url },
+      setCookie: vi.fn((name: string, value: string, opts: unknown) => {
+        cookies[name] = { value, opts }
+      }),
+      cookies,
+    }
+  }
+
+  it("sets is_new_signup cookie with method=email for email-otp path", async () => {
+    const createAuth = await loadCreateAuth()
+    const opts = (createAuth(makeEnv({ NODE_ENV: "production" }) as never) as { __options: AuthOptions }).__options
+    const afterHook = opts.databaseHooks!.user!.create!.after!
+    const ctx = makeCtx("http://localhost:3000/api/auth/sign-in/email-otp")
+    await afterHook({ id: "u1", email: "a@b.com" }, ctx)
+    expect(ctx.setCookie).toHaveBeenCalledWith("is_new_signup", "email", expect.objectContaining({ maxAge: 60 }))
+  })
+
+  it("sets method=github for github callback path", async () => {
+    const createAuth = await loadCreateAuth()
+    const opts = (createAuth(makeEnv({ NODE_ENV: "production" }) as never) as { __options: AuthOptions }).__options
+    const afterHook = opts.databaseHooks!.user!.create!.after!
+    const ctx = makeCtx("http://localhost:3000/api/auth/callback/github")
+    await afterHook({ id: "u2" }, ctx)
+    expect(ctx.setCookie).toHaveBeenCalledWith("is_new_signup", "github", expect.anything())
+  })
+
+  it("sets method=google for google callback path", async () => {
+    const createAuth = await loadCreateAuth()
+    const opts = (createAuth(makeEnv({ NODE_ENV: "production" }) as never) as { __options: AuthOptions }).__options
+    const afterHook = opts.databaseHooks!.user!.create!.after!
+    const ctx = makeCtx("http://localhost:3000/api/auth/callback/google")
+    await afterHook({ id: "u3" }, ctx)
+    expect(ctx.setCookie).toHaveBeenCalledWith("is_new_signup", "google", expect.anything())
+  })
+
+  it("sets method=unknown for unrecognized path", async () => {
+    const createAuth = await loadCreateAuth()
+    const opts = (createAuth(makeEnv({ NODE_ENV: "production" }) as never) as { __options: AuthOptions }).__options
+    const afterHook = opts.databaseHooks!.user!.create!.after!
+    const ctx = makeCtx("http://localhost:3000/api/auth/sign-up/email")
+    await afterHook({ id: "u4" }, ctx)
+    expect(ctx.setCookie).toHaveBeenCalledWith("is_new_signup", "unknown", expect.anything())
+  })
+
+  it("does nothing when ctx is null", async () => {
+    const createAuth = await loadCreateAuth()
+    const opts = (createAuth(makeEnv({ NODE_ENV: "production" }) as never) as { __options: AuthOptions }).__options
+    const afterHook = opts.databaseHooks!.user!.create!.after!
+    await expect(afterHook({ id: "u5" }, null)).resolves.toBeUndefined()
   })
 })

--- a/src/web/src/lib/auth.ts
+++ b/src/web/src/lib/auth.ts
@@ -76,6 +76,27 @@ export function createAuth(env: Env) {
         },
       },
     },
+    databaseHooks: {
+      user: {
+        create: {
+          after: async (user, ctx) => {
+            if (!ctx) return
+            const path = ctx.request?.url ? new URL(ctx.request.url).pathname : ""
+            let method = "unknown"
+            if (path.includes("email-otp")) method = "email"
+            else if (path.includes("github")) method = "github"
+            else if (path.includes("google")) method = "google"
+            ctx.setCookie("is_new_signup", method, {
+              maxAge: 60,
+              path: "/",
+              httpOnly: false,
+              secure: isProd,
+              sameSite: "lax",
+            })
+          },
+        },
+      },
+    },
     plugins: isProd
       ? [
           deviceAuthorization({ verificationUri: "/device", validateClient, expiresIn: "5m", schema: {} }),


### PR DESCRIPTION
# Why we need this PR?
> Supersedes #290 — refactored to use `@next/third-parties/google` per team guidance.

## What changed
- **`src/web/src/lib/auth.ts`** — Added `databaseHooks.user.create.after` hook that sets a short-lived `is_new_signup` cookie (60s, non-httpOnly) with the detected auth method (email/github/google/unknown)
- **`src/web/src/components/signup-tracker.tsx`** — New client component that reads the `is_new_signup` cookie on mount, fires `sendGTMEvent({ event: 'sign_up', method })` from `@next/third-parties/google`, and deletes the cookie
- **`src/web/src/app/(app)/layout.tsx`** — Mounts `SignupTracker` in the authenticated layout so it catches all post-login landing pages
- **`src/web/src/lib/auth.test.ts`** — Added 5 tests for the databaseHooks behavior
- **`src/web/src/components/signup-tracker.test.ts`** — Added 3 tests for cookie detection and GTM event firing

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)