### PR TITLE
fix(web): 301 redirect deleted agent-team blog slug

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -28,6 +28,9 @@ coverage:
 ignore:
   - "src/web/src/components/home/**"
   - "src/web/scripts/**"
+  # Next config is loaded by the Next runtime, not vitest — redirects live in
+  # `src/web/src/lib/blog/redirects.ts` (unit-tested) and are wired here only.
+  - "src/web/next.config.ts"
   # Playwright browser E2E — driven by `playwright test`, not vitest, so these
   # files never appear in coverage and shouldn't count against patch %.
   - "src/web/src/test/e2e-ui/**"

--- a/src/web/next.config.ts
+++ b/src/web/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 import path from "node:path";
 import { readFileSync } from "node:fs";
 import createMDX from "@next/mdx";
+import { blogRedirects } from "./src/lib/blog/redirects";
 
 const pkg = JSON.parse(readFileSync(path.resolve(__dirname, "package.json"), "utf-8"));
 
@@ -18,13 +19,7 @@ const nextConfig: NextConfig = {
 	},
 	pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
 	async redirects() {
-		return [
-			{
-				source: "/blog/building-your-first-agent-team",
-				destination: "/blog/ai-agent-team",
-				statusCode: 301,
-			},
-		];
+		return blogRedirects();
 	},
 };
 

--- a/src/web/next.config.ts
+++ b/src/web/next.config.ts
@@ -17,6 +17,15 @@ const nextConfig: NextConfig = {
 		root: path.resolve(__dirname, "../.."),
 	},
 	pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
+	async redirects() {
+		return [
+			{
+				source: "/blog/building-your-first-agent-team",
+				destination: "/blog/ai-agent-team",
+				statusCode: 301,
+			},
+		];
+	},
 };
 
 const withMDX = createMDX({

--- a/src/web/src/lib/blog/redirects.test.ts
+++ b/src/web/src/lib/blog/redirects.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { blogRedirects } from "./redirects";
+
+describe("blogRedirects", () => {
+	it("301s the deleted agent-team slug to ai-agent-team", () => {
+		expect(blogRedirects()).toEqual([
+			{
+				source: "/blog/building-your-first-agent-team",
+				destination: "/blog/ai-agent-team",
+				statusCode: 301,
+			},
+		]);
+	});
+});

--- a/src/web/src/lib/blog/redirects.ts
+++ b/src/web/src/lib/blog/redirects.ts
@@ -1,0 +1,16 @@
+export type BlogRedirect = {
+	source: string;
+	destination: string;
+	statusCode: 301;
+};
+
+/** Permanent blog slug redirects for Next.js `redirects()`. */
+export function blogRedirects(): BlogRedirect[] {
+	return [
+		{
+			source: "/blog/building-your-first-agent-team",
+			destination: "/blog/ai-agent-team",
+			statusCode: 301,
+		},
+	];
+}


### PR DESCRIPTION
## Summary
- permanently redirect the deleted slug `/blog/building-your-first-agent-team` to the live post `/blog/ai-agent-team`
- clear the GSC 404 for the old indexed URL after production deploy

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] After merge/deploy: `curl -I https://alook.ai/blog/building-your-first-agent-team` returns `301` with `Location: .../blog/ai-agent-team`
- [ ] In GSC, validate the old URL fix once the redirect is live


Made with [Cursor](https://cursor.com)