### PR TITLE
fix: new workspace incorrectly shows connected computer from another workspace

### DIFF
--- a/src/web/src/app/(app)/studio/new/client.tsx
+++ b/src/web/src/app/(app)/studio/new/client.tsx
@@ -85,6 +85,8 @@ export function StudioOnboardingClient({
     getMachineTokenStatus()
       .then((data) => {
         if (data.status === "registered" || data.status === "active") {
+          // If this is a new workspace and the token is already bound elsewhere, ignore its runtimes
+          if (isNewWorkspace && data.workspace_id) return;
           setMachineRegistered(true);
           if (data.daemon_online) setDaemonOnline(true);
           if (data.runtimes?.length) {

--- a/src/web/src/app/api/machine-tokens/status/route.test.ts
+++ b/src/web/src/app/api/machine-tokens/status/route.test.ts
@@ -111,4 +111,40 @@ describe("GET /api/machine-tokens/status", () => {
     expect(body.daemon_online).toBe(false);
   });
 
+  it("does NOT return runtimes when token is already bound to a workspace", async () => {
+    mockGetLatestTokenForUser.mockResolvedValue({
+      id: "mt_1", status: "active", workspaceId: "sp_ws1", hostname: "MacBook.local",
+      lastUsedAt: new Date(Date.now() - 30_000).toISOString(),
+      runtimesJson: '[{"type":"claude","version":"4.0"}]',
+    });
+
+    const req = new NextRequest("http://localhost/api/machine-tokens/status");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("active");
+    expect(body.workspace_id).toBe("sp_ws1");
+    expect(body.runtimes).toBeUndefined();
+  });
+
+  it("returns runtimes when token is NOT bound to a workspace", async () => {
+    mockGetLatestTokenForUser.mockResolvedValue({
+      id: "mt_1", status: "registered", workspaceId: null, hostname: "MacBook.local",
+      lastUsedAt: new Date(Date.now() - 30_000).toISOString(),
+      runtimesJson: '[{"type":"claude","version":"4.0"}]',
+    });
+
+    const req = new NextRequest("http://localhost/api/machine-tokens/status");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("registered");
+    expect(body.workspace_id).toBeUndefined();
+    expect(body.runtimes).toBeDefined();
+    expect(body.runtimes).toHaveLength(1);
+    expect(body.runtimes[0].type).toBe("claude");
+  });
+
 });

--- a/src/web/src/app/api/machine-tokens/status/route.ts
+++ b/src/web/src/app/api/machine-tokens/status/route.ts
@@ -20,7 +20,7 @@ export const GET = withAuth(async (_req, ctx) => {
     : false;
 
   let runtimes: Array<{ id: string; type: string; version: string; status: string }> | undefined;
-  if (token.runtimesJson) {
+  if (token.runtimesJson && !token.workspaceId) {
     try {
       const parsed = JSON.parse(token.runtimesJson) as Array<{ type: string; version?: string }>;
       runtimes = parsed.map((rt, i) => ({


### PR DESCRIPTION
## Summary
- **Backend**: `/api/machine-tokens/status` now only returns `runtimes` when the token is unbound (`workspaceId` is null). Previously it returned runtimes unconditionally, causing a new workspace to display stale "X computers connected" state from another workspace's token.
- **Frontend**: The `getMachineTokenStatus()` recovery effect in `client.tsx` now skips setting runtimes when in the new-workspace flow and the token is already bound elsewhere — defense-in-depth alongside the backend fix.
- **Tests**: Added two new unit tests covering both the "bound token → no runtimes" and "unbound token → runtimes returned" scenarios.

## Test plan
- [x] Unit tests pass: `vitest run src/app/api/machine-tokens/status/route.test.ts` (8/8 passing)
- [x] TypeScript type check passes
- [x] Pre-commit hooks (lint + typecheck) pass
- [ ] Verify manually: create workspace 1, connect a computer, then create workspace 2 — workspace 2 should show the registration form, not "1 computer connected"
- [ ] Verify existing workspace still shows correct runtime state when revisiting