### PR TITLE
feat(web): blog editorial lint (FAIL/WARN)

### DIFF
--- a/src/web/package.json
+++ b/src/web/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "tsx scripts/validate-blog-assets.ts && next build",
-    "validate:blog": "tsx scripts/validate-blog-assets.ts",
+    "validate:blog": "tsx scripts/validate-blog-assets.ts && tsx scripts/check-blog-editorial.ts --report",
+    "validate:blog:editorial": "tsx scripts/check-blog-editorial.ts",
+    "validate:blog:editorial:strict": "tsx scripts/check-blog-editorial.ts --strict",
     "start": "next start",
     "lint": "eslint src/",
     "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",

--- a/src/web/scripts/check-blog-editorial.ts
+++ b/src/web/scripts/check-blog-editorial.ts
@@ -1,0 +1,15 @@
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import { runCheckBlogEditorialCli } from "../src/lib/blog/check-editorial";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const contentDir = join(__dirname, "..", "src", "content");
+
+const strict = process.argv.includes("--strict");
+const reportOnly = process.argv.includes("--report");
+
+runCheckBlogEditorialCli(contentDir, {
+  log: console.log.bind(console),
+  error: console.error.bind(console),
+  exit: process.exit.bind(process),
+}, { strict, reportOnly });

--- a/src/web/src/lib/blog/check-editorial.test.ts
+++ b/src/web/src/lib/blog/check-editorial.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import {
+  CANONICAL_PRODUCT_SLUG,
+  PRODUCT_BOILERPLATE,
+  checkBlogEditorial,
+  countExternalLinks,
+  countWords,
+  firstNWords,
+  paragraphLengthStdev,
+  parseMdxFile,
+  sentenceCount,
+  splitParagraphs,
+  stripMdxForProse,
+} from "./check-editorial";
+
+describe("stripMdxForProse", () => {
+  it("removes metadata and code blocks", () => {
+    const content = [
+      'export const metadata = { title: "T", slug: "demo" };',
+      "",
+      "```js",
+      "code()",
+      "```",
+      "",
+      "Hello world.",
+    ].join("\n");
+    expect(stripMdxForProse(content)).toBe("Hello world.");
+  });
+});
+
+describe("parseMdxFile", () => {
+  it("reads title from metadata export", () => {
+    const parsed = parseMdxFile(
+      "demo",
+      'export const metadata = { title: "Short title", slug: "demo" };\n\nBody text.'
+    );
+    expect(parsed.title).toBe("Short title");
+    expect(parsed.bodyProse).toContain("Body text.");
+  });
+});
+
+describe("paragraphLengthStdev", () => {
+  it("returns low stdev for uniform paragraphs", () => {
+    const paragraphs = ["One. Two.", "Three. Four.", "Five. Six."];
+    expect(paragraphLengthStdev(paragraphs)).toBeLessThanOrEqual(1.5);
+  });
+
+  it("returns higher stdev for mixed lengths", () => {
+    const paragraphs = ["One.", "Two. Three. Four. Five. Six.", "Seven."];
+    expect(paragraphLengthStdev(paragraphs)).toBeGreaterThan(1.5);
+  });
+});
+
+describe("countExternalLinks", () => {
+  it("counts third-party links and ignores alook", () => {
+    const md = [
+      "[HBR](https://hbr.org/example)",
+      "[Docs](https://code.claude.com/docs)",
+      "[Alook](https://alook.ai)",
+      "[GH](https://github.com/alookai/alook)",
+    ].join("\n");
+    expect(countExternalLinks(md)).toBe(2);
+  });
+});
+
+describe("checkBlogEditorial", () => {
+  it("fails when title exceeds 60 characters", () => {
+    const longTitle = "A".repeat(61);
+    const findings = checkBlogEditorial([
+      parseMdxFile(
+        "demo",
+        `export const metadata = { title: "${longTitle}" };\n\nBody with enough words. [a](https://example.com/a) [b](https://example.com/b)`
+      ),
+    ]);
+    expect(findings.some((f) => f.rule === "title-length" && f.severity === "fail")).toBe(
+      true
+    );
+  });
+
+  it("fails when opening 100 words mention alook.ai", () => {
+    const findings = checkBlogEditorial([
+      parseMdxFile(
+        "demo",
+        'export const metadata = { title: "T" };\n\nVisit [Alook](https://alook.ai) first. More text here with [a](https://example.com/a) and [b](https://example.com/b).'
+      ),
+    ]);
+    expect(findings.some((f) => f.rule === "opening-alook")).toBe(true);
+  });
+
+  it("warns on corpus product boilerplate duplication", () => {
+    const body = `${PRODUCT_BOILERPLATE}\n\nExtra. [a](https://a.com) [b](https://b.com)`;
+    const findings = checkBlogEditorial([
+      parseMdxFile(CANONICAL_PRODUCT_SLUG, `export const metadata = { title: "T" };\n\n${body}`),
+      parseMdxFile("other-post", `export const metadata = { title: "T" };\n\n${body}`),
+    ]);
+    expect(findings.some((f) => f.rule === "corpus-product-boilerplate")).toBe(true);
+  });
+
+  it("passes a minimal valid post", () => {
+    const content = [
+      'export const metadata = { title: "Agent teams" };',
+      "",
+      "Stripe webhooks failed twice last week before we fixed handoffs.",
+      "",
+      "See [HBR](https://hbr.org/2026/06/example) and [Anthropic](https://code.claude.com/docs).",
+    ].join("\n");
+    const findings = checkBlogEditorial([parseMdxFile("good-post", content)]);
+    expect(findings.filter((f) => f.severity === "fail")).toEqual([]);
+  });
+});
+
+describe("sentenceCount", () => {
+  it("counts sentences in a paragraph", () => {
+    expect(sentenceCount("One. Two! Three?")).toBe(3);
+    expect(sentenceCount("Single")).toBe(1);
+  });
+});
+
+describe("firstNWords", () => {
+  it("returns the first n words", () => {
+    expect(firstNWords("alpha beta gamma", 2)).toBe("alpha beta");
+  });
+});
+
+describe("splitParagraphs", () => {
+  it("splits on blank lines", () => {
+    expect(splitParagraphs("A\n\nB")).toEqual(["A", "B"]);
+  });
+});
+
+describe("countWords", () => {
+  it("counts words", () => {
+    expect(countWords("one two three")).toBe(3);
+  });
+});

--- a/src/web/src/lib/blog/check-editorial.ts
+++ b/src/web/src/lib/blog/check-editorial.ts
@@ -1,0 +1,367 @@
+import { readFileSync, readdirSync } from "fs";
+import { join } from "path";
+
+export type EditorialSeverity = "fail" | "warn";
+
+export type EditorialFinding = {
+  severity: EditorialSeverity;
+  slug?: string;
+  rule: string;
+  message: string;
+};
+
+export const PRODUCT_BOILERPLATE =
+  "Alook currently supports Claude Code, Codex, and OpenCode. Cursor, Hermes, and OpenClaw are listed as coming soon.";
+
+export const PRODUCT_BOILERPLATE_PREFIX = "Alook currently supports Claude Code, Codex, and OpenCode";
+
+export const CANONICAL_PRODUCT_SLUG = "ai-agent-team";
+
+export const HIGH_RECOGNITION_PHRASES = [
+  "shared context",
+  "the bottleneck",
+  "you become the router",
+  "you become the message bus",
+  "human middleware",
+  "start with one workflow",
+  "the trouble starts",
+  "the value comes from",
+] as const;
+
+const SENTENCE_START_BANS = [
+  /^Additionally\b/i,
+  /^Furthermore\b/i,
+  /^Moreover\b/i,
+  /^In essence\b/i,
+  /^Essentially\b/i,
+  /^At its core\b/i,
+  /^It's worth noting\b/i,
+];
+
+const PHRASE_BANS = [
+  /\bLet's dive in\b/i,
+  /\bThe real question is\b/i,
+  /\bIn conclusion\b/i,
+];
+
+const VAGUE_ATTRIBUTION = [
+  /according to industry reports/i,
+  /\bstudies show\b/i,
+  /\bexperts argue\b/i,
+];
+
+const NOT_JUST_BUT = /\bnot just\b[^.!?]{0,120}\bbut\b/gi;
+
+export type ParsedMdx = {
+  slug: string;
+  title: string;
+  bodyProse: string;
+  bodyLinks: string;
+};
+
+export function stripMdxForLinkCheck(content: string): string {
+  let text = content;
+  text = text.replace(/export const metadata\s*=\s*\{[\s\S]*?\};\s*/m, "");
+  text = text.replace(/export const jsonLd\s*=\s*\[[\s\S]*?\];\s*/m, "");
+  text = text.replace(/```[\s\S]*?```/g, "\n");
+  return text;
+}
+
+export function stripMdxForProse(content: string): string {
+  let text = stripMdxForLinkCheck(content);
+  text = text.replace(/!\[[^\]]*\]\([^)]*\)/g, "\n");
+  text = text.replace(/<img[^>]*>/gi, "\n");
+  text = text.replace(/^#{1,6}\s+.*$/gm, "\n");
+  text = text.replace(/^\s*[-*+]\s+/gm, "");
+  text = text.replace(/^\s*\d+\.\s+/gm, "");
+  text = text.replace(/\|/g, " ");
+  text = text.replace(/\*\*([^*]+)\*\*/g, "$1");
+  text = text.replace(/\*([^*]+)\*/g, "$1");
+  text = text.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1");
+  text = text.replace(/\n{3,}/g, "\n\n");
+  return text.trim();
+}
+
+export function parseMdxFile(slug: string, content: string): ParsedMdx {
+  const titleMatch = content.match(/title:\s*["']([^"']+)["']/);
+  const title = titleMatch?.[1] ?? slug;
+  const bodyLinks = stripMdxForLinkCheck(content);
+  const bodyProse = stripMdxForProse(content);
+  return { slug, title, bodyProse, bodyLinks };
+}
+
+export function countWords(text: string): number {
+  const words = text.trim().split(/\s+/).filter(Boolean);
+  return words.length;
+}
+
+export function firstNWords(text: string, n: number): string {
+  return text.trim().split(/\s+/).slice(0, n).join(" ");
+}
+
+export function splitParagraphs(prose: string): string[] {
+  return prose
+    .split(/\n\s*\n/)
+    .map((p) => p.replace(/\s+/g, " ").trim())
+    .filter((p) => p.length > 0 && !/^export\b/.test(p));
+}
+
+export function sentenceCount(paragraph: string): number {
+  const parts = paragraph
+    .split(/[.!?]+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return Math.max(parts.length, 1);
+}
+
+export function paragraphLengthStdev(paragraphs: string[]): number {
+  if (paragraphs.length < 2) return 2;
+  const counts = paragraphs.map((p) => sentenceCount(p));
+  const mean = counts.reduce((a, b) => a + b, 0) / counts.length;
+  const variance =
+    counts.reduce((sum, c) => sum + (c - mean) ** 2, 0) / counts.length;
+  return Math.sqrt(variance);
+}
+
+export function countExternalLinks(content: string): number {
+  const links = [...content.matchAll(/\[[^\]]*\]\((https?:\/\/[^)]+)\)/g)].map(
+    (m) => m[1]!
+  );
+  const bare = [...content.matchAll(/(?<!\])\((https?:\/\/[^)]+)\)/g)].map(
+    (m) => m[1]!
+  );
+  const all = [...links, ...bare];
+  const thirdParty = all.filter((url) => {
+    const lower = url.toLowerCase();
+    return (
+      !lower.includes("alook.ai") &&
+      !lower.includes("github.com/alookai")
+    );
+  });
+  return new Set(thirdParty).size;
+}
+
+function checkPerPost(parsed: ParsedMdx): EditorialFinding[] {
+  const findings: EditorialFinding[] = [];
+  const { slug, title, bodyProse, bodyLinks } = parsed;
+
+  if (title.length > 60) {
+    findings.push({
+      severity: "fail",
+      slug,
+      rule: "title-length",
+      message: `Title is ${title.length} chars (max 60): "${title}"`,
+    });
+  }
+
+  const opening = firstNWords(bodyLinks, 100).toLowerCase();
+  if (opening.includes("alook.ai") || opening.includes("npx @alook/app onboard")) {
+    findings.push({
+      severity: "fail",
+      slug,
+      rule: "opening-alook",
+      message: "First 100 words contain alook.ai or onboard CTA",
+    });
+  }
+
+  const externalLinks = countExternalLinks(bodyLinks);
+  if (externalLinks < 2) {
+    findings.push({
+      severity: "fail",
+      slug,
+      rule: "external-links",
+      message: `Only ${externalLinks} third-party link(s) in body (need ≥2)`,
+    });
+  }
+
+  for (const pattern of VAGUE_ATTRIBUTION) {
+    if (pattern.test(bodyProse)) {
+      findings.push({
+        severity: "fail",
+        slug,
+        rule: "vague-attribution",
+        message: `Vague attribution matched: ${pattern}`,
+      });
+    }
+  }
+
+  for (const line of bodyProse.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    for (const pattern of SENTENCE_START_BANS) {
+      if (pattern.test(trimmed)) {
+        findings.push({
+          severity: "fail",
+          slug,
+          rule: "ai-sentence-start",
+          message: `Banned sentence start: "${trimmed.slice(0, 60)}..."`,
+        });
+      }
+    }
+  }
+
+  const paragraphs = splitParagraphs(bodyProse);
+  const stdev = paragraphLengthStdev(paragraphs);
+  if (paragraphs.length >= 3 && stdev <= 1.5) {
+    findings.push({
+      severity: "warn",
+      slug,
+      rule: "paragraph-stdev",
+      message: `Paragraph sentence-count stdev is ${stdev.toFixed(2)} (target > 1.5)`,
+    });
+  }
+
+  for (let i = 0; i + 2 < paragraphs.length; i++) {
+    const a = sentenceCount(paragraphs[i]!);
+    const b = sentenceCount(paragraphs[i + 1]!);
+    const c = sentenceCount(paragraphs[i + 2]!);
+    if (a === b && b === c) {
+      findings.push({
+        severity: "warn",
+        slug,
+        rule: "paragraph-rhythm",
+        message: `Three consecutive paragraphs with ${a} sentence(s) each (around paragraph ${i + 1})`,
+      });
+      break;
+    }
+  }
+
+  for (const pattern of PHRASE_BANS) {
+    if (pattern.test(bodyProse)) {
+      findings.push({
+        severity: "warn",
+        slug,
+        rule: "ai-phrase",
+        message: `Template phrase matched: ${pattern}`,
+      });
+    }
+  }
+
+  const notJustMatches = bodyProse.match(NOT_JUST_BUT) ?? [];
+  if (notJustMatches.length > 2) {
+    findings.push({
+      severity: "warn",
+      slug,
+      rule: "not-just-but",
+      message: `"Not just X but Y" appears ${notJustMatches.length} times (max 2)`,
+    });
+  }
+
+  if (
+    bodyProse.includes(PRODUCT_BOILERPLATE) &&
+    slug !== CANONICAL_PRODUCT_SLUG
+  ) {
+    findings.push({
+      severity: "warn",
+      slug,
+      rule: "product-boilerplate-body",
+      message:
+        "Full product capability sentence in body — link to /blog/ai-agent-team instead",
+    });
+  }
+
+  return findings;
+}
+
+function checkCorpus(all: ParsedMdx[]): EditorialFinding[] {
+  const findings: EditorialFinding[] = [];
+
+  const boilerplatePosts = all.filter((p) =>
+    p.bodyProse.includes(PRODUCT_BOILERPLATE)
+  );
+  if (boilerplatePosts.length > 1) {
+    findings.push({
+      severity: "warn",
+      rule: "corpus-product-boilerplate",
+      message: `Full product sentence in body of ${boilerplatePosts.length} posts: ${boilerplatePosts.map((p) => p.slug).join(", ")} (max 1; canonical: ${CANONICAL_PRODUCT_SLUG})`,
+    });
+  }
+
+  for (const phrase of HIGH_RECOGNITION_PHRASES) {
+    const hits = all.filter((p) =>
+      p.bodyProse.toLowerCase().includes(phrase.toLowerCase())
+    );
+    if (hits.length > 1) {
+      findings.push({
+        severity: "warn",
+        rule: "corpus-phrase",
+        message: `"${phrase}" in ${hits.length} posts: ${hits.map((p) => p.slug).join(", ")}`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+export function checkBlogEditorial(
+  posts: ParsedMdx[]
+): EditorialFinding[] {
+  const perPost = posts.flatMap((p) => checkPerPost(p));
+  const corpus = checkCorpus(posts);
+  return [...perPost, ...corpus];
+}
+
+export function loadBlogPostsFromDir(contentDir: string): ParsedMdx[] {
+  const files = readdirSync(contentDir).filter((f) => f.endsWith(".mdx"));
+  return files.map((file) => {
+    const slug = file.replace(/\.mdx$/, "");
+    const content = readFileSync(join(contentDir, file), "utf-8");
+    return parseMdxFile(slug, content);
+  });
+}
+
+export type EditorialCheckIo = {
+  log: (message: string) => void;
+  error: (message: string) => void;
+  exit: (code: number) => void;
+};
+
+export function formatEditorialReport(findings: EditorialFinding[]): string {
+  const fails = findings.filter((f) => f.severity === "fail");
+  const warns = findings.filter((f) => f.severity === "warn");
+  const lines: string[] = [];
+  if (fails.length === 0 && warns.length === 0) {
+    return "✓ Blog editorial check passed.";
+  }
+  for (const f of fails) {
+    const prefix = f.slug ? `[${f.slug}]` : "[corpus]";
+    lines.push(`FAIL ${prefix} ${f.rule}: ${f.message}`);
+  }
+  for (const f of warns) {
+    const prefix = f.slug ? `[${f.slug}]` : "[corpus]";
+    lines.push(`WARN ${prefix} ${f.rule}: ${f.message}`);
+  }
+  lines.push("");
+  lines.push(`Summary: ${fails.length} fail(s), ${warns.length} warn(s)`);
+  return lines.join("\n");
+}
+
+export function runCheckBlogEditorialCli(
+  contentDir: string,
+  io: EditorialCheckIo,
+  options: { strict?: boolean; reportOnly?: boolean } = {}
+): void {
+  const posts = loadBlogPostsFromDir(contentDir);
+  const findings = checkBlogEditorial(posts);
+  const fails = findings.filter((f) => f.severity === "fail");
+  const warns = findings.filter((f) => f.severity === "warn");
+
+  io.log(formatEditorialReport(findings));
+
+  if (options.reportOnly) {
+    io.exit(0);
+    return;
+  }
+
+  if (fails.length > 0) {
+    io.exit(1);
+    return;
+  }
+
+  if (options.strict && warns.length > 0) {
+    io.exit(1);
+    return;
+  }
+
+  io.exit(0);
+}


### PR DESCRIPTION
## Summary
- Add `check-editorial.ts` + CLI for blog corpus linting (FAIL/WARN tiers)
- `pnpm validate:blog:editorial` — per-post blockers fail CI-ready check
- `pnpm validate:blog:editorial:strict` — also fails on corpus/rhythm WARN
- `pnpm validate:blog` — assets + editorial **report mode** (exit 0) until legacy remediation
- SOP upgraded to v1.1 in `blog-editorial-sop.md` (local memory)
- Audit inventory: `plans/blog-editorial-audit.md` (local)

## Lint rules
**FAIL:** title >60, alook.ai in first 100 words, <2 third-party links, vague attribution, banned sentence starters

**WARN:** corpus phrase/boilerplate duplication, paragraph stdev/rhythm, template phrases

## Test plan
- [x] `pnpm test -- src/lib/blog/check-editorial.test.ts`
- [x] `pnpm validate:blog:editorial` on 12 posts (14 FAIL, 23 WARN documented)
- [ ] After merge: remediation PRs for P0 title + external links (Batch A/B)


Made with [Cursor](https://cursor.com)