### PR TITLE
fix(web): remove stale GSAP target and deprecated meta tag

### DIFF
--- a/src/web/src/app/layout.tsx
+++ b/src/web/src/app/layout.tsx
@@ -123,7 +123,7 @@ export default function RootLayout({
     >
       <head>
         <link rel="manifest" href="/manifest.json" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />

--- a/src/web/src/components/home/hero-section.tsx
+++ b/src/web/src/components/home/hero-section.tsx
@@ -44,12 +44,6 @@ export function HeroSection({ isLoggedIn }: { isLoggedIn: boolean }) {
           "-=0.1"
         )
         .fromTo(
-          ".hero-specs",
-          { y: 15, opacity: 0 },
-          { y: 0, opacity: 1, duration: 0.5, ease: "power2.out" },
-          "-=0.1"
-        )
-        .fromTo(
           ".hero-providers",
           { y: 10, opacity: 0 },
           { y: 0, opacity: 1, duration: 0.4, ease: "power2.out" },


### PR DESCRIPTION
# Why we need this PR?

Production console shows GSAP "target not found" warnings and a deprecated meta tag warning on the landing page.

## What changed

- **`hero-section.tsx`**: Removed the `.hero-specs` GSAP `.fromTo()` animation that was targeting a commented-out DOM element, causing "GSAP target .hero-specs not found" in production console
- **`layout.tsx`**: Replaced deprecated `<meta name="apple-mobile-web-app-capable">` with `<meta name="mobile-web-app-capable">` per Chrome's deprecation notice

## Verification

- Production build + Playwright test confirms 0 GSAP warnings after the fix

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)