### PR TITLE
fix(test): add machine owner_id to e2e seed for runtime member isolation

### DIFF
--- a/src/web/src/test/e2e/workspace-init.test.ts
+++ b/src/web/src/test/e2e/workspace-init.test.ts
@@ -161,6 +161,10 @@ describe("workspace init flow", () => {
       const now = new Date().toISOString()
       const rtId = `rt_e2e_${Date.now()}`
       sqlRun(
+        `INSERT INTO machine (daemon_id, workspace_id, device_info, last_seen_at, created_at, updated_at, owner_id) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        seed.daemonId, extraWorkspaceId, "test-device", now, now, now, seed.userId,
+      )
+      sqlRun(
         `INSERT INTO agent_runtime (id, workspace_id, daemon_id, runtime_mode, provider, status, device_info, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         rtId, extraWorkspaceId, seed.daemonId, "local", "claude", "online", "test-device", now, now,
       )

--- a/src/web/src/test/e2e/workspace-invites.test.ts
+++ b/src/web/src/test/e2e/workspace-invites.test.ts
@@ -118,6 +118,14 @@ describe("workspace invite flow", () => {
       seed.workspaceId,
     )[0].slug
 
+    // Create a runtime owned by the invitee so they can pass the member-isolation check
+    const inviteeUserId = sqlQuery<{ id: string }>(`SELECT id FROM "user" WHERE email = ?`, inviteeEmail)[0].id
+    const now = new Date().toISOString()
+    const inviteeDaemonId = `daemon_invitee_${Date.now()}`
+    const inviteeRtId = `rt_invitee_${Date.now()}`
+    sqlRun(`INSERT INTO machine (daemon_id, workspace_id, device_info, last_seen_at, created_at, updated_at, owner_id) VALUES (?, ?, ?, ?, ?, ?, ?)`, inviteeDaemonId, seed.workspaceId, "test", now, now, now, inviteeUserId)
+    sqlRun(`INSERT INTO agent_runtime (id, workspace_id, daemon_id, runtime_mode, provider, status, device_info, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, inviteeRtId, seed.workspaceId, inviteeDaemonId, "local", "claude", "online", "test", now, now)
+
     const res = await sessionRequest(`/api/studios`, inviteeCookie, {
       method: "POST",
       headers: {
@@ -126,7 +134,7 @@ describe("workspace invite flow", () => {
       },
       body: JSON.stringify({
         name: "Hijacked Studio Name",
-        members: [{ name: "Rogue", role: "leader", runtime_id: seed.runtimeId }],
+        members: [{ name: "Rogue", role: "leader", runtime_id: inviteeRtId }],
       }),
     })
     expect(res.status).toBe(201)

--- a/tests/utils/src/seed.ts
+++ b/tests/utils/src/seed.ts
@@ -41,7 +41,7 @@ export function seedTestData(): TestSeed {
   sqlRun(`INSERT INTO "user" (id, name, email, emailVerified, createdAt, updatedAt) VALUES (?, ?, ?, 1, ?, ?)`, userId, 'Test User', `${userId}@test.local`, now, now)
   sqlRun(`INSERT INTO workspace (id, name, slug, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`, workspaceId, 'Test Workspace', slug, now, now)
   sqlRun(`INSERT INTO member (id, workspace_id, user_id, role, created_at) VALUES (?, ?, ?, ?, ?)`, memberId, workspaceId, userId, 'owner', now)
-  sqlRun(`INSERT INTO machine (daemon_id, workspace_id, device_info, last_seen_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`, daemonId, workspaceId, 'test-device', now, now, now)
+  sqlRun(`INSERT INTO machine (daemon_id, workspace_id, device_info, last_seen_at, created_at, updated_at, owner_id) VALUES (?, ?, ?, ?, ?, ?, ?)`, daemonId, workspaceId, 'test-device', now, now, now, userId)
   sqlRun(`INSERT INTO agent_runtime (id, workspace_id, daemon_id, runtime_mode, provider, status, device_info, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, runtimeId, workspaceId, daemonId, 'local', 'claude', 'online', 'test-device', now, now)
   sqlRun(`INSERT INTO agent (id, workspace_id, name, runtime_id, email_handle, owner_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, agentId, workspaceId, 'Test Agent', runtimeId, emailHandle, userId, now, now)
   sqlRun(`INSERT INTO machine_token (id, user_id, workspace_id, token, name, status, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`, machineTokenId, userId, workspaceId, rawToken, 'test-token', 'active', now)


### PR DESCRIPTION
# Why we need this PR?
> Fixes E2E test failures caused by runtime member isolation (07a710a0)

## What changed
The runtime member isolation PR added `machine.owner_id` filtering to `getAgentRuntimeForWorkspace`, but e2e test seeds didn't set `owner_id` on machine records. This caused all runtime lookups to return 404 ("runtime not found in workspace").

- `tests/utils/src/seed.ts` — include `owner_id` in machine INSERT
- `workspace-init.test.ts` — insert machine record for new workspace before creating runtime
- `workspace-invites.test.ts` — create invitee-owned machine+runtime (member isolation prevents using another user's runtime)

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)
- [x] Other: test-utils