### PR TITLE
fix(blog): remove duplicate H1 from MDX posts

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -27,6 +27,7 @@ coverage:
 
 ignore:
   - "src/web/src/components/home/**"
+  - "src/web/scripts/**"
 
 comment:
   layout: "reach,diff,flags,files"

--- a/src/web/mdx-components.tsx
+++ b/src/web/mdx-components.tsx
@@ -3,5 +3,8 @@ import type { MDXComponents } from "mdx/types";
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
     ...components,
+    // Blog layout already renders the page H1 from metadata.title.
+    // Suppress MDX h1 so posts never ship a duplicate heading.
+    h1: () => null,
   };
 }

--- a/src/web/scripts/validate-blog-assets.ts
+++ b/src/web/scripts/validate-blog-assets.ts
@@ -1,62 +1,13 @@
-import { existsSync, readFileSync, readdirSync } from "fs";
-import { join, dirname } from "path";
+import { dirname, join } from "path";
 import { fileURLToPath } from "url";
+import { runValidateBlogAssetsCli } from "../src/lib/blog/validate-assets";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const contentDir = join(__dirname, "..", "src", "content");
 const publicDir = join(__dirname, "..", "public");
 
-if (!existsSync(contentDir)) {
-  console.log("✓ Blog asset validation skipped (no content directory).");
-  process.exit(0);
-}
-
-const errors: string[] = [];
-
-const mdxFiles = readdirSync(contentDir).filter((f) => f.endsWith(".mdx"));
-
-for (const file of mdxFiles) {
-  const slug = file.replace(/\.mdx$/, "");
-  const content = readFileSync(join(contentDir, file), "utf-8");
-
-  // Page shell already renders <h1> from metadata.title. MDX must not add another.
-  const h1Lines = content
-    .split("\n")
-    .map((line, index) => ({ line, index: index + 1 }))
-    .filter(({ line }) => /^# (?!#)/.test(line));
-  for (const { line, index } of h1Lines) {
-    errors.push(
-      `[post: ${slug}] Duplicate H1 at line ${index}: "${line}". Remove MDX "# Title" — the page template owns the single H1.`
-    );
-  }
-
-  const imgRegex = /!\[[^\]]*\]\(([^)]*)\)|<img[^>]+src="([^"]*)"[^>]*>/g;
-  let match: RegExpExecArray | null;
-
-  while ((match = imgRegex.exec(content)) !== null) {
-    const src = match[1] || match[2];
-
-    if (!src.startsWith("/blog/")) {
-      errors.push(
-        `[post: ${slug}] Image src "${src}" must start with /blog/ — move the file to public/blog/`
-      );
-      continue;
-    }
-
-    const filePath = join(publicDir, src);
-    if (!existsSync(filePath)) {
-      errors.push(`[post: ${slug}] Image file not found: public${src}`);
-    }
-  }
-}
-
-if (errors.length > 0) {
-  console.error("Blog asset validation failed:\n");
-  for (const err of errors) {
-    console.error(`  ✗ ${err}`);
-  }
-  console.error(`\n${errors.length} error(s) found.`);
-  process.exit(1);
-}
-
-console.log("✓ Blog asset validation passed.");
+runValidateBlogAssetsCli(contentDir, publicDir, {
+  log: console.log.bind(console),
+  error: console.error.bind(console),
+  exit: process.exit.bind(process),
+});

--- a/src/web/scripts/validate-blog-assets.ts
+++ b/src/web/scripts/validate-blog-assets.ts
@@ -19,6 +19,17 @@ for (const file of mdxFiles) {
   const slug = file.replace(/\.mdx$/, "");
   const content = readFileSync(join(contentDir, file), "utf-8");
 
+  // Page shell already renders <h1> from metadata.title. MDX must not add another.
+  const h1Lines = content
+    .split("\n")
+    .map((line, index) => ({ line, index: index + 1 }))
+    .filter(({ line }) => /^# (?!#)/.test(line));
+  for (const { line, index } of h1Lines) {
+    errors.push(
+      `[post: ${slug}] Duplicate H1 at line ${index}: "${line}". Remove MDX "# Title" — the page template owns the single H1.`
+    );
+  }
+
   const imgRegex = /!\[[^\]]*\]\(([^)]*)\)|<img[^>]+src="([^"]*)"[^>]*>/g;
   let match: RegExpExecArray | null;
 

--- a/src/web/src/content/ai-agent-orchestration.mdx
+++ b/src/web/src/content/ai-agent-orchestration.mdx
@@ -42,8 +42,6 @@ export const jsonLd = [
   },
 ];
 
-# AI Orchestration: How Multiple Agents Work Together
-
 ![Hand-drawn diagram of AI orchestration as a coordination layer connecting data, analysis, writing, and delivery agents around a shared goal](/blog/ai-agent-orchestration/hero.webp)
 
 AI orchestration is how you get multiple AI agents to finish a task together, each handling one step, without you moving work between them by hand. One agent does step one. Another picks up step two. A third closes it out. You set it up once, then stay out of the loop.

--- a/src/web/src/content/ai-agent-team.mdx
+++ b/src/web/src/content/ai-agent-team.mdx
@@ -58,8 +58,6 @@ export const jsonLd = [
   },
 ];
 
-# How to Build an AI Agent Team: Roles, Handoffs, and Oversight
-
 ![Conceptual AI agent team workflow with coordination, analysis, execution, and a completed output](/blog/ai-agent-team/hero.webp)
 
 *A conceptual workflow showing defined roles and handoffs, not a product screenshot.*

--- a/src/web/src/content/ai-agent-vs-chatbot.mdx
+++ b/src/web/src/content/ai-agent-vs-chatbot.mdx
@@ -50,8 +50,6 @@ export const jsonLd = [
   },
 ];
 
-# AI Agent vs Chatbot: What's the Difference?
-
 ![Conceptual comparison of a chatbot prompt-reply loop versus an AI agent workflow with trigger, tools, state, review, and output](/blog/ai-agent-vs-chatbot/hero.webp)
 
 *A conceptual comparison of chatbot vs AI agent flow. Not a product screenshot.*

--- a/src/web/src/content/ai-team-vs-ai-tools.mdx
+++ b/src/web/src/content/ai-team-vs-ai-tools.mdx
@@ -7,8 +7,6 @@ export const metadata = {
   readingTime: '8 min read'
 };
 
-# AI Team vs AI Tools: Stop Being the Human Copy-Paste Between Your Coding Agents
-
 ![AI Team vs AI Tools - Comparison of human copy-paste workflow versus AI team coordination](/blog/ai-team-vs-ai-tools/hero.png)
 
 You start a project in Claude Code. It builds the initial architecture beautifully.

--- a/src/web/src/content/how-to-delegate-tasks-to-ai-agents.mdx
+++ b/src/web/src/content/how-to-delegate-tasks-to-ai-agents.mdx
@@ -90,8 +90,6 @@ export const jsonLd = [
   },
 ];
 
-# How to Delegate Tasks to AI Agents
-
 ![Conceptual delegation loop from task and instructions through supervised runs to a human review boundary](/blog/how-to-delegate-tasks-to-ai-agents/hero.webp)
 
 *A conceptual loop for delegating work to AI agents: task, instructions, supervised run, output, and review boundary. Not a product screenshot.*

--- a/src/web/src/content/multi-agent-collaboration-without-code.mdx
+++ b/src/web/src/content/multi-agent-collaboration-without-code.mdx
@@ -8,8 +8,6 @@ export const metadata = {
   readingTime: "4 min read",
 };
 
-# Multi-Agent Collaboration Without Code
-
 AI agents keep getting more capable. Better reasoning, longer context, more tools. But most people still use them one at a time: ask a question, get an answer, ask the next question. And when that bottleneck becomes obvious, the instinct is to just run more agents in parallel. That doesn't work either.
 
 Multi-agent collaboration means agents that coordinate with each other autonomously. No scripting, no workflow builders, no code. You define roles and relationships. The agents handle the rest.

--- a/src/web/src/content/multi-agent-workflow-patterns.mdx
+++ b/src/web/src/content/multi-agent-workflow-patterns.mdx
@@ -50,8 +50,6 @@ export const jsonLd = [
   },
 ];
 
-# 7 Multi-Agent Workflow Patterns for AI Coding Agents
-
 ![Conceptual multi-agent workflow map with triggers, agent roles, handoffs, review points, and stop conditions](/blog/multi-agent-workflow-patterns/hero.webp)
 
 *A conceptual workflow map showing triggers, agent roles, handoffs, review points, and stop conditions. Not a product screenshot.*

--- a/src/web/src/content/no-code-automation-ai-agents.mdx
+++ b/src/web/src/content/no-code-automation-ai-agents.mdx
@@ -50,8 +50,6 @@ export const jsonLd = [
   },
 ];
 
-# No-Code Automation With AI Agents: Beyond Trigger-and-Action Workflows
-
 ![Hand-drawn comparison of traditional trigger-and-action automation versus an agent network sharing context across Content, Research, and Support roles](/blog/no-code-automation-ai-agents/hero.webp)
 
 Most people who search for no code automation want the same thing: stop doing the boring, repeatable steps by hand. A new form reply should land in a spreadsheet. A closed deal should post to Slack. A follow-up email should go out without opening the CRM every time.

--- a/src/web/src/lib/blog/validate-assets.test.ts
+++ b/src/web/src/lib/blog/validate-assets.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { join } from "path";
 import {
   collectBlogAssetErrors,
   findBlogImageErrors,
@@ -7,6 +8,11 @@ import {
   validateBlogAssets,
   type BlogAssetFs,
 } from "./validate-assets";
+
+/** Normalize path separators so mocks work on Windows and Unix. */
+function norm(p: string): string {
+  return p.replace(/\\/g, "/");
+}
 
 describe("findDuplicateMdxH1Errors", () => {
   it("flags markdown H1 lines with line numbers", () => {
@@ -65,9 +71,10 @@ describe("validateBlogAssets", () => {
   });
 
   it("returns ok for clean MDX posts", () => {
+    const heroPath = join("/public", "/blog/demo/hero.webp");
     const fs: BlogAssetFs = {
       existsSync: (path) =>
-        path === "/content" || path === "/public/blog/demo/hero.webp",
+        norm(path) === "/content" || norm(path) === norm(heroPath),
       readFileSync: () => "![alt](/blog/demo/hero.webp)\n\n## Section\n",
       readdirSync: () => ["demo.mdx", "readme.txt"],
     };
@@ -78,7 +85,7 @@ describe("validateBlogAssets", () => {
 
   it("returns failed with duplicate H1 errors", () => {
     const fs: BlogAssetFs = {
-      existsSync: (path) => path === "/content",
+      existsSync: (path) => norm(path) === "/content",
       readFileSync: () => "# Title\n\nBody\n",
       readdirSync: () => ["demo.mdx"],
     };
@@ -121,9 +128,10 @@ describe("runValidateBlogAssetsCli", () => {
 
   it("logs pass and exits 0 for clean posts", () => {
     const { io, logs, exits } = mockIo();
+    const heroPath = join("/public", "/blog/demo/hero.webp");
     const fs: BlogAssetFs = {
       existsSync: (path) =>
-        path === "/content" || path === "/public/blog/demo/hero.webp",
+        norm(path) === "/content" || norm(path) === norm(heroPath),
       readFileSync: () => "![alt](/blog/demo/hero.webp)\n",
       readdirSync: () => ["demo.mdx"],
     };
@@ -135,7 +143,7 @@ describe("runValidateBlogAssetsCli", () => {
   it("prints failures and exits 1 for duplicate H1", () => {
     const { io, errors, exits } = mockIo();
     const fs: BlogAssetFs = {
-      existsSync: (path) => path === "/content",
+      existsSync: (path) => norm(path) === "/content",
       readFileSync: () => "# Title\n",
       readdirSync: () => ["demo.mdx"],
     };

--- a/src/web/src/lib/blog/validate-assets.test.ts
+++ b/src/web/src/lib/blog/validate-assets.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectBlogAssetErrors,
+  findBlogImageErrors,
+  findDuplicateMdxH1Errors,
+  runValidateBlogAssetsCli,
+  validateBlogAssets,
+  type BlogAssetFs,
+} from "./validate-assets";
+
+describe("findDuplicateMdxH1Errors", () => {
+  it("flags markdown H1 lines with line numbers", () => {
+    const content = ["export const metadata = {};", "", "# Hello Title", "", "Body"].join(
+      "\n"
+    );
+    expect(findDuplicateMdxH1Errors(content, "demo")).toEqual([
+      '[post: demo] Duplicate H1 at line 3: "# Hello Title". Remove MDX "# Title" — the page template owns the single H1.',
+    ]);
+  });
+
+  it("ignores h2 and deeper headings", () => {
+    const content = "## Section\n### Subsection\n";
+    expect(findDuplicateMdxH1Errors(content, "demo")).toEqual([]);
+  });
+});
+
+describe("findBlogImageErrors", () => {
+  it("requires /blog/ image prefix", () => {
+    const content = "![alt](/images/hero.png)\n";
+    expect(findBlogImageErrors(content, "demo", "/public", () => true)).toEqual([
+      '[post: demo] Image src "/images/hero.png" must start with /blog/ — move the file to public/blog/',
+    ]);
+  });
+
+  it("flags missing files under public", () => {
+    const content = "![alt](/blog/demo/hero.webp)\n";
+    expect(findBlogImageErrors(content, "demo", "/public", () => false)).toEqual([
+      "[post: demo] Image file not found: public/blog/demo/hero.webp",
+    ]);
+  });
+
+  it("accepts existing /blog/ images", () => {
+    const content = '![alt](/blog/demo/hero.webp)\n<img src="/blog/demo/b.png" />\n';
+    expect(findBlogImageErrors(content, "demo", "/public", () => true)).toEqual([]);
+  });
+});
+
+describe("collectBlogAssetErrors", () => {
+  it("combines H1 and image errors", () => {
+    const content = "# Title\n\n![x](/bad.png)\n";
+    expect(collectBlogAssetErrors(content, "demo", "/public", () => true)).toHaveLength(2);
+  });
+});
+
+describe("validateBlogAssets", () => {
+  it("skips when content directory is missing", () => {
+    const fs: BlogAssetFs = {
+      existsSync: () => false,
+      readFileSync: () => "",
+      readdirSync: () => [],
+    };
+    expect(validateBlogAssets("/missing", "/public", fs)).toEqual({
+      status: "skipped",
+    });
+  });
+
+  it("returns ok for clean MDX posts", () => {
+    const fs: BlogAssetFs = {
+      existsSync: (path) =>
+        path === "/content" || path === "/public/blog/demo/hero.webp",
+      readFileSync: () => "![alt](/blog/demo/hero.webp)\n\n## Section\n",
+      readdirSync: () => ["demo.mdx", "readme.txt"],
+    };
+    expect(validateBlogAssets("/content", "/public", fs)).toEqual({
+      status: "ok",
+    });
+  });
+
+  it("returns failed with duplicate H1 errors", () => {
+    const fs: BlogAssetFs = {
+      existsSync: (path) => path === "/content",
+      readFileSync: () => "# Title\n\nBody\n",
+      readdirSync: () => ["demo.mdx"],
+    };
+    const result = validateBlogAssets("/content", "/public", fs);
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.errors[0]).toContain("Duplicate H1");
+    }
+  });
+});
+
+describe("runValidateBlogAssetsCli", () => {
+  function mockIo() {
+    const logs: string[] = [];
+    const errors: string[] = [];
+    const exits: number[] = [];
+    return {
+      logs,
+      errors,
+      exits,
+      io: {
+        log: (message: string) => logs.push(message),
+        error: (message: string) => errors.push(message),
+        exit: (code: number) => exits.push(code),
+      },
+    };
+  }
+
+  it("logs skip and exits 0 when content dir is missing", () => {
+    const { io, logs, exits } = mockIo();
+    const fs: BlogAssetFs = {
+      existsSync: () => false,
+      readFileSync: () => "",
+      readdirSync: () => [],
+    };
+    runValidateBlogAssetsCli("/missing", "/public", io, fs);
+    expect(logs[0]).toContain("skipped");
+    expect(exits).toEqual([0]);
+  });
+
+  it("logs pass and exits 0 for clean posts", () => {
+    const { io, logs, exits } = mockIo();
+    const fs: BlogAssetFs = {
+      existsSync: (path) =>
+        path === "/content" || path === "/public/blog/demo/hero.webp",
+      readFileSync: () => "![alt](/blog/demo/hero.webp)\n",
+      readdirSync: () => ["demo.mdx"],
+    };
+    runValidateBlogAssetsCli("/content", "/public", io, fs);
+    expect(logs[0]).toContain("passed");
+    expect(exits).toEqual([0]);
+  });
+
+  it("prints failures and exits 1 for duplicate H1", () => {
+    const { io, errors, exits } = mockIo();
+    const fs: BlogAssetFs = {
+      existsSync: (path) => path === "/content",
+      readFileSync: () => "# Title\n",
+      readdirSync: () => ["demo.mdx"],
+    };
+    runValidateBlogAssetsCli("/content", "/public", io, fs);
+    expect(errors.some((line) => line.includes("Duplicate H1"))).toBe(true);
+    expect(exits).toEqual([1]);
+  });
+});

--- a/src/web/src/lib/blog/validate-assets.ts
+++ b/src/web/src/lib/blog/validate-assets.ts
@@ -1,0 +1,141 @@
+import { existsSync, readFileSync, readdirSync } from "fs";
+import { join } from "path";
+
+export type BlogAssetError = string;
+
+export type BlogAssetFs = {
+  existsSync: (path: string) => boolean;
+  readFileSync: (path: string, encoding: "utf-8") => string;
+  readdirSync: (path: string) => string[];
+};
+
+const defaultFs: BlogAssetFs = {
+  existsSync,
+  readFileSync: (path, encoding) => readFileSync(path, encoding),
+  readdirSync: (path) => readdirSync(path) as string[],
+};
+
+/** Markdown ATX `# Title` lines (not ## / ###). Page shell already owns the H1. */
+export function findDuplicateMdxH1Errors(
+  content: string,
+  slug: string
+): BlogAssetError[] {
+  const errors: BlogAssetError[] = [];
+  const h1Lines = content
+    .split("\n")
+    .map((line, index) => ({ line, index: index + 1 }))
+    .filter(({ line }) => /^# (?!#)/.test(line));
+  for (const { line, index } of h1Lines) {
+    errors.push(
+      `[post: ${slug}] Duplicate H1 at line ${index}: "${line}". Remove MDX "# Title" — the page template owns the single H1.`
+    );
+  }
+  return errors;
+}
+
+export function findBlogImageErrors(
+  content: string,
+  slug: string,
+  publicDir: string,
+  fileExists: (path: string) => boolean = existsSync
+): BlogAssetError[] {
+  const errors: BlogAssetError[] = [];
+  const imgRegex = /!\[[^\]]*\]\(([^)]*)\)|<img[^>]+src="([^"]*)"[^>]*>/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = imgRegex.exec(content)) !== null) {
+    const src = match[1] || match[2];
+
+    if (!src.startsWith("/blog/")) {
+      errors.push(
+        `[post: ${slug}] Image src "${src}" must start with /blog/ — move the file to public/blog/`
+      );
+      continue;
+    }
+
+    const filePath = join(publicDir, src);
+    if (!fileExists(filePath)) {
+      errors.push(`[post: ${slug}] Image file not found: public${src}`);
+    }
+  }
+  return errors;
+}
+
+export function collectBlogAssetErrors(
+  content: string,
+  slug: string,
+  publicDir: string,
+  fileExists: (path: string) => boolean = existsSync
+): BlogAssetError[] {
+  return [
+    ...findDuplicateMdxH1Errors(content, slug),
+    ...findBlogImageErrors(content, slug, publicDir, fileExists),
+  ];
+}
+
+export type ValidateBlogAssetsResult =
+  | { status: "skipped" }
+  | { status: "ok" }
+  | { status: "failed"; errors: BlogAssetError[] };
+
+/** Validate all MDX posts under contentDir against publicDir image files. */
+export function validateBlogAssets(
+  contentDir: string,
+  publicDir: string,
+  fs: BlogAssetFs = defaultFs
+): ValidateBlogAssetsResult {
+  if (!fs.existsSync(contentDir)) {
+    return { status: "skipped" };
+  }
+
+  const errors: BlogAssetError[] = [];
+  const mdxFiles = fs.readdirSync(contentDir).filter((f) => f.endsWith(".mdx"));
+
+  for (const file of mdxFiles) {
+    const slug = file.replace(/\.mdx$/, "");
+    const content = fs.readFileSync(join(contentDir, file), "utf-8");
+    errors.push(
+      ...collectBlogAssetErrors(content, slug, publicDir, fs.existsSync)
+    );
+  }
+
+  if (errors.length > 0) {
+    return { status: "failed", errors };
+  }
+  return { status: "ok" };
+}
+
+export type ValidateBlogAssetsIo = {
+  log: (message: string) => void;
+  error: (message: string) => void;
+  exit: (code: number) => void;
+};
+
+/** CLI entry used by scripts/validate-blog-assets.ts */
+export function runValidateBlogAssetsCli(
+  contentDir: string,
+  publicDir: string,
+  io: ValidateBlogAssetsIo,
+  fs: BlogAssetFs = defaultFs
+): void {
+  const result = validateBlogAssets(contentDir, publicDir, fs);
+
+  if (result.status === "skipped") {
+    io.log("✓ Blog asset validation skipped (no content directory).");
+    io.exit(0);
+    return;
+  }
+
+  if (result.status === "failed") {
+    io.error("Blog asset validation failed:\n");
+    for (const err of result.errors) {
+      io.error(`  ✗ ${err}`);
+    }
+    io.error(`\n${result.errors.length} error(s) found.`);
+    io.exit(1);
+    return;
+  }
+
+  io.log("✓ Blog asset validation passed.");
+  io.exit(0);
+}

--- a/src/web/src/mdx-components.test.ts
+++ b/src/web/src/mdx-components.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { useMDXComponents } from "../mdx-components";
+
+describe("useMDXComponents", () => {
+  it("suppresses MDX h1 so the page template owns the single H1", () => {
+    const components = useMDXComponents({});
+    expect(components.h1).toBeTypeOf("function");
+    expect(components.h1?.({} as never)).toBeNull();
+  });
+
+  it("preserves passed-through components", () => {
+    const p = () => "paragraph";
+    const components = useMDXComponents({ p });
+    expect(components.p).toBe(p);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
         "**/__mocks__/**",
         "**/*.d.ts",
         "src/cli/src/index.ts",
+        "src/web/scripts/**",
         "src/web/src/**/*.tsx",
         // React hooks (useEffect/useState/render-time refs) with no jsdom/RTL
         // test path — excluded for the same reason as the .tsx exclude above.


### PR DESCRIPTION
## Summary
- Blog post pages already render `<h1>` from `metadata.title` in `page.tsx`
- Removed matching MDX `# Title` headings that created a second H1 on:
  - `/blog/multi-agent-collaboration-without-code`
  - `/blog/ai-team-vs-ai-tools`
  - `/blog/multi-agent-workflow-patterns`
  - `/blog/ai-agent-team`
  - `/blog/ai-agent-orchestration`
  - `/blog/ai-agent-vs-chatbot`
  - `/blog/how-to-delegate-tasks-to-ai-agents`
  - `/blog/no-code-automation-ai-agents` (same issue)
- `/blog/human-ai-collaboration-small-teams` already had a single H1 on live (no MDX `#` title); no content change needed
- Suppress MDX `h1` in `mdx-components.tsx` and reject future MDX H1s in `validate:blog`

## Test plan
- [ ] After deploy, each listed URL has exactly one `<h1>`
- [ ] Title still appears once (page header), matches metadata
- [ ] `pnpm --filter @alook/web validate:blog` passes
- [ ] Confirm human-ai page still has a single H1


Made with [Cursor](https://cursor.com)