### PR TITLE
fix(web): replace spread-based base64 encoding to prevent stack overflow on large attachments

### DIFF
--- a/src/web/src/app/api/email/send/route.test.ts
+++ b/src/web/src/app/api/email/send/route.test.ts
@@ -440,6 +440,41 @@ describe("POST /api/email/send", () => {
       expect(putBody).toContain('filename="c.txt"');
     });
 
+    it("handles large attachments (>64KB) without RangeError", async () => {
+      mockGetAgent.mockResolvedValue({ id: "a1", emailHandle: "sender-agent", workspaceId: "ws1" });
+      mockGetAgentByHandle.mockResolvedValue({ id: "a2", emailHandle: "agent-b", workspaceId: "ws1" });
+      mockIsWhitelisted.mockResolvedValue(false);
+      mockWorkerSelfRefFetch.mockResolvedValue(Response.json({ ok: true }));
+      mockCreateEmail.mockResolvedValue({ id: "e1" });
+
+      // Create a 100KB buffer — larger than the ~65,536 arg limit that caused the stack overflow
+      const largeBuffer = new Uint8Array(100 * 1024);
+      for (let i = 0; i < largeBuffer.length; i++) largeBuffer[i] = i % 256;
+      mockEmailBucketGet.mockResolvedValue({
+        arrayBuffer: () => Promise.resolve(largeBuffer.buffer),
+      });
+      mockEmailBucketPut.mockResolvedValue(undefined);
+
+      const attachments = [
+        { key: "emails/drafts/x/large.bin", filename: "large.bin", size: 100 * 1024, contentType: "application/octet-stream" },
+      ];
+
+      const req = makeReq({
+        agentId: "a1",
+        to: "agent-b@alook.ai",
+        subject: "Large attachment",
+        htmlBody: "<p>Big file</p>",
+        attachments,
+      });
+
+      const res = await POST(req, {} as any);
+      expect(res.status).toBe(200);
+
+      expect(mockEmailBucketGet).toHaveBeenCalledWith("emails/drafts/x/large.bin");
+      const putBody = mockEmailBucketPut.mock.calls[0][1] as string;
+      expect(putBody).toContain('filename="large.bin"');
+    });
+
     it("skips attachments that return null from R2 in parallel fetch", async () => {
       mockGetAgent.mockResolvedValue({ id: "a1", emailHandle: "sender-agent", workspaceId: "ws1" });
       mockGetAgentByHandle.mockResolvedValue({ id: "a2", emailHandle: "agent-b", workspaceId: "ws1" });

--- a/src/web/src/app/api/email/send/route.ts
+++ b/src/web/src/app/api/email/send/route.ts
@@ -116,7 +116,10 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
           const obj = await cfEnv.EMAIL_BUCKET.get(att.key);
           if (!obj) return null;
           const raw = await obj.arrayBuffer();
-          const base64 = btoa(String.fromCharCode(...new Uint8Array(raw)));
+          const bytes = new Uint8Array(raw);
+          let binary = '';
+          for (let i = 0; i < bytes.byteLength; i++) binary += String.fromCharCode(bytes[i]!);
+          const base64 = btoa(binary);
           return { filename: att.filename, contentType: att.contentType, base64 };
         })
       )).filter((a): a is { filename: string; contentType: string; base64: string } => a !== null);


### PR DESCRIPTION
# Why we need this PR?

The email send route at `src/web/src/app/api/email/send/route.ts:119` uses `btoa(String.fromCharCode(...new Uint8Array(raw)))` which spreads all bytes as individual function arguments. JS engines limit call stack args to ~65,536, so any email attachment >64KB throws `RangeError: Maximum call stack size exceeded` and crashes the endpoint.

## What changed

- Replaced the spread-based `btoa(String.fromCharCode(...))` pattern with a loop-based approach that builds the binary string byte-by-byte (matching the existing pattern in `src/email-worker/src/index.ts:15-22`)
- Added a unit test that verifies base64 encoding of a 100KB buffer without throwing

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)