### PR TITLE
seo(blog): /blog title+H1 and post title suffix

### DIFF
--- a/src/web/src/app/blog/[slug]/page.tsx
+++ b/src/web/src/app/blog/[slug]/page.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata({
   const ogImage = post.image ?? `/og?title=${encodeURIComponent(post.title)}`;
 
   return {
-    title: `${post.title} — Alook Blog`,
+    title: post.title,
     description: post.excerpt,
     alternates: { canonical: `https://alook.ai/blog/${post.slug}` },
     openGraph: {

--- a/src/web/src/app/blog/page.tsx
+++ b/src/web/src/app/blog/page.tsx
@@ -2,34 +2,42 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { getAllPosts } from "@/lib/blog/posts";
 
+const pageTitle = "Multi-Agent Collaboration & AI Team";
+
 const description =
   "Thoughts on building AI companies, agent collaboration, and the future of personal software.";
 
 export const metadata: Metadata = {
-  title: "Blog",
+  title: pageTitle,
   description,
   alternates: {
     canonical: "https://alook.ai/blog",
     types: { "application/rss+xml": "/blog/feed.xml" },
   },
   openGraph: {
-    title: "Blog",
+    title: pageTitle,
     description,
     url: "https://alook.ai/blog",
-    images: [{ url: "/og?title=Blog", width: 1200, height: 630 }],
+    images: [
+      {
+        url: `/og?title=${encodeURIComponent(pageTitle)}`,
+        width: 1200,
+        height: 630,
+      },
+    ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "Blog",
+    title: pageTitle,
     description,
-    images: ["/og?title=Blog"],
+    images: [`/og?title=${encodeURIComponent(pageTitle)}`],
   },
 };
 
 const collectionJsonLd = {
   "@context": "https://schema.org",
   "@type": "CollectionPage",
-  name: "Alook Blog",
+  name: pageTitle,
   description,
   url: "https://alook.ai/blog",
 };
@@ -47,7 +55,7 @@ export default async function BlogPage() {
       <div className="mx-auto max-w-3xl px-6 pt-10 sm:pt-20 pb-24">
         <header className="mb-16">
           <h1 className="font-news text-5xl sm:text-6xl font-semibold tracking-tight leading-none">
-            Blog
+            {pageTitle}
           </h1>
           <p className="mt-4 text-[1.0625rem] text-muted-foreground font-sans leading-relaxed max-w-xl">
             {description}


### PR DESCRIPTION
## Summary
- `/blog` title, H1, OG/Twitter, and CollectionPage name use **Multi-Agent Collaboration & AI Team** (final `<title>`: `… — Alook`).
- Blog post `generateMetadata` returns bare `post.title` so the root template no longer produces `{title} — Alook Blog — Alook`.

## Test plan
- [ ] `pnpm --filter @alook/web typecheck`
- [ ] After deploy, view-source `https://alook.ai/blog`: `<title>` and `<h1>` match the new copy
- [ ] Open any post: `<title>` is `{post.title} — Alook` (no double brand)
- [ ] OG title on `/blog` still shows the new string


Made with [Cursor](https://cursor.com)