### PR TITLE
ci: run E2E UI on PRs, not as a release gate

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -1,20 +1,13 @@
 name: Auto-Tag & Release
 
-# Gated on the E2E UI workflow: only tags/releases after browser E2E passes on
-# the release commit. `workflow_run` payloads have no `head_commit` on
-# `github.event` directly — use `github.event.workflow_run.*` and pin the
-# checkout to the commit that triggered E2E.
 on:
-  workflow_run:
-    workflows: ["E2E UI"]
-    types: [completed]
+  push:
+    branches: [main]
 
 jobs:
   auto-tag-release:
     name: Tag & Release
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.event.workflow_run.head_commit.message, 'release: v')
+    if: "startsWith(github.event.head_commit.message, 'release: v')"
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -23,12 +16,11 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Extract version from commit message
         id: version
         env:
-          COMMIT_MSG: ${{ github.event.workflow_run.head_commit.message }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           VERSION=$(echo "$COMMIT_MSG" | grep -oP '^release: v\K[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?')
           if [ -z "$VERSION" ]; then

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -1,13 +1,18 @@
 name: E2E UI
 
 # Playwright browser E2E for the web UI (community today; extends to the full
-# UI over time). Runs ONLY on release commits (bump), and gates the release
-# chain: auto-tag-release and the publish-* workflows trigger on this
-# workflow's successful completion (see their `on: workflow_run`). If this
-# fails or is skipped, nothing ships.
+# UI over time). Runs on PRs that touch the web app, so UI regressions are
+# caught BEFORE merge — the right gate point (a `release:` bump only changes
+# version numbers, so gating there catches nothing). Keeps main green under a
+# PR-only workflow; releases inherit that green state.
 on:
-  push:
+  pull_request:
     branches: [main]
+    paths:
+      - "src/web/**"
+      - "src/shared/**"
+      - "src/ws-do/**"
+      - ".github/workflows/e2e-ui.yml"
 
 concurrency:
   group: e2e-ui-${{ github.ref }}
@@ -16,10 +21,6 @@ concurrency:
 jobs:
   e2e-ui:
     name: UI Playwright E2E
-    # Job-level gate: a non-release push skips this job, so the workflow run's
-    # conclusion is `skipped` (not `success`) and the downstream workflow_run
-    # guards won't fire.
-    if: "startsWith(github.event.head_commit.message, 'release: v')"
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:

--- a/.github/workflows/publish-app.yml
+++ b/.github/workflows/publish-app.yml
@@ -1,12 +1,9 @@
 name: Publish App
 
-# Gated on the E2E UI workflow (release chain). `workflow_run` doesn't
-# support `on.paths`, so the "did src/app/package.json change?" gate is done in
-# a job step via `git diff head_sha^ head_sha` (needs fetch-depth ≥ 2).
 on:
-  workflow_run:
-    workflows: ["E2E UI"]
-    types: [completed]
+  push:
+    branches: [main]
+    paths: [src/app/package.json]
 
 concurrency:
   group: publish-app
@@ -15,37 +12,21 @@ concurrency:
 jobs:
   publish:
     name: Publish @alook/app to npm
-    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       id-token: write
     steps:
       - uses: actions/checkout@v7
-        with:
-          fetch-depth: 2
-          ref: ${{ github.event.workflow_run.head_sha }}
-
-      - name: Check if src/app/package.json changed in this commit
-        id: changed
-        run: |
-          if git diff --name-only "${{ github.event.workflow_run.head_sha }}^" "${{ github.event.workflow_run.head_sha }}" | grep -qx 'src/app/package.json'; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::src/app/package.json unchanged — skipping"
-          fi
 
       - name: Detect version
         id: version
-        if: steps.changed.outputs.changed == 'true'
         run: |
           VERSION=$(node -p "require('./src/app/package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Check if version already published
         id: check
-        if: steps.changed.outputs.changed == 'true'
         run: |
           if npm view "@alook/app@${{ steps.version.outputs.version }}" version >/dev/null 2>&1; then
             echo "skip=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,12 +1,9 @@
 name: Publish CLI
 
-# Gated on the E2E UI workflow (release chain). `workflow_run` doesn't
-# support `on.paths`, so the "did src/cli/package.json change?" gate is done in
-# a job step via `git diff head_sha^ head_sha` (needs fetch-depth ≥ 2).
 on:
-  workflow_run:
-    workflows: ["E2E UI"]
-    types: [completed]
+  push:
+    branches: [main]
+    paths: [src/cli/package.json]
 
 concurrency:
   group: publish-cli
@@ -15,37 +12,21 @@ concurrency:
 jobs:
   publish:
     name: Publish @alook/cli to npm
-    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       id-token: write
     steps:
       - uses: actions/checkout@v7
-        with:
-          fetch-depth: 2
-          ref: ${{ github.event.workflow_run.head_sha }}
-
-      - name: Check if src/cli/package.json changed in this commit
-        id: changed
-        run: |
-          if git diff --name-only "${{ github.event.workflow_run.head_sha }}^" "${{ github.event.workflow_run.head_sha }}" | grep -qx 'src/cli/package.json'; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::src/cli/package.json unchanged — skipping"
-          fi
 
       - name: Detect version
         id: version
-        if: steps.changed.outputs.changed == 'true'
         run: |
           VERSION=$(node -p "require('./src/cli/package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Check if version already published
         id: check
-        if: steps.changed.outputs.changed == 'true'
         run: |
           if npm view "@alook/cli@${{ steps.version.outputs.version }}" version >/dev/null 2>&1; then
             echo "skip=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-daemon.yml
+++ b/.github/workflows/publish-daemon.yml
@@ -1,12 +1,9 @@
 name: Publish Daemon
 
-# Gated on the E2E UI workflow (release chain). `workflow_run` doesn't
-# support `on.paths`, so the "did src/daemon/package.json change?" gate is done
-# in a job step via `git diff head_sha^ head_sha` (needs fetch-depth ≥ 2).
 on:
-  workflow_run:
-    workflows: ["E2E UI"]
-    types: [completed]
+  push:
+    branches: [main]
+    paths: [src/daemon/package.json]
 
 concurrency:
   group: publish-daemon
@@ -15,37 +12,21 @@ concurrency:
 jobs:
   publish:
     name: Publish @alook/daemon to npm
-    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       id-token: write
     steps:
       - uses: actions/checkout@v7
-        with:
-          fetch-depth: 2
-          ref: ${{ github.event.workflow_run.head_sha }}
-
-      - name: Check if src/daemon/package.json changed in this commit
-        id: changed
-        run: |
-          if git diff --name-only "${{ github.event.workflow_run.head_sha }}^" "${{ github.event.workflow_run.head_sha }}" | grep -qx 'src/daemon/package.json'; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::src/daemon/package.json unchanged — skipping"
-          fi
 
       - name: Detect version
         id: version
-        if: steps.changed.outputs.changed == 'true'
         run: |
           VERSION=$(node -p "require('./src/daemon/package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Check if version already published
         id: check
-        if: steps.changed.outputs.changed == 'true'
         run: |
           if npm view "@alook/daemon@${{ steps.version.outputs.version }}" version >/dev/null 2>&1; then
             echo "skip=true" >> "$GITHUB_OUTPUT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,14 +36,16 @@ git push origin main
 
 This triggers:
 - **CI** — typecheck, lint, tests, coverage (uploaded to Codecov)
-- **E2E UI** — Playwright browser E2E runs on the `release: vX.Y.Z` commit (`e2e-ui.yml`). **This gates the release chain below**: Auto-Tag & Release and every `publish-*` workflow trigger on `on: workflow_run` completion of E2E UI and only run when its `conclusion == success`. If E2E fails or is skipped, nothing is tagged, released, or published.
-- **Auto-Tag & Release** — after E2E UI passes, creates the git tag + GitHub Release with generated changelog (`auto-tag-release.yml`). Reads `github.event.workflow_run.head_commit.message` and checks out `workflow_run.head_sha`.
-- **@alook/cli** → auto-published to npm via `publish-cli.yml` (self-gates on `src/cli/package.json` changing via `git diff`)
-- **@alook/app** → auto-published to npm via `publish-app.yml` (self-gates on `src/app/package.json`)
-- **@alook/daemon** → auto-published to npm via `publish-daemon.yml` (self-gates on `src/daemon/package.json`)
+- **Auto-Tag & Release** — CI detects the `release: vX.Y.Z` commit message, creates the git tag, and creates a GitHub Release with generated changelog (`auto-tag-release.yml`)
+- **@alook/cli** → auto-published to npm via `publish-cli.yml` (watches `src/cli/package.json`)
+- **@alook/app** → auto-published to npm via `publish-app.yml` (watches `src/app/package.json`)
+- **@alook/daemon** → auto-published to npm via `publish-daemon.yml` (watches `src/daemon/package.json`)
 - **CF Workers** → each module redeploys when its own `package.json` changes
 
-> **Bootstrap note:** the `workflow_run` gate only takes effect once `e2e-ui.yml` and the rewired downstream workflows exist on `main`. The first release after merging this change is the one that starts enforcing the gate.
+### E2E UI (browser tests)
+Playwright browser E2E for the web UI lives in `src/web/src/test/e2e-ui/` and runs via `e2e-ui.yml` **on PRs that touch `src/web`/`src/shared`/`src/ws-do`** — regressions are caught before merge, keeping main green. It is deliberately NOT tied to the release chain: a `release:` bump only changes version numbers, so gating there would test nothing, and the production web app deploys via Cloudflare's own Git integration (outside GitHub Actions) which a workflow gate can't block anyway. Run locally with `pnpm test:e2e-ui` (backs up and restores your local `.wrangler/state`).
+
+> **Don't mark "UI Playwright E2E" as a required status check** in branch protection as-is. Because it uses a `paths:` filter, a PR that doesn't touch those paths never starts the job, and a required check that never runs leaves the PR pending forever. Keep it advisory, or add an always-runs skip-job with the same check name first.
 
 ## Plan-driven Development
 - You must make a markdown plan at `plans/` before you implement any my request, otherwise I will reject your implementation.


### PR DESCRIPTION
## Why

The release-chain gate added in #371 was high-complexity, low-value — undoing it.

Two problems with gating the release on E2E UI:
1. **The production web app deploys via Cloudflare's own Git integration** (Workers Builds), *outside* GitHub Actions. No web/email/ws-do/wake deploy workflow exists in `.github/workflows/` — so a `workflow_run` gate could never actually block the prod deploy.
2. **A `release:` commit only bumps version numbers** (package.json + .deploy-version). Running browser E2E against it exercises zero UI change — it caught no real regression.

## What

- **E2E UI → `on: pull_request`** (`paths:` `src/web/**`, `src/shared/**`, `src/ws-do/**`, and the workflow file). Regressions are caught *before merge*, on the diff that introduces them — the correct gate point. Keeps main green; releases inherit that.
- **Revert `auto-tag-release` + `publish-{cli,app,daemon}` to `on: push`** — byte-identical to the pre-#371 baseline (`82657e9f`). Drops the `workflow_run` remapping, `head_sha` pinning, and in-job `git diff` self-gating (which only existed because `workflow_run` can't use `on.paths`). The npm-view idempotency guards are intact.
- **AGENTS.md** updated to describe the new model, incl. a caution: don't mark the paths-filtered "UI Playwright E2E" check *required* in branch protection without a skip-job (it'd stay pending forever on PRs that don't touch those paths).

## Verification

- 4 restored workflows: `git diff 82657e9f` → 0 lines (exact baseline).
- No leftover `workflow_run` / "E2E UI" references in the restored workflows.
- `actionlint` clean.
- Reviewed by a subagent: reasoning sound, paths filter correct, docs accurate — "ship it", with the required-check caution (now added to AGENTS.md).

## Note

This PR touches `src/web`? No — only `.github/` + AGENTS.md, so **this PR won't itself trigger E2E UI** (paths filter). The workflow change is validated by the next web-touching PR.