### PR TITLE
feat(web): add loading.tsx for workspace route to fix navigation stall

### DIFF
--- a/src/web/src/app/(app)/w/[slug]/loading.tsx
+++ b/src/web/src/app/(app)/w/[slug]/loading.tsx
@@ -1,0 +1,11 @@
+import { Loader2 } from "lucide-react"
+import { GradientBackground } from "@/components/gradient-background"
+
+export default function WorkspaceLoading() {
+  return (
+    <div className="flex h-dvh items-center justify-center relative">
+      <GradientBackground />
+      <Loader2 className="size-5 animate-spin text-muted-foreground" />
+    </div>
+  )
+}


### PR DESCRIPTION
# Why we need this PR?

When navigating from `/workspaces` to a workspace, the UI stalls/freezes because the workspace layout (`/w/[slug]/layout.tsx`) performs multiple async calls (session check, Cloudflare context, DB queries) with no `loading.tsx` fallback. Next.js shows nothing while data loads, creating a poor user experience.

## What changed

Added `src/web/src/app/(app)/w/[slug]/loading.tsx` — a simple, centered loading state with:
- Gradient background (matches the app's visual style)
- Animated `Loader2` spinner from lucide-react (same pattern used in `home/page.tsx`)
- Full viewport height, responsive on all screen sizes

This is a Next.js route segment loading boundary — it renders instantly while the layout's async data fetches complete.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)