### PR TITLE
fix(web): prevent invited members from overwriting workspace slug

### DIFF
--- a/src/web/src/app/(app)/w/[slug]/layout.tsx
+++ b/src/web/src/app/(app)/w/[slug]/layout.tsx
@@ -35,7 +35,7 @@ export default async function WorkspaceLayout({
   )
   if (!membership) redirect("/workspaces")
 
-  const agents = await queries.agent.listAgents(db, ws.id, session.user.id)
+  const agents = await queries.agent.listAgents(db, ws.id)
   if (agents.length === 0) {
     const hdrs = await headers()
     const cookieHeader = hdrs.get("cookie") || ""

--- a/src/web/src/app/(app)/workspaces/page.tsx
+++ b/src/web/src/app/(app)/workspaces/page.tsx
@@ -24,7 +24,7 @@ export default async function WorkspacesPage({
   // Auto-redirect to single workspace only on post-login flow
   const params = await searchParams
   if (workspaces.length === 1 && params.auto !== undefined) {
-    const agents = await queries.agent.listAgents(db, workspaces[0].id, session.user.id)
+    const agents = await queries.agent.listAgents(db, workspaces[0].id)
     if (agents.length === 0) {
       redirect(`/studio/new?workspace_id=${workspaces[0].id}`)
     }
@@ -34,7 +34,7 @@ export default async function WorkspacesPage({
   // Find most recent workspace with 0 agents to reuse for "New workspace"
   let emptyWorkspaceId: string | null = null
   for (const ws of workspaces) {
-    const agents = await queries.agent.listAgents(db, ws.id, session.user.id)
+    const agents = await queries.agent.listAgents(db, ws.id)
     if (agents.length === 0) {
       emptyWorkspaceId = ws.id
       break

--- a/src/web/src/app/api/studios/route.test.ts
+++ b/src/web/src/app/api/studios/route.test.ts
@@ -83,8 +83,9 @@ vi.mock("@/lib/middleware/auth", () => ({
   }),
 }));
 
+const mockWithWorkspaceMember = vi.fn(async () => ({ workspaceId: "w1", memberRole: "owner" }));
 vi.mock("@/lib/middleware/workspace", () => ({
-  withWorkspaceMember: vi.fn(async () => ({ workspaceId: "w1", memberRole: "owner" })),
+  withWorkspaceMember: (...args: unknown[]) => mockWithWorkspaceMember(...args),
 }));
 
 vi.mock("@/lib/api/responses", () => ({
@@ -331,6 +332,27 @@ describe("POST /api/studios", () => {
     expect(mockCreateAgent).toHaveBeenCalledTimes(1);
     const agentData = mockCreateAgent.mock.calls[0][1];
     expect(agentData.avatarUrl).toBe("custom-avatar");
+  });
+
+  it("non-owner member cannot update workspace slug", async () => {
+    mockWithWorkspaceMember.mockResolvedValueOnce({ workspaceId: "w1", memberRole: "member" });
+    mockListAgents
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { id: "agent-1", name: "Solo", emailHandle: "solo" },
+      ]);
+
+    const req = new NextRequest("http://localhost/api/studios", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "Hijacked Name",
+        members: [{ name: "Solo", role: "leader", runtime_id: "rt1" }],
+      }),
+    });
+
+    const res = await POST(req, {});
+    expect(res.status).toBe(201);
+    expect(mockUpdateWorkspace).not.toHaveBeenCalled();
   });
 
   it("creates agents with auto-generated names when name is omitted", async () => {

--- a/src/web/src/app/api/studios/route.ts
+++ b/src/web/src/app/api/studios/route.ts
@@ -69,8 +69,8 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     return writeError("workspace not found", 404);
   }
 
-  if (body.name) {
-    const existingAgents = await queries.agent.listAgents(db, ws.workspaceId, ctx.userId);
+  if (body.name && ws.memberRole === "owner") {
+    const existingAgents = await queries.agent.listAgents(db, ws.workspaceId);
     const newSlug = slugify(body.name);
     if (existingAgents.length === 0 && newSlug) {
       let finalSlug = newSlug;

--- a/src/web/src/test/e2e/workspace-invites.test.ts
+++ b/src/web/src/test/e2e/workspace-invites.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest"
 import { randomUUID } from "crypto"
-import { seedTestData, cleanupTestData, type TestSeed, signUp, signIn, sessionRequest, tokenRequest, sqlRun } from "@alook/test-utils"
+import { seedTestData, cleanupTestData, type TestSeed, signUp, signIn, sessionRequest, tokenRequest, sqlRun, sqlQuery } from "@alook/test-utils"
 
 let seed: TestSeed
 
@@ -110,5 +110,31 @@ describe("workspace invite flow", () => {
       { method: "DELETE" },
     )
     expect(res.status).toBe(404)
+  })
+
+  it("invited member creating studio does NOT overwrite workspace slug", async () => {
+    const originalSlug = sqlQuery<{ slug: string }>(
+      `SELECT slug FROM workspace WHERE id = ?`,
+      seed.workspaceId,
+    )[0].slug
+
+    const res = await sessionRequest(`/api/studios`, inviteeCookie, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-ID": seed.workspaceId,
+      },
+      body: JSON.stringify({
+        name: "Hijacked Studio Name",
+        members: [{ name: "Rogue", role: "leader", runtime_id: seed.runtimeId }],
+      }),
+    })
+    expect(res.status).toBe(201)
+
+    const currentSlug = sqlQuery<{ slug: string }>(
+      `SELECT slug FROM workspace WHERE id = ?`,
+      seed.workspaceId,
+    )[0].slug
+    expect(currentSlug).toBe(originalSlug)
   })
 })


### PR DESCRIPTION
## Summary

- Invited users joining a workspace with private agents triggered the empty-workspace init flow, which overwrote the workspace's name and slug with the invitee's input
- Root cause: `listAgents(db, wsId, userId)` filters by visibility — invited members see 0 agents even when agents exist
- Additionally, the owner's "New workspace" button reused a workspace that appeared empty (but actually had private agents owned by another member)

## Fixes

- Use unfiltered `listAgents(db, wsId)` (no userId) for all "is workspace empty" checks in layout and workspaces page
- Gate workspace name/slug updates in `POST /api/studios` behind `ws.memberRole === "owner"` — non-owners can still create agents but cannot rename the workspace
- Use unfiltered agent count in studios route slug-update logic

## Test plan

- [x] Unit test: non-owner member calling POST /api/studios with a name does NOT update workspace slug
- [x] Unit test: owner calling POST /api/studios still updates slug (existing behavior preserved)
- [x] E2E test: invited user creating studio preserves original workspace slug
- [x] All 1476 unit tests pass
- [x] Typecheck passes