### PR TITLE
fix(community): show correct self profile from UserBar on /c/me

### DIFF
--- a/src/web/src/components/community/profile-lookup.test.ts
+++ b/src/web/src/components/community/profile-lookup.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest"
-import { resolveProfileTarget } from "./profile-lookup"
+import { resolveProfileTarget, buildSelfProfile } from "./profile-lookup"
 import type { Member, Friend } from "./_types"
+import type { CurrentUser } from "@/contexts/community/current-user"
 
 function member(overrides: Partial<Member>): Member {
   return {
@@ -44,5 +45,41 @@ describe("resolveProfileTarget", () => {
   it("checks friends when userId doesn't match any member", () => {
     const friend: Friend = { id: "fr_a", userId: "user_c", name: "Ren", avatar: "R", status: "online", sub: "" }
     expect(resolveProfileTarget([], [friend], { name: "Ren", userId: "user_c" })).toBe(friend)
+  })
+})
+
+function currentUser(overrides: Partial<CurrentUser> = {}): CurrentUser {
+  return {
+    id: overrides.id ?? "user_self",
+    name: overrides.name ?? "Me",
+    email: overrides.email ?? "me@example.com",
+    avatar: overrides.avatar ?? "M",
+    aboutMe: overrides.aboutMe,
+    discriminator: overrides.discriminator,
+    statusEmoji: overrides.statusEmoji,
+    statusText: overrides.statusText,
+  }
+}
+
+describe("buildSelfProfile", () => {
+  it("builds the viewer's own card from currentUser, independent of any member/friend list — regression for the /c/me UserBar bug where a same-named friend was shown instead of the viewer", () => {
+    const me = currentUser({ id: "user_self", name: "Ren", discriminator: "0001", aboutMe: "hi" })
+    const profile = buildSelfProfile(me, new Set())
+
+    expect(profile.userId).toBe("user_self")
+    expect(profile.name).toBe("Ren")
+    expect(profile.discriminator).toBe("0001")
+    expect(profile.about).toBe("hi")
+    expect(profile.role).toBe("You")
+  })
+
+  it("always resolves self presence to online, even when the viewer's id is absent from the online set", () => {
+    const profile = buildSelfProfile(currentUser({ id: "user_self" }), new Set())
+    expect(profile.presence).toBe("online")
+  })
+
+  it("falls back to an avatar initial when the viewer has no avatar", () => {
+    const profile = buildSelfProfile(currentUser({ name: "alice", avatar: "" }), new Set())
+    expect(profile.avatar).toBe("A")
   })
 })

--- a/src/web/src/components/community/profile-lookup.ts
+++ b/src/web/src/components/community/profile-lookup.ts
@@ -1,4 +1,33 @@
-import type { Member, Friend } from "./_types"
+import type { Member, Friend, Profile } from "./_types"
+import type { CurrentUser } from "@/contexts/community/current-user"
+import { resolveProfilePresence } from "@/lib/community/presence"
+import { avatarInitial } from "@/lib/community/avatar"
+
+/**
+ * The signed-in viewer's own profile card, built straight from `currentUser`.
+ *
+ * A profile-card click that already knows it targets the viewer (UserBar, or
+ * any caller passing the viewer's own userId) resolves here instead of through
+ * `resolveProfileTarget`. Name-based resolution can't be trusted for self: the
+ * viewer's own member row only exists in `members` while a server is active, so
+ * on `/c/me` the name-only fallback would match a same-named friend (or miss
+ * entirely) and show the wrong person.
+ */
+export function buildSelfProfile(
+  currentUser: CurrentUser,
+  onlineUserIds: ReadonlySet<string>,
+): Profile {
+  return {
+    name: currentUser.name,
+    userId: currentUser.id,
+    discriminator: currentUser.discriminator,
+    avatar: currentUser.avatar || avatarInitial(currentUser.name),
+    role: "You",
+    about: currentUser.aboutMe ?? "",
+    mutual: 0,
+    presence: resolveProfilePresence(true, undefined, onlineUserIds),
+  }
+}
 
 /**
  * Resolves the exact member/friend a profile-card click refers to.

--- a/src/web/src/components/community/shell-frame.tsx
+++ b/src/web/src/components/community/shell-frame.tsx
@@ -23,7 +23,7 @@ import { ImageLightbox } from "./image-lightbox"
 import { ImageCropDialog } from "./image-crop-dialog"
 import { validateIconSourceFile } from "@/lib/community/image-crop"
 import type { MobileZone, Profile, View } from "./_types"
-import { resolveProfileTarget } from "./profile-lookup"
+import { resolveProfileTarget, buildSelfProfile } from "./profile-lookup"
 import { resolveProfilePresence } from "@/lib/community/presence"
 import { avatarInitial } from "@/lib/community/avatar"
 import { signOut } from "@/lib/auth-client"
@@ -310,18 +310,8 @@ export function ShellFrame({
     (name: string, e: React.MouseEvent, discriminator?: string, targetUserId?: string) => {
       const isSelf = !!targetUserId && targetUserId === currentUser.id
       if (isSelf) {
-        const data: Profile = {
-          name: currentUser.name,
-          userId: currentUser.id,
-          discriminator: currentUser.discriminator,
-          avatar: currentUser.avatar || avatarInitial(currentUser.name),
-          role: "You",
-          about: currentUser.aboutMe ?? "",
-          mutual: 0,
-          presence: resolveProfilePresence(true, undefined, onlineUserIds),
-        }
         setProfile({
-          data,
+          data: buildSelfProfile(currentUser, onlineUserIds),
           x: e.clientX,
           y: e.clientY,
           initialStatusEmoji: currentUser.statusEmoji ?? null,

--- a/src/web/src/components/community/user-bar.tsx
+++ b/src/web/src/components/community/user-bar.tsx
@@ -36,10 +36,10 @@ function Inner({ user, onOpenProfile, onEditProfile, inbox, hasUnread }: {
 }) {
   return (
     <div className="flex flex-1 items-center gap-2">
-      <button onClick={(e) => onOpenProfile?.(user.name, e)} className="shrink-0 rounded-full focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none">
+      <button onClick={(e) => onOpenProfile?.(user.name, e, undefined, user.id)} className="shrink-0 rounded-full focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none">
         <Avatar label={user.avatar} seed={user.id} size={28} presence={resolveProfilePresence(true, user.id, EMPTY_ONLINE_SET)} ringColor="var(--muted)" />
       </button>
-      <button onClick={(e) => onOpenProfile?.(user.name, e)} className="min-w-0 flex-1 text-left rounded focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none">
+      <button onClick={(e) => onOpenProfile?.(user.name, e, undefined, user.id)} className="min-w-0 flex-1 text-left rounded focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none">
         <div className="truncate text-sm font-medium leading-tight">{user.name}</div>
       </button>
       <div className="flex items-center gap-1">


### PR DESCRIPTION
## Problem

Clicking your own avatar/name in the bottom-left UserBar showed the **wrong** user profile on `/c/me`, while it worked correctly inside a server view.

## Root cause

UserBar's avatar/name click passed only the display name to `openProfile`, never the viewer's `userId`. `openProfile`'s self-detection keys off that `userId` (`isSelf = !!targetUserId && targetUserId === currentUser.id`), so `isSelf` was always `false` and resolution fell through to the **name-only** branch of `resolveProfileTarget`.

- **Server view**: the viewer's own member row is present in the server roster, so the name match happened to land → looked correct.
- **`/c/me`**: the server roster is empty (`useServerMembers` is disabled when `serverId` is null), so the fallback matched a same-named *friend* — or nothing — and showed the wrong profile.

Every other caller (`member-list`, `server-settings`, `thread-opener`, `message`) already passes a `userId`; UserBar was the only one that had `user.id` on hand but didn't pass it.

## Fix

- Pass `user.id` from UserBar so `isSelf` short-circuits to the viewer's own card in **both** contexts.
- Extract the self-profile builder into `profile-lookup` as `buildSelfProfile` so the self branch is unit-testable (this repo has no jsdom/render harness — same reason `resolveProfileTarget` was extracted).

## Tests

Added `buildSelfProfile` cases to `profile-lookup.test.ts`:
- builds the viewer's own card from `currentUser`, independent of any member/friend list (regression for the `/c/me` bug)
- self presence always resolves to `online`
- avatar-initial fallback when the viewer has no avatar

`pnpm typecheck` + full web test suite pass.