### PR TITLE
fix: cleanup R2 object if DB insert fails during artifact upload

### DIFF
--- a/src/web/src/app/api/artifacts/upload/route.ts
+++ b/src/web/src/app/api/artifacts/upload/route.ts
@@ -58,26 +58,31 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     httpMetadata: { contentType },
   });
 
-  const row = await queries.artifact.createArtifact(db, {
-    id: artifactId,
-    conversationId,
-    agentId,
-    workspaceId: ws.workspaceId,
-    filename,
-    contentType,
-    size: file.size,
-    r2Key,
-  });
-  const response = queries.artifact.artifactToResponse(row);
-
-  const agent = await queries.agent.getAgent(db, agentId, ws.workspaceId, ctx.userId);
-  if (agent?.ownerId) {
-    broadcastToUser(agent.ownerId, {
-      type: "artifact.uploaded",
+  try {
+    const row = await queries.artifact.createArtifact(db, {
+      id: artifactId,
       conversationId,
-      artifact: response,
-    }).catch(() => {});
-  }
+      agentId,
+      workspaceId: ws.workspaceId,
+      filename,
+      contentType,
+      size: file.size,
+      r2Key,
+    });
+    const response = queries.artifact.artifactToResponse(row);
 
-  return writeJSON(response);
+    const agent = await queries.agent.getAgent(db, agentId, ws.workspaceId, ctx.userId);
+    if (agent?.ownerId) {
+      broadcastToUser(agent.ownerId, {
+        type: "artifact.uploaded",
+        conversationId,
+        artifact: response,
+      }).catch(() => {});
+    }
+
+    return writeJSON(response);
+  } catch (e) {
+    await bucket.delete(r2Key).catch(() => {});  // cleanup orphan
+    throw e;
+  }
 });


### PR DESCRIPTION
Closes #158

Orphaned R2 objects were created when bucket.put() succeeded but createArtifact() threw. Added try/catch to delete the R2 key on DB failure, preventing storage leaks.



## What changed

## Problem
When `bucket.put()` succeeded but `createArtifact()` threw, the R2 
object was left orphaned in storage with no corresponding DB record.

## Fix
Wrapped the DB insert and surrounding logic in a try/catch. On failure, 
`bucket.delete(r2Key)` is called to clean up the orphaned R2 object 
before re-throwing the original error.

## Testing
- pnpm typecheck ✅
- @alook/app and @alook/web tests pass ✅


