### PR TITLE
fix(web): remove 'Register another' button from new workspace page

### DIFF
--- a/src/web/src/app/(app)/studio/new/client.tsx
+++ b/src/web/src/app/(app)/studio/new/client.tsx
@@ -64,7 +64,6 @@ export function StudioOnboardingClient({
   const [generatingToken, setGeneratingToken] = useState(false);
   const [machineRegistered, setMachineRegistered] = useState(false);
   const [daemonOnline, setDaemonOnline] = useState(false);
-  const [showRegister, setShowRegister] = useState(false);
 
   const isTauriDesktop = isTauri() && isDesktop();
   const onlineRuntimes = runtimes.filter((r) => r.status === "online");
@@ -613,31 +612,9 @@ export function StudioOnboardingClient({
               <div className="space-y-3">
                 <h2 className="text-base font-semibold tracking-tight">Connect a computer</h2>
                 {(hasOnlineRuntime || (machineRegistered && daemonOnline && runtimes.length > 0)) ? (
-                  <div className="space-y-3">
-                    <div className="flex items-center justify-between">
-                      <p className="text-xs text-emerald-600 flex items-center gap-1">
-                        <CheckCircle2 className="size-3" /> {onlineMachineCount || 1} computer{(onlineMachineCount || 1) > 1 ? "s" : ""} connected
-                      </p>
-                      <button
-                        type="button"
-                        className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-                        onClick={() => setShowRegister((v) => !v)}
-                      >
-                        Register another
-                      </button>
-                    </div>
-                    {showRegister && (
-                      <div className="rounded-xl bg-muted/40 p-5">
-                        <ConnectMachineSteps
-                          generatedToken={generatedToken}
-                          generatingToken={generatingToken}
-                          onGenerateToken={handleGenerateToken}
-                          registered={machineRegistered}
-                          daemonOnline={daemonOnline}
-                        />
-                      </div>
-                    )}
-                  </div>
+                  <p className="text-xs text-emerald-600 flex items-center gap-1">
+                    <CheckCircle2 className="size-3" /> {onlineMachineCount || 1} computer{(onlineMachineCount || 1) > 1 ? "s" : ""} connected
+                  </p>
                 ) : (
                   <>
                     <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
# Why we need this PR?

Follow-up to #295. The "Register another" button on the new workspace page (`/studio/new`) doesn't work correctly — it shows all steps as "Done" because it shares parent state (`machineRegistered`, `daemonOnline`) that's already true from the first registration. The Runtimes page already provides a properly working "New machine" flow.

## What changed

- Removed `showRegister` state variable and its setter
- Removed the "Register another" button and the collapsible `ConnectMachineSteps` block from the "connected" branch
- Kept the green "X computer(s) connected" status text as-is
- The first-time flow (no machine connected) remains unchanged

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)