### PR TITLE
fix(community): bind forum post creator name to creator avatar

### DIFF
--- a/src/web/src/components/community/forum-view.test.ts
+++ b/src/web/src/components/community/forum-view.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest"
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { ForumView } from "./forum-view"
+import { tid } from "@/lib/community/testids"
+import type { ForumPost } from "./_types"
+
+const LAST_AT = "2020-01-01T00:00:00.000Z"
+
+function makePost(over: Partial<ForumPost> = {}): ForumPost {
+  return {
+    id: "p1",
+    name: "A post title",
+    messageCount: 3,
+    lastMessageAt: LAST_AT,
+    parent: { authorName: "Alice", text: "root" },
+    authorId: "usr_alice",
+    authorAvatar: "A",
+    tags: [],
+    preview: "preview text",
+    participants: [{ id: "usr_alice", name: "Alice", avatar: "A" }],
+    ...over,
+  }
+}
+
+function render(posts: ForumPost[]): string {
+  return renderToStaticMarkup(
+    createElement(ForumView, { posts, onOpenPost: () => {} })
+  )
+}
+
+describe("ForumView post card header", () => {
+  it("solo post renders the creator name and no participant AvatarGroup", () => {
+    const html = render([makePost()])
+    expect(html).toContain(">Alice<")
+    expect(html).not.toContain(tid.forumPostAvatars("p1"))
+  })
+
+  it("renders the creator name and time before the participant AvatarGroup in markup order", () => {
+    const html = render([
+      makePost({
+        participants: [
+          { id: "usr_alice", name: "Alice", avatar: "A" },
+          { id: "usr_bob", name: "Bob", avatar: "B" },
+          { id: "usr_cara", name: "Cara", avatar: "C" },
+        ],
+      }),
+    ])
+    const groupTid = tid.forumPostAvatars("p1")
+    expect(html).toContain(groupTid)
+    expect(html.indexOf(">Alice<")).toBeGreaterThanOrEqual(0)
+    expect(html.indexOf(">Alice<")).toBeLessThan(html.indexOf(groupTid))
+    expect(html.indexOf("· ")).toBeLessThan(html.indexOf(groupTid))
+  })
+
+  it("falls back to \"Unknown\" when the creator name is empty (deleted creator)", () => {
+    const html = render([makePost({ parent: { authorName: "", text: "root" } })])
+    expect(html).toContain(">Unknown<")
+  })
+
+  it("renders the time separator for both a solo post and a post with others", () => {
+    const solo = render([makePost()])
+    expect(solo).toContain("· ")
+
+    const withOthers = render([
+      makePost({
+        participants: [
+          { id: "usr_alice", name: "Alice", avatar: "A" },
+          { id: "usr_bob", name: "Bob", avatar: "B" },
+        ],
+      }),
+    ])
+    expect(withOthers).toContain("· ")
+    expect(withOthers).toContain(tid.forumPostAvatars("p1"))
+  })
+})

--- a/src/web/src/components/community/forum-view.tsx
+++ b/src/web/src/components/community/forum-view.tsx
@@ -105,17 +105,19 @@ export function ForumView({
                 >
                   <div className="flex items-center gap-2">
                     <Avatar label={p.authorAvatar} seed={p.authorId} size={24} />
+                    <span className="text-xs font-medium text-foreground" suppressHydrationWarning>{p.parent.authorName || "Unknown"}</span>
+                    <span className="text-xs text-muted-foreground" suppressHydrationWarning>· {formatRelativeTime(p.lastMessageAt)}</span>
                     {others.length > 0 && (
-                      <AvatarGroup data-testid={tid.forumPostAvatars(p.id)}>
-                        {shown.map((m) => (
-                          <Avatar key={m.id} label={m.avatar} seed={m.id} size={24} ringColor="var(--card)" />
-                        ))}
-                        {overflow > 0 && <AvatarGroupCount className="size-6 text-[11px]">+{overflow}</AvatarGroupCount>}
-                      </AvatarGroup>
+                      <>
+                        <span className="h-4 w-px shrink-0 bg-border" aria-hidden />
+                        <AvatarGroup data-testid={tid.forumPostAvatars(p.id)}>
+                          {shown.map((m) => (
+                            <Avatar key={m.id} label={m.avatar} seed={m.id} size={24} ringColor="var(--card)" />
+                          ))}
+                          {overflow > 0 && <AvatarGroupCount className="size-6 text-[11px]">+{overflow}</AvatarGroupCount>}
+                        </AvatarGroup>
+                      </>
                     )}
-                    <span className="text-xs text-muted-foreground" suppressHydrationWarning>
-                      <span className="font-medium text-foreground">{p.parent.authorName}</span> · {formatRelativeTime(p.lastMessageAt)}
-                    </span>
                     {canEdit && (
                       <button
                         type="button"


### PR DESCRIPTION
## What

The forum post card header rendered the creator's name at the **end** of the row, after the other-members `AvatarGroup`, so the name read as detached from the creator's avatar (`[Alice-avatar] [Bob+2 group] Alice · 3h`).

Reorder the header to lead with the **author cluster** (avatar + name + time), then a thin vertical divider, then the other-members group:

```
before:  [author avatar] [others group] [author name · time]
after:   [author avatar] author name · time │ [others group +N]
```

## Details

- The other-members `AvatarGroup` still only renders when `others.length > 0` (unchanged gate); `MAX_AVATARS = 4` + `+N` overflow unchanged.
- Falls back to `Unknown` when the creator account was deleted (empty `authorName`, since a post's author is the channel's `creatorId` with `ON DELETE SET NULL`) — matching the community-wide convention (mentions inbox, reply payloads, WS author resolution).
- A member-name hover tooltip was considered and **dropped**: wrapping each avatar in a `TooltipTrigger` displaced the direct child that `AvatarGroup`'s separation-ring selector targets, breaking the ring. Not worth the styling regression.

## Testing

- New unit test `forum-view.test.ts` (4 cases): solo post has no group, name+time precede the group in markup order, `Unknown` fallback, time separator present in both shapes.
- `pnpm typecheck` ✓ (7/7 packages), `pnpm test` ✓ (full suite).
- `alook-c-qa` agent drove the authenticated app end-to-end — **PASS** on solo-post and second-participant journeys with D1 + posts-API correlation (author cluster order verified by DOM order and geometry).

## Files

- `src/web/src/components/community/forum-view.tsx`
- `src/web/src/components/community/forum-view.test.ts` (new)