### PR TITLE
fix(blog): vary and sharpen SEO meta descriptions

### DIFF
--- a/src/web/src/content/ai-agent-orchestration.mdx
+++ b/src/web/src/content/ai-agent-orchestration.mdx
@@ -4,7 +4,7 @@ export const metadata = {
   date: "2026-06-03",
   author: "Alook Team",
   excerpt:
-    "AI orchestration coordinates multiple agents on a task without you in the loop. Learn how it works, what to orchestrate first, and how multi-agent workflow automation holds up in practice.",
+    "AI orchestration coordinates specialized agents through roles, handoffs, retries, and shared context. It covers first workflows and build-vs-buy tradeoffs.",
   readingTime: "5 min read",
   image: "/blog/ai-agent-orchestration/hero.webp",
 };

--- a/src/web/src/content/ai-agent-team.mdx
+++ b/src/web/src/content/ai-agent-team.mdx
@@ -4,7 +4,7 @@ export const metadata = {
   date: "2026-06-08",
   author: "Alook Team",
   excerpt:
-    "Learn how to build an AI agent team around one reliable workflow, with clear roles, shared context, tested handoffs, and human approval.",
+    "Build an AI agent team around one reliable workflow with defined roles, structured handoffs, shared context, failure paths, and human approval.",
   readingTime: "7 min read",
   image: "/blog/ai-agent-team/hero.webp",
 };

--- a/src/web/src/content/ai-agent-vs-chatbot.mdx
+++ b/src/web/src/content/ai-agent-vs-chatbot.mdx
@@ -4,7 +4,7 @@ export const metadata = {
   date: "2026-06-03",
   author: "Alook Team",
   excerpt:
-    "AI agent vs chatbot comes down to initiative. A chatbot waits for a prompt. An AI agent can pursue a goal with tools, state, and a trigger.",
+    "AI agent vs chatbot: chatbots answer prompts, while agents pursue goals with tools, state, and triggers. Compare their limits and choose the right fit.",
   readingTime: "6 min read",
   image: "/blog/ai-agent-vs-chatbot/hero.webp",
 };

--- a/src/web/src/content/ai-team-vs-ai-tools.mdx
+++ b/src/web/src/content/ai-team-vs-ai-tools.mdx
@@ -3,7 +3,7 @@ export const metadata = {
   title: 'AI Team vs AI Tools: Stop Being the Human Copy-Paste Between Your Coding Agents',
   date: '2026-06-15',
   author: 'Donia',
-  excerpt: 'Every context switch between Claude Code, Cursor, and Windsurf costs you 23 minutes. Learn how AI teams eliminate the human bottleneck in your development workflow.',
+  excerpt: 'AI team vs AI tools comes down to coordination. Isolated coding assistants lose context; a coordinated team shares decisions, handoffs, and workflow state.',
   readingTime: '8 min read'
 };
 

--- a/src/web/src/content/claude-code-dynamic-workflow-alternative.mdx
+++ b/src/web/src/content/claude-code-dynamic-workflow-alternative.mdx
@@ -4,7 +4,7 @@ export const metadata = {
   date: "2026-06-01",
   author: "Alook Team",
   excerpt:
-    "Claude Code's dynamic workflows orchestrate 100+ agents from JavaScript. Powerful for one-shot tasks. But what if you need team coordination, persistent memory, or multi-day workflows? Compare script orchestration vs email-based coordination.",
+    "Claude Code dynamic workflows suit one-shot parallel tasks. Email-based agent coordination adds persistent context, multi-day handoffs, and team visibility.",
   readingTime: "4 min read",
 };
 

--- a/src/web/src/content/how-to-delegate-tasks-to-ai-agents.mdx
+++ b/src/web/src/content/how-to-delegate-tasks-to-ai-agents.mdx
@@ -4,7 +4,7 @@ export const metadata = {
   date: "2026-06-03",
   author: "Alook Team",
   excerpt:
-    "Learn how to delegate tasks to AI agents: pick a stable job, write specific instructions, run supervised, then set a review boundary.",
+    "Delegate tasks to AI agents with a five-step method for choosing stable work, writing instructions, supervising early runs, and setting review boundaries.",
   readingTime: "7 min read",
   image: "/blog/how-to-delegate-tasks-to-ai-agents/hero.webp",
 };

--- a/src/web/src/content/human-ai-collaboration-small-teams.mdx
+++ b/src/web/src/content/human-ai-collaboration-small-teams.mdx
@@ -4,7 +4,7 @@ export const metadata = {
   date: "2026-06-30",
   author: "Donia",
   excerpt:
-    "Human-AI collaboration has moved past chatbots. For small teams and solo founders, the real question is how to manage multiple AI agents as a coordinated workforce.",
+    "Human-AI collaboration for small teams evolves from command-and-response tools to coordinated agents, shared context, parallel work, and human approval.",
   readingTime: "7 min read",
 };
 

--- a/src/web/src/content/multi-agent-collaboration-without-code.mdx
+++ b/src/web/src/content/multi-agent-collaboration-without-code.mdx
@@ -4,7 +4,7 @@ export const metadata = {
   date: "2026-07-07",
   author: "Alook Team",
   excerpt:
-    "Running more AI agents in parallel is not collaboration. Learn how multi-agent collaboration works without code, scripts, or workflow builders.",
+    "Multi-agent collaboration needs more than parallel runs. Shared context, specialized roles, autonomous handoffs, and communication make it work without code.",
   readingTime: "4 min read",
 };
 

--- a/src/web/src/content/multi-agent-workflow-patterns.mdx
+++ b/src/web/src/content/multi-agent-workflow-patterns.mdx
@@ -4,7 +4,7 @@ export const metadata = {
   date: "2026-06-11",
   author: "Alook Team",
   excerpt:
-    "Learn seven practical multi-agent workflow patterns for AI coding agents, with roles, handoffs, review points, and limits for each pattern.",
+    "Seven multi-agent workflow patterns for AI coding agents, from bug-to-PR and releases to research briefs, documentation, monitoring, and follow-up.",
   readingTime: "8 min read",
   image: "/blog/multi-agent-workflow-patterns/hero.webp",
 };

--- a/src/web/src/content/no-code-automation-ai-agents.mdx
+++ b/src/web/src/content/no-code-automation-ai-agents.mdx
@@ -4,7 +4,7 @@ export const metadata = {
   date: "2026-07-14",
   author: "Alook Team",
   excerpt:
-    "No-code automation means setting a trigger and an action between apps, without writing code. Learn what that covers, where fixed rules stall, and when AI agents take over.",
+    "No-code automation handles trigger-and-action tasks across apps. When work needs judgment, AI agents add roles, handoffs, shared context, and review points.",
   readingTime: "6 min read",
   image: "/blog/no-code-automation-ai-agents/hero.webp",
 };

--- a/src/web/src/content/personal-ai-company.mdx
+++ b/src/web/src/content/personal-ai-company.mdx
@@ -4,7 +4,7 @@ export const metadata = {
   date: "2026-06-10",
   author: "Alook Team",
   excerpt:
-    "A practical guide to building a one-person business with AI agents, including which workflows to delegate, where human approval belongs, and how orchestration keeps the work connected.",
+    "Build a one-person business with AI agents through repeatable workflows, defined handoffs, limited access, and human approval for high-impact work.",
   readingTime: "6 min read",
   image: "/blog/personal-ai-company/hero.webp",
 };

--- a/src/web/src/content/why-we-built-alook.mdx
+++ b/src/web/src/content/why-we-built-alook.mdx
@@ -4,7 +4,7 @@ export const metadata = {
   date: "2026-05-15",
   author: "Gus",
   excerpt:
-    "Agents got powerful. I got more anxious. The problem was never AI capability — it was that I became the bottleneck.",
+    "Why we built Alook: powerful coding agents still left one person routing context between sessions. A shared coordination layer became the missing piece.",
   readingTime: "4 min read",
 };
 


### PR DESCRIPTION
## Summary
- rewrite all 12 published blog meta descriptions around each page's actual search intent and content structure
- remove repeated `Learn...` templates while keeping primary topics near the beginning
- replace unsupported numerical hooks with specific, verifiable page scope
- keep every description unique and between 143–157 characters

## Test plan
- [x] `pnpm --filter @alook/web validate:blog`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] audit confirms zero `Learn` occurrences, unique descriptions, and no unsupported stats/ROI claims

Made with [Cursor](https://cursor.com)