### PR TITLE
feat(web): add GA4 custom events across the app

### DIFF
--- a/src/web/src/app/(app)/invite/[token]/page.tsx
+++ b/src/web/src/app/(app)/invite/[token]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { getInviteInfo, acceptInvite, type InviteInfo } from "@/lib/api";
+import { trackInviteAccepted } from "@/lib/analytics";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -35,6 +36,7 @@ export default function InvitePage() {
     setState("accepting");
     try {
       const result = await acceptInvite(token);
+      trackInviteAccepted({ workspace_id: result.workspace_id ?? "" });
       setState("done");
       toast.success(`Joined ${info?.workspace_name ?? "workspace"}`);
       router.replace(`/w/${result.workspace_slug}/home`);

--- a/src/web/src/app/(app)/layout.tsx
+++ b/src/web/src/app/(app)/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/session";
 import { SignupTracker } from "@/components/signup-tracker";
+import { SigninTracker } from "@/components/signin-tracker";
 
 export const metadata: Metadata = {
   robots: { index: false, follow: false },
@@ -18,6 +19,7 @@ export default async function AppLayout({
   return (
     <>
       <SignupTracker />
+      <SigninTracker />
       {children}
     </>
   );

--- a/src/web/src/app/(app)/studio/new/client.tsx
+++ b/src/web/src/app/(app)/studio/new/client.tsx
@@ -8,6 +8,7 @@ import { Loader2, CheckCircle2, XCircle, LogOut, ArrowLeft, LayoutGrid } from "l
 import { toast } from "sonner";
 import { signOut } from "@/lib/auth-client";
 import { clearAllCache } from "@/lib/chat-cache";
+import { trackWorkspaceCreated, trackOnboardingCompleted, trackAgentCreated } from "@/lib/analytics";
 
 import { PublicLayout } from "@/components/public-layout";
 import { ConnectMachineSteps } from "@/components/connect-machine-steps";
@@ -422,6 +423,19 @@ export function StudioOnboardingClient({
       }
 
       const data = (await res.json()) as { workspace: { slug: string }; leader_agent_id: string };
+      if (!initialWorkspaceId) {
+        trackWorkspaceCreated("onboarding");
+      }
+      trackOnboardingCompleted({
+        template_used: scenarioId ?? undefined,
+        agent_count: resolvedMembers.length,
+      });
+      for (let i = 0; i < resolvedMembers.length; i++) {
+        trackAgentCreated({
+          is_first_agent: i === 0,
+          has_email: !!resolvedMembers[i].emailHandle,
+        });
+      }
       toast.success("Company created!");
       router.push(`/w/${data.workspace.slug}/agents/${data.leader_agent_id}`);
     } catch (e) {

--- a/src/web/src/app/(app)/w/[slug]/agents/[id]/email/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/agents/[id]/email/page.tsx
@@ -15,6 +15,7 @@ import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ArrowLeft, Loader2, Mail, Inbox, Send, Plus, Trash2, Forward, Reply, Paperclip, File as FileIcon, Copy, Check, ShieldAlert, ChevronDown } from "lucide-react";
+import { trackEmailComposed, trackEmailReceived } from "@/lib/analytics";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { EmailBodyFrame } from "@/components/email-body-frame";
@@ -111,14 +112,17 @@ export default function AgentEmailPage() {
 
   useEffect(() => {
     return subscribeWs((msg) => {
-      if (
-        (msg.type === "email.received" && msg.agentId === agentId) ||
-        (msg.type === "email.sent" && msg.agentId === agentId)
-      ) {
+      if (msg.type === "email.received" && msg.agentId === agentId) {
+        trackEmailReceived({
+          agent_id: agentId,
+          mailbox_type: activeMailbox?.type === "custom" ? "imap" : "alook",
+        });
+        loadEmails(folder, activeAddress);
+      } else if (msg.type === "email.sent" && msg.agentId === agentId) {
         loadEmails(folder, activeAddress);
       }
     });
-  }, [subscribeWs, agentId, folder, activeAddress, loadEmails]);
+  }, [subscribeWs, agentId, folder, activeAddress, loadEmails, activeMailbox?.type]);
 
   const handleSelect = async (emailId: string) => {
     setComposing(false);
@@ -196,6 +200,7 @@ export default function AgentEmailPage() {
   const handleSend = async (to: string, subject: string, htmlBody: string, attachments: EmailAttachment[], threading?: { inReplyTo?: string; references?: string }): Promise<boolean> => {
     try {
       await sendEmail(agentId, to, subject, htmlBody, workspaceId, attachments.length > 0 ? attachments : undefined, threading, activeAccountId);
+      trackEmailComposed({ agent_id: agentId, has_attachments: attachments.length > 0 });
       toast.success("Email sent");
       setComposing(false);
       switchFolder("sent");

--- a/src/web/src/app/(app)/w/[slug]/agents/new/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/agents/new/page.tsx
@@ -8,6 +8,7 @@ import { AgentCreateForm } from "@/components/agent-create-form";
 import { fetchModelOptions, createEmailAccount } from "@/lib/api";
 import { toast } from "sonner";
 import { CircleHelp } from "lucide-react";
+import { trackAgentCreated, trackSecondAgentCreated, trackCustomEmailConnected } from "@/lib/analytics";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
@@ -76,10 +77,19 @@ export default function CreateAgentPage() {
               avatar_url: data.avatar_url,
             });
             if (agent) {
+              trackAgentCreated({
+                is_first_agent: agents.length === 0,
+                has_email: !!data.email_handle || !!data.custom_email,
+              });
+              if (agents.length === 1) {
+                trackSecondAgentCreated({ total_agents: 2 });
+              }
               if (data.custom_email) {
                 try {
                   await createEmailAccount(agent.id, data.custom_email, workspaceId);
                   toast.success("Custom email connected");
+                  const domain = data.custom_email.emailAddress?.split("@")[1] ?? "";
+                  trackCustomEmailConnected({ email_domain: domain });
                 } catch (err) {
                   toast.error(err instanceof Error ? err.message : "Failed to connect custom email");
                 }

--- a/src/web/src/app/(app)/w/[slug]/calendar/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/calendar/page.tsx
@@ -34,6 +34,7 @@ import { getWeekStart, weekRangeIso } from "@/components/calendar/calendar-week-
 import type { CalendarEvent, UpdateCalendarEventRequest } from "@alook/shared";
 import { isTypingTarget } from "@/components/calendar/keyboard";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { trackCalendarEventCreated } from "@/lib/analytics";
 
 /**
  * The month grid always renders six full weeks (42 cells), which means the
@@ -275,6 +276,10 @@ export default function CalendarPage() {
     setSubmitting(true);
     try {
       const created = await createCalendarEvent(values, workspaceId);
+      trackCalendarEventCreated({
+        agent_id: values.agent_id,
+        is_recurring: !!values.repeat_interval,
+      });
       const { from, to } =
         view === "week"
           ? weekRangeIso(weekAnchor)

--- a/src/web/src/app/(app)/w/[slug]/home/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/home/page.tsx
@@ -52,6 +52,7 @@ import {
 } from "@/lib/api";
 import { toast } from "sonner";
 import { ApiError } from "@/lib/errors";
+import { trackAgentLinkCreated, trackCanvasLayoutChanged } from "@/lib/analytics";
 import { AgentNode, type AgentNodeData } from "@/components/canvas/agent-node";
 import { LinkEdge } from "@/components/canvas/link-edge";
 import { LinkSidecar } from "@/components/canvas/link-sidecar";
@@ -312,6 +313,10 @@ function AgentCanvas({ onAgentClick }: { onAgentClick?: (agent: Agent) => void }
           },
           workspaceId,
         );
+        trackAgentLinkCreated({
+          source_agent: connection.source,
+          target_agent: connection.target,
+        });
         if (connection.sourceHandle || connection.targetHandle) {
           handleMap.current[created.id] = {
             sourceHandle: connection.sourceHandle ?? "right",
@@ -359,6 +364,7 @@ function AgentCanvas({ onAgentClick }: { onAgentClick?: (agent: Agent) => void }
   );
 
   const handleLayoutChange = useCallback((newLayout: LayoutType) => {
+    trackCanvasLayoutChanged({ layout_type: newLayout });
     setLayoutType(newLayout);
     saveLayoutType(workspaceId, newLayout);
     try {

--- a/src/web/src/app/(app)/w/[slug]/issues/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/issues/page.tsx
@@ -19,6 +19,7 @@ import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { DndContext, DragOverlay, PointerSensor, useSensor, useSensors, useDroppable, useDraggable, type DragEndEvent, type DragStartEvent } from "@dnd-kit/core";
 import { IssueSheet } from "@/components/issues/issue-sheet";
+import { trackIssueCreated, trackIssueStatusChanged } from "@/lib/analytics";
 import { ArtifactSheet } from "@/components/agent-chat/artifact-sheet";
 import { isPreviewable, getArtifactUrl, computeArtifactVersions } from "@/components/artifact-content-renderer";
 
@@ -468,6 +469,7 @@ export default function IssuesPage() {
         title: values.title,
         description: values.description,
       });
+      trackIssueCreated({ agent_id: values.agent_id ?? "" });
       setIssues((prev) => [res.issue, ...prev]);
       if (values.agent_id) setRecentAgentId(values.agent_id);
       setDraft({ title: "", description: "", agentId: "" });
@@ -497,6 +499,8 @@ export default function IssuesPage() {
     if (!issue) return;
     const oldStatus = issue.status;
     if (newStatus === oldStatus) return;
+
+    trackIssueStatusChanged({ from: oldStatus, to: newStatus, method: "button" });
 
     const now = new Date().toISOString();
     setIssues((prev) => prev.map((i) => i.id === issueId ? { ...i, status: newStatus as Issue["status"], updated_at: now } : i));
@@ -574,6 +578,8 @@ export default function IssuesPage() {
 
     const newStatus = targetColId === "completed" ? "done" : targetColId;
     const oldStatus = issue.status;
+
+    trackIssueStatusChanged({ from: oldStatus, to: newStatus, method: "drag" });
 
     const now = new Date().toISOString();
     setIssues((prev) => prev.map((i) => i.id === issueId ? { ...i, status: newStatus as Issue["status"], updated_at: now } : i));

--- a/src/web/src/app/(app)/w/[slug]/runtimes/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/runtimes/page.tsx
@@ -33,6 +33,7 @@ import { triggerRuntimeUpdate, triggerRuntimeRescan, fetchLatestCliVersion } fro
 import { Loader2, RefreshCw } from "lucide-react";
 
 import { ConnectMachineSteps } from "@/components/connect-machine-steps";
+import { trackRuntimeConnected } from "@/lib/analytics";
 
 export default function RuntimesPage() {
   const { agents, runtimes, loading, handleGenerateToken, handleDeleteMachine, subscribeWs, workspaceId } =
@@ -97,6 +98,7 @@ export default function RuntimesPage() {
         registeredDaemonIdRef.current &&
         msg.daemonId === registeredDaemonIdRef.current
       ) {
+        trackRuntimeConnected({ runtime_type: "desktop" });
         setSheetOpen(false);
         setGeneratedToken("");
         setRegisteredDaemonId(null);

--- a/src/web/src/app/(app)/w/[slug]/settings/general-tab.tsx
+++ b/src/web/src/app/(app)/w/[slug]/settings/general-tab.tsx
@@ -20,6 +20,7 @@ import {
   hasWorkspaceFormErrors,
   validateWorkspaceForm,
 } from "@/lib/form-validation";
+import { trackSettingsUpdated } from "@/lib/analytics";
 
 export function GeneralTab() {
   const { workspaceId, slug } = useWorkspace();
@@ -88,6 +89,7 @@ export function GeneralTab() {
         name: workspaceName.trim(),
         slug: workspaceSlug.trim(),
       });
+      trackSettingsUpdated({ setting_tab: "general" });
       setSavedWorkspaceName(updated.name);
       setSavedWorkspaceSlug(updated.slug);
       toast.success("Workspace updated");

--- a/src/web/src/app/(app)/w/[slug]/settings/members-tab.tsx
+++ b/src/web/src/app/(app)/w/[slug]/settings/members-tab.tsx
@@ -18,6 +18,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { trackTeamMemberInvited } from "@/lib/analytics";
 
 function getInviteLink(token: string) {
   return `${window.location.origin}/invite/${token}`;
@@ -60,6 +61,7 @@ export function MembersTab() {
     setGeneratingInvite(true);
     try {
       const invite = await createInvite(workspaceId);
+      trackTeamMemberInvited({ workspace_id: workspaceId });
       setInvites((prev) => [...prev, invite]);
       const link = getInviteLink(invite.token);
       await navigator.clipboard.writeText(link);

--- a/src/web/src/app/(app)/w/[slug]/threads/[traceId]/page.tsx
+++ b/src/web/src/app/(app)/w/[slug]/threads/[traceId]/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { useWorkspace } from "@/contexts/workspace-context";
 import { getTrace, type TraceTask } from "@/lib/api";
+import { trackThreadViewed } from "@/lib/analytics";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ArrowLeft } from "lucide-react";
 import { AvatarRenderer, parseAvatarUrl } from "@/components/avatar";
@@ -178,6 +179,9 @@ export default function TraceDetailPage() {
       .then((data) => {
         setTasks(data.tasks);
         setChannel(data.channel);
+        const agentIds = new Set(data.tasks.map((t: TraceTask) => t.agent_id));
+        const rootStatus = data.tasks.find((t: TraceTask) => !t.parent_task_id)?.status ?? "unknown";
+        trackThreadViewed({ agent_count: agentIds.size, status: rootStatus });
       })
       .catch(() => { })
       .finally(() => setLoading(false));

--- a/src/web/src/app/templates/_components/template-card.tsx
+++ b/src/web/src/app/templates/_components/template-card.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { ArrowUpRight } from "lucide-react";
 import type { TemplatePreset } from "@/lib/templates";
+import { trackTemplateUsed } from "@/lib/analytics";
 
 const ROLE_DOT_COLORS: Record<string, string> = {
   leader: "bg-amber-500/70 dark:bg-amber-400/60",
@@ -72,6 +73,7 @@ export function TemplateCard({
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
+            trackTemplateUsed({ template_id: template.id, template_name: template.name });
             router.push(href);
           }}
           className="flex items-center gap-1 rounded-md px-2.5 py-1 text-xs font-medium text-muted-foreground opacity-0 transition-all duration-150 group-hover:opacity-100 group-hover:bg-foreground group-hover:text-background"

--- a/src/web/src/app/templates/client.tsx
+++ b/src/web/src/app/templates/client.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { PublicLayout } from "@/components/public-layout";
 import { TemplateCard } from "./_components/template-card";
 import type { TemplatePreset, TemplateCategory } from "@/lib/templates";
+import { trackTemplatesBrowsed } from "@/lib/analytics";
 
 export function TemplatesClient({
   templates,
@@ -18,6 +19,19 @@ export function TemplatesClient({
   workspaceId?: string;
 }) {
   const [activeCategory, setActiveCategory] = useState<"All" | TemplateCategory>("All");
+  const tracked = useRef(false);
+
+  useEffect(() => {
+    if (!tracked.current) {
+      tracked.current = true;
+      trackTemplatesBrowsed({ category_filter: "All" });
+    }
+  }, []);
+
+  const handleCategoryChange = (cat: "All" | TemplateCategory) => {
+    setActiveCategory(cat);
+    trackTemplatesBrowsed({ category_filter: cat });
+  };
 
   const filtered =
     activeCategory === "All"
@@ -78,7 +92,7 @@ export function TemplatesClient({
           {["All", ...categories].map((cat) => (
             <button
               key={cat}
-              onClick={() => setActiveCategory(cat as "All" | TemplateCategory)}
+              onClick={() => handleCategoryChange(cat as "All" | TemplateCategory)}
               className={`rounded-full px-4 py-1.5 text-xs font-medium transition-colors duration-150 ${
                 activeCategory === cat
                   ? "bg-foreground text-background"

--- a/src/web/src/components/custom-email-form.tsx
+++ b/src/web/src/components/custom-email-form.tsx
@@ -31,6 +31,7 @@ import {
   hasCustomEmailErrors,
   validateCustomEmailFields,
 } from "@/lib/form-validation";
+import { trackCustomEmailConnected } from "@/lib/analytics";
 
 const PRESETS: Record<string, { imapHost: string; imapPort: number; smtpHost: string; smtpPort: number }> = {
   Gmail: { imapHost: "imap.gmail.com", imapPort: 993, smtpHost: "smtp.gmail.com", smtpPort: 587 },
@@ -278,6 +279,8 @@ export function CustomEmailForm({ agentId, workspaceId, onDataChange, getDataRef
     setSaving(true);
     try {
       await createEmailAccount(agentId, data, workspaceId);
+      const domain = fields.emailAddress.split("@")[1] ?? "";
+      trackCustomEmailConnected({ email_domain: domain });
       toast.success("Custom email configured");
       setOpen(false);
       await load();

--- a/src/web/src/components/home/hero-section.tsx
+++ b/src/web/src/components/home/hero-section.tsx
@@ -8,6 +8,7 @@ import { useGSAP } from "@gsap/react";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
 import { SplitText } from "gsap/SplitText";
 import { TypewriterVisual } from "@/components/typewriter-visual";
+import { trackLandingCtaClicked } from "@/lib/analytics";
 
 gsap.registerPlugin(ScrollTrigger, SplitText);
 
@@ -285,6 +286,7 @@ export function HeroSection({ isLoggedIn }: { isLoggedIn: boolean }) {
           {isLoggedIn ? (
             <a
               href="/workspaces?auto"
+              onClick={() => trackLandingCtaClicked({ cta_name: "open_app" })}
               className="inline-flex items-center gap-2 px-6 py-2.5 text-sm transition-all duration-200 hover:opacity-80"
               style={{
                 fontFamily: "var(--font-mono)",
@@ -303,6 +305,7 @@ export function HeroSection({ isLoggedIn }: { isLoggedIn: boolean }) {
           ) : (
             <a
               href="/sign-in"
+              onClick={() => trackLandingCtaClicked({ cta_name: "get_started" })}
               className="inline-flex items-center gap-2 px-6 py-2.5 text-sm transition-all duration-200 hover:opacity-80"
               style={{
                 fontFamily: "var(--font-mono)",
@@ -321,6 +324,7 @@ export function HeroSection({ isLoggedIn }: { isLoggedIn: boolean }) {
           )}
           <Link
             href="/templates"
+            onClick={() => trackLandingCtaClicked({ cta_name: "templates" })}
             className="inline-flex items-center gap-2 px-6 py-2.5 text-sm transition-all duration-200 hover:opacity-80"
             style={{
               fontFamily: "var(--font-mono)",

--- a/src/web/src/components/signin-tracker.test.ts
+++ b/src/web/src/components/signin-tracker.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+const mockSendGTMEvent = vi.fn()
+vi.mock("@next/third-parties/google", () => ({
+  sendGTMEvent: (...args: unknown[]) => mockSendGTMEvent(...args),
+}))
+
+vi.mock("react", () => ({
+  useEffect: (fn: () => void) => fn(),
+}))
+
+describe("SigninTracker", () => {
+  let cookieValue = ""
+  let cookieSetValue = ""
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    cookieValue = ""
+    cookieSetValue = ""
+    // @ts-expect-error stub global document
+    globalThis.document = {
+      get cookie() { return cookieValue },
+      set cookie(val: string) { cookieSetValue = val },
+    }
+  })
+
+  afterEach(() => {
+    // @ts-expect-error cleanup
+    delete globalThis.document
+  })
+
+  it("fires sign_in_success event and clears cookie when is_sign_in is present", async () => {
+    cookieValue = "is_sign_in=email_otp"
+    vi.resetModules()
+    const { SigninTracker } = await import("./signin-tracker")
+    SigninTracker()
+
+    expect(mockSendGTMEvent).toHaveBeenCalledWith({ event: "sign_in_success", method: "email_otp" })
+    expect(cookieSetValue).toBe("is_sign_in=; max-age=0; path=/")
+  })
+
+  it("does nothing when is_sign_in cookie is absent", async () => {
+    cookieValue = "other_cookie=value"
+    vi.resetModules()
+    const { SigninTracker } = await import("./signin-tracker")
+    SigninTracker()
+
+    expect(mockSendGTMEvent).not.toHaveBeenCalled()
+  })
+
+  it("handles github method correctly", async () => {
+    cookieValue = "session=abc; is_sign_in=github; other=xyz"
+    vi.resetModules()
+    const { SigninTracker } = await import("./signin-tracker")
+    SigninTracker()
+
+    expect(mockSendGTMEvent).toHaveBeenCalledWith({ event: "sign_in_success", method: "github" })
+  })
+
+  it("handles google method correctly", async () => {
+    cookieValue = "is_sign_in=google"
+    vi.resetModules()
+    const { SigninTracker } = await import("./signin-tracker")
+    SigninTracker()
+
+    expect(mockSendGTMEvent).toHaveBeenCalledWith({ event: "sign_in_success", method: "google" })
+  })
+})

--- a/src/web/src/components/signin-tracker.tsx
+++ b/src/web/src/components/signin-tracker.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import { useEffect } from "react"
+import { trackSignInSuccess } from "@/lib/analytics"
+
+export function SigninTracker() {
+  useEffect(() => {
+    const match = document.cookie.match(/(?:^|; )is_sign_in=([^;]*)/)
+    if (!match) return
+    const method = decodeURIComponent(match[1])
+    trackSignInSuccess(method)
+    document.cookie = "is_sign_in=; max-age=0; path=/"
+  }, [])
+
+  return null
+}

--- a/src/web/src/components/signup-tracker.tsx
+++ b/src/web/src/components/signup-tracker.tsx
@@ -1,14 +1,14 @@
 "use client"
 
 import { useEffect } from "react"
-import { sendGTMEvent } from "@next/third-parties/google"
+import { trackSignUp } from "@/lib/analytics"
 
 export function SignupTracker() {
   useEffect(() => {
     const match = document.cookie.match(/(?:^|; )is_new_signup=([^;]*)/)
     if (!match) return
     const method = decodeURIComponent(match[1])
-    sendGTMEvent({ event: "sign_up", method })
+    trackSignUp(method)
     document.cookie = "is_new_signup=; max-age=0; path=/"
   }, [])
 

--- a/src/web/src/hooks/use-agent-chat.ts
+++ b/src/web/src/hooks/use-agent-chat.ts
@@ -67,6 +67,7 @@ import type {
 import { toast } from "sonner";
 import type { ChatComposerHandle } from "@/components/agent-chat/chat-composer";
 import { useCachedMessages } from "@/hooks/use-cached-messages";
+import { trackAgentChatOpened, trackMessageSent } from "@/lib/analytics";
 
 const MESSAGE_LIMIT = 20;
 const MAX_CONV_FETCHES_PER_CLICK = 5;
@@ -166,6 +167,16 @@ export function useAgentChat(
   useEffect(() => {
     writeToCacheRef.current = writeToCache;
   }, [writeToCache]);
+
+  const chatOpenedTracked = useRef(false);
+  useEffect(() => {
+    if (!conversation || chatOpenedTracked.current) return;
+    chatOpenedTracked.current = true;
+    trackAgentChatOpened({
+      agent_id: agentId,
+      is_first_chat: messages.length === 0,
+    });
+  }, [conversation, agentId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const agentArtifacts = useMemo(
     () => artifacts.filter((a) => a.source === "agent"),
@@ -1586,6 +1597,7 @@ export function useAgentChat(
     }
 
     const filesToSend = [...pendingFilesRef.current];
+    trackMessageSent({ agent_id: agentId, message_length: content.length });
     setInput("");
     setPendingFiles([]);
     setQuotedMessage(null);

--- a/src/web/src/lib/analytics.test.ts
+++ b/src/web/src/lib/analytics.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const mockSendGTMEvent = vi.fn()
+vi.mock("@next/third-parties/google", () => ({
+  sendGTMEvent: (...args: unknown[]) => mockSendGTMEvent(...args),
+}))
+
+import {
+  trackSignUp,
+  trackSignInSuccess,
+  trackWorkspaceCreated,
+  trackAgentCreated,
+  trackOnboardingCompleted,
+  trackAgentChatOpened,
+  trackMessageSent,
+  trackEmailComposed,
+  trackEmailReceived,
+  trackCalendarEventCreated,
+  trackIssueCreated,
+  trackIssueStatusChanged,
+  trackThreadViewed,
+  trackTemplateUsed,
+  trackCustomEmailConnected,
+  trackTeamMemberInvited,
+  trackInviteAccepted,
+  trackSecondAgentCreated,
+  trackAgentLinkCreated,
+  trackRuntimeConnected,
+  trackLandingCtaClicked,
+  trackTemplatesBrowsed,
+  trackSettingsUpdated,
+  trackCanvasLayoutChanged,
+} from "./analytics"
+
+describe("analytics utility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe("P0 — Core Funnel Events", () => {
+    it("trackSignUp sends sign_up event", () => {
+      trackSignUp("github")
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({ event: "sign_up", method: "github" })
+    })
+
+    it("trackSignInSuccess sends sign_in_success event", () => {
+      trackSignInSuccess("email_otp")
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({ event: "sign_in_success", method: "email_otp" })
+    })
+
+    it("trackWorkspaceCreated sends workspace_created event", () => {
+      trackWorkspaceCreated("onboarding")
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({ event: "workspace_created", source: "onboarding" })
+    })
+
+    it("trackAgentCreated sends agent_created event with all params", () => {
+      trackAgentCreated({ is_first_agent: true, has_email: false, template_id: "tmpl_1" })
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({
+        event: "agent_created",
+        is_first_agent: true,
+        has_email: false,
+        template_id: "tmpl_1",
+      })
+    })
+
+    it("trackOnboardingCompleted sends onboarding_completed event", () => {
+      trackOnboardingCompleted({ template_used: "startup", agent_count: 3 })
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({
+        event: "onboarding_completed",
+        template_used: "startup",
+        agent_count: 3,
+      })
+    })
+
+    it("trackAgentChatOpened sends agent_chat_opened event", () => {
+      trackAgentChatOpened({ agent_id: "ag_123", is_first_chat: true })
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({
+        event: "agent_chat_opened",
+        agent_id: "ag_123",
+        is_first_chat: true,
+      })
+    })
+
+    it("trackMessageSent sends message_sent event", () => {
+      trackMessageSent({ agent_id: "ag_123", message_length: 42 })
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({
+        event: "message_sent",
+        agent_id: "ag_123",
+        message_length: 42,
+      })
+    })
+  })
+
+  describe("P1 — Feature Usage Events", () => {
+    it("trackEmailComposed sends email_composed event", () => {
+      trackEmailComposed({ agent_id: "ag_1", has_attachments: true })
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({
+        event: "email_composed",
+        agent_id: "ag_1",
+        has_attachments: true,
+      })
+    })
+
+    it("trackEmailReceived sends email_received event", () => {
+      trackEmailReceived({ agent_id: "ag_1", mailbox_type: "imap" })
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({
+        event: "email_received",
+        agent_id: "ag_1",
+        mailbox_type: "imap",
+      })
+    })
+
+    it("trackCalendarEventCreated sends calendar_event_created event", () => {
+      trackCalendarEventCreated({ agent_id: "ag_1", is_recurring: false })
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({
+        event: "calendar_event_created",
+        agent_id: "ag_1",
+        is_recurring: false,
+      })
+    })
+
+    it("trackIssueCreated sends issue_created event", () => {
+      trackIssueCreated({ agent_id: "ag_1" })
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({
+        event: "issue_created",
+        agent_id: "ag_1",
+      })
+    })
+
+    it("trackIssueStatusChanged sends issue_status_changed event", () => {
+      trackIssueStatusChanged({ from: "todo", to: "running", method: "drag" })
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({
+        event: "issue_status_changed",
+        from: "todo",
+        to: "running",
+        method: "drag",
+      })
+    })
+
+    it("trackThreadViewed sends thread_viewed event", () => {
+      trackThreadViewed({ agent_count: 3, status: "completed" })
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({
+        event: "thread_viewed",
+        agent_count: 3,
+        status: "completed",
+      })
+    })
+
+    it("trackTemplateUsed sends template_used event", () => {
+      trackTemplateUsed({ template_id: "t_1", template_name: "Startup" })
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({
+        event: "template_used",
+        template_id: "t_1",
+        template_name: "Startup",
+      })
+    })
+
+    it("trackCustomEmailConnected sends custom_email_connected event", () => {
+      trackCustomEmailConnected({ email_domain: "gmail.com" })
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({
+        event: "custom_email_connected",
+        email_domain: "gmail.com",
+      })
+    })
+  })
+
+  describe("P2 — Growth & Retention Signals", () => {
+    it("trackTeamMemberInvited sends team_member_invited event", () => {
+      trackTeamMemberInvited({ workspace_id: "ws_1" })
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({
+        event: "team_member_invited",
+        workspace_id: "ws_1",
+      })
+    })
+
+    it("trackInviteAccepted sends invite_accepted event", () => {
+      trackInviteAccepted({ workspace_id: "ws_1" })
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({
+        event: "invite_accepted",
+        workspace_id: "ws_1",
+      })
+    })
+
+    it("trackSecondAgentCreated sends second_agent_created event", () => {
+      trackSecondAgentCreated({ total_agents: 2 })
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({
+        event: "second_agent_created",
+        total_agents: 2,
+      })
+    })
+
+    it("trackAgentLinkCreated sends agent_link_created event", () => {
+      trackAgentLinkCreated({ source_agent: "ag_1", target_agent: "ag_2" })
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({
+        event: "agent_link_created",
+        source_agent: "ag_1",
+        target_agent: "ag_2",
+      })
+    })
+
+    it("trackRuntimeConnected sends runtime_connected event", () => {
+      trackRuntimeConnected({ runtime_type: "desktop" })
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({
+        event: "runtime_connected",
+        runtime_type: "desktop",
+      })
+    })
+  })
+
+  describe("P3 — Page-Level Behavior", () => {
+    it("trackLandingCtaClicked sends landing_cta_clicked event", () => {
+      trackLandingCtaClicked({ cta_name: "get_started" })
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({
+        event: "landing_cta_clicked",
+        cta_name: "get_started",
+      })
+    })
+
+    it("trackTemplatesBrowsed sends templates_browsed event", () => {
+      trackTemplatesBrowsed({ category_filter: "Engineering" })
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({
+        event: "templates_browsed",
+        category_filter: "Engineering",
+      })
+    })
+
+    it("trackSettingsUpdated sends settings_updated event", () => {
+      trackSettingsUpdated({ setting_tab: "general" })
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({
+        event: "settings_updated",
+        setting_tab: "general",
+      })
+    })
+
+    it("trackCanvasLayoutChanged sends canvas_layout_changed event", () => {
+      trackCanvasLayoutChanged({ layout_type: "tree" })
+      expect(mockSendGTMEvent).toHaveBeenCalledWith({
+        event: "canvas_layout_changed",
+        layout_type: "tree",
+      })
+    })
+  })
+})

--- a/src/web/src/lib/analytics.ts
+++ b/src/web/src/lib/analytics.ts
@@ -1,0 +1,144 @@
+"use client";
+
+import { sendGTMEvent } from "@next/third-parties/google";
+
+// ─── P0 — Core Funnel Events ───────────────────────────────────────────────
+
+export function trackSignUp(method: string) {
+  sendGTMEvent({ event: "sign_up", method });
+}
+
+export function trackSignInSuccess(method: string) {
+  sendGTMEvent({ event: "sign_in_success", method });
+}
+
+export function trackWorkspaceCreated(source: "onboarding" | "manual") {
+  sendGTMEvent({ event: "workspace_created", source });
+}
+
+export function trackAgentCreated(params: {
+  is_first_agent: boolean;
+  has_email: boolean;
+  template_id?: string;
+}) {
+  sendGTMEvent({ event: "agent_created", ...params });
+}
+
+export function trackOnboardingCompleted(params: {
+  template_used?: string;
+  agent_count: number;
+}) {
+  sendGTMEvent({ event: "onboarding_completed", ...params });
+}
+
+export function trackAgentChatOpened(params: {
+  agent_id: string;
+  is_first_chat: boolean;
+}) {
+  sendGTMEvent({ event: "agent_chat_opened", ...params });
+}
+
+export function trackMessageSent(params: {
+  agent_id: string;
+  message_length: number;
+}) {
+  sendGTMEvent({ event: "message_sent", ...params });
+}
+
+// ─── P1 — Feature Usage Events ─────────────────────────────────────────────
+
+export function trackEmailComposed(params: {
+  agent_id: string;
+  has_attachments: boolean;
+}) {
+  sendGTMEvent({ event: "email_composed", ...params });
+}
+
+export function trackEmailReceived(params: {
+  agent_id: string;
+  mailbox_type: "alook" | "imap";
+}) {
+  sendGTMEvent({ event: "email_received", ...params });
+}
+
+export function trackCalendarEventCreated(params: {
+  agent_id: string;
+  is_recurring: boolean;
+}) {
+  sendGTMEvent({ event: "calendar_event_created", ...params });
+}
+
+export function trackIssueCreated(params: { agent_id: string }) {
+  sendGTMEvent({ event: "issue_created", ...params });
+}
+
+export function trackIssueStatusChanged(params: {
+  from: string;
+  to: string;
+  method: "drag" | "button";
+}) {
+  sendGTMEvent({ event: "issue_status_changed", ...params });
+}
+
+export function trackThreadViewed(params: {
+  agent_count: number;
+  status: string;
+}) {
+  sendGTMEvent({ event: "thread_viewed", ...params });
+}
+
+export function trackTemplateUsed(params: {
+  template_id: string;
+  template_name: string;
+}) {
+  sendGTMEvent({ event: "template_used", ...params });
+}
+
+export function trackCustomEmailConnected(params: { email_domain: string }) {
+  sendGTMEvent({ event: "custom_email_connected", ...params });
+}
+
+// ─── P2 — Growth & Retention Signals ───────────────────────────────────────
+
+export function trackTeamMemberInvited(params: { workspace_id: string }) {
+  sendGTMEvent({ event: "team_member_invited", ...params });
+}
+
+export function trackInviteAccepted(params: { workspace_id: string }) {
+  sendGTMEvent({ event: "invite_accepted", ...params });
+}
+
+export function trackSecondAgentCreated(params: { total_agents: number }) {
+  sendGTMEvent({ event: "second_agent_created", ...params });
+}
+
+export function trackAgentLinkCreated(params: {
+  source_agent: string;
+  target_agent: string;
+}) {
+  sendGTMEvent({ event: "agent_link_created", ...params });
+}
+
+export function trackRuntimeConnected(params: {
+  runtime_type: "desktop" | "cloud";
+}) {
+  sendGTMEvent({ event: "runtime_connected", ...params });
+}
+
+// ─── P3 — Page-Level Behavior ───────────────────────────────────────────────
+
+export function trackLandingCtaClicked(params: { cta_name: string }) {
+  sendGTMEvent({ event: "landing_cta_clicked", ...params });
+}
+
+export function trackTemplatesBrowsed(params: { category_filter: string }) {
+  sendGTMEvent({ event: "templates_browsed", ...params });
+}
+
+export function trackSettingsUpdated(params: { setting_tab: string }) {
+  sendGTMEvent({ event: "settings_updated", ...params });
+}
+
+export function trackCanvasLayoutChanged(params: { layout_type: string }) {
+  sendGTMEvent({ event: "canvas_layout_changed", ...params });
+}

--- a/src/web/src/lib/auth.ts
+++ b/src/web/src/lib/auth.ts
@@ -96,6 +96,27 @@ export function createAuth(env: Env) {
           },
         },
       },
+      session: {
+        create: {
+          after: async (session, ctx) => {
+            if (!ctx) return
+            const signupCookie = ctx.getCookie("is_new_signup")
+            if (signupCookie) return
+            const path = ctx.request?.url ? new URL(ctx.request.url).pathname : ""
+            let method = "unknown"
+            if (path.includes("email-otp")) method = "email_otp"
+            else if (path.includes("github")) method = "github"
+            else if (path.includes("google")) method = "google"
+            ctx.setCookie("is_sign_in", method, {
+              maxAge: 60,
+              path: "/",
+              httpOnly: false,
+              secure: isProd,
+              sameSite: "lax",
+            })
+          },
+        },
+      },
     },
     plugins: isProd
       ? [


### PR DESCRIPTION
# Why we need this PR?

Improve GA4 funnel accuracy and feature usage tracking. Currently only `sign_up` is tracked — everything else relies on inaccurate page_view path matching. This PR adds 23 custom events across the app.

## What changed

- **New shared analytics utility** at `src/web/src/lib/analytics.ts` wrapping `sendGTMEvent` with typed helpers for all events
- **Migrated existing `sign_up` event** in `signup-tracker.tsx` to use the new utility
- **Added `sign_in_success`** via cookie-based server→client bridge (same pattern as sign_up, using `databaseHooks.session.create.after`)
- **P0 events**: sign_in_success, workspace_created, agent_created, onboarding_completed, agent_chat_opened, message_sent
- **P1 events**: email_composed, email_received, calendar_event_created, issue_created, issue_status_changed, thread_viewed, template_used, custom_email_connected
- **P2 events**: team_member_invited, invite_accepted, second_agent_created, agent_link_created, runtime_connected
- **P3 events**: landing_cta_clicked, templates_browsed, settings_updated, canvas_layout_changed
- **Unit tests** for the analytics utility (23 events) and signin-tracker (4 tests)

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)
- [ ] Shared library (`@alook/shared`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...