### PR TITLE
fix(web): fetch runtimes on machine.registered event in new workspace flow

### DIFF
--- a/src/web/src/app/(app)/studio/new/client.tsx
+++ b/src/web/src/app/(app)/studio/new/client.tsx
@@ -114,6 +114,26 @@ export function StudioOnboardingClient({
     const currentWsId = workspaceIdRef.current;
     if (msg.type === "machine.registered") {
       setMachineRegistered(true);
+      if (runtimesRef.current.length === 0) {
+        getMachineTokenStatus().then(data => {
+          if (data.runtimes?.length) {
+            setRuntimes(data.runtimes.map(rt => ({
+              id: rt.id,
+              workspace_id: "",
+              daemon_id: data.hostname || null,
+              runtime_mode: "local",
+              provider: rt.type,
+              status: "online" as const,
+              device_info: data.hostname || "",
+              metadata: { version: rt.version },
+              last_seen_at: null,
+              created_at: "",
+              updated_at: "",
+            })));
+          }
+          if (data.daemon_online) setDaemonOnline(true);
+        }).catch(() => {});
+      }
     } else if (msg.type === "runtime.registered") {
       setMachineRegistered(true);
       const eventWsId = msg.workspaceId;


### PR DESCRIPTION
# Why we need this PR?
> Follow-up to PR #295 and #296. When creating a second workspace, after registering a new token, the `machine.registered` WS event sets `machineRegistered=true` but doesn't fetch runtimes. The `runtime.status: online` handler (which does fetch runtimes) already fired before registration and won't fire again — leaving runtimes empty, no "1 computer connected" text, no runtime selector, and Launch button disabled.

## What changed
- In `src/web/src/app/(app)/studio/new/client.tsx`, the `machine.registered` WS handler now also calls `getMachineTokenStatus()` when `runtimesRef.current` is empty, populating runtimes and setting `daemonOnline` from the newly registered token.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)