### PR TITLE
Update personal-ai-company article: new title & content optimization

### DIFF
--- a/src/web/src/content/personal-ai-company.mdx
+++ b/src/web/src/content/personal-ai-company.mdx
@@ -1,239 +1,84 @@
 export const metadata = {
   slug: "personal-ai-company",
-  title: "Build Your Personal AI Company in 2026: The Solo Founder's Playbook",
+  title: "How to Build a One-Person Company With AI Agents",
   date: "2026-06-10",
   author: "Alook Team",
   excerpt:
-    "Transform from solo founder to AI-powered company. Build, deploy and manage autonomous AI agents for sales, support, and operations. Complete playbook inside.",
-  readingTime: "10 min read",
+    "The complete guide to AI for solopreneurs. Learn which AI agents work best for small business and how to build a one-person company with an AI workforce.",
+  readingTime: "5 min read",
 };
-
-_Running a company alone used to mean choosing between growth and sanity. Not anymore._
-
-I just watched a newsletter operator hit $50k monthly revenue. Team size: one human, twelve AI agents. No employees. No contractors. Just strategic decisions and automated execution.
-
-Welcome to the era of personal AI companies.
-
-## What Defines a Personal AI Company
-
-Forget the traditional startup playbook. A personal AI company operates differently.
-
-You're the CEO of a digital workforce. AI agents handle sales outreach, customer support, content production, data analysis. You focus on strategy, relationships, and creative vision. The boring stuff runs itself.
-
-Here's what makes it revolutionary:
-
-- Your sales team qualifies 200 leads daily without your input
-- Support tickets resolve in 30 seconds, not 30 hours
-- Content publishes across 8 platforms while you have lunch
-- Financial reports generate themselves every morning at 7 AM
-
-Marcus runs a B2B lead generation service with 200 paying clients. His secret? Eight specialized AI agents managing everything from prospect research to email delivery. Monthly overhead: $127.
-
-The math is simple. Traditional business: hire ten people, manage ten problems. Personal AI company: deploy ten agents, solve one problem - scaling.
-
-## Why 2026 Is the Inflection Point
-
-Three shifts happened simultaneously this year.
-
-First, AI crossed the competence threshold. Claude handles 200,000 tokens of context. GPT-4 understands nuance like a senior employee. Specialized models outperform human specialists in narrow domains. The tools finally work.
-
-Second, no-code platforms democratized access. Building agent workflows now takes minutes, not months. Platforms like Alook handle the infrastructure. You handle the vision.
-
-Third, market acceptance hit critical mass. Customers care about results, not who delivers them. My AI support agent scores 4.8/5 satisfaction. My previous human team scored 4.2/5. Nobody complains about talking to AI when problems get solved instantly.
-
-We're not replacing doctors or therapists. We're automating the 80% of business tasks that are systematic, predictable, and better suited to machines than humans.
-
-## Your Personal AI Company Structure
 
 ![Personal AI Company Organizational Chart](/blog/personal-ai-company/2026-06-10-personal-ai-company-org-chart.png)
 
-Five components. Skip one and everything breaks.
+Running a company alone used to mean choosing between growth and sanity. That tradeoff is dissolving. If you're a solopreneur looking for AI tools to scale without hiring, or a small business owner exploring AI agents for the first time, this is how it works.
 
-### You: Strategic Commander
+## What is a one-person company AI setup?
 
-You make decisions, build relationships, set direction. No more task execution. Pure strategy and creativity.
+You're the CEO of a digital workforce. AI agents handle sales outreach, customer support, content production, data analysis. You focus on strategy, relationships, and creative direction.
 
-I work two hours daily on operations. The rest? Thinking, planning, adjusting workflows. My calendar stays 90% empty by design.
+In practice this means:
 
-### AI Sales Department
+- A sales agent qualifies leads without your input
+- Support tickets resolve in under a minute
+- Content publishes across platforms while you're offline
+- Reports generate themselves every morning
 
-Your agents research prospects, craft personalized messages, handle objections, book meetings. One founder's AI SDR books 15 qualified calls weekly with a 34% conversion rate. Industry average for human SDRs: 22%.
+The math works differently from a traditional business. Instead of hiring ten people and managing ten problems, you deploy ten agents. Monthly cost for a full AI workforce for solo founders: typically under $200. The scaling problem separates from the people problem.
 
-Why the difference? AI doesn't burn out at 3 PM. Every prospect gets maximum effort.
+## Best AI agents for small business and solopreneurs
 
-### AI Support Department
+Five agents deliver most of the value. Start with whichever matches your biggest bottleneck:
 
-Support tickets used to ruin my mornings. Now AI handles 94% without me. Response time: 30 seconds. Consistency: perfect. Customer feedback: "Your support team is incredible!"
+**Customer support agent.** Handles FAQs, troubleshooting, onboarding. Probably the highest-ROI first agent for any small business. Saves 15-20 hours weekly from the first week.
 
-That "team" is three agents and a knowledge base.
+**Content creator agent.** Produces blog posts, social content, newsletters. Feed it your previous work so it matches your voice. Consistency beats occasional perfection when you're building an audience.
 
-### AI Operations Department
+**Sales development agent.** Identifies prospects, researches companies, sends outreach, books meetings. One AI agent for small business development handles the function of a dedicated SDR.
 
-Invoice processing, data entry, report generation, calendar management. The mundane work that steals entire afternoons.
+**Data analyst agent.** Pulls metrics, generates reports, alerts you on anomalies. Configure it to surface signal rather than dump dashboards at you.
 
-My operations agent consolidates data from seven platforms every morning. Delivers three bullets: what's working, what's broken, what needs attention. Time saved: 2 hours daily.
-
-### AI Content Department
-
-Content drives modern business. Writing is slow. AI changes the equation.
-
-My content cluster produces 10 pieces weekly. Blog posts, social updates, newsletters. I edit 20%. The rest ships immediately. Quarterly growth: 3x audience.
-
-Stop calling it cheating. Perfectionism that prevents publishing is the real failure.
-
-## 30-Day Launch Roadmap
+**Project coordinator agent.** Tracks tasks, sends reminders, maintains schedules. Removing the "what do I need to do next" mental load frees real capacity for strategic work.
 
 ![Personal AI Company Development Timeline](/blog/personal-ai-company/2026-06-10-personal-ai-company-timeline.png)
 
-Here's exactly how to build your personal AI company.
+## Best AI tools for solopreneurs (2026 stack)
 
-### Week 1: Foundation
+The best tools for solopreneurs replace entire departments, not individual tasks. Keep the stack simple:
 
-**Days 1-3:** Pick your niche. What knowledge do you have that others need? Newsletter curation, lead generation, content creation, market research. Choose one.
+**Agent orchestration:** [Alook.ai](https://alook.ai). Built for non-technical founders. Your agents share context, communicate with each other, and hand off work without you routing every message. This is the layer that turns isolated AI tools into an actual team.
 
-**Days 4-5:** Assemble your tech stack:
-- Alook.ai for agent orchestration (free tier works)
-- Simple website (Carrd or Framer)
-- Stripe for payments
-- Basic email setup
+**Payments:** Stripe. **Analytics:** Plausible. **Website:** Framer or Carrd.
 
-**Days 6-7:** Build your first agent. Start with one painful task. Get it working perfectly before expanding.
+Total monthly cost for the complete stack: under $100. That's what makes AI tools for one person business viable in a way that hiring contractors never was.
 
-Common mistake: trying to automate everything immediately. Start small, nail it, then scale.
+## How to run a business with AI agents: getting started
 
-### Week 2: First AI Employee
+**Week 1:** Pick your niche and build your first agent. Choose one task you repeat daily that doesn't require your judgment. Get that agent working reliably before touching anything else.
 
-Choose your highest-leverage function. Usually support (if you have customers) or content (if you need customers).
+**Week 2:** Add your second agent in your highest-leverage function. Usually support (if you have customers) or content (if you need customers). Train it well. Spend days on this, not hours. A poorly trained agent creates problems you'll spend weeks fixing.
 
-Train the agent obsessively. Feed it documentation, examples, edge cases. I spent three days training my support agent. It's now handled 4,200 tickets. ROI: infinite.
+**Week 3-4:** Add agents that complement each other. Content agent writes, distribution agent publishes, analytics agent measures. Solopreneur automation works best when agents share context and talk to each other rather than operating in isolation.
 
-Test everything. Break your agent intentionally. Find limits. Fix problems. Mediocre human employees get patience. Mediocre AI agents destroy trust.
+**Month 2:** Start selling. Deploy AI sales outreach. Your costs are near zero, so you can price competitively from day one. Most AI-powered small businesses reach profitability quickly because overhead barely exists.
 
-### Week 3-4: Building Your Team
+## What makes this work (and what breaks it)
 
-Add complementary agents. Support needs analytics. Content needs distribution. Each agent should amplify the others.
+The difference between a functioning one-person company and a mess of disconnected AI tools comes down to coordination.
 
-My setup: Content agent writes, distribution agent publishes, engagement agent responds to comments, analytics agent measures performance. They operate as a system, not isolated tools.
+Agents working in isolation create contradictions. Your marketing agent promises something your product agent can't deliver. Your support agent gives answers that conflict with your content. You end up spending more time fixing miscommunication than you saved on automation.
 
-By week 4, you should have 3-5 agents handling 60-80% of operations.
+Agents working as a team, with shared context and communication channels, compound each other's output. Content informs marketing. Support feedback reaches product. Sales knows what just shipped.
 
-### Month 2: Revenue Activation
-
-Launch your service at 50% competitor pricing. Your costs are near zero - you can afford it.
-
-Deploy your AI sales team. 50 personalized outreach messages daily minimum. Your agents research each prospect, craft unique angles, follow up systematically.
-
-First customer validates concept. Second confirms it wasn't luck. Third means you have a business.
-
-Most personal AI companies reach profitability by week 6. Not because they're brilliant. Because overhead is nothing.
-
-## Essential AI Agents for Success
-
-Five agents deliver 80% of value:
-
-**Customer Support Agent**  
-Handles FAQs, troubleshooting, basic onboarding. Train it on your documentation and past conversations. Saves 20 hours weekly immediately.
-
-**Content Creator Agent**  
-Produces blog posts, social content, newsletters. Feed it your best work as training data. Volume beats perfection in content marketing.
-
-**Sales Development Agent**  
-Identifies prospects, researches companies, sends outreach, books meetings. One agent replaces a $4,000/month SDR for $19/month.
-
-**Data Analyst Agent**  
-Pulls metrics, generates reports, identifies trends. Mine alerts me only to anomalies: "Conversion dropped 5% yesterday. Checkout page load time increased."
-
-**Project Coordinator Agent**  
-Tracks tasks, sends reminders, maintains schedules. Seems minor. It's not. Mental load reduction doubles your strategic capacity.
-
-## Technology Stack Essentials
-
-Keep it simple. Every tool must earn its place.
-
-**Agent Orchestration:** Alook.ai - built for non-technical founders. Describe what you want in plain English. No coding required.
-
-**Communication:** Email plus Slack for internal alerts. Both integrate directly with Alook.
-
-**Payments:** Stripe with payment links. Sophisticated billing comes later.
-
-**Analytics:** Plausible or SimpleAnalytics. You need three metrics: visitors, conversions, revenue.
-
-**Website:** Framer or Carrd. One page explaining your service. My first $10k came through a 45-minute Carrd build.
-
-Total monthly cost: $67. Less than a gym membership.
-
-## Real Personal AI Companies Generating Revenue
+That coordination layer is the actual product. Individual AI agents are commodities. The orchestration is what turns them into a workforce.
 
 ![Traditional vs Personal AI Company Comparison](/blog/personal-ai-company/2026-06-10-personal-ai-company-comparison.png)
 
-**Newsletter Empire: $50k/month**  
-Sarah runs a daily AI newsletter. 45,000 subscribers. Revenue from sponsorships and paid tiers.
+## Start building
 
-Her agents:
-- Content agent writes summaries
-- Curation agent finds news
-- Email agent handles subscribers
-- Analytics agent optimizes send times
+A solopreneur with the right AI agents today has capabilities that required a large team two years ago. The gap between "solo founder with AI" and "funded startup with employees" is shrinking every month.
 
-Time investment: 1 hour daily. Profit margin: 94%.
-
-**B2B Lead Machine: $100k/month**  
-Tom sells qualified leads to SaaS companies. 200 clients at $500/month average.
-
-His agents:
-- Research agent identifies prospects
-- Enrichment agent adds contact data
-- Qualification agent scores leads
-- Delivery agent distributes to clients
-
-He hasn't touched a spreadsheet in six months.
-
-**Content Agency Without Writers**  
-Maria runs a content service for ecommerce brands. 15 clients, $120k/month total.
-
-Plot twist: Zero human writers. 15 specialized AI agents, each trained on client voice. Clients get 4 posts weekly. Maria handles strategy calls only.
-
-Clients know it's AI-generated. They don't care. Results matter.
-
-## Overcoming the Three Killers
-
-**Quality Control**  
-Agents will make mistakes. Build review loops. My content agent can publish directly, but high-stakes pieces route through me first. Catch the 5% that could damage reputation.
-
-**Client Resistance**  
-Some clients fear AI. Don't hide it, but lead with outcomes. "24-hour delivery" sells better than "AI-powered." Transparency builds trust: "We use AI for execution, humans for strategy."
-
-**Scaling Beyond Oversight**  
-Eventually you'll have too many agents to monitor personally. Solution: supervisor agents that monitor other agents. Meta? Yes. Necessary? Absolutely.
-
-## When (If Ever) to Hire Humans
-
-You might never need to.
-
-If you do hire, focus on:
-- Complex strategy development
-- Relationship building
-- Creative vision
-- Ethical judgment calls
-
-Don't hire for tasks. Hire for thinking.
-
-Personal AI companies doing $3M/year with one human exist. It's about leverage, not headcount.
-
-## Launch Your Personal AI Company Today
-
-You could spend months researching. Watching videos. Waiting for the perfect moment.
-
-Or you could start now.
-
-Build one agent. Solve one problem. Get one customer.
-
-The barrier has never been lower. The opportunity never bigger. This window won't stay open - once everyone catches on, first-mover advantage disappears.
-
-Your solo empire starts with a single AI agent.
-
-What's stopping you?
+Your one-person company starts with a single agent doing a single job well. Then a second. Then they start talking to each other. That's when things get interesting.
 
 ---
 
-_Ready to build your personal AI company? Start free with [Alook.ai](https://alook.ai). No code required. Your first AI employee is 10 minutes away._
+_Ready to build your personal AI company? Start free with [Alook.ai](https://alook.ai). No code required. Your first AI employee is ten minutes away._


### PR DESCRIPTION
## Summary

Updates the existing published article at `/blog/personal-ai-company`:

- **Title changed**: "Build Your Personal AI Company in 2026: The Solo Founder's Playbook" → "How to Build a One-Person Company With AI Agents"
- **Removed fabricated case studies** (Sarah $50k newsletter, Tom $100k lead gen, Maria content agency) — replaced with a section on why coordination matters
- **Tightened content** from ~1500 words to ~1200 words
- **Optimized for keywords**: "one person company AI", "AI agents for small business", "solopreneur AI tools"
- **Images unchanged**: all 3 existing published images retained in place

## Context

This is a content update to an already-published article, not a new post. The slug (`personal-ai-company`) and image paths remain unchanged so no redirects are needed.

## Test plan

- [ ] Verify page renders correctly at `/blog/personal-ai-company`
- [ ] Confirm all 3 images load
- [ ] Check meta title/description in page source