### PR TITLE
feat(daemon, web): KV cost caching, WS auth fallback + token-death hardening

### DIFF
--- a/src/cli/commands/email.test.ts
+++ b/src/cli/commands/email.test.ts
@@ -32,7 +32,8 @@ vi.mock("../lib/client.js", () => ({
   },
 }));
 
-vi.mock("../lib/config.js", () => ({
+vi.mock("../lib/config.js", async (importActual) => ({
+  ...(await importActual<typeof import("../lib/config.js")>()),
   loadCLIConfigForProfile: vi.fn(() => ({
     server_url: "http://localhost:3000",
     watched_workspaces: [

--- a/src/cli/commands/login.test.ts
+++ b/src/cli/commands/login.test.ts
@@ -5,7 +5,8 @@ const mockSaveCLIConfigForProfile = vi.fn();
 const mockReadDaemonPid = vi.fn();
 const mockIsProcessAlive = vi.fn();
 
-vi.mock("../lib/config.js", () => ({
+vi.mock("../lib/config.js", async (importActual) => ({
+  ...(await importActual<typeof import("../lib/config.js")>()),
   loadCLIConfigForProfile: (...args: any[]) => mockLoadCLIConfigForProfile(...args),
   saveCLIConfigForProfile: (...args: any[]) => mockSaveCLIConfigForProfile(...args),
 }));

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -3,7 +3,7 @@ import { fork, spawn } from "child_process";
 import { fileURLToPath } from "url";
 import { APIClient } from "../lib/client.js";
 import { activateAndSave } from "../lib/activate.js";
-import { loadCLIConfigForProfile, saveCLIConfigForProfile } from "../lib/config.js";
+import { loadCLIConfigForProfile, saveCLIConfigForProfile, activeWorkspaces, markWorkspaceActive, markWorkspaceDeletedInList } from "../lib/config.js";
 import { cmdPrefix, getServerUrl } from "../lib/env.js";
 
 const DEVICE_CLIENT_ID = process.env.ALOOK_DEVICE_CLIENT_ID || "alook-cli";
@@ -64,18 +64,12 @@ function syncWorkspacesToConfig(
   const serverIds = new Set(serverWorkspaces.map((w) => w.id));
 
   for (const sw of serverWorkspaces) {
-    const existing = watched.find((w) => w.id === sw.id);
-    if (existing) {
-      existing.status = "active";
-      existing.name = sw.name;
-    } else {
-      watched.push({ id: sw.id, name: sw.name, token: "", status: "active", agent_ids: [] });
-    }
+    markWorkspaceActive(watched, { id: sw.id, name: sw.name });
   }
 
   for (const w of watched) {
     if (w.id && !serverIds.has(w.id)) {
-      w.status = "deleted";
+      markWorkspaceDeletedInList(watched, w.id);
     }
   }
 
@@ -213,7 +207,7 @@ async function checkExistingAuth(serverUrl: string, profile?: string): Promise<{
 
   // Try session token first, then machine token from workspaces
   const sessionToken = config.session_token;
-  const workspaces = config.watched_workspaces || [];
+  const workspaces = activeWorkspaces(config.watched_workspaces);
   const ws = workspaces[0];
   const authToken = sessionToken || ws?.token;
 
@@ -232,7 +226,7 @@ async function checkExistingAuth(serverUrl: string, profile?: string): Promise<{
     const serverWorkspaces = await res.json() as WorkspaceResponse[];
 
     // Sync workspaces when config has no workspace with a valid id
-    const hasValidWorkspace = workspaces.some((w) => w.id && w.status !== "deleted");
+    const hasValidWorkspace = workspaces.length > 0;
     if (!hasValidWorkspace && serverWorkspaces.length > 0) {
       syncWorkspacesToConfig(serverWorkspaces, profile);
     }

--- a/src/cli/commands/register.test.ts
+++ b/src/cli/commands/register.test.ts
@@ -5,7 +5,8 @@ const mockSaveCLIConfigForProfile = vi.fn();
 const mockReadDaemonPid = vi.fn();
 const mockIsProcessAlive = vi.fn();
 
-vi.mock("../lib/config.js", () => ({
+vi.mock("../lib/config.js", async (importActual) => ({
+  ...(await importActual<typeof import("../lib/config.js")>()),
   loadCLIConfigForProfile: (...args: any[]) => mockLoadCLIConfigForProfile(...args),
   saveCLIConfigForProfile: (...args: any[]) => mockSaveCLIConfigForProfile(...args),
 }));

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { loadCLIConfigForProfile } from "../lib/config.js";
+import { loadCLIConfigForProfile, activeWorkspaces } from "../lib/config.js";
 import { cmdPrefix } from "../lib/env.js";
 
 export function statusCommand(): Command {
@@ -9,7 +9,7 @@ export function statusCommand(): Command {
       const profile: string | undefined = command.parent?.opts().profile;
       const cfg = loadCLIConfigForProfile(profile);
 
-      const ws = cfg.watched_workspaces?.[0];
+      const ws = activeWorkspaces(cfg.watched_workspaces)[0];
       if (!ws?.token) {
         console.log("Not registered");
         console.log(

--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -5,7 +5,7 @@ import { APIClient } from "../lib/client.js";
 import { cmdPrefix } from "../lib/env.js";
 import { printJSON } from "../lib/output.js";
 import { resolveClientOptsPartial } from "../lib/resolve-client.js";
-import { loadCLIConfigForProfile, saveCLIConfigForProfile } from "../lib/config.js";
+import { loadCLIConfigForProfile, saveCLIConfigForProfile, markWorkspaceActive } from "../lib/config.js";
 import { getRootOpts } from "../lib/command-utils.js";
 
 interface RuntimeResponse {
@@ -156,15 +156,11 @@ export function workspaceCommand(): Command {
           // Update local config with the resolved workspace
           try {
             const freshCfg = loadCLIConfigForProfile(parentOpts.profile);
-            const watched = freshCfg.watched_workspaces || [];
-            const existing = watched.find((w) => w.id === targetWorkspaceId);
-            if (existing) {
-              existing.status = "active";
-              existing.name = res.workspace.name;
-            } else {
-              watched.push({ id: targetWorkspaceId, name: res.workspace.name, token: token, status: "active", agent_ids: [] });
-            }
-            freshCfg.watched_workspaces = watched;
+            freshCfg.watched_workspaces = markWorkspaceActive(freshCfg.watched_workspaces || [], {
+              id: targetWorkspaceId,
+              name: res.workspace.name,
+              token,
+            });
             saveCLIConfigForProfile(parentOpts.profile, freshCfg);
           } catch {
             // Best-effort config update

--- a/src/cli/daemon/config.test.ts
+++ b/src/cli/daemon/config.test.ts
@@ -35,6 +35,7 @@ describe("loadDaemonConfig defaults", () => {
 
     expect(cfg.serverURL).toBe("https://alook.ai");
     expect(cfg.pollInterval).toBe(3000);
+    expect(cfg.wsPollInterval).toBe(60000);
     expect(cfg.agentTimeout).toBe(43200000);
     expect(cfg.maxConcurrentTasks).toBe(20);
     expect(cfg.claudePath).toBe("claude");
@@ -52,6 +53,7 @@ describe("loadDaemonConfig env overrides", () => {
     process.env.ALOOK_DAEMON_POLL_INTERVAL = "5s";
     expect(loadDaemonConfig().pollInterval).toBe(5000);
   });
+
 
   it("ALOOK_DAEMON_MAX_CONCURRENT_TASKS='10' → 10", () => {
     process.env.ALOOK_DAEMON_MAX_CONCURRENT_TASKS = "10";

--- a/src/cli/daemon/daemon.test.ts
+++ b/src/cli/daemon/daemon.test.ts
@@ -56,12 +56,14 @@ vi.mock("./health.js", () => ({
 }));
 
 let capturedWsOnMessage: ((msg: any) => void) | null = null;
+let capturedWsOpts: any = null;
 vi.mock("./ws-client.js", () => {
   class MockDaemonWsClient {
     connect = vi.fn();
     close = vi.fn();
     isConnected = vi.fn(() => false);
     constructor(opts: any) {
+      capturedWsOpts = opts;
       if (opts?.onMessage) capturedWsOnMessage = opts.onMessage;
     }
   }
@@ -73,7 +75,8 @@ vi.mock("./agent/index.js", () => ({
   createBackend: vi.fn(() => ({ lifecycle: { kind: "per_turn" }, busyDeliveryMode: "none", supportsStdinNotification: false })),
 }));
 
-vi.mock("../lib/config.js", () => ({
+vi.mock("../lib/config.js", async (importActual) => ({
+  ...(await importActual<typeof import("../lib/config.js")>()),
   loadCLIConfigForProfile: vi.fn(() => ({
     server_url: null,
     watched_workspaces: [{ id: "ws1", name: "Test WS", token: "al_test_token" }],
@@ -242,10 +245,14 @@ vi.spyOn(process, "once").mockImplementation(((event: string, handler: any) => {
 const realSetInterval = globalThis.setInterval;
 const realClearInterval = globalThis.clearInterval;
 const intervalTimers: NodeJS.Timeout[] = [];
+const intervalMsArgs: number[] = [];
+const intervalFns: Array<() => void> = [];
 
 vi.spyOn(globalThis, "setInterval").mockImplementation(((fn: any, ms: any) => {
   const timer = realSetInterval(() => {}, 999999) as NodeJS.Timeout;
   intervalTimers.push(timer);
+  intervalMsArgs.push(ms);
+  intervalFns.push(fn);
   return timer;
 }) as any);
 
@@ -1387,16 +1394,17 @@ describe("daemon workspace eviction", () => {
     await startDaemon();
     await new Promise((r) => setTimeout(r, 50));
 
-    // ws2 was evicted — only ws1 should remain
-    // Verify config was saved to remove ws2
+    // ws2 was evicted — soft-marked status="deleted" (not physically removed),
+    // so a restart's status!=="deleted" filter skips it while ws1 stays active.
     expect(saveCLIConfigForProfile).toHaveBeenCalled();
     const savedConfig = vi.mocked(saveCLIConfigForProfile).mock.calls[0][1];
-    const wsIds = savedConfig.watched_workspaces!.map((w: any) => w.id);
-    expect(wsIds).toContain("ws1");
-    expect(wsIds).not.toContain("ws2");
+    const ws1 = savedConfig.watched_workspaces!.find((w: any) => w.id === "ws1");
+    const ws2 = savedConfig.watched_workspaces!.find((w: any) => w.id === "ws2");
+    expect(ws1?.status).not.toBe("deleted");
+    expect(ws2?.status).toBe("deleted");
   });
 
-  it("removes evicted workspace from local config file", async () => {
+  it("soft-marks evicted workspace status=deleted in local config file", async () => {
     vi.mocked(loadCLIConfigForProfile).mockReturnValue({
       server_url: "",
       watched_workspaces: [{ id: "ws1", name: "Test WS", token: "al_test_token" }],
@@ -1409,7 +1417,9 @@ describe("daemon workspace eviction", () => {
 
     expect(saveCLIConfigForProfile).toHaveBeenCalled();
     const savedConfig = vi.mocked(saveCLIConfigForProfile).mock.calls[0][1];
-    expect(savedConfig.watched_workspaces).toEqual([]);
+    // Entry lingers (recoverable by re-pair) but is marked deleted.
+    expect(savedConfig.watched_workspaces).toHaveLength(1);
+    expect(savedConfig.watched_workspaces![0].status).toBe("deleted");
   });
 
   it("shuts down gracefully when all workspaces are evicted", async () => {
@@ -1459,11 +1469,13 @@ describe("daemon workspace eviction", () => {
     expect(pollTokens).toContain("al_tok_ws2");
     expect(pollTokens).toContain("al_tok_ws3");
 
-    // Verify config saved without ws2
+    // Verify config saved with ws2 soft-marked deleted, ws1/ws3 still active
     expect(saveCLIConfigForProfile).toHaveBeenCalled();
     const savedConfig = vi.mocked(saveCLIConfigForProfile).mock.calls[0][1];
-    const wsIds = savedConfig.watched_workspaces!.map((w: any) => w.id);
-    expect(wsIds).toEqual(["ws1", "ws3"]);
+    const byId = (id: string) => savedConfig.watched_workspaces!.find((w: any) => w.id === id);
+    expect(byId("ws1")?.status).not.toBe("deleted");
+    expect(byId("ws2")?.status).toBe("deleted");
+    expect(byId("ws3")?.status).not.toBe("deleted");
 
     // Daemon should NOT have shut down (still has ws1 and ws3)
     expect(mockProcessExit).not.toHaveBeenCalled();
@@ -2551,5 +2563,220 @@ describe("daemon SIGHUP reload", () => {
       "al_tok2",
       expect.objectContaining({ workspace_id: "ws2" }),
     );
+  });
+});
+
+describe("WS poll-frequency fallback", () => {
+  beforeEach(() => {
+    signalHandlers.clear();
+    intervalTimers.length = 0;
+    intervalMsArgs.length = 0;
+    clearedTimers.length = 0;
+    spawnedChildren.length = 0;
+    nextPid = 50000;
+    capturedWsOnMessage = null;
+    capturedWsOpts = null;
+    vi.clearAllMocks();
+    mockProcessExit.mockImplementation((() => {}) as any);
+    mockOpenSync.mockReturnValue(42);
+  });
+
+  afterEach(() => {
+    for (const t of intervalTimers) realClearInterval(t);
+  });
+
+  async function boot() {
+    vi.mocked(loadCLIConfigForProfile).mockReturnValue({
+      server_url: "",
+      watched_workspaces: [{ id: "ws1", name: "Test WS", token: "al_test_token" }],
+    });
+    mockClientInstance.register.mockResolvedValue({ runtimes: [{ id: "rt1" }] });
+    mockClientInstance.poll.mockResolvedValue({ tasks: [], evicted: false });
+    await startDaemon();
+    await new Promise((r) => setTimeout(r, 50));
+  }
+
+  it("starts poll at high-frequency (pollInterval)", async () => {
+    await boot();
+    // The very first setInterval is the poll timer.
+    expect(intervalMsArgs[0]).toBe(3000);
+  });
+
+  it("onConnected switches poll to low-frequency (wsPollInterval)", async () => {
+    await boot();
+    intervalMsArgs.length = 0;
+    capturedWsOpts.onConnected();
+    expect(intervalMsArgs).toContain(30000);
+  });
+
+  it("onDisconnected reverts to high-frequency (pollInterval)", async () => {
+    await boot();
+    intervalMsArgs.length = 0;
+    capturedWsOpts.onDisconnected();
+    expect(intervalMsArgs).toContain(3000);
+  });
+});
+
+describe("WS token invalidation + rotation (T6b)", () => {
+  beforeEach(() => {
+    signalHandlers.clear();
+    intervalTimers.length = 0;
+    intervalMsArgs.length = 0;
+    clearedTimers.length = 0;
+    spawnedChildren.length = 0;
+    nextPid = 50000;
+    capturedWsOnMessage = null;
+    capturedWsOpts = null;
+    vi.clearAllMocks();
+    mockProcessExit.mockImplementation((() => {}) as any);
+    mockOpenSync.mockReturnValue(42);
+  });
+
+  afterEach(() => {
+    for (const t of intervalTimers) realClearInterval(t);
+  });
+
+  async function bootMulti(workspaces: { id: string; name: string; token: string }[]) {
+    vi.mocked(loadCLIConfigForProfile).mockReturnValue({ server_url: "", watched_workspaces: workspaces });
+    let n = 0;
+    mockClientInstance.register.mockImplementation(async () => ({ runtimes: [{ id: `rt${++n}` }] }));
+    mockClientInstance.poll.mockResolvedValue({ tasks: [], evicted: false });
+    await startDaemon();
+    await new Promise((r) => setTimeout(r, 50));
+  }
+
+  it("AUTH_REJECTED confirmed by poll 401 marks the correct workspace, not undefined — no hot loop", async () => {
+    // MEDIUM-1 regression guard: wsWorkspaceId must be set at the startup
+    // construction, so onAuthRejected confirms ws1 (the WS token's workspace),
+    // removes it, and rebuilds with ws2's token instead of spinning.
+    await bootMulti([
+      { id: "ws1", name: "A", token: "al_dead" },
+      { id: "ws2", name: "B", token: "al_good" },
+    ]);
+    const tokenBefore = capturedWsOpts.machineToken;
+    expect(tokenBefore).toBe("al_dead");
+
+    // Confirm poll 401s → token confirmed dead.
+    mockClientInstance.poll.mockRejectedValue(new Error("HTTP 401 Unauthorized"));
+    capturedWsOpts.onAuthRejected("revoked");
+    await new Promise((r) => setTimeout(r, 10));
+
+    // ws1 soft-marked deleted in config
+    const savedConfig = vi.mocked(saveCLIConfigForProfile).mock.calls.at(-1)![1];
+    expect(savedConfig.watched_workspaces!.find((w: any) => w.id === "ws1")?.status).toBe("deleted");
+    // WS rebuilt with a DIFFERENT (surviving) token — no same-token respin
+    expect(capturedWsOpts.machineToken).toBe("al_good");
+    expect(mockProcessExit).not.toHaveBeenCalled();
+  });
+
+  it("AUTH_REJECTED confirmed by poll 401 with a single workspace rebuilds to no client and shuts down", async () => {
+    await bootMulti([{ id: "ws1", name: "Only", token: "al_dead" }]);
+    mockClientInstance.poll.mockRejectedValue(new Error("HTTP 401 Unauthorized"));
+    capturedWsOpts.onAuthRejected();
+    await new Promise((r) => setTimeout(r, 10));
+
+    const savedConfig = vi.mocked(saveCLIConfigForProfile).mock.calls.at(-1)![1];
+    expect(savedConfig.watched_workspaces!.find((w: any) => w.id === "ws1")?.status).toBe("deleted");
+    expect(mockProcessExit).toHaveBeenCalledWith(0);
+  });
+
+  it("AUTH_REJECTED NOT confirmed (confirm poll succeeds) keeps the workspace — false-invalid guard", async () => {
+    // Replica lag right after activation: the WS-DO rejects a token that is
+    // actually valid. The confirm poll succeeds, so the workspace must survive.
+    await bootMulti([{ id: "ws1", name: "Only", token: "al_lagged" }]);
+    // poll still resolves (bootMulti default) → rejection not confirmed.
+    capturedWsOpts.onAuthRejected("replica-lag");
+    await new Promise((r) => setTimeout(r, 10));
+
+    const deletedWrites = vi.mocked(saveCLIConfigForProfile).mock.calls.filter(
+      (c) => c[1].watched_workspaces?.some((w: any) => w.id === "ws1" && w.status === "deleted"),
+    );
+    expect(deletedWrites).toHaveLength(0);
+    // WS rebuilt with the same still-valid token, daemon stays up.
+    expect(capturedWsOpts.machineToken).toBe("al_lagged");
+    expect(mockProcessExit).not.toHaveBeenCalled();
+  });
+
+  it("AUTH_REJECTED with a non-401 confirm error keeps the workspace — treated transient", async () => {
+    await bootMulti([{ id: "ws1", name: "Only", token: "al_x" }]);
+    mockClientInstance.poll.mockRejectedValue(new Error("HTTP 503 Service Unavailable"));
+    capturedWsOpts.onAuthRejected();
+    await new Promise((r) => setTimeout(r, 10));
+
+    const deletedWrites = vi.mocked(saveCLIConfigForProfile).mock.calls.filter(
+      (c) => c[1].watched_workspaces?.some((w: any) => w.id === "ws1" && w.status === "deleted"),
+    );
+    expect(deletedWrites).toHaveLength(0);
+    expect(mockProcessExit).not.toHaveBeenCalled();
+  });
+
+  it("single poll 401 does NOT mark the workspace deleted (below threshold)", async () => {
+    vi.mocked(loadCLIConfigForProfile).mockReturnValue({
+      server_url: "",
+      watched_workspaces: [{ id: "ws1", name: "A", token: "al_x" }],
+    });
+    mockClientInstance.register.mockResolvedValue({ runtimes: [{ id: "rt1" }] });
+    mockClientInstance.poll.mockRejectedValue(new Error("HTTP 401 Unauthorized"));
+    await startDaemon();
+    await new Promise((r) => setTimeout(r, 50));
+
+    // One cycle → one 401 → below WS_AUTH_401_THRESHOLD (5) → no status write to deleted
+    const deletedWrites = vi.mocked(saveCLIConfigForProfile).mock.calls.filter(
+      (c) => c[1].watched_workspaces?.some((w: any) => w.id === "ws1" && w.status === "deleted"),
+    );
+    expect(deletedWrites).toHaveLength(0);
+    expect(mockProcessExit).not.toHaveBeenCalled();
+  });
+
+  it("5 consecutive poll 401s mark the workspace deleted (threshold reached)", async () => {
+    vi.mocked(loadCLIConfigForProfile).mockReturnValue({
+      server_url: "",
+      watched_workspaces: [{ id: "ws1", name: "A", token: "al_x" }],
+    });
+    mockClientInstance.register.mockResolvedValue({ runtimes: [{ id: "rt1" }] });
+    intervalFns.length = 0;
+    mockClientInstance.poll.mockRejectedValue(new Error("HTTP 401 Unauthorized"));
+    await startDaemon();
+    await new Promise((r) => setTimeout(r, 50));
+
+    // startDaemon ran one immediate poll (401 #1). Drive 4 more back-to-back
+    // 401s via the captured poll cycle to reach WS_AUTH_401_THRESHOLD (5).
+    const pollCycle = intervalFns[0];
+    for (let i = 0; i < 4; i++) await pollCycle();
+
+    const deletedWrites = vi.mocked(saveCLIConfigForProfile).mock.calls.filter(
+      (c) => c[1].watched_workspaces?.some((w: any) => w.id === "ws1" && w.status === "deleted"),
+    );
+    expect(deletedWrites.length).toBeGreaterThan(0);
+  });
+
+  it("401s interleaved with transient errors do NOT reach the threshold (streak resets)", async () => {
+    vi.mocked(loadCLIConfigForProfile).mockReturnValue({
+      server_url: "",
+      watched_workspaces: [{ id: "ws1", name: "A", token: "al_x" }],
+    });
+    mockClientInstance.register.mockResolvedValue({ runtimes: [{ id: "rt1" }] });
+    intervalFns.length = 0;
+    // Alternate 401 / non-401 across cycles. The non-401 (503) must reset the
+    // streak so scattered 401s never accumulate to the threshold.
+    let call = 0;
+    mockClientInstance.poll.mockImplementation(async () => {
+      call++;
+      if (call % 2 === 1) throw new Error("HTTP 401 Unauthorized");
+      throw new Error("HTTP 503 Service Unavailable");
+    });
+    await startDaemon();
+    await new Promise((r) => setTimeout(r, 50));
+
+    // startDaemon ran poll #1 (401). Drive 8 more: 503,401,503,401,503,401,503,401.
+    // That's 5 total 401s but never 2 in a row → below threshold.
+    const pollCycle = intervalFns[0];
+    for (let i = 0; i < 8; i++) await pollCycle();
+
+    const deletedWrites = vi.mocked(saveCLIConfigForProfile).mock.calls.filter(
+      (c) => c[1].watched_workspaces?.some((w: any) => w.id === "ws1" && w.status === "deleted"),
+    );
+    expect(deletedWrites).toHaveLength(0);
+    expect(mockProcessExit).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/daemon/daemon.ts
+++ b/src/cli/daemon/daemon.ts
@@ -5,7 +5,7 @@ import { detectVersion, createBackend } from "./agent/index.js";
 import { type Task, type Attachment, type SessionRunnerInput, fromApiTask } from "./types.js";
 import { type MarkerData, writeMarkerFile, downloadAttachments } from "./session-runner.js";
 import { buildPrompt, buildMergedPrompt } from "./prompt.js";
-import { loadCLIConfigForProfile, saveCLIConfigForProfile } from "../lib/config.js";
+import { loadCLIConfigForProfile, saveCLIConfigForProfile, activeWorkspaces, markWorkspaceDeletedInList } from "../lib/config.js";
 import { createLogger } from "../lib/logger.js";
 import { DaemonWsClient } from "./ws-client.js";
 import type { DaemonPushMessage } from "@alook/shared";
@@ -137,6 +137,10 @@ function isValidMarker(data: unknown): data is MarkerData {
 
 const MARKER_STALE_MS = 24 * 60 * 60 * 1000;
 const TMP_STALE_MS = 60 * 60 * 1000;
+// Consecutive poll-401s before a workspace is marked auth-failed. The server
+// only returns 401 for a definitely-invalid token (transient DB failure → 503),
+// so this is a belt-and-braces guard against any residual transient 401.
+const WS_AUTH_401_THRESHOLD = 5;
 
 export async function reconcilePendingCompletions(workspacesRoot: string): Promise<void> {
   const dir = join(workspacesRoot, ".pending_completions");
@@ -257,8 +261,7 @@ export async function startDaemon(
 
   const cliConfig = loadCLIConfigForProfile(profile);
 
-  const allEntries = cliConfig.watched_workspaces || [];
-  const workspaces = allEntries.filter((ws): ws is typeof ws & { id: string; name: string } => ws.status !== "deleted" && !!ws.id);
+  const workspaces = activeWorkspaces(cliConfig.watched_workspaces);
 
   if (workspaces.length === 0) {
     log.info("No workspaces configured — daemon starting in standby mode. Register a workspace to begin.");
@@ -307,6 +310,10 @@ export async function startDaemon(
   const workspaceStates: WorkspaceState[] = [];
   const runtimeIndex = new Map<string, RuntimeData>();
   let hadWorkspaces = workspaces.length > 0;
+  // Per-workspace consecutive poll-401 count. A workspace is marked deleted
+  // only after WS_AUTH_401_THRESHOLD consecutive 401s (reset on any success),
+  // so a transient 503/blip can't wrongly drop a healthy workspace.
+  const consecutive401 = new Map<string, number>();
 
   for (const ws of workspaces) {
     const runtimes = providers.map((p) => ({
@@ -384,15 +391,29 @@ export async function startDaemon(
     }
   }
 
-  function evictWorkspace(workspaceId: string): void {
+  /**
+   * Single owner for taking a workspace out of the active poll set. Used by
+   * every "this workspace is no longer usable" path: server evict, WS
+   * AUTH_REJECTED, and repeated poll-401. It does the full in-memory cleanup
+   * (workspaceStates + runtimeIndex + health count + 401 counter) AND persists
+   * `status="deleted"` so a restart doesn't re-poll it (every reader goes
+   * through `activeWorkspaces()`, which keeps only `status === "active"`).
+   *
+   * Soft-delete (mark), not physical removal: the config entry lingers so the
+   * cause is inspectable and re-pairing (`activate.ts` sets status back to
+   * "active" with a fresh token) recovers it. `reason` is logged, not stored
+   * — status stays a 2-value field.
+   */
+  function markWorkspaceDeleted(workspaceId: string, reason: string): void {
     const idx = workspaceStates.findIndex((ws) => ws.workspaceId === workspaceId);
-    if (idx === -1) return;
+    if (idx === -1) return; // idempotent — already gone
 
     const ws = workspaceStates[idx];
     for (const rid of ws.runtimeIds) {
       runtimeIndex.delete(rid);
     }
     workspaceStates.splice(idx, 1);
+    consecutive401.delete(workspaceId);
 
     health.setRuntimeCount(
       workspaceStates.reduce((sum, w) => sum + w.runtimeIds.length, 0),
@@ -400,15 +421,14 @@ export async function startDaemon(
 
     try {
       const cfg = loadCLIConfigForProfile(profile);
-      cfg.watched_workspaces = (cfg.watched_workspaces || []).filter(
-        (w) => w.id !== workspaceId,
-      );
-      saveCLIConfigForProfile(profile, cfg);
+      if (markWorkspaceDeletedInList(cfg.watched_workspaces || [], workspaceId)) {
+        saveCLIConfigForProfile(profile, cfg);
+      }
     } catch {
-      // Best-effort — config write failure must not block eviction
+      // Best-effort — config write failure must not block in-memory removal
     }
 
-    log.info(`Workspace ${workspaceId} deleted server-side — removed from config`);
+    log.info(`Workspace ${workspaceId} removed from polling — ${reason}`);
   }
 
   // Staggered per-workspace polling
@@ -418,7 +438,9 @@ export async function startDaemon(
 
     const N = workspaceStates.length;
     const staggerMs = N > 1 ? Math.floor(config.pollInterval / N) : 0;
-    const evictedIds: string[] = [];
+    // Deferred removal — collected during the loop and applied AFTER it, because
+    // markWorkspaceDeleted splices workspaceStates while we index by [i].
+    const toRemove = new Map<string, string>(); // workspaceId -> reason
 
     for (let i = 0; i < N; i++) {
       if (remaining <= 0) break;
@@ -436,8 +458,11 @@ export async function startDaemon(
           config.cliVersion,
         );
 
+        // Any successful poll clears the workspace's 401 streak.
+        consecutive401.delete(ws.workspaceId);
+
         if (evicted) {
-          evictedIds.push(ws.workspaceId);
+          toRemove.set(ws.workspaceId, "server evicted");
           continue;
         }
 
@@ -447,8 +472,8 @@ export async function startDaemon(
 
         if (pending_rescan) {
           log.info("Rescan requested — restarting daemon to re-detect runtimes");
-          for (const id of evictedIds) {
-            evictWorkspace(id);
+          for (const [id, reason] of toRemove) {
+            markWorkspaceDeleted(id, reason);
           }
           requestRestart();
           return;
@@ -496,15 +521,35 @@ export async function startDaemon(
         }
       } catch (e) {
         if (e instanceof Error && e.message.startsWith("HTTP 401")) {
-          log.warn(`Workspace ${ws.workspaceId} poll returned 401 — will retry next cycle`);
+          // 401 = definitely-invalid token (transient infra → 503, which lands
+          // in the else branch). Count consecutive 401s; only mark deleted at
+          // the threshold, as a guard against any residual transient 401.
+          const n = (consecutive401.get(ws.workspaceId) ?? 0) + 1;
+          consecutive401.set(ws.workspaceId, n);
+          if (n >= WS_AUTH_401_THRESHOLD) {
+            toRemove.set(ws.workspaceId, `poll 401 x${n}`);
+          } else {
+            log.warn(`Workspace ${ws.workspaceId} poll 401 (${n}/${WS_AUTH_401_THRESHOLD}) — will retry`);
+          }
         } else {
+          // Any non-401 outcome (503, network blip) breaks the 401 streak —
+          // "consecutive" means back-to-back 401s, not 401s scattered across a
+          // flaky window. Without this a 401/blip/401/blip… pattern would creep
+          // to the threshold and wrongly delete a live workspace.
+          consecutive401.delete(ws.workspaceId);
           log.debug("Poll error", e);
         }
       }
     }
 
-    for (const id of evictedIds) {
-      evictWorkspace(id);
+    // Deferred removal (see toRemove comment). If we drop the workspace whose
+    // token the WS client is using, rebuild the WS with a surviving token.
+    if (toRemove.size > 0) {
+      const wsTokenWorkspaceDropped = wsWorkspaceId != null && toRemove.has(wsWorkspaceId);
+      for (const [id, reason] of toRemove) {
+        markWorkspaceDeleted(id, reason);
+      }
+      if (wsTokenWorkspaceDropped) rebuildWsClient();
     }
 
     if (workspaceStates.length === 0 && hadWorkspaces) {
@@ -513,6 +558,11 @@ export async function startDaemon(
     }
   };
 
+  // Start at high-frequency poll; drop to low-frequency once WS auths
+  // (onConnected). A dead machine token no longer pins the daemon here — T6's
+  // AUTH_REJECTED handling removes the bad workspace and rotates the WS token
+  // — so a transient WS outage polling at 3s is self-limiting (recovers on the
+  // next auth.ok) and doesn't warrant a separate mid-frequency tier.
   let pollTimer = setInterval(pollCycle, config.pollInterval);
 
   // --- Heartbeat timer (independent of poll and WS state) ---
@@ -526,10 +576,6 @@ export async function startDaemon(
   const heartbeatTimer = setInterval(heartbeatPing, config.heartbeatInterval);
 
   // --- WS Push Channel (primary) + Poll fallback ---
-  // Any active machine token suffices — WS auth validates daemon-level access,
-  // not per-workspace. Tasks are routed by workspaceId within handleWsPush.
-  const firstToken = workspaceStates[0]?.token;
-
   function updatePollInterval(newInterval: number) {
     clearInterval(pollTimer);
     pollTimer = setInterval(pollCycle, newInterval);
@@ -586,9 +632,16 @@ export async function startDaemon(
         }
         break;
 
-      case "daemon.evict":
-        evictWorkspace(msg.workspaceId);
+      case "daemon.evict": {
+        const wasWsToken = wsWorkspaceId === msg.workspaceId;
+        markWorkspaceDeleted(msg.workspaceId, "server evicted");
+        if (wasWsToken) rebuildWsClient();
+        if (workspaceStates.length === 0 && hadWorkspaces) {
+          log.info("All workspaces removed — shutting down");
+          shutdown();
+        }
         break;
+      }
 
       case "daemon.update":
         if (!isUpdating() && msg.version !== config.cliVersion) {
@@ -634,26 +687,110 @@ export async function startDaemon(
     }
   }
 
-  const wsToken = firstToken;
+  let wsClient: DaemonWsClient | null = null;
+  // Which workspace's token the current wsClient authenticates with. Needed so
+  // that when that workspace is marked deleted (dead token) we know to rebuild
+  // the WS with a surviving token. Set ONLY in rebuildWsClient — the single
+  // construction path — so it can never drift out of sync with wsClient.
+  let wsWorkspaceId: string | undefined;
 
-  let wsClient = wsToken
-    ? new DaemonWsClient({
-        serverURL: config.serverURL,
-        daemonId: config.daemonId,
-        machineToken: wsToken,
-        onMessage: handleWsPush,
-        onConnected: () => {
-          log.info("WS connected — switching to low-frequency poll");
-          updatePollInterval(config.wsPollInterval);
-        },
-        onDisconnected: () => {
-          log.info("WS disconnected — reverting to high-frequency poll");
-          updatePollInterval(config.pollInterval);
-        },
-      })
-    : null;
+  // Shared callbacks — stable across every (re)build so poll-frequency policy
+  // and auth handling can't drift between construction sites.
+  const wsCallbacks = {
+    onMessage: handleWsPush,
+    onConnected: () => {
+      log.info("WS connected — switching to low-frequency poll");
+      updatePollInterval(config.wsPollInterval);
+    },
+    onDisconnected: () => {
+      log.info("WS disconnected — reverting to high-frequency poll");
+      updatePollInterval(config.pollInterval);
+    },
+    onAuthRejected: (reason?: string) => {
+      // A WS AUTH_REJECTED can be a false-invalid: the WS-DO may read a
+      // replica-lagged (not-yet-propagated) token row right after activation
+      // and reject a token that is actually valid. Rather than delete on this
+      // one signal (the poll path already tolerates 4 transient 401s), confirm
+      // with one authoritative HTTP poll before deleting.
+      const rejectedWorkspaceId = wsWorkspaceId;
+      const rejectedToken = workspaceStates.find(
+        (ws) => ws.workspaceId === rejectedWorkspaceId,
+      )?.token;
 
-  wsClient?.connect();
+      // Tear down the rejected socket up front so its auto-reconnect can't
+      // respin the same token during the confirm window. Don't rebuild yet:
+      // rebuilding now would repick the still-present rejected workspace
+      // (workspaceStates[0]) and reconnect the same token — the confirm decides
+      // whether it stays, and every exit path below rebuilds afterwards.
+      wsClient?.close();
+      wsClient = null;
+      wsWorkspaceId = undefined;
+
+      if (rejectedWorkspaceId != null && rejectedToken) {
+        void confirmAuthRejection(rejectedWorkspaceId, rejectedToken, reason);
+      } else {
+        rebuildWsClient();
+      }
+    },
+  };
+
+  /**
+   * Confirm a WS AUTH_REJECTED with one authoritative poll before deleting the
+   * workspace. `maxTasks: 0` makes the probe side-effect-free — it exercises the
+   * same auth middleware as a normal poll but claims no tasks. Delete only on a
+   * confirmed `HTTP 401`; a success or any non-401 error is treated as a
+   * transient false-invalid and the workspace survives. Every path rebuilds the
+   * WS (torn down by the caller) so the daemon never lingers without a socket.
+   */
+  async function confirmAuthRejection(
+    workspaceId: string,
+    token: string,
+    reason?: string,
+  ): Promise<void> {
+    let confirmedDead = false;
+    try {
+      await client.poll(token, config.daemonId, 0, config.cliVersion);
+      // Poll succeeded — the token is live; the WS rejection was a false-invalid
+      // (likely replica lag). Keep the workspace; the rebuilt WS reconnects it.
+      log.info(`Workspace ${workspaceId} WS auth rejection not confirmed by poll — keeping (likely transient)`);
+    } catch (e) {
+      if (e instanceof Error && e.message.startsWith("HTTP 401")) {
+        confirmedDead = true;
+        markWorkspaceDeleted(workspaceId, `WS auth rejected${reason ? ` (${reason})` : ""} — confirmed by poll 401`);
+      } else {
+        // Non-401 (503, network) — transient, not a token problem. Keep it.
+        log.debug("Confirm-poll error (transient) — keeping workspace", e);
+      }
+    }
+
+    rebuildWsClient();
+    if (confirmedDead && workspaceStates.length === 0 && hadWorkspaces) {
+      log.info("All workspaces removed — shutting down");
+      shutdown();
+    }
+  }
+
+  // The single WS (re)construction path. Any active machine token suffices —
+  // WS auth is daemon-level; tasks route by workspaceId in handleWsPush.
+  function rebuildWsClient(): void {
+    wsClient?.close();
+    const first = workspaceStates[0];
+    if (!first) {
+      wsClient = null;
+      wsWorkspaceId = undefined;
+      return;
+    }
+    wsWorkspaceId = first.workspaceId;
+    wsClient = new DaemonWsClient({
+      serverURL: config.serverURL,
+      daemonId: config.daemonId,
+      machineToken: first.token,
+      ...wsCallbacks,
+    });
+    wsClient.connect();
+  }
+
+  rebuildWsClient();
 
   // --- Sweep timer: triggers server-side sweep + local reconciliation ---
   const sweepTick = async () => {
@@ -748,8 +885,7 @@ export async function startDaemon(
     log.info("SIGHUP received — reloading config...");
     try {
       const freshConfig = loadCLIConfigForProfile(profile);
-      const freshWorkspaces = (freshConfig.watched_workspaces || [])
-        .filter((ws): ws is typeof ws & { id: string } => ws.status !== "deleted" && !!ws.id);
+      const freshWorkspaces = activeWorkspaces(freshConfig.watched_workspaces);
       const existingIds = new Set(workspaceStates.map((ws) => ws.workspaceId));
 
       const newWorkspaces = freshWorkspaces.filter(
@@ -788,23 +924,10 @@ export async function startDaemon(
         health.setRuntimeCount(
           workspaceStates.reduce((sum, w) => sum + w.runtimeIds.length, 0),
         );
+        // Only (re)build if we don't already have a live WS — never tear down a
+        // healthy connection on reload. rebuildWsClient sets wsWorkspaceId.
         if (!wsClient && workspaceStates.length > 0) {
-          const token = workspaceStates[0].token;
-          wsClient = new DaemonWsClient({
-            serverURL: config.serverURL,
-            daemonId: config.daemonId,
-            machineToken: token,
-            onMessage: handleWsPush,
-            onConnected: () => {
-              log.info("WS connected — switching to low-frequency poll");
-              updatePollInterval(config.wsPollInterval);
-            },
-            onDisconnected: () => {
-              log.info("WS disconnected — reverting to high-frequency poll");
-              updatePollInterval(config.pollInterval);
-            },
-          });
-          wsClient.connect();
+          rebuildWsClient();
           log.info("WS push client initialized after SIGHUP reload");
         }
         log.info(`Reload complete — now polling ${workspaceStates.length} workspace(s)`);

--- a/src/cli/daemon/ws-client.test.ts
+++ b/src/cli/daemon/ws-client.test.ts
@@ -115,6 +115,23 @@ describe("DaemonWsClient", () => {
     expect(onMessage).toHaveBeenCalledWith({ type: "daemon.rescan" });
   });
 
+  it("AUTH_REJECTED frame triggers onAuthRejected (before schema parse) and not onMessage", () => {
+    const onAuthRejected = vi.fn();
+    const onMessage = vi.fn();
+    const client = makeClient({ onAuthRejected, onMessage });
+    client.connect();
+
+    const ws = (client as any).ws as MockWebSocket;
+    ws.simulateOpen();
+    // The error frame is NOT in DaemonPushMessageSchema — it must be handled
+    // before safeParse or it'd be dropped as "invalid push message".
+    ws.simulateMessage(JSON.stringify({ type: "error", code: "AUTH_REJECTED", reason: "revoked" }));
+
+    expect(onAuthRejected).toHaveBeenCalledTimes(1);
+    expect(onAuthRejected).toHaveBeenCalledWith("revoked");
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
   it("invalid message (bad schema) does not call onMessage", () => {
     const onMessage = vi.fn();
     const client = makeClient({ onMessage });

--- a/src/cli/daemon/ws-client.ts
+++ b/src/cli/daemon/ws-client.ts
@@ -17,6 +17,13 @@ export interface DaemonWsClientOptions {
   onMessage: (msg: DaemonPushMessage) => void;
   onConnected: () => void;
   onDisconnected: () => void;
+  /**
+   * Fired when the server sends an `AUTH_REJECTED` frame — the definitive
+   * "this machine token is dead" signal. The daemon marks the workspace
+   * auth-failed and rebuilds the WS with a different token. `reason` is
+   * whatever the server attached (may be undefined).
+   */
+  onAuthRejected?: (reason?: string) => void;
 }
 
 export class DaemonWsClient {
@@ -84,6 +91,14 @@ export class DaemonWsClient {
           this.opts.onConnected();
           return;
         }
+        // Must be checked BEFORE DaemonPushMessageSchema.safeParse —
+        // the schema is a discriminatedUnion with no "error" member, so an
+        // AUTH_REJECTED frame would otherwise be dropped as "invalid push".
+        if (msg.type === "error" && msg.code === "AUTH_REJECTED") {
+          log.warn("machine token rejected by server (AUTH_REJECTED)", { reason: msg.reason });
+          this.opts.onAuthRejected?.(msg.reason);
+          return;
+        }
         const parsed = DaemonPushMessageSchema.safeParse(msg);
         if (!parsed.success) {
           log.warn("invalid push message", { err: parsed.error.message });
@@ -95,14 +110,19 @@ export class DaemonWsClient {
       }
     });
 
-    this.ws.addEventListener("error", () => {
-      log.debug("ws error");
+    this.ws.addEventListener("error", (event) => {
+      const err = (event as unknown as { message?: string; error?: unknown });
+      log.warn("ws error", { err: String(err?.message ?? err?.error ?? "unknown") });
     });
 
-    this.ws.addEventListener("close", () => {
+    this.ws.addEventListener("close", (event) => {
+      const { code, reason } = event as unknown as { code?: number; reason?: string };
       const wasConnected = this.connected;
       this.connected = false;
       this.stopHeartbeat();
+      // Surface close code/reason so a daemon stuck reconnecting is
+      // diagnosable (auth-close 1008 vs transient 1011 vs network).
+      log.info("ws closed", { code, reason, wasConnected });
       if (wasConnected) {
         this.opts.onDisconnected();
       }
@@ -135,7 +155,7 @@ export class DaemonWsClient {
     const delay = Math.min(this.reconnectDelay, WS_RECONNECT_MAX);
     this.reconnectDelay = Math.min(delay * 2, WS_RECONNECT_MAX);
     const jitter = Math.random() * 500;
-    log.debug("reconnecting", { delayMs: Math.round(delay + jitter) });
+    log.info("reconnecting", { delayMs: Math.round(delay + jitter) });
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
       this.connect();

--- a/src/cli/lib/activate.ts
+++ b/src/cli/lib/activate.ts
@@ -3,7 +3,7 @@ import { spawn } from "child_process";
 import { openSync, closeSync, mkdirSync } from "fs";
 import { dirname } from "path";
 import { APIClient } from "./client.js";
-import { loadCLIConfigForProfile, saveCLIConfigForProfile } from "./config.js";
+import { loadCLIConfigForProfile, saveCLIConfigForProfile, markWorkspaceActive } from "./config.js";
 import { cmdPrefix, isDev } from "./env.js";
 import { readDaemonPid, isProcessAlive } from "../daemon/pidfile.js";
 import { daemonLogFilePath } from "../daemon/config.js";
@@ -100,13 +100,12 @@ export async function activateAndSave(opts: {
   }
 
   const existing = loadCLIConfigForProfile(profile);
-  const watched = existing.watched_workspaces || [];
-  const idx = watched.findIndex((w) => w.id === ws.id);
-  if (idx >= 0) {
-    watched[idx] = { id: ws.id, name: ws.name, token, status: "active", agent_ids: agentIds };
-  } else {
-    watched.push({ id: ws.id, name: ws.name, token, status: "active", agent_ids: agentIds });
-  }
+  const watched = markWorkspaceActive(existing.watched_workspaces || [], {
+    id: ws.id,
+    name: ws.name,
+    token,
+    agent_ids: agentIds,
+  });
 
   saveCLIConfigForProfile(profile, {
     server_url: serverUrl,

--- a/src/cli/lib/config.ts
+++ b/src/cli/lib/config.ts
@@ -10,6 +10,8 @@ interface WatchedWorkspace {
   agent_ids?: string[];
 }
 
+type ActiveWorkspace = WatchedWorkspace & { id: string };
+
 interface ProfileConfig {
   server_url: string;
   session_token?: string;
@@ -24,7 +26,74 @@ interface CLIConfig {
   profiles?: Record<string, ProfileConfig>;
 }
 
-export type { CLIConfig, ProfileConfig };
+export type { CLIConfig, ProfileConfig, WatchedWorkspace, ActiveWorkspace };
+
+/**
+ * Effective status of a workspace entry. Soft-deleted entries linger in config
+ * but are dead; legacy entries without an explicit status inherit the same rule
+ * `loadCLIConfigForProfile` normalizes with (id ⇒ active, no id ⇒ deleted).
+ */
+function workspaceStatus(ws: WatchedWorkspace): "active" | "deleted" {
+  return ws.status ?? (ws.id ? "active" : "deleted");
+}
+
+/**
+ * The active workspaces are the only ones the daemon and CLI should ever act
+ * on. All readers go through this so the "is this workspace live?" rule lives
+ * in exactly one place — select the active entries, never scatter a
+ * `status !== "deleted"` filter at each call site.
+ */
+export function activeWorkspaces(
+  workspaces: WatchedWorkspace[] | undefined,
+): ActiveWorkspace[] {
+  return (workspaces || []).filter(
+    (ws): ws is ActiveWorkspace => workspaceStatus(ws) === "active" && !!ws.id,
+  );
+}
+
+/**
+ * Mark a workspace live: upsert the entry, set `status="active"`, and refresh
+ * name/token/agent_ids. Sole writer of the active transition — pairing,
+ * re-login sync, and studio creation all funnel through here. Mutates `watched`
+ * in place and returns it so the caller keeps ownership of load/save.
+ */
+export function markWorkspaceActive(
+  watched: WatchedWorkspace[],
+  fields: { id: string; name: string | null; token?: string; agent_ids?: string[] },
+): WatchedWorkspace[] {
+  const existing = watched.find((w) => w.id === fields.id);
+  if (existing) {
+    existing.status = "active";
+    existing.name = fields.name;
+    if (fields.token !== undefined) existing.token = fields.token;
+    if (fields.agent_ids !== undefined) existing.agent_ids = fields.agent_ids;
+  } else {
+    watched.push({
+      id: fields.id,
+      name: fields.name,
+      token: fields.token ?? "",
+      status: "active",
+      agent_ids: fields.agent_ids ?? [],
+    });
+  }
+  return watched;
+}
+
+/**
+ * Soft-delete a workspace by id: flip `status="deleted"` in place, leaving the
+ * entry so the cause stays inspectable and re-pairing can revive it. Sole
+ * writer of the deleted transition. No-op if the id is absent. Returns whether
+ * an entry was found so the caller can decide to persist.
+ */
+export function markWorkspaceDeletedInList(
+  watched: WatchedWorkspace[],
+  workspaceId: string,
+): boolean {
+  const entry = watched.find((w) => w.id === workspaceId);
+  if (!entry) return false;
+  entry.status = "deleted";
+  return true;
+}
 
 export function configDir(): string {
   return process.env.ALOOK_PROJECT_ROOT || join(homedir(), ".alook");
@@ -56,7 +125,7 @@ export function loadCLIConfigForProfile(profile?: string): ProfileConfig {
 
   // Default status for old entries without it
   for (const ws of result.watched_workspaces) {
-    if (!ws.status) ws.status = ws.id ? "active" : "deleted";
+    if (!ws.status) ws.status = workspaceStatus(ws);
   }
 
   return result;

--- a/src/cli/lib/resolve-client.test.ts
+++ b/src/cli/lib/resolve-client.test.ts
@@ -1,6 +1,7 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 
-vi.mock("./config.js", () => ({
+vi.mock("./config.js", async (importActual) => ({
+  ...(await importActual<typeof import("./config.js")>()),
   loadCLIConfigForProfile: vi.fn(),
 }));
 

--- a/src/cli/lib/resolve-client.ts
+++ b/src/cli/lib/resolve-client.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { loadCLIConfigForProfile } from "./config.js";
+import { loadCLIConfigForProfile, activeWorkspaces } from "./config.js";
 import { cmdPrefix } from "./env.js";
 import { getRootOpts } from "./command-utils.js";
 
@@ -43,7 +43,7 @@ export function resolveClientOptsPartial(command: Command, opts: ResolveClientOp
     process.exit(1);
   }
 
-  const workspaces = cfg.watched_workspaces || [];
+  const workspaces = activeWorkspaces(cfg.watched_workspaces);
 
   // Workspace resolution: flag > env > config lookup by agent_id > single workspace fallback
   let ws;

--- a/src/web/src/app/api/agent-links/[id]/route.ts
+++ b/src/web/src/app/api/agent-links/[id]/route.ts
@@ -4,7 +4,6 @@ import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
 import { agentLinkToResponse } from "@/lib/api/responses";
-import { invalidate, cacheKeys } from "@/lib/cache";
 
 export const PATCH = withAuth(async (req, ctx) => {
   const ws = await withWorkspaceMember(req, ctx);
@@ -32,8 +31,6 @@ export const PATCH = withAuth(async (req, ctx) => {
   });
   if (!updated) return writeError("not found", 404);
 
-  await invalidate(cacheKeys.agentLinks(ws.workspaceId));
-
   return writeJSON(agentLinkToResponse(updated));
 });
 
@@ -57,8 +54,6 @@ export const DELETE = withAuth(async (req, ctx) => {
 
   const deleted = await queries.agentLink.remove(db, id, ws.workspaceId);
   if (!deleted) return writeError("not found", 404);
-
-  await invalidate(cacheKeys.agentLinks(ws.workspaceId));
 
   return writeJSON(agentLinkToResponse(deleted));
 });

--- a/src/web/src/app/api/agent-links/route.test.ts
+++ b/src/web/src/app/api/agent-links/route.test.ts
@@ -221,7 +221,7 @@ describe("PUT /api/agent-links (upsert)", () => {
   });
 
   // TC8
-  it("creates a new pair -> 201, created:true, invalidates caches", async () => {
+  it("creates a new pair -> 201, created:true", async () => {
     mockGetAgent.mockResolvedValue({ id: "ag_x" });
     mockUpsertByPair.mockResolvedValue({
       row: {
@@ -240,7 +240,6 @@ describe("PUT /api/agent-links (upsert)", () => {
     const body = await res.json();
     expect(body.created).toBe(true);
     expect(body.instruction).toBe("delegate");
-    expect(mockInvalidate).toHaveBeenCalledWith("agentLinks:ws1");
   });
 
   // TC9

--- a/src/web/src/app/api/agent-links/route.ts
+++ b/src/web/src/app/api/agent-links/route.ts
@@ -10,7 +10,7 @@ import { withAuth } from "@/lib/middleware/auth";
 import { withWorkspaceMember } from "@/lib/middleware/workspace";
 import { writeJSON, writeError, parseBody } from "@/lib/middleware/helpers";
 import { agentLinkToResponse } from "@/lib/api/responses";
-import { cached, invalidate, cacheKeys } from "@/lib/cache";
+import { cached, cacheKeys } from "@/lib/cache";
 import { filterVisibleAgents } from "@/lib/agent-visibility";
 
 export const GET = withAuth(async (req: NextRequest, ctx) => {
@@ -64,7 +64,6 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
       targetAgentId: body.target_agent_id,
       instruction: body.instruction,
     });
-    await invalidate(cacheKeys.agentLinks(ws.workspaceId));
     return writeJSON(agentLinkToResponse(created), 201);
   } catch (e) {
     if (isUniqueConstraintError(e)) {
@@ -125,8 +124,6 @@ export const PUT = withAuth(async (req: NextRequest, ctx) => {
     });
     created = false;
   }
-
-  await invalidate(cacheKeys.agentLinks(ws.workspaceId));
 
   return writeJSON({ ...agentLinkToResponse(row), created }, created ? 201 : 200);
 });

--- a/src/web/src/app/api/agents/[id]/route.ts
+++ b/src/web/src/app/api/agents/[id]/route.ts
@@ -71,7 +71,6 @@ export const PATCH = withAuth(async (req, ctx) => {
   }
 
   await Promise.all([
-    invalidate(cacheKeys.agent(ws.workspaceId, id)),
     invalidate(cacheKeys.allHandles(ws.workspaceId)),
     invalidate(cacheKeys.allAgentAccess(ws.workspaceId)),
   ]);
@@ -100,7 +99,6 @@ export const DELETE = withAuth(async (req, ctx) => {
   }
 
   await Promise.all([
-    invalidate(cacheKeys.agent(ws.workspaceId, id)),
     invalidate(cacheKeys.allHandles(ws.workspaceId)),
     invalidate(cacheKeys.allAgentAccess(ws.workspaceId)),
   ]);

--- a/src/web/src/app/api/agents/[id]/whitelist/route.ts
+++ b/src/web/src/app/api/agents/[id]/whitelist/route.ts
@@ -66,7 +66,6 @@ export const POST = withAuth(async (req, ctx) => {
       );
       const dateStr = new Date().toISOString().slice(0, 10);
       invalidate(cacheKeys.overviewTaskStats(ws.workspaceId, dateStr)).catch(() => {});
-      invalidate(cacheKeys.activeTaskCounts(ws.workspaceId)).catch(() => {});
     } catch {
       // Best-effort — don't fail the whitelist operation
     }

--- a/src/web/src/app/api/agents/recruit/route.ts
+++ b/src/web/src/app/api/agents/recruit/route.ts
@@ -103,7 +103,6 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
   await Promise.all([
     invalidate(cacheKeys.allHandles(ws.workspaceId)),
     invalidate(cacheKeys.allAgentAccess(ws.workspaceId)),
-    invalidate(cacheKeys.agentLinks(ws.workspaceId)),
   ]);
 
   broadcastToUser(ctx.userId, {

--- a/src/web/src/app/api/agents/route.ts
+++ b/src/web/src/app/api/agents/route.ts
@@ -108,7 +108,6 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
       );
       const dateStr = new Date().toISOString().slice(0, 10);
       invalidate(cacheKeys.overviewTaskStats(ws.workspaceId, dateStr)).catch(() => {});
-      invalidate(cacheKeys.activeTaskCounts(ws.workspaceId)).catch(() => {});
     } catch {
       // Best-effort — don't fail agent creation
     }

--- a/src/web/src/app/api/daemon/deregister/route.ts
+++ b/src/web/src/app/api/daemon/deregister/route.ts
@@ -31,7 +31,6 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
 
   await Promise.all([
     invalidate(cacheKeys.runtimeIds(ctx.workspaceId, body.daemon_id)),
-    invalidate(cacheKeys.allRuntimes(ctx.workspaceId)),
   ]);
 
   // Single broadcast at daemon level

--- a/src/web/src/app/api/daemon/register/route.ts
+++ b/src/web/src/app/api/daemon/register/route.ts
@@ -95,7 +95,6 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
 
   await Promise.all([
     invalidate(cacheKeys.runtimeIds(workspaceId, daemonId)),
-    invalidate(cacheKeys.allRuntimes(workspaceId)),
   ]);
 
   broadcastToUser(ctx.userId, {

--- a/src/web/src/app/api/machine-tokens/activate/route.test.ts
+++ b/src/web/src/app/api/machine-tokens/activate/route.test.ts
@@ -6,11 +6,13 @@ const mockActivateMachineToken = vi.fn();
 const mockUpsertMachine = vi.fn();
 const mockBatchUpsertAgentRuntimes = vi.fn();
 const mockBroadcastToUser = vi.fn();
+const mockWarmMachineTokenCache = vi.fn();
+const mockKv = { put: vi.fn(), get: vi.fn(), delete: vi.fn() };
 
 function sharedMocks() {
   return {
     "@opennextjs/cloudflare": {
-      getCloudflareContext: vi.fn(() => Promise.resolve({ env: { DB: {} } })),
+      getCloudflareContext: vi.fn(() => Promise.resolve({ env: { DB: {}, CACHE_KV: mockKv } })),
     },
     "@alook/shared": async () => ({
       createDb: vi.fn(() => ({})),
@@ -63,6 +65,9 @@ describe("POST /api/machine-tokens/activate", () => {
         runtimeIds: () => "ri:",
         allRuntimes: () => "ar:",
       },
+    }));
+    vi.doMock("@/lib/middleware/auth", () => ({
+      warmMachineTokenCache: (...a: any[]) => mockWarmMachineTokenCache(...a),
     }));
     vi.doMock("@/lib/middleware/helpers", async () => {
       return await vi.importActual<typeof import("@/lib/middleware/helpers")>(
@@ -131,6 +136,58 @@ describe("POST /api/machine-tokens/activate", () => {
       "mt_1",
       "TestMachine.local",
     );
+  });
+
+  it("warms the token cache with the activated row (not a delete)", async () => {
+    const POST = await loadRoute();
+
+    mockGetMachineTokenByToken.mockResolvedValue(pendingToken);
+    mockUpsertMachine.mockResolvedValue(undefined);
+    mockBatchUpsertAgentRuntimes.mockResolvedValue([{ id: "rt_1", provider: "claude" }]);
+    mockActivateMachineToken.mockResolvedValue(undefined);
+    mockBroadcastToUser.mockResolvedValue(undefined);
+
+    await POST(makeReq(validBody));
+
+    // Warmed with the just-activated row (status flipped to active), through
+    // the explicit CACHE_KV binding — closes the daemon's first-poll false-401.
+    expect(mockWarmMachineTokenCache).toHaveBeenCalledWith(
+      mockKv,
+      "al_test123",
+      expect.objectContaining({ id: "mt_1", status: "active" }),
+    );
+  });
+
+  it("succeeds when CACHE_KV is absent (warm is a no-op, no throw)", async () => {
+    vi.resetModules();
+    const mocks = sharedMocks();
+    (mocks["@opennextjs/cloudflare"].getCloudflareContext as any) = vi.fn(() =>
+      Promise.resolve({ env: { DB: {} } }),
+    );
+    vi.doMock("@opennextjs/cloudflare", () => mocks["@opennextjs/cloudflare"]);
+    vi.doMock("@alook/shared", mocks["@alook/shared"]);
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+    vi.doMock("@/lib/broadcast", () => mocks["@/lib/broadcast"]);
+    vi.doMock("@/lib/cache", () => ({
+      invalidate: vi.fn(() => Promise.resolve()),
+      cacheKeys: { machineToken: (t: string) => `mt:${t}`, runtimeIds: () => "ri:", allRuntimes: () => "ar:" },
+    }));
+    vi.doMock("@/lib/middleware/auth", () => ({
+      warmMachineTokenCache: (...a: any[]) => mockWarmMachineTokenCache(...a),
+    }));
+    vi.doMock("@/lib/api/responses", () => ({ runtimeToResponse: (r: any) => ({ id: r.id, provider: r.provider }) }));
+    const { POST } = await import("./route");
+
+    mockGetMachineTokenByToken.mockResolvedValue(pendingToken);
+    mockUpsertMachine.mockResolvedValue(undefined);
+    mockBatchUpsertAgentRuntimes.mockResolvedValue([{ id: "rt_1", provider: "claude" }]);
+    mockActivateMachineToken.mockResolvedValue(undefined);
+    mockBroadcastToUser.mockResolvedValue(undefined);
+
+    const res = await POST(makeReq(validBody));
+    expect(res.status).toBe(200);
+    // Called with null KV — the helper itself no-ops; here we just assert wiring.
+    expect(mockWarmMachineTokenCache).toHaveBeenCalledWith(null, "al_test123", expect.anything());
   });
 
   it("broadcasts runtime.registered event", async () => {

--- a/src/web/src/app/api/machine-tokens/activate/route.ts
+++ b/src/web/src/app/api/machine-tokens/activate/route.ts
@@ -66,7 +66,6 @@ export const POST = withEnv(async (req: NextRequest, ctx) => {
   await Promise.all([
     invalidate(cacheKeys.machineToken(token)),
     invalidate(cacheKeys.runtimeIds(workspaceId, daemonId)),
-    invalidate(cacheKeys.allRuntimes(workspaceId)),
   ]);
 
   broadcastToUser(mt.userId, {

--- a/src/web/src/app/api/machine-tokens/activate/route.ts
+++ b/src/web/src/app/api/machine-tokens/activate/route.ts
@@ -6,6 +6,7 @@ import { writeJSON } from "@/lib/middleware/helpers";
 import { runtimeToResponse } from "@/lib/api/responses";
 import { broadcastToUser } from "@/lib/broadcast";
 import { invalidate, cacheKeys } from "@/lib/cache";
+import { warmMachineTokenCache } from "@/lib/middleware/auth";
 
 const log = createLogger({ service: "machine-tokens/activate" });
 
@@ -63,8 +64,13 @@ export const POST = withEnv(async (req: NextRequest, ctx) => {
 
   await queries.machineToken.activateMachineToken(db, mt.id, hostname);
 
+  // Warm the positive token cache with the just-activated row (the route
+  // already holds it, incl. the userEmail join auth needs — activate only
+  // flips status). This closes the false-401 window where the daemon's first
+  // poll reads a lagged replica and negative-caches a 401. withEnv doesn't
+  // bind cache KV, so pass the namespace explicitly.
   await Promise.all([
-    invalidate(cacheKeys.machineToken(token)),
+    warmMachineTokenCache(ctx.env.CACHE_KV ?? null, token, { ...mt, status: "active" }),
     invalidate(cacheKeys.runtimeIds(workspaceId, daemonId)),
   ]);
 

--- a/src/web/src/app/api/runtimes/machine/route.ts
+++ b/src/web/src/app/api/runtimes/machine/route.ts
@@ -29,7 +29,6 @@ export const DELETE = withAuth(async (req: NextRequest, ctx) => {
     await queries.machine.deleteMachine(db, daemonId, ws.workspaceId);
     await Promise.all([
       invalidate(cacheKeys.runtimeIds(ws.workspaceId, daemonId)),
-      invalidate(cacheKeys.allRuntimes(ws.workspaceId)),
     ]);
   } catch (e) {
     log.error("Failed to delete machine", { err: e });

--- a/src/web/src/app/api/studios/route.ts
+++ b/src/web/src/app/api/studios/route.ts
@@ -184,7 +184,6 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     invalidate(cacheKeys.allAgentAccess(ws.workspaceId)),
     invalidate(cacheKeys.allMembers(ws.workspaceId)),
     invalidate(cacheKeys.overviewTaskStats(ws.workspaceId, dateStr)),
-    invalidate(cacheKeys.agentLinks(ws.workspaceId)),
   ]);
 
   // Pin leader agent by default

--- a/src/web/src/lib/cache.test.ts
+++ b/src/web/src/lib/cache.test.ts
@@ -220,14 +220,11 @@ describe("cache", () => {
 
   describe("cacheKeys", () => {
     it("generates correct key formats", () => {
-      expect(cacheKeys.agent("ws1", "ag1")).toBe("ag:ws1:ag1");
       expect(cacheKeys.member("ws1", "usr1")).toBe("mem:ws1:usr1");
       expect(cacheKeys.user("usr1")).toBe("usr:usr1");
       expect(cacheKeys.allEmailAccounts("ws1")).toBe("ea:ws1");
       expect(cacheKeys.allHandles("ws1")).toBe("handles:ws1");
-      expect(cacheKeys.heartbeat("ws1", "d1")).toBe("hb:ws1:d1");
       expect(cacheKeys.machineToken("al_1234567890abcdefghij_rest")).toBe("mt:al_1234567890abcdefg");
-      expect(cacheKeys.machineTokenLastUsed("al_1234567890abcdefghij_rest")).toBe("mt_lu:al_1234567890abcdefg");
       expect(cacheKeys.runtimeIds("ws1", "d1")).toBe("rt:ws1:d1");
     });
 
@@ -235,13 +232,11 @@ describe("cache", () => {
       expect(cacheKeys.overviewEmailStats("ws1")).toBe("ov_email:ws1");
       expect(cacheKeys.overviewTaskStats("ws1", "2026-05-18")).toBe("ov_task:ws1:2026-05-18");
       expect(cacheKeys.allAgentAccess("ws1")).toBe("aa:ws1");
-      expect(cacheKeys.allRuntimes("ws1")).toBe("runtimes:ws1");
       expect(cacheKeys.allMembers("ws1")).toBe("members:ws1");
     });
 
     it("workspace-scoped keys differ by workspace", () => {
       expect(cacheKeys.overviewEmailStats("ws1")).not.toBe(cacheKeys.overviewEmailStats("ws2"));
-      expect(cacheKeys.allRuntimes("ws1")).not.toBe(cacheKeys.allRuntimes("ws2"));
       expect(cacheKeys.allMembers("ws1")).not.toBe(cacheKeys.allMembers("ws2"));
       expect(cacheKeys.allAgentAccess("ws1")).not.toBe(cacheKeys.allAgentAccess("ws2"));
     });
@@ -252,12 +247,11 @@ describe("cache", () => {
         cacheKeys.overviewEmailStats(ws),
         cacheKeys.overviewTaskStats(ws, "2026-01-01"),
         cacheKeys.allAgentAccess(ws),
-        cacheKeys.allRuntimes(ws),
         cacheKeys.allMembers(ws),
         cacheKeys.allEmailAccounts(ws),
         cacheKeys.allHandles(ws),
       ]);
-      expect(keys.size).toBe(7);
+      expect(keys.size).toBe(6);
     });
 
     it("overviewTaskStats includes date for cross-midnight isolation", () => {

--- a/src/web/src/lib/cache.ts
+++ b/src/web/src/lib/cache.ts
@@ -218,22 +218,16 @@ export function invalidateInboxCounts(userId: string, workspaceId: string): Prom
 
 export const cacheKeys = {
   machineToken: (token: string) => `mt:${token.slice(0, 20)}`,
-  machineTokenLastUsed: (token: string) => `mt_lu:${token.slice(0, 20)}`,
   member: (workspaceId: string, userId: string) => `mem:${workspaceId}:${userId}`,
   runtimeIds: (workspaceId: string, daemonId: string) => `rt:${workspaceId}:${daemonId}`,
-  agent: (workspaceId: string, agentId: string) => `ag:${workspaceId}:${agentId}`,
-  heartbeat: (workspaceId: string, daemonId: string) => `hb:${workspaceId}:${daemonId}`,
   user: (userId: string) => `usr:${userId}`,
   allEmailAccounts: (workspaceId: string) => `ea:${workspaceId}`,
-  agentLinks: (workspaceId: string) => `al:${workspaceId}`,
   allHandles: (workspaceId: string) => `handles:${workspaceId}`,
   overviewEmailAccounts: (workspaceId: string) => `ov_ea:${workspaceId}`,
   overviewEmailStats: (workspaceId: string) => `ov_email:${workspaceId}`,
   overviewTaskStats: (workspaceId: string, dateStr: string) => `ov_task:${workspaceId}:${dateStr}`,
   allAgentAccess: (workspaceId: string) => `aa:${workspaceId}`,
-  allRuntimes: (workspaceId: string) => `runtimes:${workspaceId}`,
   allMembers: (workspaceId: string) => `members:${workspaceId}`,
-  activeTaskCounts: (workspaceId: string) => `atc:${workspaceId}`,
   inboxCount: (userId: string, workspaceId: string, types?: string[]) =>
     `inbox:${userId}:${workspaceId}:${types ? [...types].sort().join(",") : "*"}`,
   hasPendingFileRequest: (workspaceId: string) => `fr_p:${workspaceId}`,

--- a/src/web/src/lib/middleware/auth.test.ts
+++ b/src/web/src/lib/middleware/auth.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest, NextResponse } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
 
 vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(async () => ({ env: { DB: {} } })),
@@ -31,13 +32,29 @@ const mockGetMachineTokenByHash = queries.machineToken
   .getMachineTokenByToken as ReturnType<typeof vi.fn>;
 const mockUpdateMachineTokenLastUsed = queries.machineToken
   .updateMachineTokenLastUsed as ReturnType<typeof vi.fn>;
+const mockGetCloudflareContext = getCloudflareContext as unknown as ReturnType<typeof vi.fn>;
+
+/** Build a stub KV and point the CF context at it for one test. */
+function bindMockKV(overrides?: { get?: ReturnType<typeof vi.fn> }) {
+  const kv = {
+    get: overrides?.get ?? vi.fn().mockResolvedValue(null),
+    put: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+  };
+  mockGetCloudflareContext.mockResolvedValue({ env: { DB: {}, CACHE_KV: kv } });
+  return kv;
+}
 
 const testHandler = vi.fn(async (_req: NextRequest, ctx: any) =>
   NextResponse.json({ ok: true, ctx })
 );
 
 describe("withAuth middleware", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: no KV bound (cold-path every request), matching original tests.
+    mockGetCloudflareContext.mockResolvedValue({ env: { DB: {} } });
+  });
 
   const wrapped = withAuth(testHandler);
 
@@ -143,6 +160,21 @@ describe("withAuth middleware", () => {
     expect(body.error).toBe("invalid token");
   });
 
+  it("returns 503 (not 401) when the D1 token lookup throws — transient, daemon must retry", async () => {
+    mockGetMachineTokenByHash.mockRejectedValue(new Error("D1 unavailable"));
+
+    const req = new NextRequest("http://localhost/api/test", {
+      headers: { Authorization: "Bearer al_valid_but_db_down" },
+    });
+    const res = await wrapped(req);
+    const body = await res.json();
+
+    // Must NOT be 401 — a DB blip is not a revoked token; the daemon uses 401
+    // to mark a workspace auth-failed, so a transient failure must be 503.
+    expect(res.status).toBe(503);
+    expect(body.error).not.toBe("invalid token");
+  });
+
   it("updates lastUsedAt on machine token auth", async () => {
     mockGetMachineTokenByHash.mockResolvedValue({
       id: "mt-2",
@@ -158,6 +190,100 @@ describe("withAuth middleware", () => {
     await wrapped(req);
 
     expect(mockUpdateMachineTokenLastUsed).toHaveBeenCalledWith({}, "mt-2");
+  });
+
+  it("cold KV miss populates the merged entry and bumps last_used immediately", async () => {
+    const kv = bindMockKV();
+    mockGetMachineTokenByHash.mockResolvedValue({
+      id: "mt-cold",
+      userId: "user-cold",
+      userEmail: "cold@example.com",
+      workspaceId: null,
+    });
+
+    const req = new NextRequest("http://localhost/api/test", {
+      headers: { Authorization: "Bearer al_cold_token" },
+    });
+    const res = await wrapped(req);
+
+    expect(res.status).toBe(200);
+    expect(mockGetMachineTokenByHash).toHaveBeenCalledOnce();
+    expect(mockUpdateMachineTokenLastUsed).toHaveBeenCalledWith({}, "mt-cold");
+    // Entry written back with luAt so the throttle window starts now.
+    expect(kv.put).toHaveBeenCalledOnce();
+    const [, storedJson] = kv.put.mock.calls[0];
+    const stored = JSON.parse(storedJson);
+    expect(stored.row.id).toBe("mt-cold");
+    expect(typeof stored.luAt).toBe("number");
+  });
+
+  it("warm KV hit within throttle window skips D1 and does not bump", async () => {
+    const entry = {
+      row: { id: "mt-warm", userId: "user-warm", userEmail: "warm@example.com", workspaceId: "ws-w" },
+      luAt: Date.now(),
+    };
+    bindMockKV({ get: vi.fn().mockResolvedValue(JSON.stringify(entry)) });
+
+    const req = new NextRequest("http://localhost/api/test", {
+      headers: { Authorization: "Bearer al_warm_token" },
+    });
+    const res = await wrapped(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ctx.userId).toBe("user-warm");
+    expect(mockGetMachineTokenByHash).not.toHaveBeenCalled();
+    expect(mockUpdateMachineTokenLastUsed).not.toHaveBeenCalled();
+  });
+
+  it("warm KV hit past throttle window bumps last_used and refreshes luAt", async () => {
+    const stale = {
+      row: { id: "mt-stale", userId: "user-stale", userEmail: "stale@example.com", workspaceId: null },
+      luAt: Date.now() - 901_000,
+    };
+    const kv = bindMockKV({ get: vi.fn().mockResolvedValue(JSON.stringify(stale)) });
+
+    const req = new NextRequest("http://localhost/api/test", {
+      headers: { Authorization: "Bearer al_stale_token" },
+    });
+    const res = await wrapped(req);
+
+    expect(res.status).toBe(200);
+    expect(mockGetMachineTokenByHash).not.toHaveBeenCalled();
+    expect(mockUpdateMachineTokenLastUsed).toHaveBeenCalledWith({}, "mt-stale");
+    expect(kv.put).toHaveBeenCalledOnce();
+  });
+
+  it("negative-caches an invalid token so a repeat request skips D1", async () => {
+    bindMockKV({ get: vi.fn().mockResolvedValue(JSON.stringify({ row: null, luAt: Date.now() })) });
+
+    const req = new NextRequest("http://localhost/api/test", {
+      headers: { Authorization: "Bearer al_negcached_token" },
+    });
+    const res = await wrapped(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe("invalid token");
+    expect(mockGetMachineTokenByHash).not.toHaveBeenCalled();
+  });
+
+  it("falls back to D1 when KV read throws (a blip must not 401 a valid token)", async () => {
+    bindMockKV({ get: vi.fn().mockRejectedValue(new Error("kv down")) });
+    mockGetMachineTokenByHash.mockResolvedValue({
+      id: "mt-blip",
+      userId: "user-blip",
+      userEmail: "blip@example.com",
+      workspaceId: null,
+    });
+
+    const req = new NextRequest("http://localhost/api/test", {
+      headers: { Authorization: "Bearer al_blip_token" },
+    });
+    const res = await wrapped(req);
+
+    expect(res.status).toBe(200);
+    expect(mockGetMachineTokenByHash).toHaveBeenCalledOnce();
   });
 
   it("resolves dynamic params from context", async () => {

--- a/src/web/src/lib/middleware/auth.test.ts
+++ b/src/web/src/lib/middleware/auth.test.ts
@@ -25,7 +25,7 @@ vi.mock("@/lib/auth", () => ({
   })),
 }));
 
-import { withAuth } from "./auth";
+import { withAuth, warmMachineTokenCache } from "./auth";
 import { queries } from "@alook/shared";
 
 const mockGetMachineTokenByHash = queries.machineToken
@@ -300,5 +300,49 @@ describe("withAuth middleware", () => {
 
     expect(res.status).toBe(200);
     expect(body.ctx.params).toEqual({ id: "x" });
+  });
+});
+
+describe("warmMachineTokenCache", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const row = {
+    id: "mt-warm",
+    userId: "user-warm",
+    userEmail: "warm@example.com",
+    workspaceId: "ws-w",
+    status: "active",
+  } as any;
+
+  it("writes a positive { row, luAt } entry at the 15-min TTL", async () => {
+    const kv = { get: vi.fn(), put: vi.fn().mockResolvedValue(undefined), delete: vi.fn() };
+    await warmMachineTokenCache(kv as any, "al_warm_token", row);
+
+    expect(kv.put).toHaveBeenCalledOnce();
+    const [key, value, opts] = kv.put.mock.calls[0];
+    expect(key).toBe(`mt:${"al_warm_token".slice(0, 20)}`);
+    const parsed = JSON.parse(value);
+    expect(parsed.row).toEqual(row);
+    expect(typeof parsed.luAt).toBe("number");
+    expect(opts.expirationTtl).toBe(900);
+  });
+
+  it("a subsequent withAuth read hits the warmed entry without touching D1", async () => {
+    const entry = { row, luAt: Date.now() };
+    bindMockKV({ get: vi.fn().mockResolvedValue(JSON.stringify(entry)) });
+    const wrapped = withAuth(testHandler);
+
+    const req = new NextRequest("http://localhost/api/test", {
+      headers: { Authorization: "Bearer al_warm_token" },
+    });
+    const res = await wrapped(req);
+
+    expect(res.status).toBe(200);
+    // Warm hit — no cold D1 read.
+    expect(mockGetMachineTokenByHash).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when KV is null (no throw)", async () => {
+    await expect(warmMachineTokenCache(null, "al_x", row)).resolves.toBeUndefined();
   });
 });

--- a/src/web/src/lib/middleware/auth.ts
+++ b/src/web/src/lib/middleware/auth.ts
@@ -3,7 +3,7 @@ import { getCloudflareContext } from "@opennextjs/cloudflare"
 import { queries } from "@alook/shared"
 import { getDb } from "@/lib/db"
 import { createAuth } from "@/lib/auth"
-import { cached, cacheKeys, bindCacheKV, throttled } from "@/lib/cache"
+import { getKV, cacheKeys, bindCacheKV } from "@/lib/cache"
 
 export interface AuthContext {
   env: Env
@@ -11,6 +11,33 @@ export interface AuthContext {
   email: string
   workspaceId?: string
 }
+
+/**
+ * Merged machine-token cache entry. One KV read per authenticated request
+ * yields BOTH the token-validation result (`row`) and the last-used bump
+ * throttle (`luAt`, the epoch ms of the last `last_used_at` D1 write),
+ * replacing the old two-key `mt:` + `mt_lu:` pair.
+ *
+ * `row: null` is a NEGATIVE cache — an invalid token is remembered so a
+ * repeated bad token doesn't re-hit D1 every request. A token string only
+ * exists after `createMachineToken` commits, and revoke/delete paths
+ * `invalidate(cacheKeys.machineToken(token))`. The one null→non-null window
+ * is read-replica lag on a freshly-created token, so negative entries use a
+ * short `MT_NEG_TTL_S` to bound any false-401 lockout.
+ */
+type MachineTokenRow = Awaited<ReturnType<typeof queries.machineToken.getMachineTokenByToken>>
+interface MachineTokenEntry {
+  row: MachineTokenRow
+  luAt: number
+}
+const MT_TTL_S = 900
+// Negative (`row: null`) entries live only briefly. D1 reads go through
+// read-replica sessions (`first-unconstrained`), so a freshly-created token
+// can momentarily read null due to replication lag; a full 15-min negative
+// TTL would then 401 a valid token for the whole window. 60s (KV's floor)
+// still absorbs repeated-bad-token storms without a long lockout.
+const MT_NEG_TTL_S = 60
+const MT_BUMP_INTERVAL_MS = 900_000
 
 export type AuthenticatedHandler = (
   req: NextRequest,
@@ -38,19 +65,65 @@ export function withAuth(handler: AuthenticatedHandler) {
       if (raw.startsWith("al_")) {
         try {
           const db = getDb(cloudflareEnv.DB)
-          const mt = await cached(
-            cacheKeys.machineToken(raw),
-            900,
-            () => queries.machineToken.getMachineTokenByToken(db, raw),
-          )
+          const kv = getKV()
+          const key = cacheKeys.machineToken(raw)
+          const now = Date.now()
+
+          // Read the merged entry. A KV blip must NOT turn a valid token into
+          // a 401 — on read failure we fall through to D1 (mirrors `cached`).
+          let entry: MachineTokenEntry | null = null
+          if (kv) {
+            try {
+              const cachedRaw = await kv.get(key)
+              if (cachedRaw) {
+                const parsed = JSON.parse(cachedRaw) as Partial<MachineTokenEntry>
+                // Shape guard: a pre-upgrade deploy stored the bare row under
+                // this same `mt:` key (old `cached()` format). Reading that as
+                // a MachineTokenEntry would leave `row` undefined → a false 401
+                // for a VALID token until the old entry's TTL expires (and the
+                // daemon treats sustained 401s as a dead token). Only accept the
+                // new `{ row, luAt }` shape; anything else falls through to a
+                // cold D1 miss that repopulates in the new format.
+                if (parsed && "row" in parsed && typeof parsed.luAt === "number") {
+                  entry = parsed as MachineTokenEntry
+                }
+              }
+            } catch {
+              entry = null
+            }
+          }
+
+          let bump = false
+          if (!entry) {
+            // Cold miss: hit D1 and populate. On a hit, bump immediately so
+            // `last_used_at` reflects first contact (preserves prior
+            // semantics), then remember it for the TTL window.
+            const row = await queries.machineToken.getMachineTokenByToken(db, raw)
+            entry = { row, luAt: now }
+            bump = row != null
+            if (kv) {
+              const ttl = row != null ? MT_TTL_S : MT_NEG_TTL_S
+              kv.put(key, JSON.stringify(entry), { expirationTtl: ttl }).catch(() => {})
+            }
+          } else if (entry.row && now - entry.luAt > MT_BUMP_INTERVAL_MS) {
+            // Warm hit, throttle window elapsed: bump and refresh luAt.
+            bump = true
+            if (kv) {
+              kv.put(key, JSON.stringify({ row: entry.row, luAt: now }), { expirationTtl: MT_TTL_S }).catch(() => {})
+            }
+          }
+
+          const mt = entry.row
           if (!mt) {
+            // row === null is the ONLY "definitely invalid" signal (token
+            // doesn't exist). The daemon uses this 401 to mark a workspace
+            // as auth-failed, so it must never fire on transient infra
+            // failure — those throw and fall to the 503 catch below.
             return NextResponse.json({ error: "invalid token" }, { status: 401 })
           }
-          throttled(
-            cacheKeys.machineTokenLastUsed(raw),
-            900,
-            () => queries.machineToken.updateMachineTokenLastUsed(db, mt.id),
-          ).catch(() => {});
+          if (bump) {
+            Promise.resolve(queries.machineToken.updateMachineTokenLastUsed(db, mt.id)).catch(() => {})
+          }
           const authCtx: AuthContext = {
             env: cloudflareEnv,
             userId: mt.userId,
@@ -59,7 +132,11 @@ export function withAuth(handler: AuthenticatedHandler) {
           }
           return handler(req, { ...authCtx, params: resolvedParams })
         } catch {
-          return NextResponse.json({ error: "invalid token" }, { status: 401 })
+          // D1 query / getDb / getKV threw — transient infra failure, NOT an
+          // invalid token. Mirror the session path's 503 so the daemon retries
+          // instead of treating a DB blip as a revoked token (which would
+          // wrongly mark the workspace deleted).
+          return NextResponse.json({ error: "auth temporarily unavailable" }, { status: 503 })
         }
       }
     }

--- a/src/web/src/lib/middleware/auth.ts
+++ b/src/web/src/lib/middleware/auth.ts
@@ -39,6 +39,28 @@ const MT_TTL_S = 900
 const MT_NEG_TTL_S = 60
 const MT_BUMP_INTERVAL_MS = 900_000
 
+/**
+ * Warm the positive machine-token cache entry with a known-good row. Called at
+ * activation time so the daemon's first poll — a separate Worker invocation
+ * that may read a lagged replica (D1 uses `first-unconstrained` sessions) —
+ * hits a positive KV entry instead of reading `null` and negative-caching a
+ * 401 for `MT_NEG_TTL_S`. Best-effort (a KV blip just means the next poll does
+ * a cold read); no-op without KV. This is the ONLY other writer of the `mt:`
+ * entry, so it lives beside the reader to keep the `{ row, luAt }` shape and
+ * `MT_TTL_S` in one place.
+ */
+export async function warmMachineTokenCache(
+  kv: KVNamespace | null,
+  token: string,
+  row: NonNullable<MachineTokenRow>,
+): Promise<void> {
+  if (!kv) return
+  const entry: MachineTokenEntry = { row, luAt: Date.now() }
+  await kv
+    .put(cacheKeys.machineToken(token), JSON.stringify(entry), { expirationTtl: MT_TTL_S })
+    .catch(() => {})
+}
+
 export type AuthenticatedHandler = (
   req: NextRequest,
   ctx: AuthContext & { params?: Record<string, string> }

--- a/src/web/src/lib/services/sweep.ts
+++ b/src/web/src/lib/services/sweep.ts
@@ -46,9 +46,6 @@ export async function sweepStaleState(db: Database, workspaceId: string) {
 
     // Invalidate caches that sweep modified
     const dateStr = new Date().toISOString().slice(0, 10);
-    await Promise.all([
-      invalidate(cacheKeys.overviewTaskStats(workspaceId, dateStr)),
-      invalidate(cacheKeys.activeTaskCounts(workspaceId)),
-    ]).catch(() => {});
+    await invalidate(cacheKeys.overviewTaskStats(workspaceId, dateStr)).catch(() => {});
   }
 }

--- a/src/web/src/lib/services/task.ts
+++ b/src/web/src/lib/services/task.ts
@@ -3,7 +3,6 @@ import { queries, TASK_TYPES, MAX_TASKS_PER_TRACE } from "@alook/shared";
 import { log } from "@/lib/logger";
 import { broadcastToUser, broadcastToDaemon } from "@/lib/broadcast";
 import { messageToResponse } from "@/lib/api/responses";
-import { invalidate, cacheKeys } from "@/lib/cache";
 import { TaskPayloadBuilder } from "@/lib/services/task-payload-builder";
 
 const taskQueries = queries.task;
@@ -52,7 +51,6 @@ export class TaskService {
       traceId: opts?.traceId ?? null,
       parentTaskId: opts?.parentTaskId ?? null,
     });
-    invalidate(cacheKeys.activeTaskCounts(workspaceId)).catch(() => {});
     // Push task to daemon via WS (best-effort). Awaited to ensure task state
     // settles (dispatched on success, reverted to queued on failure) before
     // the HTTP response returns, preventing races with subsequent poll calls.
@@ -382,7 +380,6 @@ export class TaskService {
     const running = await taskQueries.countRunningTasks(this.db, agentId, workspaceId);
     const status = running > 0 ? "working" : "idle";
     await agentQueries.updateAgentStatus(this.db, agentId, workspaceId, status);
-    invalidate(cacheKeys.activeTaskCounts(workspaceId)).catch(() => {});
   }
 
   async cancelTrace(traceId: string, workspaceId: string, opts?: { reason?: string }) {

--- a/src/ws-do/src/ws-durable.test.ts
+++ b/src/ws-do/src/ws-durable.test.ts
@@ -66,6 +66,7 @@ const mockGetValidSession = vi.fn<(db: unknown, token: string) => Promise<string
 const mockGetMachineTokenByToken = vi.fn()
 const mockGetLatestTokenForUser = vi.fn()
 const mockGetRuntimeIdsByDaemon = vi.fn()
+const mockGetMachineByDaemon = vi.fn().mockResolvedValue({ daemonId: "my-daemon", workspaceId: "sp_ws1" })
 const mockCreateDb = vi.fn().mockReturnValue({})
 const mockHashCredential = vi.fn(async (bearer: string) => `hash:${bearer}`)
 const mockFindCredentialByHash = vi.fn()
@@ -279,6 +280,7 @@ vi.mock("@alook/shared", () => {
         getLatestTokenForUser: (...a: any[]) => mockGetLatestTokenForUser(...a),
       },
       runtime: { getRuntimeIdsByDaemon: (...a: any[]) => mockGetRuntimeIdsByDaemon(...a) },
+      machine: { getMachineByDaemon: (...a: any[]) => mockGetMachineByDaemon(...a) },
       communityMachine: {
         hashCredential: (bearer: string) => mockHashCredential(bearer),
         findCredentialByHash: (...a: any[]) => mockFindCredentialByHash(...a),
@@ -376,6 +378,10 @@ describe("WebSocketDurableObject", () => {
     mockUpdateProfile.mockResolvedValue({})
     mockGetProfile.mockResolvedValue(null)
     mockReconcileBotActivityFromRunningAgents.mockResolvedValue([])
+    // Daemon-auth binds the token to a machine row for daemonId+workspace;
+    // default to a present row so auth-flow success tests pass. Tests that
+    // exercise a missing machine override this.
+    mockGetMachineByDaemon.mockResolvedValue({ daemonId: "my-daemon", workspaceId: "sp_ws1" })
   })
 
   describe("fetch — WebSocket upgrade", () => {
@@ -884,12 +890,11 @@ describe("WebSocketDurableObject", () => {
       expect(mockGetRuntimeIdsByDaemon).not.toHaveBeenCalled()
     })
 
-    it("authenticates daemon with active token and runtimes", async () => {
+    it("authenticates daemon with active token (no runtime check in auth)", async () => {
       const { durable } = createDO()
       mockGetMachineTokenByToken.mockResolvedValue({
         id: "mt_1", userId: "u1", status: "active", workspaceId: "sp_ws1",
       })
-      mockGetRuntimeIdsByDaemon.mockResolvedValue(["rt_1"])
 
       const ws = createMockWebSocket()
       ws.serializeAttachment({ type: "daemon", daemonId: "", authenticated: false })
@@ -900,15 +905,16 @@ describe("WebSocketDurableObject", () => {
       )
 
       expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: "auth.ok" }))
-      expect(mockGetRuntimeIdsByDaemon).toHaveBeenCalledWith({}, "my-daemon", "sp_ws1")
+      // Runtime presence is no longer part of auth — it must not gate the WS
+      // connection (tasks route by workspaceId; runtimes may be mid-register).
+      expect(mockGetRuntimeIdsByDaemon).not.toHaveBeenCalled()
     })
 
-    it("rejects daemon with active token but no runtimes", async () => {
+    it("authenticates daemon with active token even when it has no runtimes yet", async () => {
       const { durable } = createDO()
       mockGetMachineTokenByToken.mockResolvedValue({
         id: "mt_1", userId: "u1", status: "active", workspaceId: "sp_ws1",
       })
-      mockGetRuntimeIdsByDaemon.mockResolvedValue([])
 
       const ws = createMockWebSocket()
       ws.serializeAttachment({ type: "daemon", daemonId: "", authenticated: false })
@@ -918,8 +924,41 @@ describe("WebSocketDurableObject", () => {
         JSON.stringify({ type: "auth", machineToken: "al_noruntimes", daemonId: "my-daemon" }),
       )
 
+      // No-runtime is a valid state (not an auth failure) — auth.ok, no reject.
+      expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: "auth.ok" }))
+      expect(ws.send).not.toHaveBeenCalledWith(JSON.stringify({ type: "error", code: "AUTH_REJECTED" }))
+    })
+
+    it("sends AUTH_REJECTED then closes on definitely-invalid token", async () => {
+      const { durable } = createDO()
+      mockGetMachineTokenByToken.mockResolvedValue(null)
+
+      const ws = createMockWebSocket()
+      ws.serializeAttachment({ type: "daemon", daemonId: "", authenticated: false })
+
+      await durable.webSocketMessage(
+        ws as any,
+        JSON.stringify({ type: "auth", machineToken: "al_dead", daemonId: "my-daemon" }),
+      )
+
+      expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: "error", code: "AUTH_REJECTED" }))
       expect(ws.close).toHaveBeenCalledWith(1008, "Unauthorized")
-      expect(ws.send).not.toHaveBeenCalled()
+    })
+
+    it("closes WITHOUT AUTH_REJECTED on transient D1 failure (daemon must retry)", async () => {
+      const { durable } = createDO()
+      mockGetMachineTokenByToken.mockRejectedValue(new Error("D1 unavailable"))
+
+      const ws = createMockWebSocket()
+      ws.serializeAttachment({ type: "daemon", daemonId: "", authenticated: false })
+
+      await durable.webSocketMessage(
+        ws as any,
+        JSON.stringify({ type: "auth", machineToken: "al_blip", daemonId: "my-daemon" }),
+      )
+
+      expect(ws.send).not.toHaveBeenCalledWith(JSON.stringify({ type: "error", code: "AUTH_REJECTED" }))
+      expect(ws.close).toHaveBeenCalledWith(1011, "Auth temporarily unavailable")
     })
 
     it("rejects daemon with unknown token", async () => {

--- a/src/ws-do/src/ws-durable.ts
+++ b/src/ws-do/src/ws-durable.ts
@@ -341,9 +341,21 @@ export class WebSocketDurableObject extends DurableObject<Env> {
     if (msg.type === "auth") {
       if (msg.machineToken && msg.daemonId) {
         const authResult = await this.validateMachineToken(msg.machineToken, msg.daemonId)
-        if (!authResult) {
-          log.warn("daemon websocket auth failed", { daemonId: msg.daemonId })
+        if (authResult.kind === "invalid") {
+          // Definitely-dead token — tell the daemon so it stops using it
+          // (AUTH_REJECTED is its trigger to mark the workspace auth-failed),
+          // then close.
+          log.warn("daemon websocket auth rejected", { daemonId: msg.daemonId })
+          try { ws.send(JSON.stringify({ type: "error", code: "AUTH_REJECTED" })) } catch { /* ok */ }
           ws.close(1008, "Unauthorized")
+          return
+        }
+        if (authResult.kind === "transient") {
+          // Infra blip, not a token problem. Plain close (NO AUTH_REJECTED)
+          // so the daemon reconnects with backoff and does not drop the
+          // workspace.
+          log.warn("daemon websocket auth transient failure", { daemonId: msg.daemonId })
+          ws.close(1011, "Auth temporarily unavailable")
           return
         }
         ws.serializeAttachment({ type: "daemon", daemonId: msg.daemonId, userId: authResult.userId, authenticated: true } as ConnectionState)
@@ -1175,14 +1187,45 @@ export class WebSocketDurableObject extends DurableObject<Env> {
     return queries.session.getValidSession(db, token)
   }
 
-  private async validateMachineToken(token: string, daemonId: string): Promise<{ userId: string } | null> {
-    if (!token.startsWith("al_")) return null
-    const db = createDb(this.env.DB)
-    const mt = await queries.machineToken.getMachineTokenByToken(db, token)
-    if (!mt) return null
-    if (mt.status !== "active" || !mt.workspaceId) return null
-    const runtimes = await queries.runtime.getRuntimeIdsByDaemon(db, daemonId, mt.workspaceId)
-    return runtimes.length > 0 ? { userId: mt.userId } : null
+  /**
+   * Three-state machine-token validation. The daemon marks a workspace
+   * auth-failed only on `invalid`, so a transient D1 failure must NEVER be
+   * reported as `invalid` — it maps to `transient` (plain close, no
+   * AUTH_REJECTED) so the daemon retries instead of dropping the workspace.
+   *
+   * - `valid`     — token exists, active, has a workspace, AND owns the
+   *                 daemon it is connecting as (a machine row for
+   *                 daemonId+workspace exists). The daemonId is an
+   *                 unauthenticated URL param that selects the DO instance,
+   *                 so without this bind ANY valid token could authenticate
+   *                 as ANOTHER tenant's daemon socket and receive that
+   *                 daemon's task/file broadcasts. Machine-level (not runtime-
+   *                 level) so a workspace mid-registration with 0 runtimes is
+   *                 still valid — the machine row is written at register time.
+   * - `invalid`   — token doesn't exist, isn't active, or doesn't own this
+   *                 daemon. Definitely dead / not authorized.
+   * - `transient` — D1 threw. Infra blip, not a token problem.
+   */
+  private async validateMachineToken(
+    token: string,
+    daemonId: string,
+  ): Promise<
+    | { kind: "valid"; userId: string }
+    | { kind: "invalid" }
+    | { kind: "transient" }
+  > {
+    if (!token.startsWith("al_")) return { kind: "invalid" }
+    try {
+      const db = createDb(this.env.DB)
+      const mt = await queries.machineToken.getMachineTokenByToken(db, token)
+      if (!mt || mt.status !== "active" || !mt.workspaceId) return { kind: "invalid" }
+      const machine = await queries.machine.getMachineByDaemon(db, daemonId, mt.workspaceId)
+      if (!machine) return { kind: "invalid" }
+      return { kind: "valid", userId: mt.userId }
+    } catch (err) {
+      log.warn("daemon websocket auth lookup threw", { err: String(err) })
+      return { kind: "transient" }
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Machine-token auth now caches on a single merged KV entry to cut D1 reads, the daemon gains a WebSocket push channel with a hardened poll fallback, and workspace eviction moved to soft-delete. This PR also folds in fixes from two `/code-review` passes and hardens the three "token looks dead" paths (labelled F3/F4/F5 below).

### Web / KV
- Consolidate machine-token auth onto one merged KV entry (`{ row, luAt }`), replacing the separate row-cache + last-used keys. A shape guard rejects the pre-upgrade bare-row format so an old entry can't false-401 a valid token across the deploy boundary.
- Distinguish 401 (definitively dead token) from 503 (transient infra) in machine-token auth.
- **F4 — warm-on-activate:** `getDb()` uses `first-unconstrained` D1 sessions, so a freshly-activated daemon token's first poll could read a lagged replica, see `row: null`, and negative-cache a 401 for `MT_NEG_TTL_S` — long enough to wrongly evict a brand-new workspace. The activate route now warms the positive `{ row, luAt }` KV entry with the row it already holds (activate only flips status), so the first poll hits a positive entry regardless of replica lag. `warmMachineTokenCache` lives beside the reader in `auth.ts` to keep the `mt:` shape + TTL in one place.

### WS-DO
- Three-state machine-token validation: `valid` / `invalid` / `transient` (D1 throw becomes a transient close, not a rejection).
- **Security:** restore the daemon-to-workspace binding in `validateMachineToken` — `daemonId` is an unauthenticated URL param, so without the bind any valid token could authenticate as another tenant's daemon socket and receive its task/file broadcasts. Now requires a machine row for `daemonId + workspace`.

### Daemon
- **Soft-delete workspaces** (`status="deleted"`) instead of physical removal, so the cause stays inspectable and re-pairing revives the entry. All reads funnel through `activeWorkspaces()` and all status writes through `markWorkspaceActive()` / `markWorkspaceDeletedInList()` — the "is this workspace live?" rule lives in exactly one place (`config.ts`).
- **F3 — truly consecutive 401s:** the streak counter now resets on any non-401 poll outcome, so a flaky link interleaving 401 / blip / 401 can't creep to the delete threshold.
- **F5 — confirm before WS delete:** a single `AUTH_REJECTED` frame now triggers one authoritative confirming poll before deleting; a success (replica-lag false-invalid) or non-401 error keeps the workspace. Closes the new-user false-eviction window right after activation.

## Test plan
- `pnpm typecheck` — clean across all 10 packages
- `pnpm test` — full suite green (CLI 1017, web 3176, ws-do 114, and the rest), incl. new cases: daemon consecutive-401 threshold, interleaved-401 streak reset, AUTH_REJECTED confirm-succeeds/confirm-401/non-401-transient; `warmMachineTokenCache` positive-entry + warm-hit + null-KV no-op; activate route warms cache with activated row.
- `pnpm lint` — 0 errors (pre-existing warnings only)