### PR TITLE
fix(web): message text selection, square avatars, thread default members

### DIFF
--- a/src/web/src/app/api/community/messages/[id]/threads/route.test.ts
+++ b/src/web/src/app/api/community/messages/[id]/threads/route.test.ts
@@ -11,6 +11,7 @@ const mockListChildChannels = vi.fn()
 const mockCreateChannel = vi.fn()
 const mockCreateMessage = vi.fn()
 const mockListMessages = vi.fn()
+const mockAddThreadParticipants = vi.fn()
 
 const mockFanOutToChannel = vi.fn()
 
@@ -30,6 +31,9 @@ vi.mock("@alook/shared", async () => {
         getMessage: (...a: unknown[]) => mockGetMessage(...a),
         createMessage: (...a: unknown[]) => mockCreateMessage(...a),
         listMessages: (...a: unknown[]) => mockListMessages(...a),
+      },
+      communityThread: {
+        addThreadParticipants: (...a: unknown[]) => mockAddThreadParticipants(...a),
       },
     },
   }
@@ -72,6 +76,9 @@ describe("POST /api/community/messages/[id]/threads", () => {
     // The unified pipeline fires `fanOutToChannel(...).catch(...)` — the mock
     // must return a promise so the `.catch` chain resolves.
     mockFanOutToChannel.mockResolvedValue(undefined)
+    mockAddThreadParticipants.mockResolvedValue(undefined)
+    // Both the caller (u1) and the parent-message author (u-author) resolve as
+    // members by default — the seeding path checks membership per userId.
     mockGetChannelForMember.mockResolvedValue({
       id: "c-parent",
       serverId: "s1",
@@ -190,5 +197,58 @@ describe("POST /api/community/messages/[id]/threads", () => {
     const res = await POST(req({ name: "x" }), ctx)
     expect(res.status).toBe(403)
     expect(mockCreateChannel).not.toHaveBeenCalled()
+  })
+
+  it("seeds the creator (spoke) AND the parent-message author (added) as default participants", async () => {
+    const res = await POST(req({ name: "my thread" }), ctx)
+    expect(res.status).toBe(201)
+    expect(mockAddThreadParticipants).toHaveBeenCalledTimes(1)
+    const [, threadId, rows] = mockAddThreadParticipants.mock.calls[0] as [
+      unknown,
+      string,
+      { userId: string; source: string }[],
+    ]
+    expect(threadId).toBe("t-new")
+    // Creator uses "spoke" (matches the forum-post creation flow); the author
+    // was pulled in by someone else, so "added".
+    expect(rows).toEqual([
+      { userId: "u1", source: "spoke" },
+      { userId: "u-author", source: "added" },
+    ])
+  })
+
+  it("de-dupes when the creator threads their own message (one 'spoke' row, no duplicate)", async () => {
+    mockGetMessage.mockResolvedValue({
+      id: "msg-p",
+      authorId: "u1",
+      content: "my own message",
+      channelId: "c-parent",
+    })
+    const res = await POST(req({ name: "my thread" }), ctx)
+    expect(res.status).toBe(201)
+    const [, , rows] = mockAddThreadParticipants.mock.calls[0] as [
+      unknown,
+      string,
+      { userId: string; source: string }[],
+    ]
+    expect(rows).toEqual([{ userId: "u1", source: "spoke" }])
+  })
+
+  it("does NOT seed the author when they've lost access to the parent channel", async () => {
+    // Caller (u1) resolves as a member; the author (u-author) does not — the
+    // per-userId getChannelForMember returns null for them, so seeding skips
+    // the author to avoid pushing a private thread to a non-member.
+    mockGetChannelForMember.mockImplementation(async (_db: unknown, _channelId: string, userId: string) => {
+      if (userId === "u1") return { id: "c-parent", serverId: "s1" }
+      return null
+    })
+    const res = await POST(req({ name: "my thread" }), ctx)
+    expect(res.status).toBe(201)
+    const [, , rows] = mockAddThreadParticipants.mock.calls[0] as [
+      unknown,
+      string,
+      { userId: string; source: string }[],
+    ]
+    expect(rows).toEqual([{ userId: "u1", source: "spoke" }])
   })
 })

--- a/src/web/src/app/api/community/messages/[id]/threads/route.ts
+++ b/src/web/src/app/api/community/messages/[id]/threads/route.ts
@@ -59,6 +59,25 @@ export const POST = withAuth(async (req: NextRequest, ctx) => {
     creatorId: ctx.userId,
   })
 
+  // Seed the default NOTIFY set: the thread creator (source "spoke", matching
+  // the forum-post creation flow and what the message-handler would write once
+  // they post), plus the original message's author (source "added" — they were
+  // pulled in by someone else, like the manual add-participant flow). The
+  // author is only enrolled if they are STILL a member of the parent channel —
+  // `requireChannelMember` above only gated the creator, so seeding the author
+  // unconditionally could push a private channel's thread to someone who lost
+  // access (the leak `removeParticipantFromChildChannels` exists to prevent).
+  const seedRows: { userId: string; source: "spoke" | "added" }[] = [
+    { userId: ctx.userId, source: "spoke" },
+  ]
+  // De-dupe: when the creator threads their own message the author is the same
+  // user, and the creator's "spoke" row already covers them.
+  if (message.authorId !== ctx.userId) {
+    const authorStillMember = await requireChannelMember(db, message.channelId, message.authorId)
+    if (authorStillMember.ok) seedRows.push({ userId: message.authorId, source: "added" })
+  }
+  await queries.communityThread.addThreadParticipants(db, childChannel.id, seedRows)
+
   // Note: we intentionally do NOT clone the parent message into the new thread
   // channel. The `parentMessageId` pointer above is the single source of truth
   // for the opener — the thread page fetches the parent live via

--- a/src/web/src/components/avatar/animated-avatar.tsx
+++ b/src/web/src/components/avatar/animated-avatar.tsx
@@ -53,7 +53,7 @@ export function AnimatedAvatar({ seed, avatarUrl, size, className, isHovered, is
   return (
     <div className={animClass ?? undefined}>
       {resolved.kind === "photo" ? (
-        <img src={resolved.url} alt="" className={`object-cover ${className ?? ""}`} style={{ width: size, height: size }} />
+        <img src={resolved.url} alt="" className={`object-cover align-middle ${className ?? ""}`} style={{ width: size, height: size }} />
       ) : (
         <BoringAvatar seed={resolved.seed} size={size} className={className} />
       )}

--- a/src/web/src/components/avatar/boring-avatar.test.ts
+++ b/src/web/src/components/avatar/boring-avatar.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest"
+import Avatar from "boring-avatars"
+import { BoringAvatar } from "./boring-avatar"
+
+// BoringAvatar returns a wrapper <span> (co-locating the caller's radius
+// className with overflow-hidden so a square SVG gets cropped to the container
+// shape) whose single child is the boring-avatars <Avatar>.
+type SpanEl = {
+  type: "span"
+  props: { className: string; style: { width: number | string; height: number | string }; children: AvatarEl }
+}
+type AvatarEl = { type: typeof Avatar; props: { square: boolean; size: number | string; className: string; variant: string; preserveAspectRatio?: string } }
+
+function inner(el: unknown): AvatarEl["props"] {
+  return (el as SpanEl).props.children.props
+}
+
+describe("BoringAvatar", () => {
+  it("defaults to a SQUARE svg so the container radius crops it", () => {
+    const el = BoringAvatar({ seed: "s1" }) as unknown as SpanEl
+    expect(el.type).toBe("span")
+    expect(inner(el).square).toBe(true)
+  })
+
+  it("still honors an explicit square={false}", () => {
+    const el = BoringAvatar({ seed: "s1", square: false }) as unknown as SpanEl
+    expect(inner(el).square).toBe(false)
+  })
+
+  it("co-locates the caller's radius className with overflow-hidden on the wrapper", () => {
+    const el = BoringAvatar({ seed: "s1", className: "rounded-full" }) as unknown as SpanEl
+    expect(el.props.className).toContain("rounded-full")
+    expect(el.props.className).toContain("overflow-hidden")
+  })
+
+  it("gives the wrapper an explicit box from size, and fills it with the inner avatar", () => {
+    const el = BoringAvatar({ seed: "s1", size: 40 }) as unknown as SpanEl
+    expect(el.props.style).toEqual({ width: 40, height: 40 })
+    expect(inner(el).size).toBe("100%")
+    expect(inner(el).className).toContain("size-full")
+  })
+
+  it("forwards variant and preserveAspectRatio to the inner avatar (marble background)", () => {
+    const el = BoringAvatar({ seed: "s1", variant: "marble", size: "100%", preserveAspectRatio: "none" }) as unknown as SpanEl
+    expect(inner(el).variant).toBe("marble")
+    expect(inner(el).preserveAspectRatio).toBe("none")
+    expect(el.props.style).toEqual({ width: "100%", height: "100%" })
+  })
+})

--- a/src/web/src/components/avatar/boring-avatar.tsx
+++ b/src/web/src/components/avatar/boring-avatar.tsx
@@ -2,6 +2,7 @@
 
 import Avatar from "boring-avatars";
 import { paletteFromSeed } from "@/lib/avatar/boring-palettes";
+import { cn } from "@/lib/utils";
 
 /**
  * The single wrapper around boring-avatars. Every generated avatar/gradient in
@@ -11,12 +12,22 @@ import { paletteFromSeed } from "@/lib/avatar/boring-palettes";
  *
  * `beam` (default) is the face fallback; `marble` is the gradient background
  * used for server/channel icons and the profile banner.
+ *
+ * `square` defaults to true so the underlying SVG is a full square that the
+ * container's radius crops — matching how photo `object-cover` avatars behave.
+ * The crop is done here, at one place, by a wrapper span that co-locates the
+ * caller's `className` (which carries the radius, e.g. `rounded-full` /
+ * `rounded-xl`) with `overflow-hidden`: `overflow-hidden` clips to the
+ * border-box, so the radius must live on the SAME element or a circular caller
+ * would clip to a rectangle. The span gets an explicit box (`inline-flex` +
+ * `size`) because standalone callers pass a numeric `size` with no flex parent,
+ * and a bare inline span would ignore width/height and collapse.
  */
 export function BoringAvatar({
   seed,
   size = 40,
   variant = "beam",
-  square = false,
+  square = true,
   className,
   preserveAspectRatio,
 }: {
@@ -28,14 +39,16 @@ export function BoringAvatar({
   preserveAspectRatio?: string;
 }) {
   return (
-    <Avatar
-      size={size}
-      name={seed}
-      variant={variant}
-      colors={paletteFromSeed(seed)}
-      square={square}
-      className={className}
-      preserveAspectRatio={preserveAspectRatio}
-    />
+    <span className={cn("inline-flex overflow-hidden align-middle", className)} style={{ width: size, height: size }}>
+      <Avatar
+        size="100%"
+        name={seed}
+        variant={variant}
+        colors={paletteFromSeed(seed)}
+        square={square}
+        className="size-full"
+        preserveAspectRatio={preserveAspectRatio}
+      />
+    </span>
   );
 }

--- a/src/web/src/components/community/message.tsx
+++ b/src/web/src/components/community/message.tsx
@@ -322,7 +322,7 @@ export function Message({
   if (!interactive) return row
   return (
     <ContextMenu>
-      <ContextMenuTrigger render={row} />
+      <ContextMenuTrigger className="select-text" render={row} />
       <ContextMenuContent className="w-48">
         <MessageContextItems {...menuHandlers} />
       </ContextMenuContent>

--- a/src/web/src/components/sidebar/agent-sidebar-button.tsx
+++ b/src/web/src/components/sidebar/agent-sidebar-button.tsx
@@ -59,7 +59,12 @@ export function AgentSidebarButton({
                   type="button"
                   onClick={() => { setPreviewOpen(false); onClick(); }}
                   className={cn(
-                    "relative flex shrink-0 items-center justify-center size-10 rounded-xl text-sm font-medium transition-all duration-200 cursor-pointer",
+                    "relative flex shrink-0 items-center justify-center size-10 text-sm font-medium transition-all duration-200 cursor-pointer",
+                    // Corner radius morphs WITH the avatar (both round↔rounded-xl)
+                    // so the ring — which hugs the button's corners — reshapes in
+                    // lockstep with the avatar instead of staying a fixed square
+                    // outline while the avatar rounds.
+                    isActive ? "rounded-xl" : "rounded-[20px]",
                     isActive
                       ? "ring-2 ring-primary/50 shadow-sm"
                       : "ring-0 bg-secondary text-secondary-foreground hover:bg-accent"
@@ -69,7 +74,13 @@ export function AgentSidebarButton({
             />
           }
         >
-          <AnimatedAvatar seed={agent.id} avatarUrl={agent.avatar_url} size={40} className="rounded-xl" isHovered={false} />
+          <AnimatedAvatar
+            seed={agent.id}
+            avatarUrl={agent.avatar_url}
+            size={40}
+            className={cn("transition-all duration-200", isActive ? "rounded-xl" : "rounded-[20px]")}
+            isHovered={false}
+          />
           <span className={cn(
             "absolute bottom-0 right-0 size-2 rounded-full ring-2 ring-background",
             isOnline ? "bg-status-online" : "bg-status-offline"


### PR DESCRIPTION
## Summary

Three community/workspace fixes, plus the avatar-rail regressions surfaced while implementing them.

### 1. Message text is drag-selectable again (`/c`)
Interactive message rows render through `ContextMenuTrigger`, which hard-codes `select-none` — that `user-select: none` cascaded onto all message body text, so nothing could be selected. Adding `select-text` on the message-row trigger makes `tailwind-merge` drop the inherited `select-none`; drag-select + copy work again, and the right-click context menu still opens.

### 2. Random beam avatars are square-cropped by their container
`BoringAvatar` rendered a circular SVG by default, so in the agents rail's `rounded-xl` active button the round avatar left the corners empty. It now defaults to a **square** SVG, wrapped in a span that co-locates the caller's radius className with `overflow-hidden` — the container shape controls the crop, exactly like photo `object-cover`. This is a single-point change; every beam call site inherits it.

### 3. Agents rail active-state polish (`/w`)
- `align-middle` removes the inline baseline gap that pushed the avatar up.
- The button corner-radius now **morphs with the avatar** (`rounded-[20px]` ↔ `rounded-xl`) under one shared `transition-all duration-200`, so the active ring and the avatar reshape in lockstep instead of the ring staying a fixed square while the avatar rounds. (`rounded-[20px]` rather than `rounded-full` because a 9999px radius makes the linear interpolation look static until the final frame.)

### 4. Thread creation seeds its default NOTIFY set (`/c`)
Opening a thread previously seeded **nobody** into `community_thread_participant` — members were only added lazily on message-send. Now creation seeds:
- the **creator** (`source: "spoke"`, matching the forum-post flow), and
- the **original message author** (`source: "added"`), gated on their still being a member of the parent channel so a private thread is never pushed to someone who lost access.

Deduped when the creator threads their own message.

## Testing
- `pnpm typecheck` — pass
- `pnpm test` — pass (web 3200, cli 1021, daemon 598)
- New: `boring-avatar.test.ts` (square default + wrapper crop); 3 new thread-route integration cases (creator+author seed, self-thread dedup, non-member author skipped)
- `alook-c-qa` end-to-end: PASS on all three `/c` journeys (message drag-select coexists with context menu; D1 shows both participant rows + `CHILD_CHANNEL_CREATE` broadcast; `/c` circular avatars render as clean filled circles)

Rail visual (morph/alignment) is a `/w` surface — not covered by `alook-c-qa`; verified via unit assertions on the class output.