### PR TITLE
feat(web): restore animated hamburger/X toggle on chat input button

### DIFF
--- a/src/web/src/components/agent-chat/agent-chat-view.tsx
+++ b/src/web/src/components/agent-chat/agent-chat-view.tsx
@@ -43,7 +43,6 @@ import {
   Loader2,
   Mail,
   MessageSquareQuote,
-
   Paperclip,
   Square,
   X,

--- a/src/web/src/components/agent-chat/agent-chat-view.tsx
+++ b/src/web/src/components/agent-chat/agent-chat-view.tsx
@@ -43,7 +43,7 @@ import {
   Loader2,
   Mail,
   MessageSquareQuote,
-  MoreHorizontal,
+
   Paperclip,
   Square,
   X,
@@ -75,6 +75,7 @@ import {
 import { ScrollToBottomButton } from "@/components/ui/scroll-to-bottom-button";
 import { MessageItem, AgentRow } from "@/components/agent-chat/message-list";
 import { PresenceLine } from "@/components/agent-chat/presence-line";
+import { MenuToggleIcon } from "@/components/agent-chat/menu-toggle-icon";
 import { parseAvatarUrl } from "@/components/avatar";
 import {
   MENTION_COMPONENTS,
@@ -835,7 +836,7 @@ export function AgentChatView({
                     />
                   }
                 >
-                  <MoreHorizontal className="size-4" />
+                  <MenuToggleIcon open={menuOpen} />
                 </PopoverTrigger>
                 <PopoverContent
                   side="top"

--- a/src/web/src/components/agent-chat/menu-toggle-icon.test.ts
+++ b/src/web/src/components/agent-chat/menu-toggle-icon.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from "vitest";
+import { MenuToggleIcon } from "./menu-toggle-icon";
+
+describe("MenuToggleIcon", () => {
+  it("exports a function component", () => {
+    expect(typeof MenuToggleIcon).toBe("function");
+  });
+});

--- a/src/web/src/components/agent-chat/menu-toggle-icon.tsx
+++ b/src/web/src/components/agent-chat/menu-toggle-icon.tsx
@@ -1,0 +1,25 @@
+import { Menu, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export function MenuToggleIcon({ open }: { open: boolean }) {
+  return (
+    <span className="relative size-4">
+      <Menu
+        className={cn(
+          "size-4 absolute transition-all duration-200",
+          open
+            ? "opacity-0 rotate-90 scale-75"
+            : "opacity-100 rotate-0 scale-100",
+        )}
+      />
+      <X
+        className={cn(
+          "size-4 absolute transition-all duration-200",
+          open
+            ? "opacity-100 rotate-0 scale-100"
+            : "opacity-0 -rotate-90 scale-75",
+        )}
+      />
+    </span>
+  );
+}


### PR DESCRIPTION
# Why we need this PR?
> Restores the animated hamburger (≡) / X (✕) toggle on the chat input overflow button, replacing the static MoreHorizontal icon.

## What changed
- Created `menu-toggle-icon.tsx` — a small presentational component that crossfades with rotation between Menu and X icons based on an `open` prop
- Updated `agent-chat-view.tsx` to import and use `MenuToggleIcon` instead of `MoreHorizontal`
- Removed `MoreHorizontal` from the lucide-react imports entirely
- Added a basic test for the new component

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)