### PR TITLE
fix(web): change mobile input focus background from solid color to gradient

### DIFF
--- a/src/web/src/app/globals.css
+++ b/src/web/src/app/globals.css
@@ -1890,8 +1890,9 @@ html, body {
   content: "";
   position: absolute;
   inset: 0;
+  top: -100vh;
   bottom: -100vh;
-  background: linear-gradient(to bottom, transparent, var(--background) 15%);
+  background: linear-gradient(to top, var(--background) 50%, transparent);
   z-index: -1;
 }
 

--- a/src/web/src/app/globals.css
+++ b/src/web/src/app/globals.css
@@ -1890,9 +1890,8 @@ html, body {
   content: "";
   position: absolute;
   inset: 0;
-  top: -100vh;
   bottom: -100vh;
-  background: linear-gradient(to top, var(--background) 50%, transparent);
+  background: linear-gradient(to bottom, transparent, var(--background) 15%);
   z-index: -1;
 }
 

--- a/src/web/src/app/globals.css
+++ b/src/web/src/app/globals.css
@@ -1891,7 +1891,7 @@ html, body {
   position: absolute;
   inset: 0;
   bottom: -100vh;
-  background: var(--background);
+  background: linear-gradient(to bottom, transparent, var(--background) 15%);
   z-index: -1;
 }
 


### PR DESCRIPTION
# Why we need this PR?
> Mobile input focus background uses a flat solid color which looks abrupt. A vertical gradient (transparent → opaque) creates a more polished transition.

## What changed
- `src/web/src/app/globals.css`: Changed `background: var(--background)` to `background: linear-gradient(to bottom, transparent, var(--background) 15%)` in the `[data-keyboard-offset][data-keyboard-active]::before` rule.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)