### PR TITLE
feat: Add custom JSON-LD structured data support for blog posts

### DIFF
--- a/src/web/src/app/blog/[slug]/page.tsx
+++ b/src/web/src/app/blog/[slug]/page.tsx
@@ -62,7 +62,9 @@ export default async function BlogPostPage({
   const prevPost = currentIndex < posts.length - 1 ? posts[currentIndex + 1] : null;
   const nextPost = currentIndex > 0 ? posts[currentIndex - 1] : null;
 
-  const { default: PostContent } = await import(`@/content/${slug}.mdx`);
+  const { default: PostContent, jsonLd } = await import(
+    `@/content/${slug}.mdx`
+  );
 
   const blogPostingJsonLd = {
     "@context": "https://schema.org",
@@ -88,6 +90,16 @@ export default async function BlogPostPage({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(blogPostingJsonLd) }}
       />
+      {jsonLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(
+              Array.isArray(jsonLd) ? jsonLd : [jsonLd]
+            ),
+          }}
+        />
+      )}
       <article className="mx-auto max-w-3xl px-6 pt-12 sm:pt-24 pb-28">
         <Link
           href="/blog"

--- a/src/web/src/mdx.d.ts
+++ b/src/web/src/mdx.d.ts
@@ -3,6 +3,7 @@ declare module "*.mdx" {
   import type { BlogPost } from "@/lib/blog/types";
 
   export const metadata: BlogPost;
+  export const jsonLd: Record<string, unknown>[] | Record<string, unknown> | undefined;
   const MDXComponent: ComponentType;
   export default MDXComponent;
 }


### PR DESCRIPTION
## Summary
Allow blog posts to export custom JSON-LD structured data (FAQ, HowTo, etc.) for Google rich snippet eligibility.

## Changes
- Modified `blog/[slug]/page.tsx` to read optional `jsonLd` export from MDX files
- Renders additional JSON-LD script tags when present
- Added TypeScript type declaration in `mdx.d.ts`
- Backward compatible: posts without jsonLd export work unchanged

## Usage
In any MDX blog post:
```javascript
export const jsonLd = [{
  "@context": "https://schema.org",
  "@type": "FAQPage",
  "mainEntity": [...]
}];
```

## Test plan
- [x] TypeScript typecheck passes (all 5 packages)
- [x] All 803 tests pass
- [ ] Verify blog posts without jsonLd export still render correctly
- [ ] Verify blog posts with jsonLd export render the additional script tags