### PR TITLE
fix(knip): allowlist execSync system binaries in app + cli

### DIFF
--- a/src/app/knip.json
+++ b/src/app/knip.json
@@ -11,7 +11,11 @@
     "bun-types"
   ],
   "ignoreBinaries": [
-    "predev"
+    "predev",
+    "printf",
+    "pbcopy",
+    "xclip",
+    "taskkill"
   ],
   "vitest": {
     "entry": ["test/**/*.test.ts"]

--- a/src/cli/knip.json
+++ b/src/cli/knip.json
@@ -10,6 +10,9 @@
   "ignoreDependencies": [
     "citty"
   ],
+  "ignoreBinaries": [
+    "taskkill"
+  ],
   "vitest": {
     "entry": ["**/*.test.ts"]
   },


### PR DESCRIPTION
## Problem

The knip 6.x bump in #366 tightened detection and started failing the **Dead Code Detection (knip)** checks for `app` and `cli` with `Unlisted binaries`:

- **app** — `printf`, `pbcopy`, `xclip` (`src/commands/onboard.ts`), `taskkill` (`src/lib/services.ts`)
- **cli** — `taskkill` (`daemon/kill-tree.ts`)

These are OS commands invoked via `execSync`, not npm dependencies, so they belong in knip's `ignoreBinaries` allowlist — not installed as packages.

## Fix

- `src/app/knip.json` — add `printf`, `pbcopy`, `xclip`, `taskkill` to `ignoreBinaries`
- `src/cli/knip.json` — add an `ignoreBinaries` with `taskkill`

## Verification

Ran knip locally for both packages after the fix — both exit 0 with no reported issues. Full pre-commit (typecheck + lint + test + ws-typegrep) passed.