### PR TITLE
feat(web): local perf-diagnosis toolchain for community switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ docs/
 .alook/
 .dev.vars
 plans/
+perf-artifacts/
 .agents/
 .context_timeline/
 .claude/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -550,6 +550,9 @@ importers:
       knip:
         specifier: ^6.29.0
         version: 6.29.0
+      react-scan:
+        specifier: 0.5.7
+        version: 0.5.7(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/react@19.2.17)(esbuild@0.28.1)(eslint@9.39.5(jiti@2.7.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.0.8(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.16.9)(tsx@4.23.1)(yaml@2.9.0))
       react-test-renderer:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
@@ -624,12 +627,27 @@ importers:
 
 packages:
 
+  '@alcalzone/ansi-tokenize@0.3.0':
+    resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
+    engines: {node: '>=18'}
+
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@apm-js-collab/code-transformer-bundler-plugins@0.7.1':
+    resolution: {integrity: sha512-Yidf5GOl60db80UxUtNdKK3pnY7obU/gs0xOfA0SCdnvVLMCvfYIer/egC3TqpPiT0Jg22eg3RlzcO+zKfPMcA==}
+    engines: {node: '>=18.0.0'}
+
+  '@apm-js-collab/code-transformer@0.18.1':
+    resolution: {integrity: sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==}
+    hasBin: true
+
+  '@apm-js-collab/tracing-hooks@0.13.0':
+    resolution: {integrity: sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==}
 
   '@ast-grep/napi-darwin-arm64@0.40.5':
     resolution: {integrity: sha512-2F072fGN0WTq7KI3okuEnkGJVEHLbi56Bw1H6NAMf7j2mJJeQWsRyGOMcyNnUXZDeNdvoMH0OB2a5wwUegY/nQ==}
@@ -1694,6 +1712,9 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@iarna/toml@2.2.5':
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
+
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
@@ -2283,9 +2304,43 @@ packages:
       rclone.js:
         optional: true
 
+  '@opentelemetry/api-logs@0.220.0':
+    resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation@0.220.0':
+    resolution: {integrity: sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.10.0':
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.10.0':
+    resolution: {integrity: sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.10.0':
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
   '@opentelemetry/semantic-conventions@1.43.0':
     resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
@@ -2297,8 +2352,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@oxc-parser/binding-android-arm-eabi@0.141.0':
+    resolution: {integrity: sha512-jk7086MFvR/T4DG9IY7MKBVt1PMxvSZoz/TvnifodvS0pjghVwJHRttnAExhlwdMOgHv1TmLdENnbNpYk2zjvA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
   '@oxc-parser/binding-android-arm64@0.140.0':
     resolution: {integrity: sha512-Ia8jSvikUX6Sf+Ht+KOCUF/k1HpR0VlmqIYymubmWDebOEGtsyliHDR6JxsZ4IX3/c/GbrB1uh09aVGQv/LQmQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.141.0':
+    resolution: {integrity: sha512-a4XDQ27ZT7e7zwAlxJDTiCA7IBGWDuy2+MhFq85Of7XlBSmpkfcBFml11q0Zx6f7RMuI0B4xCtt2ytBS4yOptg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -2309,8 +2376,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@oxc-parser/binding-darwin-arm64@0.141.0':
+    resolution: {integrity: sha512-m/kVk6rzYmBeHYnz+1Y5fod00AVTTxMbC71azFfm/zjx1j9XxwKtA0+VfkKuVMC8rbghb9TtfevnuWZa9OuPEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@oxc-parser/binding-darwin-x64@0.140.0':
     resolution: {integrity: sha512-HazBOuZzd2pO1C2uMmp8Gv7mhzMHqKSKDS1OZfcLEvpIcgA+48J92HEtNanVHDIzRD9PRPCV6aS6fkZIWOVl8Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.141.0':
+    resolution: {integrity: sha512-o0X+6KZlfucWU/v5oKRQPwdFXsXAjW8jmpo/Gpw/qyKsbKtlfkHoeH9Bjp/m13TwjewvJnCkwF0DWzgpC4HjTQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -2321,8 +2400,20 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@oxc-parser/binding-freebsd-x64@0.141.0':
+    resolution: {integrity: sha512-W5KbTnNkTMMMylqj6dYqnsXvkmESVPodPKYLJ5zdzIPdl9fUJtolkpUeSzYEbGGYB4a4A4avl3EePnZ/wLIdJg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@oxc-parser/binding-linux-arm-gnueabihf@0.140.0':
     resolution: {integrity: sha512-RAEuQsYtS0KcDFqN0ABTjyyNlokS91JeuDuoW9tEbG0JTbRNXnpQUdbYc/16JoA6Z/2ALbNrE3KmxtqDiuIjCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.141.0':
+    resolution: {integrity: sha512-g3dtbJa8zeOGK36Sr9cQavsdi5H/ie2hVjrSjIxsNAR1qZA40ZYVXnfdfoMAlq8CmB9qFL1yhsSCUHeNmdmt8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -2333,8 +2424,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@oxc-parser/binding-linux-arm-musleabihf@0.141.0':
+    resolution: {integrity: sha512-e6hwQqd+3lvP13G2jxvFpoA7dzHcFLN+Mq47JCVMtdNHbbyBRo756JCtbbJH6ca8inTfyqZoqBmS3vhQlzAK2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@oxc-parser/binding-linux-arm64-gnu@0.140.0':
     resolution: {integrity: sha512-yrjmLj8ixPB25yqvPGr28meGjb+keed7m1GqqY/0uqkhZIoT4t9zmfwUgFEtC33C7dtE+UQ7TU0IaVxf97SWJg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.141.0':
+    resolution: {integrity: sha512-vXz2BLAuypA+4MLyBg94pzEo6THVnzYnCtAjXoihIIQo0t2pnp/AmW+SH1EI+4VbuJnC//KplIJ5yyaCGua4jA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -2347,8 +2451,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxc-parser/binding-linux-arm64-musl@0.141.0':
+    resolution: {integrity: sha512-jMkS/EztNW34HKsXIaT/SoHcmtocq/vWhwFOVduF9kduuuRIVwfwQ6uxzIO+qPKSXdd2TXt54of0BJ2zFMXnmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@oxc-parser/binding-linux-ppc64-gnu@0.140.0':
     resolution: {integrity: sha512-IgTs8xYAFgAUGNmR65tIqjlJ8vKgrfXzC515e9goSdfMyKQV4aJpd2pUUudU4u51G64H0/DSEJEXKOraxm9ZCA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.141.0':
+    resolution: {integrity: sha512-vo+MR+n3zQJ6Mq92hiP084NZcgDv5iJlVR02gMf28neMvVT1tKVm7VeiW/DxhdqOi3QLeaXIk9cUcLL1qrkngw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -2361,8 +2479,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxc-parser/binding-linux-riscv64-gnu@0.141.0':
+    resolution: {integrity: sha512-oh80w+7RuiO5gBp9Jnoa/H8Qlt3JsHL2MkW+0dwEdlDMdslVZX/YsekSK6EeyEenY66/mhCfypsNATQ7Ph3qlQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@oxc-parser/binding-linux-riscv64-musl@0.140.0':
     resolution: {integrity: sha512-zBqpfRo2myWPrPo5xUjeZqlnPXPXsX8BcWtWff66/eGRQdbPjhzPgXa/F+AtxT2afUViPxbuDlwscMKzQ5tg+g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.141.0':
+    resolution: {integrity: sha512-LOyEmFA8sCnYbEXP1+iQvCC/P1YXHMA/t6x1Ksp0Y9VwhLFsiBJFzV1zIxrOIE2LKaGGhDjQ29xq9cbq6omDXA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -2375,8 +2507,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxc-parser/binding-linux-s390x-gnu@0.141.0':
+    resolution: {integrity: sha512-3wnwk/l1CvszVE5TJR1wSl/zSEfydRqrNhn6s7Vr9IzSJpUQIroqVsIoPARHRFA+FQwkxAFDAHDAasa7v8OobQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@oxc-parser/binding-linux-x64-gnu@0.140.0':
     resolution: {integrity: sha512-8aRDbZ/U/jO8N7go1MO72jtbpb4uswV8d7vOkMvt/BPgZiyEYvl1VIWK4ESxZZhnJ4tqwVldgX7dNiP/eB1Jdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.141.0':
+    resolution: {integrity: sha512-qtyQVAAebFq57B2tifTlel3TgGqUtsYNI/e+p6aya9rN9lOZVTDvr215fGYSA9XWooxzMxDiVxkBLk2jQHbsOQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -2389,8 +2535,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxc-parser/binding-linux-x64-musl@0.141.0':
+    resolution: {integrity: sha512-SkGV1nKw40roEc94pv5EaaeH2ay14G6+roe8Q0wIUC1LcEKxzKW921h7+ZuZX0D3q2Mb/7aSFmxEVqnko3lPRw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@oxc-parser/binding-openharmony-arm64@0.140.0':
     resolution: {integrity: sha512-GbGRe26MqAKciFRvXeHNQJ6VAHYs9R4miP89sEAncysM3n+f4lnyLWgsa9kklJNpfnxdq2yRoNYHFqwBckVimw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-openharmony-arm64@0.141.0':
+    resolution: {integrity: sha512-cVgDM7n8QziQqOaP5hNgUYfMG7S/ZeuPxFWXnnHRv7rh025COk0rfQ6eEdKG3j/GaUuyvNZN4ifF1J8KmuXLLA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -2400,8 +2559,19 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
+  '@oxc-parser/binding-wasm32-wasi@0.141.0':
+    resolution: {integrity: sha512-HggH++Fkn3OilBn+bs3jpgIFQa34oMAyUUHy0vpGum+gt1Eb5nyLc8dNU/RAPSw6lsLrx7ncKtHSZE+3Sp0l2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
   '@oxc-parser/binding-win32-arm64-msvc@0.140.0':
     resolution: {integrity: sha512-fGSQldwEYKhM+H8uLt76Op8hh5+FYaR6lvvQ1Txw3Mhn86DyQXLcI0fi1EkFlTK7F+46OCk/j0AJMzZQm6g5Xg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.141.0':
+    resolution: {integrity: sha512-KLSEH9GwgbrqbJOjtGHt9STw96s+78yDzp7IDN8Lno+7Ut9sNBfZ4jYZIz4mD50qmWUjoOI7i9I6UENbhNbMZQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -2412,8 +2582,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@oxc-parser/binding-win32-ia32-msvc@0.141.0':
+    resolution: {integrity: sha512-9UVWUOOCI/1YkiSSNjg2zyBJYM9E/t1A/8GNobd48JDn/fQ6mzxcVO3H08jb3rAaW/B1VBf8eCORTvSsO9T08g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@oxc-parser/binding-win32-x64-msvc@0.140.0':
     resolution: {integrity: sha512-kHbE1zWyb5OQgJA6/5P4WjiuB01sYdQwtZnSSyE58FQEXDAMnyeeq4vj7KgN75i5SlBzOs8A5MrtlD3gOlDKqQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.141.0':
+    resolution: {integrity: sha512-HI/wsvbWT5RHHw5c37D0fEgeTd8/1Q4OJs5jUmEBc17VZFG6SsCIe4barq7NsAPPks/JW+3ayi3Rp+PQI5h4Kg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -2423,6 +2605,9 @@ packages:
 
   '@oxc-project/types@0.140.0':
     resolution: {integrity: sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==}
+
+  '@oxc-project/types@0.141.0':
+    resolution: {integrity: sha512-S4as7z0j0xQkXcJlyY5ehntwK8/wRkQb9Cyqw+J/N2rkWGQGK0SxD6X6DhQTc7qsxVTBxXbxZtBJh3mr3PtIzQ==}
 
   '@oxc-resolver/binding-android-arm-eabi@11.24.2':
     resolution: {integrity: sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==}
@@ -2527,6 +2712,128 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@oxlint/binding-android-arm-eabi@1.74.0':
+    resolution: {integrity: sha512-+gHd12muVI9ZLBaWLPkHt3Fj7jihFjgQ1MGtBaRL8vWrWrI0P7dLUty/cHrHS0oqPYIRgQUJsPu2CExQuMcwNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.74.0':
+    resolution: {integrity: sha512-xjKdoMB+H+RCOByv/7l7nfIGW9mlOisqYdcyC75UqYuQecLpReAeEYUf2CNeDEI3KtmUgxpRw/+c63y4AeF/Bw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.74.0':
+    resolution: {integrity: sha512-iUK7wvc6sejMKsC+Pt67mntoF5weFcyEunhZfLJceU6gL419mexz5wBkSx/EnkFBExMLNtOi9fnDSc5xfK0IzQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.74.0':
+    resolution: {integrity: sha512-ggKc/tn5SJ1u2yG2izC6VKODfYKV8MQ2AicJlNzOjuyrC29udvOef6/JzK2r32xqCnBDLFouR1VCkjzEI0/N9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.74.0':
+    resolution: {integrity: sha512-u++dH/43jy9hTLbneaWlS0gla/Bp1JdwJ2zgevCl8nDFUh6qRCGMxcL0f0lb7By3A9p/LfFr+7cG4HU1hG856g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.74.0':
+    resolution: {integrity: sha512-Sj1zmtFDVTPeIbIz4ZfcXAbFHqCmKCXdCUlAJzvTF7I20NTH1RDpoF2PhkqNODutJzVhJYmm3oz0GwgY+tvE2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.74.0':
+    resolution: {integrity: sha512-//PKyQb/tQXcHArx2f7z+oVI/eMS2Jpv+edNuAtOrgIhWdGcpHxogveAxzmF2rpH1AIHp4Hq04RF/rgJdiICnQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.74.0':
+    resolution: {integrity: sha512-/k1Me+aX2tjuH10K62mLS0y8cLkJBHX6Ce0xPK+eWeel4bSdEGZ8dv4+hYMzg0GrSmjwy4yAYsDPeEeKBft/2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.74.0':
+    resolution: {integrity: sha512-3tFSjBxc5D8/zvjEuLvOqcA8ZXKD0+6NuaVO/edeamNc49MoAsbfaC9s1UiwODwgF6slGaF8yJA2TPkukd77tg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.74.0':
+    resolution: {integrity: sha512-9QggtPkSPXOCTu8Szis7auOK/sC7KdQaN+/TujP7YVVhzCAOhgdRfgv8uEz0r2tk5xdgus5rLYUrCDoZNtiRUw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.74.0':
+    resolution: {integrity: sha512-VM5VPUJ4DJIWiK+AZn8FScUqMr6OFrCAYybMYjEEi7W13ParI64MByiXTkKMqZpBmvQ9zxl9Ebq2VUOiZRJYUg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-musl@1.74.0':
+    resolution: {integrity: sha512-SaDY1gh9rOA592J54g+gu5hkOFFQBZsMmIYHs+NRHG+Uq0OxtuuCXMWQ3vu1830Eugv5uMXyjG+bv2Z9y4IXjw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-s390x-gnu@1.74.0':
+    resolution: {integrity: sha512-ZATQeHZCyr6MbDveg0obD5sxLHFOghtOdC5jwVwYlvFWqtFOxctgFEG6Ef/64hYvZrWyhyCckB10AelqLopeDA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.74.0':
+    resolution: {integrity: sha512-+aIvJyrdeD7LwCQ2WYLMUWNmnbeDRSPb40aBYtPjD9+PTqUwgJnk+HK5yLfSMeqXrMrDhE9uTmtt2y50tvjhHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-musl@1.74.0':
+    resolution: {integrity: sha512-XyktaR8lhK2qWiCK0Tk8oYD+/cgn+oHA6ddRnxSSXUKkkojkV78CmShZUxQF+yrBFs0SuW+JBOPG6hecyc/iZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-openharmony-arm64@1.74.0':
+    resolution: {integrity: sha512-mzbjrPl4neaVUiJ1fUiEUxTGaSZBoiKtaoB6jmIpz9S+VOA2vDYmJpihQ82w6178V5jxziclTg8Cgj5yF6tTDg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.74.0':
+    resolution: {integrity: sha512-vUAe9okpS2Oa5+lX67lqHMuNUvfkleRKwrUDJ/WJBsgmddvZ1mrsh2HVmuFDRzqFELhaJhFaCNOuR6a7L3rtIA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.74.0':
+    resolution: {integrity: sha512-yyXXJyYYSXL4I8K8jAWjJs+J3fa9gH2JmEbo4f5adm+1tNC9itseicBNuwK7BDHvqQ5J534s+yDULu89vYL2ZQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.74.0':
+    resolution: {integrity: sha512-VTC9IYTIMrVUk/i6Ms1ohzzDKZFkWn0KU2OBbPBzgmVZ2V30165T/zK4LztTr0Xgp9fZ1qQZ1rsZAu/rEmySlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@paulirish/trace_engine@0.0.53':
     resolution: {integrity: sha512-PUl/vlfo08Oj804VI5nDPeSk9vyslnBlVzDDwFt8SUVxY8+KdGMkra/vrXjEEHe8gb7+RqVTfOIlGw0nyrEelA==}
 
@@ -2548,9 +2855,21 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
+  '@preact/signals-core@1.14.4':
+    resolution: {integrity: sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==}
+
+  '@preact/signals@2.10.0':
+    resolution: {integrity: sha512-avH1zQLZR6c0DmH3pT/sn4RIzsNDXAue+MEoyS5RIvApKALSU8m05KyBOL8ua21gxeDYp1DclTMcFd+N1zaL1Q==}
+    peerDependencies:
+      preact: '>= 10.25.0 || >=11.0.0-0'
+
   '@puppeteer/browsers@2.13.0':
     resolution: {integrity: sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==}
     engines: {node: '>=18'}
+    hasBin: true
+
+  '@react-grab/cli@0.1.50':
+    resolution: {integrity: sha512-Px/Hwhhyk2PubCA4ZaRFsfvwxhbxXsetJyvqC6aFFi8WhJhA+oVC33aTzuAeWmM3fhb4/8ce8YsHXI1d6ChcKg==}
     hasBin: true
 
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
@@ -2651,6 +2970,15 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.15':
     resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -2661,6 +2989,14 @@ packages:
     resolution: {integrity: sha512-Fz5+4XCg3akeoFK+K7g+d7HqGMjmnLoY2eJlpONJmaeT9pXY7yfUyXKZMmMajdE2LxxKJgQ2YKvSCaGVamTjHw==}
     engines: {node: '>=8'}
 
+  '@sentry/conventions@0.16.0':
+    resolution: {integrity: sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==}
+    engines: {node: '>=14'}
+
+  '@sentry/core@10.68.0':
+    resolution: {integrity: sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==}
+    engines: {node: '>=18'}
+
   '@sentry/core@7.120.4':
     resolution: {integrity: sha512-TXu3Q5kKiq8db9OXGkWyXUbIxMMuttB5vJ031yolOl5T/B69JRyAoKuojLBjRv1XX583gS1rSSoX8YXX7ATFGA==}
     engines: {node: '>=8'}
@@ -2669,9 +3005,46 @@ packages:
     resolution: {integrity: sha512-kkBTLk053XlhDCg7OkBQTIMF4puqFibeRO3E3YiVc4PGLnocXMaVpOSCkMqAc1k1kZ09UgGi8DxfQhnFEjUkpA==}
     engines: {node: '>=8'}
 
+  '@sentry/node-core@10.68.0':
+    resolution: {integrity: sha512-VreORXnruy8A2SyprZKENAq3ArGwn35KPewLQSQ5dgDXSFtUj2scLuzZoVsZ/Uyt83td0WPvD6Lv0X7MvSYAMQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+
+  '@sentry/node@10.68.0':
+    resolution: {integrity: sha512-bnvRzEehquG/894DD3BWNCBUbDWsLQfYPU+SNCMd6G4Ext75RthVkRs8R0sRaE6b8Tw9HSEgySHL834Tf8lVsA==}
+    engines: {node: '>=18'}
+
   '@sentry/node@7.120.4':
     resolution: {integrity: sha512-qq3wZAXXj2SRWhqErnGCSJKUhPSlZ+RGnCZjhfjHpP49KNpcd9YdPTIUsFMgeyjdh6Ew6aVCv23g1hTP0CHpYw==}
     engines: {node: '>=8'}
+
+  '@sentry/opentelemetry@10.68.0':
+    resolution: {integrity: sha512-JDNH9dacX0MSi7FRvabPCJUAXRMTe16bE/Gajc/7Gfcw7Rwvo4DZ0nd162PCSAW9QoEjUT12upDehEHJuFmsXg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+
+  '@sentry/server-utils@10.68.0':
+    resolution: {integrity: sha512-lp1ZSs1auw7HrCESSYt/n4dOUaKPVUIAKyVYRk6xVr4bMIN3RPub/H5Wm7QPj9CpXVC5bQFvB6+dHZXz809oMg==}
+    engines: {node: '>=18'}
 
   '@sentry/types@7.120.4':
     resolution: {integrity: sha512-cUq2hSSe6/qrU6oZsEP4InMI5VVdD86aypE+ENrQ6eZEVLTCYm1w6XhW1NvIu3UuWh7gZec4a9J7AFpYxki88Q==}
@@ -3458,6 +3831,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -3809,6 +4185,14 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  agent-install@0.0.5:
+    resolution: {integrity: sha512-nHlms9BkP8ZiY79HrwCGiA2DcNaXrAaJrCM/BEqQ7MEsSKyCk+2A76xPGylIfASZSZE0SaU3T0bNSg4rBPIJAQ==}
+    hasBin: true
+
+  agent-install@0.0.6:
+    resolution: {integrity: sha512-7NRMZ/ZDz2vHevQTgJsocBFpakB1/Wx5ip19YSJuj4VOXpraWztTerViNtdSyARKZT9e2yVwUUB5JXXCE7mNrA==}
+    hasBin: true
+
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
@@ -3842,6 +4226,10 @@ packages:
   ansi-escapes@3.2.0:
     resolution: {integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==}
     engines: {node: '>=4'}
+
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
 
   ansi-regex@3.0.1:
     resolution: {integrity: sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==}
@@ -3951,6 +4339,13 @@ packages:
   atomically@1.7.0:
     resolution: {integrity: sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==}
     engines: {node: '>=10.12.0'}
+
+  atomically@2.1.1:
+    resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
+
+  auto-bind@5.0.1:
+    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -4119,6 +4514,16 @@ packages:
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
+  bippy@0.5.43:
+    resolution: {integrity: sha512-Tvu7b1M7+d8b9/YHaCeODEsi2CgbuoBql+dWSBrNnCuqJ1gMUeY3i0r+319hvjjl5GVBP6FFWxrKnq3fhZER0w==}
+    peerDependencies:
+      react: '>=17.0.1'
+
+  bippy@0.6.1:
+    resolution: {integrity: sha512-ky4m94Y/KfsddjGkKTsV4uFjZqkJjpOjQ2t5gKPdX6XH1MNxMNX5FrVefsxV4lpjemEmEdwe0e0YbzAMNs3oUQ==}
+    peerDependencies:
+      react: '>=17.0.1'
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -4270,15 +4675,26 @@ packages:
   citty@0.2.2:
     resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
 
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
   classcat@5.0.5:
     resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
 
+  cli-boxes@4.0.1:
+    resolution: {integrity: sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==}
+    engines: {node: '>=18.20 <19 || >=20.10'}
+
   cli-cursor@2.1.0:
     resolution: {integrity: sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==}
     engines: {node: '>=4'}
+
+  cli-cursor@4.0.0:
+    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -4287,6 +4703,14 @@ packages:
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
+
+  cli-spinners@3.4.0:
+    resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
+    engines: {node: '>=18.20'}
+
+  cli-truncate@6.1.1:
+    resolution: {integrity: sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw==}
+    engines: {node: '>=22'}
 
   cli-width@2.2.1:
     resolution: {integrity: sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==}
@@ -4318,6 +4742,10 @@ packages:
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
+
+  code-excerpt@4.0.0:
+    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -4384,8 +4812,15 @@ packages:
     resolution: {integrity: sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==}
     engines: {node: '>=12'}
 
+  conf@15.1.0:
+    resolution: {integrity: sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==}
+    engines: {node: '>=20'}
+
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
   configstore@5.0.1:
     resolution: {integrity: sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==}
@@ -4409,6 +4844,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  convert-to-spaces@2.0.1:
+    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
@@ -4648,6 +5087,10 @@ packages:
     resolution: {integrity: sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==}
     engines: {node: '>=10'}
 
+  debounce-fn@6.0.0:
+    resolution: {integrity: sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==}
+    engines: {node: '>=18'}
+
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -4752,6 +5195,9 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  deslop-js@0.9.1:
+    resolution: {integrity: sha512-eo3Tn37bqC1mMS3BwsdwRITYgQQQdT30g8SMY9C/zRbMu6ekNf9o7aGNUEkxWiKd1dTND58Sndi5fBlT9V6UvA==}
+
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -4779,6 +5225,10 @@ packages:
 
   dompurify@3.3.3:
     resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+
+  dot-prop@10.2.0:
+    resolution: {integrity: sha512-BTJ9aZYL3vCfZlZOBLy9v8TUqWGQ0pzFnygKwFZt5udj6viBoFIBviKPUoZLDCPn1FoXffv6McQFDenrm5Krfw==}
+    engines: {node: '>=20'}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -4943,6 +5393,14 @@ packages:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
 
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
@@ -4988,6 +5446,9 @@ packages:
     resolution: {integrity: sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.50.0:
+    resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
+
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
 
@@ -5014,6 +5475,10 @@ packages:
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -5119,6 +5584,10 @@ packages:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5182,6 +5651,9 @@ packages:
 
   estree-util-visit@2.0.0:
     resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -5706,9 +6178,17 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-in-the-middle@3.3.2:
+    resolution: {integrity: sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA==}
+    engines: {node: '>=18'}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -5719,6 +6199,26 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ink-spinner@5.0.0:
+    resolution: {integrity: sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==}
+    engines: {node: '>=14.16'}
+    peerDependencies:
+      ink: '>=4.0.0'
+      react: '>=18.0.0'
+
+  ink@7.1.1:
+    resolution: {integrity: sha512-Y43xxa1ZSPvpmfLHcN5o+OdP8Rf8ykkNJEuKYOUNZKT8wXVNLFTtEm1nSDMQkfBH+YANF4Xuu0hhZ4ejqAtN2w==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@types/react': '>=19.2.0'
+      react: '>=19.2.0'
+      react-devtools-core: '>=6.1.2'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-devtools-core:
+        optional: true
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -5836,6 +6336,10 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
@@ -5846,6 +6350,11 @@ packages:
 
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-in-ci@2.0.0:
+    resolution: {integrity: sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   is-in-ssh@1.0.0:
     resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
@@ -6056,6 +6565,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
@@ -6318,6 +6830,10 @@ packages:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
 
+  log-symbols@7.0.1:
+    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
+    engines: {node: '>=18'}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -6460,6 +6976,10 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  meriyah@6.1.4:
+    resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
+    engines: {node: '>=18.0.0'}
 
   mermaid@11.14.0:
     resolution: {integrity: sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==}
@@ -6701,6 +7221,9 @@ packages:
   mnemonist@0.38.3:
     resolution: {integrity: sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==}
 
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -6924,6 +7447,10 @@ packages:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
 
+  ora@9.4.1:
+    resolution: {integrity: sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==}
+    engines: {node: '>=20'}
+
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
 
@@ -6942,8 +7469,29 @@ packages:
     resolution: {integrity: sha512-h6QFWd6lBMfjESqgQ27GjzrSDb0qbznp7VDQqp2zvgsrWut4vcchyMIzOVXvGQ2GMZgKw9RWrFNWv9WqGL0p7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
+  oxc-parser@0.141.0:
+    resolution: {integrity: sha512-uFkGGr1KMWd6aWv9UAqooYrN78trw8MWWmoPvgWokfBEUq1+eiIQ+qfj3wokhy0fxtZWZk+0dHoS7/yRTJtd6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   oxc-resolver@11.24.2:
     resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
+
+  oxlint-plugin-react-doctor@0.9.1:
+    resolution: {integrity: sha512-yCW8USbiuszbVsUMN4fL1iU7mRu3Ae3w96+k/xqCyWvW6bF6DzCMtLy5N/w6WLRX78iQsWxVqW/SEgzRBXLfsA==}
+    engines: {node: ^20.19.0 || >=22.13.0}
+
+  oxlint@1.74.0:
+    resolution: {integrity: sha512-odGl2s2x5IOJoj3A0v1k0PGBXVFBZeZ2+AK/+K2MJur7Ghi3bkyX5NuLUWHKqa4js1wjep3hJeuTQJOlr+4+dA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.24.0'
+      vite-plus: '*'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+      vite-plus:
+        optional: true
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -7010,6 +7558,10 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  patch-console@2.0.0:
+    resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -7123,6 +7675,14 @@ packages:
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
+
+  preact@10.29.7:
+    resolution: {integrity: sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
 
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
@@ -7251,6 +7811,11 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-doctor@0.9.1:
+    resolution: {integrity: sha512-pKCWENXuYZK7UNBHpNLbEBlpy+oVWwPnOxTD2B//gmrQLm+UvIknArzP3IOjNP5Nk1NKCR9uavypFA1QMbYFyg==}
+    engines: {node: ^20.19.0 || >=22.13.0}
+    hasBin: true
+
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
@@ -7262,11 +7827,26 @@ packages:
       react: '>=16.4.0'
       react-dom: '>=16.4.0'
 
+  react-grab@0.1.50:
+    resolution: {integrity: sha512-zRkHKq/8a1msCpEOp8BDROeQZT50m0OH2XPrP6jk5op+JAHrlsm3pj7eAQMOsct87EZDeGNnu4r+sGsJJzyw1Q==}
+    hasBin: true
+    peerDependencies:
+      react: '>=17.0.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-is@19.2.8:
     resolution: {integrity: sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==}
+
+  react-reconciler@0.33.0:
+    resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.2.0
 
   react-resizable-panels@4.12.2:
     resolution: {integrity: sha512-NwY5LCo4WrxVvDh0xoMML6EMLPONP/8ckKcIdpnojxexoatZdjLiRqLJQjQK5CPkd4SYiB/2M5BVrjZBQtOO7Q==}
@@ -7274,10 +7854,25 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
+  react-scan@0.5.7:
+    resolution: {integrity: sha512-KRlq734yN6q/f2CZmZi9CWHuiqSzoLhPFLtcJOL6XM4lR54myyFcY81pG9QOwj+eBC1hIHm5n+Ntbtqiilu8Rg==}
+    hasBin: true
+    peerDependencies:
+      esbuild: '>=0.18.0'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+
   react-test-renderer@19.2.8:
     resolution: {integrity: sha512-GHKPaDRaNYU24PHTLG8Bx8VMY9t+qNfxQbt/Yjp7aMWBkKU6766SR0n6TnYu7P5I1MfEuAMUadqiyDHyI4Yy9Q==}
     peerDependencies:
       react: ^19.2.8
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
 
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
@@ -7407,6 +8002,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
@@ -7428,6 +8027,10 @@ packages:
   restore-cursor@2.0.0:
     resolution: {integrity: sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==}
     engines: {node: '>=4'}
+
+  restore-cursor@4.0.0:
+    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
@@ -7513,6 +8116,9 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semifies@1.0.0:
+    resolution: {integrity: sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==}
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -7637,6 +8243,10 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  slice-ansi@9.0.0:
+    resolution: {integrity: sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==}
+    engines: {node: '>=22'}
+
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
@@ -7687,6 +8297,10 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -7699,6 +8313,10 @@ packages:
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+    engines: {node: '>=18'}
+
+  stdin-discarder@0.3.2:
+    resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
     engines: {node: '>=18'}
 
   stop-iteration-iterator@1.1.0:
@@ -7728,6 +8346,10 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
 
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
@@ -7801,6 +8423,12 @@ packages:
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
+
+  stubborn-fs@2.0.0:
+    resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
+
+  stubborn-utils@1.0.2:
+    resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -7879,6 +8507,10 @@ packages:
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  terminal-size@4.0.1:
+    resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
+    engines: {node: '>=18'}
 
   terser@5.16.9:
     resolution: {integrity: sha512-HPa/FdTB9XGI2H1/keLFZHxl6WNvAI4YalHGtDQTlMnJcoqSab1UwL4l1hGEhs6/GmLHBZIg/YgB++jcbzoOEg==}
@@ -8053,6 +8685,11 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -8060,6 +8697,10 @@ packages:
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   unbash@4.0.3:
     resolution: {integrity: sha512-3cudTErfToSc4Ggv8XGXVNVli/xHKUtUZvaY5UVwhOcUPbQGz7PeaEnT/SAVgNziZtX67KEN9swMUYkLghxA1w==}
@@ -8134,6 +8775,39 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  unplugin@3.3.0:
+    resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@farmfe/core': '*'
+      '@rspack/core': '*'
+      bun-types-no-globals: '*'
+      esbuild: '*'
+      rolldown: '*'
+      rollup: '*'
+      unloader: '*'
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      '@farmfe/core':
+        optional: true
+      '@rspack/core':
+        optional: true
+      bun-types-no-globals:
+        optional: true
+      esbuild:
+        optional: true
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+      unloader:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
 
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
@@ -8315,11 +8989,17 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  when-exit@2.1.5:
+    resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -8355,6 +9035,10 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  widest-line@6.0.0:
+    resolution: {integrity: sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==}
+    engines: {node: '>=20'}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -8376,6 +9060,10 @@ packages:
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
+
+  wrap-ansi@10.0.0:
+    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
+    engines: {node: '>=20'}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -8496,6 +9184,9 @@ packages:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
 
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
+
   youch-core@0.3.3:
     resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
 
@@ -8539,12 +9230,41 @@ packages:
 
 snapshots:
 
+  '@alcalzone/ansi-tokenize@0.3.0':
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.2.4
+
+  '@apm-js-collab/code-transformer-bundler-plugins@0.7.1':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.18.1
+      es-module-lexer: 2.3.1
+      magic-string: 0.30.21
+      module-details-from-path: 1.0.4
+
+  '@apm-js-collab/code-transformer@0.18.1':
+    dependencies:
+      '@types/estree': 1.0.9
+      astring: 1.9.0
+      esquery: 1.7.0
+      meriyah: 6.1.4
+      semifies: 1.0.0
+      source-map: 0.6.1
+
+  '@apm-js-collab/tracing-hooks@0.13.0':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.18.1
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   '@ast-grep/napi-darwin-arm64@0.40.5':
     optional: true
@@ -9850,6 +10570,8 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@iarna/toml@2.2.5': {}
+
   '@iconify/types@2.0.0': {}
 
   '@iconify/utils@3.1.0':
@@ -10466,57 +11188,143 @@ snapshots:
       - encoding
       - supports-color
 
-  '@opentelemetry/api@1.9.1':
-    optional: true
+  '@opentelemetry/api-logs@0.220.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.220.0
+      import-in-the-middle: 3.3.2
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
 
   '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@oxc-parser/binding-android-arm-eabi@0.140.0':
     optional: true
 
+  '@oxc-parser/binding-android-arm-eabi@0.141.0':
+    optional: true
+
   '@oxc-parser/binding-android-arm64@0.140.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.141.0':
     optional: true
 
   '@oxc-parser/binding-darwin-arm64@0.140.0':
     optional: true
 
+  '@oxc-parser/binding-darwin-arm64@0.141.0':
+    optional: true
+
   '@oxc-parser/binding-darwin-x64@0.140.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.141.0':
     optional: true
 
   '@oxc-parser/binding-freebsd-x64@0.140.0':
     optional: true
 
+  '@oxc-parser/binding-freebsd-x64@0.141.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm-gnueabihf@0.140.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.141.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm-musleabihf@0.140.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm-musleabihf@0.141.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm64-gnu@0.140.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.141.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-musl@0.140.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm64-musl@0.141.0':
+    optional: true
+
   '@oxc-parser/binding-linux-ppc64-gnu@0.140.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.141.0':
     optional: true
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.140.0':
     optional: true
 
+  '@oxc-parser/binding-linux-riscv64-gnu@0.141.0':
+    optional: true
+
   '@oxc-parser/binding-linux-riscv64-musl@0.140.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.141.0':
     optional: true
 
   '@oxc-parser/binding-linux-s390x-gnu@0.140.0':
     optional: true
 
+  '@oxc-parser/binding-linux-s390x-gnu@0.141.0':
+    optional: true
+
   '@oxc-parser/binding-linux-x64-gnu@0.140.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.141.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-musl@0.140.0':
     optional: true
 
+  '@oxc-parser/binding-linux-x64-musl@0.141.0':
+    optional: true
+
   '@oxc-parser/binding-openharmony-arm64@0.140.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.141.0':
     optional: true
 
   '@oxc-parser/binding-wasm32-wasi@0.140.0':
@@ -10526,18 +11334,36 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
+  '@oxc-parser/binding-wasm32-wasi@0.141.0':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
   '@oxc-parser/binding-win32-arm64-msvc@0.140.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.141.0':
     optional: true
 
   '@oxc-parser/binding-win32-ia32-msvc@0.140.0':
     optional: true
 
+  '@oxc-parser/binding-win32-ia32-msvc@0.141.0':
+    optional: true
+
   '@oxc-parser/binding-win32-x64-msvc@0.140.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.141.0':
     optional: true
 
   '@oxc-project/types@0.124.0': {}
 
   '@oxc-project/types@0.140.0': {}
+
+  '@oxc-project/types@0.141.0': {}
 
   '@oxc-resolver/binding-android-arm-eabi@11.24.2':
     optional: true
@@ -10600,6 +11426,63 @@ snapshots:
   '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
     optional: true
 
+  '@oxlint/binding-android-arm-eabi@1.74.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.74.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.74.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.74.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.74.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.74.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.74.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.74.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.74.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.74.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.74.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.74.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.74.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.74.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.74.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.74.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.74.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.74.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.74.0':
+    optional: true
+
   '@paulirish/trace_engine@0.0.53':
     dependencies:
       legacy-javascript: 0.0.1
@@ -10623,6 +11506,13 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
+  '@preact/signals-core@1.14.4': {}
+
+  '@preact/signals@2.10.0(preact@10.29.7)':
+    dependencies:
+      '@preact/signals-core': 1.14.4
+      preact: 10.29.7
+
   '@puppeteer/browsers@2.13.0':
     dependencies:
       debug: 4.4.3
@@ -10637,6 +11527,17 @@ snapshots:
       - bare-buffer
       - react-native-b4a
       - supports-color
+
+  '@react-grab/cli@0.1.50':
+    dependencies:
+      agent-install: 0.0.6
+      commander: 14.0.3
+      ignore: 7.0.6
+      ora: 9.4.1
+      package-manager-detector: 1.6.0
+      picocolors: 1.1.1
+      prompts: 2.4.2
+      tinyexec: 1.2.4
 
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     optional: true
@@ -10689,6 +11590,12 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.15': {}
 
+  '@rollup/pluginutils@5.4.0':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.5
+
   '@rtsao/scc@1.1.0': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
@@ -10698,6 +11605,12 @@ snapshots:
       '@sentry/core': 7.120.4
       '@sentry/types': 7.120.4
       '@sentry/utils': 7.120.4
+
+  '@sentry/conventions@0.16.0': {}
+
+  '@sentry/core@10.68.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
 
   '@sentry/core@7.120.4':
     dependencies:
@@ -10711,6 +11624,34 @@ snapshots:
       '@sentry/utils': 7.120.4
       localforage: 1.10.0
 
+  '@sentry/node-core@10.68.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.68.0
+      '@sentry/opentelemetry': 10.68.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      import-in-the-middle: 3.3.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@sentry/node@10.68.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.68.0
+      '@sentry/node-core': 10.68.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.68.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/server-utils': 10.68.0
+      import-in-the-middle: 3.3.2
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
   '@sentry/node@7.120.4':
     dependencies:
       '@sentry-internal/tracing': 7.120.4
@@ -10718,6 +11659,24 @@ snapshots:
       '@sentry/integrations': 7.120.4
       '@sentry/types': 7.120.4
       '@sentry/utils': 7.120.4
+
+  '@sentry/opentelemetry@10.68.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.68.0
+
+  '@sentry/server-utils@10.68.0':
+    dependencies:
+      '@apm-js-collab/code-transformer-bundler-plugins': 0.7.1
+      '@apm-js-collab/tracing-hooks': 0.13.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.68.0
+      meriyah: 6.1.4
+    transitivePeerDependencies:
+      - supports-color
 
   '@sentry/types@7.120.4': {}
 
@@ -11548,6 +12507,8 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/esrecurse@4.3.1': {}
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.9
@@ -11812,7 +12773,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.10)(msw@2.14.6(@types/node@26.0.0)(typescript@6.0.3))(vite@8.0.8(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.16.9)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(@vitest/coverage-v8@4.1.10)(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.8(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.16.9)(tsx@4.23.1)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -11927,6 +12888,24 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  agent-install@0.0.5:
+    dependencies:
+      '@iarna/toml': 2.2.5
+      commander: 14.0.3
+      jsonc-parser: 3.3.1
+      picocolors: 1.1.1
+      prompts: 2.4.2
+      yaml: 2.9.0
+
+  agent-install@0.0.6:
+    dependencies:
+      '@iarna/toml': 2.2.5
+      commander: 14.0.3
+      jsonc-parser: 3.3.1
+      picocolors: 1.1.1
+      prompts: 2.4.2
+      yaml: 2.9.0
+
   agentkeepalive@4.6.0:
     dependencies:
       humanize-ms: 1.2.1
@@ -11956,6 +12935,10 @@ snapshots:
   ansi-colors@4.1.3: {}
 
   ansi-escapes@3.2.0: {}
+
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
 
   ansi-regex@3.0.1: {}
 
@@ -12080,6 +13063,13 @@ snapshots:
 
   atomically@1.7.0: {}
 
+  atomically@2.1.1:
+    dependencies:
+      stubborn-fs: 2.0.0
+      when-exit: 2.1.5
+
+  auto-bind@5.0.1: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -12185,6 +13175,14 @@ snapshots:
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
+
+  bippy@0.5.43(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+
+  bippy@0.6.1(react@19.2.8):
+    dependencies:
+      react: 19.2.8
 
   bl@4.1.0:
     dependencies:
@@ -12371,21 +13369,36 @@ snapshots:
 
   citty@0.2.2: {}
 
+  cjs-module-lexer@2.2.0: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
 
   classcat@5.0.5: {}
 
+  cli-boxes@4.0.1: {}
+
   cli-cursor@2.1.0:
     dependencies:
       restore-cursor: 2.0.0
+
+  cli-cursor@4.0.0:
+    dependencies:
+      restore-cursor: 4.0.0
 
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
 
   cli-spinners@2.9.2: {}
+
+  cli-spinners@3.4.0: {}
+
+  cli-truncate@6.1.1:
+    dependencies:
+      slice-ansi: 9.0.0
+      string-width: 8.2.2
 
   cli-width@2.2.1: {}
 
@@ -12427,6 +13440,10 @@ snapshots:
   clsx@2.1.1: {}
 
   code-block-writer@13.0.3: {}
+
+  code-excerpt@4.0.0:
+    dependencies:
+      convert-to-spaces: 2.0.1
 
   collapse-white-space@2.1.0: {}
 
@@ -12496,7 +13513,21 @@ snapshots:
       pkg-up: 3.1.0
       semver: 7.8.5
 
+  conf@15.1.0:
+    dependencies:
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      atomically: 2.1.1
+      debounce-fn: 6.0.0
+      dot-prop: 10.2.0
+      env-paths: 3.0.0
+      json-schema-typed: 8.0.2
+      semver: 7.8.5
+      uint8array-extras: 1.5.0
+
   confbox@0.1.8: {}
+
+  confbox@0.2.4: {}
 
   configstore@5.0.1:
     dependencies:
@@ -12518,6 +13549,8 @@ snapshots:
   content-type@2.0.0: {}
 
   convert-source-map@2.0.0: {}
+
+  convert-to-spaces@2.0.1: {}
 
   cookie-signature@1.0.7: {}
 
@@ -12778,6 +13811,10 @@ snapshots:
     dependencies:
       mimic-fn: 3.1.0
 
+  debounce-fn@6.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -12851,6 +13888,15 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  deslop-js@0.9.1:
+    dependencies:
+      '@oxc-project/types': 0.141.0
+      fast-glob: 3.3.3
+      minimatch: 10.2.5
+      oxc-parser: 0.141.0
+      oxc-resolver: 11.24.2
+      typescript: 5.9.3
+
   destroy@1.2.0: {}
 
   detect-libc@2.1.2: {}
@@ -12872,6 +13918,10 @@ snapshots:
   dompurify@3.3.3:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  dot-prop@10.2.0:
+    dependencies:
+      type-fest: 5.8.0
 
   dot-prop@5.3.0:
     dependencies:
@@ -12942,6 +13992,10 @@ snapshots:
   entities@6.0.1: {}
 
   env-paths@2.2.1: {}
+
+  env-paths@3.0.0: {}
+
+  environment@1.1.0: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -13062,6 +14116,8 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  es-toolkit@1.50.0: {}
+
   esast-util-from-estree@2.0.0:
     dependencies:
       '@types/estree-jsx': 1.0.5
@@ -13139,6 +14195,8 @@ snapshots:
 
   escape-string-regexp@1.0.5: {}
 
+  escape-string-regexp@2.0.0: {}
+
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
@@ -13156,7 +14214,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.11
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
@@ -13179,7 +14237,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -13194,13 +14252,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -13215,7 +14273,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -13291,6 +14349,13 @@ snapshots:
 
   eslint-scope@8.4.0:
     dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
@@ -13389,6 +14454,8 @@ snapshots:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/unist': 3.0.3
+
+  estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -14107,7 +15174,15 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-in-the-middle@3.3.2:
+    dependencies:
+      cjs-module-lexer: 2.2.0
+      es-module-lexer: 2.3.1
+      module-details-from-path: 1.0.4
+
   imurmurhash@0.1.4: {}
+
+  indent-string@5.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -14117,6 +15192,46 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  ink-spinner@5.0.0(ink@7.1.1(@types/react@19.2.17)(react@19.2.5))(react@19.2.5):
+    dependencies:
+      cli-spinners: 2.9.2
+      ink: 7.1.1(@types/react@19.2.17)(react@19.2.5)
+      react: 19.2.5
+
+  ink@7.1.1(@types/react@19.2.17)(react@19.2.5):
+    dependencies:
+      '@alcalzone/ansi-tokenize': 0.3.0
+      ansi-escapes: 7.3.0
+      ansi-styles: 6.2.3
+      auto-bind: 5.0.1
+      chalk: 5.6.2
+      cli-boxes: 4.0.1
+      cli-cursor: 4.0.0
+      cli-truncate: 6.1.1
+      code-excerpt: 4.0.0
+      es-toolkit: 1.50.0
+      indent-string: 5.0.0
+      is-in-ci: 2.0.0
+      patch-console: 2.0.0
+      react: 19.2.5
+      react-reconciler: 0.33.0(react@19.2.5)
+      scheduler: 0.27.0
+      signal-exit: 3.0.7
+      slice-ansi: 9.0.0
+      stack-utils: 2.0.6
+      string-width: 8.2.2
+      terminal-size: 4.0.1
+      type-fest: 5.8.0
+      widest-line: 6.0.0
+      wrap-ansi: 10.0.0
+      ws: 8.21.1
+      yoga-layout: 3.2.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   inline-style-parser@0.2.7: {}
 
@@ -14237,6 +15352,10 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
+
   is-generator-function@1.1.2:
     dependencies:
       call-bound: 1.0.4
@@ -14250,6 +15369,8 @@ snapshots:
       is-extglob: 2.1.1
 
   is-hexadecimal@2.0.1: {}
+
+  is-in-ci@2.0.0: {}
 
   is-in-ssh@1.0.0: {}
 
@@ -14421,6 +15542,8 @@ snapshots:
       minimist: 1.2.8
 
   json5@2.2.3: {}
+
+  jsonc-parser@3.3.1: {}
 
   jsonfile@6.2.1:
     dependencies:
@@ -14685,6 +15808,11 @@ snapshots:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
 
+  log-symbols@7.0.1:
+    dependencies:
+      is-unicode-supported: 2.1.0
+      yoctocolors: 2.1.2
+
   longest-streak@3.1.0: {}
 
   lookup-closest-locale@6.2.0: {}
@@ -14928,6 +16056,8 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  meriyah@6.1.4: {}
 
   mermaid@11.14.0:
     dependencies:
@@ -15343,6 +16473,8 @@ snapshots:
     dependencies:
       obliterator: 1.6.1
 
+  module-details-from-path@1.0.4: {}
+
   ms@2.0.0: {}
 
   ms@2.1.3: {}
@@ -15634,6 +16766,17 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
+  ora@9.4.1:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 3.4.0
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 7.0.1
+      stdin-discarder: 0.3.2
+      string-width: 8.2.2
+
   orderedmap@2.1.1: {}
 
   os-tmpdir@1.0.2: {}
@@ -15673,6 +16816,31 @@ snapshots:
       '@oxc-parser/binding-win32-ia32-msvc': 0.140.0
       '@oxc-parser/binding-win32-x64-msvc': 0.140.0
 
+  oxc-parser@0.141.0:
+    dependencies:
+      '@oxc-project/types': 0.141.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.141.0
+      '@oxc-parser/binding-android-arm64': 0.141.0
+      '@oxc-parser/binding-darwin-arm64': 0.141.0
+      '@oxc-parser/binding-darwin-x64': 0.141.0
+      '@oxc-parser/binding-freebsd-x64': 0.141.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.141.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.141.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.141.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.141.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.141.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.141.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.141.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.141.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.141.0
+      '@oxc-parser/binding-linux-x64-musl': 0.141.0
+      '@oxc-parser/binding-openharmony-arm64': 0.141.0
+      '@oxc-parser/binding-wasm32-wasi': 0.141.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.141.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.141.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.141.0
+
   oxc-resolver@11.24.2:
     optionalDependencies:
       '@oxc-resolver/binding-android-arm-eabi': 11.24.2
@@ -15694,6 +16862,35 @@ snapshots:
       '@oxc-resolver/binding-wasm32-wasi': 11.24.2
       '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
       '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
+
+  oxlint-plugin-react-doctor@0.9.1:
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      oxc-parser: 0.141.0
+
+  oxlint@1.74.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.74.0
+      '@oxlint/binding-android-arm64': 1.74.0
+      '@oxlint/binding-darwin-arm64': 1.74.0
+      '@oxlint/binding-darwin-x64': 1.74.0
+      '@oxlint/binding-freebsd-x64': 1.74.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.74.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.74.0
+      '@oxlint/binding-linux-arm64-gnu': 1.74.0
+      '@oxlint/binding-linux-arm64-musl': 1.74.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.74.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.74.0
+      '@oxlint/binding-linux-riscv64-musl': 1.74.0
+      '@oxlint/binding-linux-s390x-gnu': 1.74.0
+      '@oxlint/binding-linux-x64-gnu': 1.74.0
+      '@oxlint/binding-linux-x64-musl': 1.74.0
+      '@oxlint/binding-openharmony-arm64': 1.74.0
+      '@oxlint/binding-win32-arm64-msvc': 1.74.0
+      '@oxlint/binding-win32-ia32-msvc': 1.74.0
+      '@oxlint/binding-win32-x64-msvc': 1.74.0
 
   p-limit@2.3.0:
     dependencies:
@@ -15771,6 +16968,8 @@ snapshots:
       entities: 6.0.1
 
   parseurl@1.3.3: {}
+
+  patch-console@2.0.0: {}
 
   path-browserify@1.0.1: {}
 
@@ -15863,6 +17062,8 @@ snapshots:
       source-map-js: 1.2.1
 
   powershell-utils@0.1.0: {}
+
+  preact@10.29.7: {}
 
   prebuild-install@7.1.3:
     dependencies:
@@ -16060,6 +17261,41 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  react-doctor@0.9.1(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/react@19.2.17)(eslint@9.39.5(jiti@2.7.0)):
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@sentry/node': 10.68.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
+      agent-install: 0.0.5
+      conf: 15.1.0
+      confbox: 0.2.4
+      deslop-js: 0.9.1
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5(jiti@2.7.0))
+      figures: 6.1.0
+      ink: 7.1.1(@types/react@19.2.17)(react@19.2.5)
+      ink-spinner: 5.0.0(ink@7.1.1(@types/react@19.2.17)(react@19.2.5))(react@19.2.5)
+      jiti: 2.7.0
+      magicast: 0.5.3
+      oxlint: 1.74.0
+      oxlint-plugin-react-doctor: 0.9.1
+      prompts: 2.4.2
+      react: 19.2.5
+      typescript: 5.9.3
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@types/react'
+      - bufferutil
+      - eslint
+      - oxlint-tsgolint
+      - react-devtools-core
+      - supports-color
+      - utf-8-validate
+      - vite-plus
+
   react-dom@19.2.8(react@19.2.8):
     dependencies:
       react: 19.2.8
@@ -16071,20 +17307,73 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
+  react-grab@0.1.50(react@19.2.8):
+    dependencies:
+      '@react-grab/cli': 0.1.50
+      bippy: 0.6.1(react@19.2.8)
+    optionalDependencies:
+      react: 19.2.8
+
   react-is@16.13.1: {}
 
   react-is@19.2.8: {}
+
+  react-reconciler@0.33.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
 
   react-resizable-panels@4.12.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
+  react-scan@0.5.7(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/react@19.2.17)(esbuild@0.28.1)(eslint@9.39.5(jiti@2.7.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.0.8(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.16.9)(tsx@4.23.1)(yaml@2.9.0)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/types': 7.29.7
+      '@preact/signals': 2.10.0(preact@10.29.7)
+      '@rollup/pluginutils': 5.4.0
+      bippy: 0.5.43(react@19.2.8)
+      commander: 14.0.3
+      picocolors: 1.1.1
+      preact: 10.29.7
+      prompts: 2.4.2
+      react: 19.2.8
+      react-doctor: 0.9.1(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/react@19.2.17)(eslint@9.39.5(jiti@2.7.0))
+      react-dom: 19.2.8(react@19.2.8)
+      react-grab: 0.1.50(react@19.2.8)
+    optionalDependencies:
+      esbuild: 0.28.1
+      unplugin: 3.3.0(esbuild@0.28.1)(vite@8.0.8(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.16.9)(tsx@4.23.1)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@rspack/core'
+      - '@types/react'
+      - bufferutil
+      - bun-types-no-globals
+      - eslint
+      - oxlint-tsgolint
+      - preact-render-to-string
+      - react-devtools-core
+      - rolldown
+      - rollup
+      - supports-color
+      - unloader
+      - utf-8-validate
+      - vite
+      - vite-plus
+      - webpack
+
   react-test-renderer@19.2.8(react@19.2.8):
     dependencies:
       react: 19.2.8
       react-is: 19.2.8
       scheduler: 0.27.0
+
+  react@19.2.5: {}
 
   react@19.2.8: {}
 
@@ -16318,6 +17607,13 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
   require-main-filename@2.0.0: {}
 
   reselect@5.2.0: {}
@@ -16338,6 +17634,11 @@ snapshots:
   restore-cursor@2.0.0:
     dependencies:
       onetime: 2.0.1
+      signal-exit: 3.0.7
+
+  restore-cursor@4.0.0:
+    dependencies:
+      onetime: 5.1.2
       signal-exit: 3.0.7
 
   restore-cursor@5.1.0:
@@ -16442,6 +17743,8 @@ snapshots:
   safer-buffer@2.1.2: {}
 
   scheduler@0.27.0: {}
+
+  semifies@1.0.0: {}
 
   semver@5.7.2: {}
 
@@ -16704,6 +18007,11 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  slice-ansi@9.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   smart-buffer@4.2.0: {}
 
   smol-toml@1.7.0: {}
@@ -16749,6 +18057,10 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
+
   stackback@0.0.2: {}
 
   statuses@2.0.2: {}
@@ -16756,6 +18068,8 @@ snapshots:
   std-env@4.2.0: {}
 
   stdin-discarder@0.2.2: {}
+
+  stdin-discarder@0.3.2: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -16811,6 +18125,11 @@ snapshots:
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.2:
+    dependencies:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
@@ -16908,6 +18227,12 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
+  stubborn-fs@2.0.0:
+    dependencies:
+      stubborn-utils: 1.0.2
+
+  stubborn-utils@1.0.2: {}
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -16943,8 +18268,7 @@ snapshots:
 
   systeminformation@5.33.0: {}
 
-  tagged-tag@1.0.0:
-    optional: true
+  tagged-tag@1.0.0: {}
 
   tailwind-merge@3.6.0: {}
 
@@ -16996,6 +18320,8 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+
+  terminal-size@4.0.1: {}
 
   terser@5.16.9:
     dependencies:
@@ -17130,7 +18456,6 @@ snapshots:
   type-fest@5.8.0:
     dependencies:
       tagged-tag: 1.0.0
-    optional: true
 
   type-is@1.6.18:
     dependencies:
@@ -17193,9 +18518,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  typescript@5.9.3: {}
+
   typescript@6.0.3: {}
 
   ufo@1.6.3: {}
+
+  uint8array-extras@1.5.0: {}
 
   unbash@4.0.3: {}
 
@@ -17279,6 +18608,16 @@ snapshots:
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
+
+  unplugin@3.3.0(esbuild@0.28.1)(vite@8.0.8(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.16.9)(tsx@4.23.1)(yaml@2.9.0)):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.5
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      esbuild: 0.28.1
+      vite: 8.0.8(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.16.9)(tsx@4.23.1)(yaml@2.9.0)
+    optional: true
 
   unrs-resolver@1.12.2:
     dependencies:
@@ -17517,12 +18856,17 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
+  webpack-virtual-modules@0.6.2:
+    optional: true
+
   whatwg-fetch@3.6.20: {}
 
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  when-exit@2.1.5: {}
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -17580,6 +18924,10 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  widest-line@6.0.0:
+    dependencies:
+      string-width: 8.2.2
+
   word-wrap@1.2.5: {}
 
   worker-mailer@1.2.1: {}
@@ -17608,6 +18956,12 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  wrap-ansi@10.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.2
+      strip-ansi: 7.2.0
 
   wrap-ansi@6.2.0:
     dependencies:
@@ -17716,6 +19070,8 @@ snapshots:
       yoctocolors: 2.1.2
 
   yoctocolors@2.1.2: {}
+
+  yoga-layout@3.2.1: {}
 
   youch-core@0.3.3:
     dependencies:

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -18,6 +18,8 @@
     "test:e2e-ui": "playwright test",
     "test:e2e-ui:headed": "playwright test --headed",
     "knip": "knip",
+    "seed:stress": "tsx scripts/seed-stress.ts",
+    "perf:switch": "playwright test --config playwright.perf.config.ts; tsx scripts/perf-report.ts",
     "typecheck": "tsc --noEmit",
     "seo:check": "lhci autorun --config=lighthouserc.json && node scripts/print-lighthouse-scores.mjs"
   },
@@ -120,6 +122,7 @@
     "eslint-plugin-tailwind-canonical-classes": "^1.4.1",
     "fake-indexeddb": "^6.2.5",
     "knip": "^6.29.0",
+    "react-scan": "0.5.7",
     "react-test-renderer": "19.2.8",
     "remark-parse": "^11.0.0",
     "tailwindcss": "^4",

--- a/src/web/playwright.perf.config.ts
+++ b/src/web/playwright.perf.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from "@playwright/test"
+
+// Perf-diagnosis config — deliberately separate from playwright.config.ts.
+//
+// - Matches only `*.perf.ts`, so the CI e2e-ui workflow (which matches
+//   `**/*.spec.ts`) never picks these up. This is a LOCAL diagnostic.
+// - NO globalSetup/globalTeardown: the e2e global-setup resets the local D1 and
+//   registers ephemeral stamped users. The perf run must NOT wipe the DB the
+//   stress-seed just populated, and must drive as the STABLE seed identity
+//   (loaded from perf-artifacts/seed-manifest.json inside the spec), not a
+//   fresh stamped user.
+const BASE_URL = process.env.ALOOK_SERVER_URL || "http://localhost:3000"
+
+export default defineConfig({
+  testDir: "./src/test/e2e-ui/perf",
+  testMatch: "**/*.perf.ts",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: 1,
+  reporter: "list",
+  // Generous: each switch pays full dev-build API fan-out + paint + reflow.
+  // The spec also flushes its capture incrementally, so even if this cap is hit
+  // the report generator still has data to work with.
+  timeout: 600_000,
+  expect: { timeout: 15_000 },
+  use: {
+    baseURL: BASE_URL,
+    trace: "off",
+    video: "off",
+    screenshot: "off",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+})

--- a/src/web/scripts/perf-report.test.ts
+++ b/src/web/scripts/perf-report.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest"
+import { analyzeSwitch, renderReport } from "./perf-report"
+import type { CapturedSwitch, CaptureFile } from "../src/test/e2e-ui/perf/perf-capture-types"
+
+function baseSwitch(over: Partial<CapturedSwitch> = {}): CapturedSwitch {
+  return {
+    kind: "channel",
+    targetId: "chan-1",
+    cacheState: "cold",
+    clickTs: 1000,
+    skeletonTs: 1010,
+    paintedTs: 1500,
+    contentStableTs: 1600,
+    resources: [],
+    commits: [],
+    unmounts: [],
+    layoutShifts: [],
+    degraded: false,
+    ...over,
+  }
+}
+
+describe("analyzeSwitch — phases & perceived latency", () => {
+  it("computes the three-phase breakdown and perceived total", () => {
+    const a = analyzeSwitch(baseSwitch())
+    expect(a.perceivedMs).toBe(600) // 1600 - 1000
+    expect(a.clickToSkeletonMs).toBe(10)
+    expect(a.skeletonToPaintedMs).toBe(490)
+    expect(a.paintedToStableMs).toBe(100)
+  })
+
+  it("falls back to painted when there is no content-stable anchor", () => {
+    const a = analyzeSwitch(baseSwitch({ contentStableTs: null }))
+    expect(a.perceivedMs).toBe(500) // painted(1500) - click(1000)
+  })
+})
+
+describe("analyzeSwitch — serialization verdict", () => {
+  it("labels SERIALIZED when read-state response-end precedes messages request-start", () => {
+    const a = analyzeSwitch(
+      baseSwitch({
+        resources: [
+          { name: "http://x/api/community/channels/c/read-state", startTime: 1010, responseEnd: 1300 },
+          { name: "http://x/api/community/channels/c/messages", startTime: 1305, responseEnd: 1580 },
+        ],
+      }),
+    )
+    expect(a.readStateBlocksMessages).toBe(true)
+    expect(a.verdict).toMatch(/SERIALIZED/)
+  })
+
+  it("labels parallel when read-state and messages overlap", () => {
+    const a = analyzeSwitch(
+      baseSwitch({
+        resources: [
+          { name: "http://x/api/community/channels/c/read-state", startTime: 1010, responseEnd: 1400 },
+          { name: "http://x/api/community/channels/c/messages", startTime: 1050, responseEnd: 1580 },
+        ],
+      }),
+    )
+    expect(a.readStateBlocksMessages).toBe(false)
+  })
+})
+
+describe("analyzeSwitch — non-network attribution", () => {
+  it("blames render/remount/reflow when network is a small slice", () => {
+    // 600ms perceived, but only ~30ms of network.
+    const a = analyzeSwitch(
+      baseSwitch({
+        resources: [
+          { name: "http://x/api/community/channels/c/read-state", startTime: 1010, responseEnd: 1025 },
+          { name: "http://x/api/community/channels/c/messages", startTime: 1025, responseEnd: 1040 },
+        ],
+        unmounts: ["ChannelView"],
+        commits: [
+          {
+            ts: 1050,
+            kind: "commit",
+            mounts: [{ name: "ChannelView", fiberId: 1, actualDuration: 5 }],
+            rerenders: [],
+          },
+        ],
+      }),
+    )
+    expect(a.verdict).toMatch(/NOT network-bound/)
+    expect(a.networkMs).toBeLessThan(a.perceivedMs! * 0.6)
+  })
+})
+
+describe("analyzeSwitch — StrictMode adjustment", () => {
+  it("halves mount count for fibers that double-committed", () => {
+    const a = analyzeSwitch(
+      baseSwitch({
+        commits: [
+          {
+            ts: 1050,
+            kind: "commit",
+            mounts: [
+              { name: "ChannelView", fiberId: 7, actualDuration: 3 },
+              { name: "ChannelView", fiberId: 7, actualDuration: 3 },
+              { name: "MessageList", fiberId: 8, actualDuration: 2 },
+              { name: "MessageList", fiberId: 8, actualDuration: 2 },
+            ],
+            rerenders: [],
+          },
+        ],
+      }),
+    )
+    expect(a.mountCountRaw).toBe(4)
+    expect(a.mountCountAdjusted).toBe(2)
+  })
+})
+
+describe("renderReport — cache-state split", () => {
+  it("emits a section per switch across cache states", () => {
+    const file: CaptureFile = {
+      owner: { email: "perf-seed@alook.test", userId: "u1" },
+      createdAt: "2026-07-24T00:00:00.000Z",
+      switches: [
+        baseSwitch({ cacheState: "cold" }),
+        baseSwitch({ cacheState: "memory-warm" }),
+        baseSwitch({ cacheState: "disk-warm" }),
+      ],
+    }
+    const md = renderReport(file)
+    expect(md).toMatch(/cache: cold/)
+    expect(md).toMatch(/cache: memory-warm/)
+    expect(md).toMatch(/cache: disk-warm/)
+    expect(md).toMatch(/PERCEIVED/)
+  })
+})

--- a/src/web/scripts/perf-report.ts
+++ b/src/web/scripts/perf-report.ts
@@ -1,0 +1,232 @@
+/**
+ * Turn perf-artifacts/switch-events.json into a human-readable
+ * perf-artifacts/switch-report.md. See plans/community-switch-perf-diagnosis.md.
+ *
+ * The correlation core (`analyzeSwitch`, `renderReport`) is pure and exported
+ * for unit testing — no filesystem, no browser.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+import type {
+  CaptureFile,
+  CapturedSwitch,
+  CapturedResource,
+} from "../src/test/e2e-ui/perf/perf-capture-types"
+
+const ARTIFACTS_DIR = resolve(import.meta.dirname, "..", "perf-artifacts")
+const CAPTURE_IN = resolve(ARTIFACTS_DIR, "switch-events.json")
+const REPORT_OUT = resolve(ARTIFACTS_DIR, "switch-report.md")
+
+export interface SwitchAnalysis {
+  kind: string
+  targetId: string
+  cacheState: string
+  /** click → content-stable (or painted if no resize settle). The headline. */
+  perceivedMs: number | null
+  clickToSkeletonMs: number | null
+  skeletonToPaintedMs: number | null
+  paintedToStableMs: number | null
+  /** sum of gaps where exactly one /api/community request was in flight. */
+  networkMs: number
+  /** wall time from first request start to last response end. */
+  networkSpanMs: number
+  /** true if read-state's response-end precedes messages' request-start. */
+  readStateBlocksMessages: boolean | null
+  mountCountRaw: number
+  mountCountAdjusted: number
+  rerenderCountRaw: number
+  unmounts: string[]
+  topRenders: Array<{ name: string; count: number; reason?: string }>
+  /** attribution of the perceived total. */
+  verdict: string
+}
+
+function findResource(resources: CapturedResource[], needle: string): CapturedResource | undefined {
+  return resources.find((r) => r.name.includes(needle))
+}
+
+/**
+ * Detect StrictMode double-commit inflation: in dev, the same logical fiber
+ * (fiberId) mounts twice in immediate succession. We halve mount counts for
+ * fiberIds seen exactly twice back-to-back.
+ */
+function adjustForStrictMode(sw: CapturedSwitch): { mountRaw: number; mountAdjusted: number } {
+  const mountIds: number[] = []
+  let mountRaw = 0
+  for (const commit of sw.commits) {
+    for (const m of commit.mounts) {
+      mountRaw++
+      if (typeof m.fiberId === "number") mountIds.push(m.fiberId)
+    }
+  }
+  // Count fiberIds appearing an even number of times as StrictMode doubles.
+  const seen = new Map<number, number>()
+  for (const id of mountIds) seen.set(id, (seen.get(id) ?? 0) + 1)
+  let doubled = 0
+  for (const [, n] of seen) if (n >= 2) doubled += Math.floor(n / 2)
+  const mountAdjusted = Math.max(mountRaw - doubled, 0)
+  return { mountRaw, mountAdjusted }
+}
+
+export function analyzeSwitch(sw: CapturedSwitch): SwitchAnalysis {
+  const clickToSkeletonMs = sw.skeletonTs != null ? sw.skeletonTs - sw.clickTs : null
+  const skeletonToPaintedMs =
+    sw.skeletonTs != null && sw.paintedTs != null ? sw.paintedTs - sw.skeletonTs : null
+  const paintedToStableMs =
+    sw.paintedTs != null && sw.contentStableTs != null ? sw.contentStableTs - sw.paintedTs : null
+  const stableTs = sw.contentStableTs ?? sw.paintedTs
+  const perceivedMs = stableTs != null ? stableTs - sw.clickTs : null
+
+  const sorted = [...sw.resources].sort((a, b) => a.startTime - b.startTime)
+  const networkSpanMs = sorted.length
+    ? Math.max(...sorted.map((r) => r.responseEnd)) - Math.min(...sorted.map((r) => r.startTime))
+    : 0
+  // Union of busy intervals = actual time at least one request was in flight.
+  let networkMs = 0
+  let curStart = -1
+  let curEnd = -1
+  for (const r of sorted) {
+    if (curEnd < r.startTime) {
+      if (curStart >= 0) networkMs += curEnd - curStart
+      curStart = r.startTime
+      curEnd = r.responseEnd
+    } else {
+      curEnd = Math.max(curEnd, r.responseEnd)
+    }
+  }
+  if (curStart >= 0) networkMs += curEnd - curStart
+
+  const readState = findResource(sw.resources, "/read-state")
+  const messages = findResource(sw.resources, "/messages")
+  const readStateBlocksMessages =
+    readState && messages ? readState.responseEnd <= messages.startTime + 1 : null
+
+  const { mountRaw, mountAdjusted } = adjustForStrictMode(sw)
+  let rerenderCountRaw = 0
+  const renderTally = new Map<string, { count: number; reason?: string }>()
+  for (const commit of sw.commits) {
+    for (const r of commit.rerenders) {
+      rerenderCountRaw++
+      const cur = renderTally.get(r.name) ?? { count: 0, reason: r.reason }
+      cur.count++
+      if (!cur.reason && r.reason) cur.reason = r.reason
+      renderTally.set(r.name, cur)
+    }
+  }
+  const topRenders = [...renderTally.entries()]
+    .map(([name, v]) => ({ name, count: v.count, reason: v.reason }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 8)
+
+  // Attribution verdict.
+  let verdict: string
+  if (perceivedMs == null) {
+    verdict = "incomplete capture — no content-stable anchor"
+  } else if (networkMs >= perceivedMs * 0.6) {
+    verdict =
+      readStateBlocksMessages === true
+        ? `network-bound, and read-state→messages is SERIALIZED (${networkMs.toFixed(0)}ms of ${perceivedMs.toFixed(0)}ms)`
+        : `network-bound (${networkMs.toFixed(0)}ms of ${perceivedMs.toFixed(0)}ms)`
+  } else {
+    const nonNetwork = perceivedMs - networkMs
+    verdict = `NOT network-bound — ${nonNetwork.toFixed(0)}ms of ${perceivedMs.toFixed(0)}ms is render/remount/reflow (network only ${networkMs.toFixed(0)}ms); remount=${mountAdjusted} fibers, unmounts=${sw.unmounts.length}`
+  }
+
+  return {
+    kind: sw.kind,
+    targetId: sw.targetId,
+    cacheState: sw.cacheState,
+    perceivedMs,
+    clickToSkeletonMs,
+    skeletonToPaintedMs,
+    paintedToStableMs,
+    networkMs,
+    networkSpanMs,
+    readStateBlocksMessages,
+    mountCountRaw: mountRaw,
+    mountCountAdjusted: mountAdjusted,
+    rerenderCountRaw,
+    unmounts: sw.unmounts,
+    topRenders,
+    verdict,
+  }
+}
+
+function ms(n: number | null): string {
+  return n == null ? "—" : `${n.toFixed(0)}ms`
+}
+
+export function renderReport(file: CaptureFile): string {
+  const lines: string[] = []
+  lines.push("# Community Switch — Perceived-Latency Report")
+  lines.push("")
+  lines.push(`Owner: \`${file.owner.email}\` (userId \`${file.owner.userId}\`)`)
+  lines.push(`Captured: ${file.createdAt}`)
+  lines.push("")
+  lines.push(
+    "> Baseline: on local, network is ~0, so a visible loading spell is itself the anomaly. " +
+      "The headline is perceived latency (click → content stable). Counts are dev-mode; " +
+      "StrictMode-adjusted values remove the double-invoke inflation.",
+  )
+  lines.push("")
+
+  for (const sw of file.switches) {
+    const a = analyzeSwitch(sw)
+    lines.push(`## ${a.kind} switch → \`${a.targetId}\`  _(cache: ${a.cacheState})_`)
+    lines.push("")
+    lines.push(`- PERCEIVED (click → content stable): **${ms(a.perceivedMs)}**`)
+    lines.push(`  - click → skeleton: ${ms(a.clickToSkeletonMs)}`)
+    lines.push(`  - skeleton → painted: ${ms(a.skeletonToPaintedMs)}`)
+    lines.push(`  - painted → stable: ${ms(a.paintedToStableMs)}`)
+    lines.push(
+      `- network: ${ms(a.networkMs)} busy / ${ms(a.networkSpanMs)} span` +
+        (a.readStateBlocksMessages == null
+          ? ""
+          : a.readStateBlocksMessages
+            ? " · read-state→messages **SERIALIZED**"
+            : " · read-state/messages overlap (parallel)"),
+    )
+    lines.push(
+      `- renders: mounts ${a.mountCountRaw} raw / ${a.mountCountAdjusted} StrictMode-adjusted · re-renders ${a.rerenderCountRaw} · unmounts ${a.unmounts.length}`,
+    )
+    if (a.topRenders.length) {
+      lines.push("- top re-renders:")
+      for (const r of a.topRenders) {
+        lines.push(`  - ${r.name} ×${r.count}${r.reason ? ` (${r.reason})` : ""}`)
+      }
+    }
+    // network waterfall
+    const sorted = [...sw.resources].sort((x, y) => x.startTime - y.startTime)
+    if (sorted.length) {
+      lines.push("- waterfall:")
+      const base = sorted[0].startTime
+      for (const r of sorted) {
+        const short = r.name.replace(/^https?:\/\/[^/]+/, "").split("?")[0]
+        lines.push(
+          `  - ${short}  [t+${(r.startTime - base).toFixed(0)} → t+${(r.responseEnd - base).toFixed(0)}ms]`,
+        )
+      }
+    }
+    lines.push(`- **VERDICT:** ${a.verdict}`)
+    lines.push("")
+  }
+
+  return lines.join("\n")
+}
+
+function main(): void {
+  let file: CaptureFile
+  try {
+    file = JSON.parse(readFileSync(CAPTURE_IN, "utf8")) as CaptureFile
+  } catch {
+    console.error(`Missing ${CAPTURE_IN}. Run the perf spec first (pnpm perf:switch).`)
+    process.exit(1)
+  }
+  const report = renderReport(file)
+  writeFileSync(REPORT_OUT, report)
+  console.log(`Wrote ${REPORT_OUT} (${file.switches.length} switches)`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}

--- a/src/web/scripts/seed-stress.test.ts
+++ b/src/web/scripts/seed-stress.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { parseSeedArgs, runSeedStress, mergeSetCookies, extractSetCookies, RatePacer } from "./seed-stress"
+
+vi.mock("../src/lib/logger", () => ({ log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }))
+
+describe("parseSeedArgs", () => {
+  it("applies breadth-heavy, shallow-message defaults", () => {
+    const opts = parseSeedArgs([])
+    expect(opts.servers).toBe(30)
+    expect(opts.channels).toBe(40)
+    expect(opts.messages).toBe(60)
+    expect(opts.serverUrl).toBe("http://localhost:3000")
+    expect(opts.owner).toBe("perf-seed")
+  })
+
+  it("overrides via flags", () => {
+    const opts = parseSeedArgs(["--servers=3", "--channels=5", "--messages=10", "--owner=x"])
+    expect(opts).toMatchObject({ servers: 3, channels: 5, messages: 10, owner: "x" })
+  })
+
+  it("rejects non-integer / negative numbers", () => {
+    expect(() => parseSeedArgs(["--servers=abc"])).toThrow(/servers/)
+    expect(() => parseSeedArgs(["--messages=-1"])).toThrow(/messages/)
+  })
+})
+
+describe("cookie jar — better-auth two-cookie handshake", () => {
+  it("MERGES cookies across responses instead of replacing (the 401 regression)", () => {
+    const jar = new Map<string, string>()
+    // Response 1: sign-in sets both token + data.
+    mergeSetCookies(jar, [
+      "better-auth.session_token=TOK; Path=/; HttpOnly",
+      "better-auth.session_data=DATA; Path=/; HttpOnly",
+    ])
+    // Response 2: a later call re-emits ONLY session_data. A replace-semantics
+    // jar would drop the token here and 401 the next request.
+    mergeSetCookies(jar, ["better-auth.session_data=DATA2; Path=/"])
+    expect(jar.get("better-auth.session_token")).toBe("TOK")
+    expect(jar.get("better-auth.session_data")).toBe("DATA2")
+  })
+
+  it("deletes a cookie when set to empty value", () => {
+    const jar = new Map<string, string>([["x", "1"]])
+    mergeSetCookies(jar, ["x=; Path=/; Max-Age=0"])
+    expect(jar.has("x")).toBe(false)
+  })
+
+  it("extractSetCookies prefers getSetCookie() (undici) over the joined header", () => {
+    const res = {
+      headers: {
+        getSetCookie: () => ["a=1; Path=/", "b=2; Path=/"],
+        get: () => "a=1, b=2",
+      },
+    } as unknown as Response
+    expect(extractSetCookies(res)).toEqual(["a=1; Path=/", "b=2; Path=/"])
+  })
+})
+
+describe("RatePacer — proactive throttle under the per-user msgSend limit", () => {
+  it("admits up to `max` within the window without blocking, then blocks", async () => {
+    // Fixed clock: no time passes, so after `max` acquisitions the next would
+    // block. We assert the first `max` resolve immediately.
+    const pacer = new RatePacer(3, 10_000)
+    const clock = () => 1000
+    await pacer.acquire(clock)
+    await pacer.acquire(clock)
+    await pacer.acquire(clock)
+    // A 4th at the same instant must not resolve synchronously — race it
+    // against a microtask and confirm it hasn't settled.
+    let settled = false
+    const pending = pacer.acquire(clock).then(() => { settled = true })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+    // Not awaiting `pending` (it would sleep on the real timer); the assertion
+    // above already proves it blocked.
+    void pending
+  })
+
+  it("evicts stamps older than the window so slots free up over time", async () => {
+    const pacer = new RatePacer(2, 10_000)
+    let t = 0
+    const clock = () => t
+    await pacer.acquire(clock) // t=0
+    await pacer.acquire(clock) // t=0, bucket full
+    t = 10_001 // both stamps now older than the window
+    let settled = false
+    await pacer.acquire(clock).then(() => { settled = true })
+    expect(settled).toBe(true)
+  })
+})
+
+// --- Idempotency + manifest via mocked fetch ---
+
+interface FetchCall {
+  url: string
+  method: string
+  body?: unknown
+}
+
+function installFetchMock(handlers: {
+  existingServers?: Array<{ id: string; name: string }>
+  existingChannels?: Array<{ id: string; name: string }>
+  existingMessageCount?: number
+  /** Return 429 (with tiny Retry-After) for the first N message POSTs. */
+  messageFailWith429Times?: number
+}): { calls: FetchCall[] } {
+  const calls: FetchCall[] = []
+  const existingServers = handlers.existingServers ?? []
+  const existingChannels = handlers.existingChannels ?? []
+  const msgCount = handlers.existingMessageCount ?? 0
+  let remaining429 = handlers.messageFailWith429Times ?? 0
+
+  const jsonRes = (data: unknown): Response =>
+    ({ ok: true, status: 200, headers: { get: () => null }, json: async () => data }) as unknown as Response
+  const rateLimited = (): Response =>
+    ({
+      ok: false,
+      status: 429,
+      headers: { get: (h: string) => (h === "Retry-After" ? "0.01" : null) },
+      json: async () => ({}),
+    }) as unknown as Response
+
+  const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? "GET"
+    const body = init?.body ? JSON.parse(init.body as string) : undefined
+    calls.push({ url, method, body })
+
+    if (url.includes("/api/auth/sign-in/email")) return jsonRes({})
+    if (url.endsWith("/api/ws/token")) return jsonRes({ userId: "user-seed-1" })
+    if (url.endsWith("/api/community/servers") && method === "GET") {
+      return jsonRes({ servers: existingServers })
+    }
+    if (url.endsWith("/api/community/servers") && method === "POST") {
+      return jsonRes({ server: { id: "new-server" } })
+    }
+    if (/\/api\/community\/servers\/[^/]+$/.test(url) && method === "GET") {
+      return jsonRes({ categories: [{ channels: existingChannels }] })
+    }
+    if (/\/channels$/.test(url) && method === "POST") {
+      return jsonRes({ channel: { id: "new-channel" } })
+    }
+    if (/\/messages\?limit=100/.test(url) && method === "GET") {
+      return jsonRes({ messages: new Array(msgCount).fill({}), hasMore: false })
+    }
+    if (/\/messages$/.test(url) && method === "POST") {
+      if (remaining429 > 0) {
+        remaining429--
+        return rateLimited()
+      }
+      return jsonRes({ message: { id: "m" } })
+    }
+    throw new Error(`unhandled ${method} ${url}`)
+  })
+  vi.stubGlobal("fetch", fetchMock)
+  return { calls }
+}
+
+beforeEach(() => vi.unstubAllGlobals())
+afterEach(() => vi.unstubAllGlobals())
+
+describe("runSeedStress — idempotency", () => {
+  it("skips re-creating an existing server, matching the SLUGIFIED stored name", async () => {
+    // The route stores the slugified name ("Load Test 01" -> "Load-Test-01").
+    // Idempotency must match that, not the raw input.
+    const { calls } = installFetchMock({
+      existingServers: [{ id: "srv-existing", name: "Load-Test-01" }],
+      existingChannels: [{ id: "ch-existing", name: "channel-01" }],
+      existingMessageCount: 100,
+    })
+    const manifest = await runSeedStress({
+      servers: 1,
+      channels: 1,
+      messages: 60,
+      serverUrl: "http://localhost:3000",
+      owner: "perf-seed",
+    })
+    // No POST to create a server.
+    const serverPosts = calls.filter(
+      (c) => c.url.endsWith("/api/community/servers") && c.method === "POST",
+    )
+    expect(serverPosts).toHaveLength(0)
+    expect(manifest.servers[0].id).toBe("srv-existing")
+  })
+
+  it("seeds ZERO messages when the channel already meets the target", async () => {
+    const { calls } = installFetchMock({
+      existingServers: [{ id: "srv-existing", name: "Load-Test-01" }],
+      existingChannels: [{ id: "ch-existing", name: "channel-01" }],
+      existingMessageCount: 60,
+    })
+    await runSeedStress({
+      servers: 1,
+      channels: 1,
+      messages: 60,
+      serverUrl: "http://localhost:3000",
+      owner: "perf-seed",
+    })
+    const messagePosts = calls.filter((c) => /\/messages$/.test(c.url) && c.method === "POST")
+    expect(messagePosts).toHaveLength(0)
+  })
+
+  it("tops up to exactly the target when the channel is below it", async () => {
+    const { calls } = installFetchMock({
+      existingServers: [{ id: "srv-existing", name: "Load-Test-01" }],
+      existingChannels: [{ id: "ch-existing", name: "channel-01" }],
+      existingMessageCount: 50,
+    })
+    await runSeedStress({
+      servers: 1,
+      channels: 1,
+      messages: 60,
+      serverUrl: "http://localhost:3000",
+      owner: "perf-seed",
+    })
+    const messagePosts = calls.filter((c) => /\/messages$/.test(c.url) && c.method === "POST")
+    expect(messagePosts).toHaveLength(10)
+  })
+
+  it("records the resolved owner userId in the manifest", async () => {
+    installFetchMock({
+      existingServers: [{ id: "srv-existing", name: "Load-Test-01" }],
+      existingChannels: [{ id: "ch-existing", name: "channel-01" }],
+      existingMessageCount: 60,
+    })
+    const manifest = await runSeedStress({
+      servers: 1,
+      channels: 1,
+      messages: 60,
+      serverUrl: "http://localhost:3000",
+      owner: "perf-seed",
+    })
+    expect(manifest.owner).toEqual({ email: "perf-seed@alook.test", userId: "user-seed-1" })
+  })
+
+  it("retries a 429 (honoring Retry-After) instead of aborting the seed", async () => {
+    const { calls } = installFetchMock({
+      existingServers: [{ id: "srv-existing", name: "Load-Test-01" }],
+      existingChannels: [{ id: "ch-existing", name: "channel-01" }],
+      existingMessageCount: 0,
+      messageFailWith429Times: 2, // first two message POSTs get rate-limited
+    })
+    await runSeedStress({
+      servers: 1,
+      channels: 1,
+      messages: 1, // one message needed → 2×429 then success = 3 POSTs
+      serverUrl: "http://localhost:3000",
+      owner: "perf-seed",
+    })
+    const messagePosts = calls.filter((c) => /\/messages$/.test(c.url) && c.method === "POST")
+    expect(messagePosts).toHaveLength(3) // 2 rate-limited + 1 success, no abort
+  })
+})

--- a/src/web/scripts/seed-stress.ts
+++ b/src/web/scripts/seed-stress.ts
@@ -1,0 +1,413 @@
+/**
+ * Stress-seed the local community DB for perf diagnosis.
+ *
+ * See plans/community-switch-perf-diagnosis.md. This is a LOCAL diagnostic tool
+ * — it is not wired into CI and ships nothing to prod.
+ *
+ * Usage:
+ *   pnpm --filter @alook/web seed:stress [--servers=30] [--channels=40] \
+ *     [--messages=60] [--server-url=http://localhost:3000] [--owner=perf-seed]
+ *
+ * Prerequisites:
+ *   - The local dev stack is running (`pnpm --filter @alook/web dev`).
+ *
+ * Identity pinning (why this doesn't reuse the e2e `.auth` state):
+ *   The Playwright e2e `global-setup` registers a NEW stamped user each run, so
+ *   a server seeded under "alice-stamp-A" is invisible to a later perf run
+ *   driving "alice-stamp-B". Instead this script establishes a STABLE identity
+ *   over HTTP — a fixed email (`--owner`) + DEV_PASSWORD, auto-registered on
+ *   first use — and records the resolved userId in the manifest so the perf
+ *   spec drives as exactly that account.
+ *
+ * Right-sizing (why messages default is shallow):
+ *   The switch hot-path loads only the FIRST PAGE of messages and re-renders
+ *   the channel tree; message depth barely touches it. So defaults emphasize
+ *   BREADTH (servers × channels, which stress sidebar/tree render) over depth.
+ *   High `--messages` remains available for a targeted deep-channel probe.
+ *
+ * Idempotency:
+ *   Servers named `Load Test NN`, channels `channel-NN`; re-runs top up to the
+ *   target counts (never blindly re-POST), so `--messages=N` means "N each"
+ *   across runs.
+ */
+import { parseArgs } from "node:util"
+import { mkdirSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { DEV_PASSWORD, slugify } from "@alook/shared"
+import { log } from "../src/lib/logger"
+
+export interface SeedStressOptions {
+  servers: number
+  channels: number
+  messages: number
+  serverUrl: string
+  owner: string
+}
+
+const DEFAULTS: SeedStressOptions = {
+  servers: 30,
+  channels: 40,
+  messages: 60,
+  serverUrl: "http://localhost:3000",
+  owner: "perf-seed",
+}
+
+/** Parse + validate CLI args. Exported for unit testing (no network). */
+export function parseSeedArgs(argv: string[]): SeedStressOptions {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      servers: { type: "string" },
+      channels: { type: "string" },
+      messages: { type: "string" },
+      "server-url": { type: "string" },
+      owner: { type: "string" },
+    },
+    allowPositionals: false,
+  })
+
+  const num = (raw: string | undefined, fallback: number, name: string): number => {
+    if (raw === undefined) return fallback
+    const n = Number(raw)
+    if (!Number.isInteger(n) || n < 0) {
+      throw new Error(`--${name} must be a non-negative integer, got "${raw}"`)
+    }
+    return n
+  }
+
+  return {
+    servers: num(values.servers, DEFAULTS.servers, "servers"),
+    channels: num(values.channels, DEFAULTS.channels, "channels"),
+    messages: num(values.messages, DEFAULTS.messages, "messages"),
+    serverUrl: values["server-url"] ?? DEFAULTS.serverUrl,
+    owner: values.owner ?? DEFAULTS.owner,
+  }
+}
+
+export interface SeedManifest {
+  owner: { email: string; userId: string }
+  serverUrl: string
+  createdAt: string
+  servers: Array<{
+    id: string
+    name: string
+    channels: Array<{ id: string; name: string; messageCount: number }>
+  }>
+}
+
+// ---------------------------------------------------------------------------
+// HTTP layer — a stable, cookie-bearing client against the local dev server.
+// ---------------------------------------------------------------------------
+
+function isRetryableStatus(status: number): boolean {
+  return status === 401 || status === 403 || status >= 500
+}
+
+/**
+ * Merge Set-Cookie lines into an existing jar (in place). Exported for testing
+ * the regression where better-auth's two-cookie handshake (`session_token` +
+ * `session_data`, delivered across separate responses) must MERGE, not replace
+ * — a replace dropped one and 401'd the next call.
+ */
+export function mergeSetCookies(jar: Map<string, string>, lines: string[]): void {
+  for (const line of lines) {
+    const pair = line.split(";")[0].trim()
+    const eq = pair.indexOf("=")
+    if (eq <= 0) continue
+    const name = pair.slice(0, eq)
+    const value = pair.slice(eq + 1)
+    if (value === "") jar.delete(name) // empty value = cookie deletion
+    else jar.set(name, value)
+  }
+}
+
+/** Extract already-split Set-Cookie lines from a Response, robust to undici. */
+export function extractSetCookies(res: Response): string[] {
+  const headers = res.headers as Headers & { getSetCookie?: () => string[] }
+  if (typeof headers.getSetCookie === "function") return headers.getSetCookie()
+  return headers.get("set-cookie")?.split(/,(?=[^;,]+=)/) ?? []
+}
+
+class SeedClient {
+  // A real cookie jar keyed by name so successive responses MERGE rather than
+  // replace. better-auth sets `session_token` and `session_data` in separate
+  // responses; a replace-semantics jar would drop one and 401 the next call.
+  private readonly jar = new Map<string, string>()
+  constructor(private readonly baseUrl: string) {}
+
+  private cookieHeader(): string {
+    return [...this.jar].map(([k, v]) => `${k}=${v}`).join("; ")
+  }
+
+  private headers(extra?: Record<string, string>): Record<string, string> {
+    const cookie = this.cookieHeader()
+    return {
+      "Content-Type": "application/json",
+      Origin: this.baseUrl,
+      ...(cookie ? { Cookie: cookie } : {}),
+      ...extra,
+    }
+  }
+
+  private captureCookie(res: Response): void {
+    mergeSetCookies(this.jar, extractSetCookies(res))
+  }
+
+  async post<T>(path: string, body?: unknown): Promise<T> {
+    let lastStatus = 0
+    // Rate-limit (429) can recur many times during a large message seed, so
+    // allow generous attempts and honor Retry-After rather than failing.
+    for (let attempt = 0; attempt < 12; attempt++) {
+      const res = await fetch(`${this.baseUrl}${path}`, {
+        method: "POST",
+        headers: this.headers(),
+        body: body === undefined ? undefined : JSON.stringify(body),
+      })
+      this.captureCookie(res)
+      if (res.ok) return (await res.json()) as T
+      lastStatus = res.status
+      if (res.status === 429) {
+        // Honor Retry-After (seconds); default to a full window if absent.
+        const retryAfter = Number(res.headers.get("Retry-After"))
+        await sleep(Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter * 1000 : 10_000)
+        continue
+      }
+      if (!isRetryableStatus(res.status)) break
+      await sleep(400)
+    }
+    throw new Error(`POST ${path} failed (${lastStatus})`)
+  }
+
+  async get<T>(path: string): Promise<T> {
+    const res = await fetch(`${this.baseUrl}${path}`, { headers: this.headers() })
+    if (!res.ok) throw new Error(`GET ${path} failed (${res.status})`)
+    return (await res.json()) as T
+  }
+
+  /**
+   * Establish a stable identity: try sign-in, fall back to sign-up on failure
+   * (mirrors the dev sign-in UI's `handleDevSignIn`). Both set the session
+   * cookie we then carry for all seeding.
+   */
+  async authenticate(email: string): Promise<void> {
+    const body = { email, password: DEV_PASSWORD }
+    const signIn = await fetch(`${this.baseUrl}/api/auth/sign-in/email`, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify(body),
+    })
+    this.captureCookie(signIn)
+    if (signIn.ok) return
+
+    const signUp = await fetch(`${this.baseUrl}/api/auth/sign-up/email`, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify({ name: email.split("@")[0], email, password: DEV_PASSWORD }),
+    })
+    this.captureCookie(signUp)
+    if (!signUp.ok) {
+      throw new Error(
+        `Could not establish seed identity for ${email} (sign-in ${signIn.status}, sign-up ${signUp.status}). Is the dev server running?`,
+      )
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+/** Run `items` through `fn` with at most `limit` in flight. */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length)
+  let cursor = 0
+  async function worker(): Promise<void> {
+    while (cursor < items.length) {
+      const i = cursor++
+      results[i] = await fn(items[i], i)
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker))
+  return results
+}
+
+// ---------------------------------------------------------------------------
+// Seeding logic
+// ---------------------------------------------------------------------------
+
+// `community:msgSend` is rate-limited per-user to 30 messages / 10s (see
+// src/shared/src/lib/rate-limits.ts), keyed on userId — ONE bucket shared
+// across every channel/server. Pace proactively under that ceiling so the seed
+// rarely trips 429 (the post() retry honors Retry-After as a safety net), and
+// keep concurrency modest so a burst can't overshoot between pacer ticks.
+const MESSAGE_CONCURRENCY = 4
+const MSG_RATE_MAX = 28 // stay just under the server's 30/10s
+const MSG_RATE_WINDOW_MS = 10_000
+
+/** Sliding-window pacer: await a slot before each rate-limited send. */
+export class RatePacer {
+  private readonly stamps: number[] = []
+  constructor(
+    private readonly max: number,
+    private readonly windowMs: number,
+  ) {}
+
+  async acquire(now: () => number = Date.now): Promise<void> {
+    for (;;) {
+      const t = now()
+      while (this.stamps.length && t - this.stamps[0] >= this.windowMs) this.stamps.shift()
+      if (this.stamps.length < this.max) {
+        this.stamps.push(t)
+        return
+      }
+      const waitMs = this.windowMs - (t - this.stamps[0]) + 5
+      await sleep(waitMs)
+    }
+  }
+}
+
+interface ServerRow { id: string; name: string }
+interface ChannelRow { id: string; name: string; categoryId?: string | null }
+
+async function ensureServer(client: SeedClient, existing: ServerRow[], name: string): Promise<string> {
+  // The server route slugifies the name before storing (`"Load Test 01"` ->
+  // `"Load-Test-01"`), so idempotency must compare against the SLUGIFIED form —
+  // matching the raw input would never hit and every re-run would duplicate.
+  const slug = slugify(name)
+  const found = existing.find((s) => s.name === slug)
+  if (found) return found.id
+  const data = await client.post<{ server: { id: string } }>("/api/community/servers", { name })
+  return data.server.id
+}
+
+async function listChannels(client: SeedClient, serverId: string): Promise<ChannelRow[]> {
+  const detail = await client.get<{
+    categories: Array<{ channels: ChannelRow[] }>
+  }>(`/api/community/servers/${serverId}`)
+  return detail.categories.flatMap((c) => c.channels)
+}
+
+async function ensureChannel(
+  client: SeedClient,
+  serverId: string,
+  existing: ChannelRow[],
+  name: string,
+): Promise<string> {
+  // Channel names are slugified server-side too — compare against the slug.
+  const slug = slugify(name)
+  const found = existing.find((c) => c.name === slug)
+  if (found) return found.id
+  const data = await client.post<{ channel: { id: string } }>(
+    `/api/community/servers/${serverId}/channels`,
+    { name, type: "text" },
+  )
+  return data.channel.id
+}
+
+async function countMessages(client: SeedClient, channelId: string): Promise<number> {
+  // The list endpoint pages newest-first; for idempotency we only need to know
+  // whether the channel already has >= target. Read one large page and count;
+  // if it reports hasMore, it already far exceeds any sane seed target.
+  const data = await client.get<{ messages: unknown[]; hasMore?: boolean }>(
+    `/api/community/channels/${channelId}/messages?limit=100`,
+  )
+  return data.hasMore ? Number.MAX_SAFE_INTEGER : data.messages.length
+}
+
+async function topUpMessages(
+  client: SeedClient,
+  channelId: string,
+  target: number,
+  channelName: string,
+  pacer: RatePacer,
+): Promise<number> {
+  const current = await countMessages(client, channelId)
+  if (current >= target) return current
+  const toCreate = target - current
+  const indices = Array.from({ length: toCreate }, (_, i) => current + i + 1)
+  await mapWithConcurrency(indices, MESSAGE_CONCURRENCY, async (n) => {
+    // Proactively pace under the shared per-user msgSend limit before sending.
+    await pacer.acquire()
+    await client.post(`/api/community/channels/${channelId}/messages`, {
+      content: `${channelName} stress message #${n}`,
+    })
+  })
+  return target
+}
+
+export async function runSeedStress(opts: SeedStressOptions): Promise<SeedManifest> {
+  const client = new SeedClient(opts.serverUrl)
+  const email = `${opts.owner}@alook.test`
+
+  log.info("[seed] establishing stable identity", { email })
+  await client.authenticate(email)
+  const me = await client.get<{ userId: string }>("/api/ws/token")
+  log.info("[seed] identity ready", { userId: me.userId })
+
+  const existingServers = await client.get<{ servers: ServerRow[] }>("/api/community/servers")
+
+  // One pacer for the whole run — the msgSend limit is a single per-user bucket
+  // shared across all channels/servers, so pacing must be global, not per-channel.
+  const pacer = new RatePacer(MSG_RATE_MAX, MSG_RATE_WINDOW_MS)
+
+  const manifest: SeedManifest = {
+    owner: { email, userId: me.userId },
+    serverUrl: opts.serverUrl,
+    createdAt: new Date().toISOString(),
+    servers: [],
+  }
+
+  for (let s = 1; s <= opts.servers; s++) {
+    const serverName = `Load Test ${String(s).padStart(2, "0")}`
+    const serverId = await ensureServer(client, existingServers.servers, serverName)
+
+    const existingChannels = await listChannels(client, serverId)
+    const channelEntries: SeedManifest["servers"][number]["channels"] = []
+
+    for (let c = 1; c <= opts.channels; c++) {
+      const channelName = `channel-${String(c).padStart(2, "0")}`
+      const channelId = await ensureChannel(client, serverId, existingChannels, channelName)
+      const count = await topUpMessages(client, channelId, opts.messages, channelName, pacer)
+      channelEntries.push({ id: channelId, name: slugify(channelName), messageCount: count })
+    }
+
+    // Record the SLUGIFIED name — that's what's stored and rendered in the rail.
+    manifest.servers.push({ id: serverId, name: slugify(serverName), channels: channelEntries })
+    log.info("[seed] server ready", { serverName: slugify(serverName), channels: channelEntries.length })
+  }
+
+  return manifest
+}
+
+const ARTIFACTS_DIR = resolve(import.meta.dirname, "..", "perf-artifacts")
+const MANIFEST_PATH = resolve(ARTIFACTS_DIR, "seed-manifest.json")
+
+async function main(): Promise<void> {
+  const opts = parseSeedArgs(process.argv.slice(2))
+  log.info("[seed] starting", { ...opts })
+  const manifest = await runSeedStress(opts)
+  mkdirSync(ARTIFACTS_DIR, { recursive: true })
+  writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2))
+  const totalMsgs = manifest.servers.reduce(
+    (sum, s) => sum + s.channels.reduce((cs, c) => cs + c.messageCount, 0),
+    0,
+  )
+  log.info("[seed] done", {
+    servers: manifest.servers.length,
+    channels: manifest.servers.reduce((n, s) => n + s.channels.length, 0),
+    messages: totalMsgs,
+    manifest: MANIFEST_PATH,
+  })
+}
+
+// Only run when invoked directly (not when imported by unit tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    log.error("[seed] failed", { error: err instanceof Error ? err.message : String(err) })
+    process.exit(1)
+  })
+}

--- a/src/web/src/app/c/channels/layout.tsx
+++ b/src/web/src/app/c/channels/layout.tsx
@@ -6,6 +6,7 @@ import { useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { apiFetch, toastApiError } from "@/lib/api/client"
 import { communityKeys } from "@/lib/query-keys"
+import { markSwitch } from "@/lib/perf/switch-mark"
 import { Dialog, DialogContent } from "@/components/ui/dialog"
 import { useBreakpoint } from "@/hooks/use-mobile"
 import { useChannelTree } from "@/components/community/use-channel-tree"
@@ -267,6 +268,7 @@ export default function ServerLayout({ children }: { children: ReactNode }) {
     // unrelated sibling-channel WS patch would resurrect the just-cleared dot
     // before the user even navigates away — `useChannelTree`'s metadata merge
     // trusts the cache unconditionally, so both directions must write to it.
+    markSwitch("channel", id)
     router.push(`/c/channels/${serverId}/${id}`)
     channelTree.markRead(id)
     queryClient.setQueryData<ServerDetail | undefined>(

--- a/src/web/src/app/c/community-shell.tsx
+++ b/src/web/src/app/c/community-shell.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/contexts/community/current-user"
 import { useCommunityWs } from "@/hooks/community/use-community-ws"
 import { useCommunityWsStore } from "@/stores/community/ws"
+import { PerfTraceBootstrap } from "@/components/perf/perf-trace-bootstrap"
 
 /**
  * Client wrapper that provides the QueryClient, CurrentUser, and the
@@ -83,5 +84,10 @@ function CommunityBootstrap({ children }: { children: ReactNode }) {
       .catch(() => { })
   }, [setCurrentUser, currentUserId])
 
-  return <>{children}</>
+  return (
+    <>
+      <PerfTraceBootstrap />
+      {children}
+    </>
+  )
 }

--- a/src/web/src/components/community/shell-frame.tsx
+++ b/src/web/src/components/community/shell-frame.tsx
@@ -6,6 +6,7 @@ import { useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { toastApiError } from "@/lib/api/client"
 import { communityKeys } from "@/lib/query-keys"
+import { markSwitch } from "@/lib/perf/switch-mark"
 import { userProfileQueryFn, PROFILE_STALE_TIME_MS } from "@/hooks/community/use-user-profile"
 import { useDefaultLayout } from "react-resizable-panels"
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable"
@@ -164,7 +165,7 @@ export function ShellFrame({
   )
 
   const onRailServerNavigate = useCallback(
-    (id: string) => { router.push(`/c/channels/${id}`) },
+    (id: string) => { markSwitch("server", id); router.push(`/c/channels/${id}`) },
     [router],
   )
   const onRailCreateServer = useCallback(

--- a/src/web/src/components/perf/perf-trace-bootstrap.tsx
+++ b/src/web/src/components/perf/perf-trace-bootstrap.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { useEffect } from "react"
+import { perfTraceEnabled } from "@/lib/perf/perf-gate"
+import { installReactScan } from "@/lib/perf/react-scan-install"
+
+/**
+ * Diagnosis-only marker mounted once in the community shell. The real install
+ * happens pre-hydration in `instrumentation-client.ts`; this component just
+ * ENSURES it (idempotent — the single-install guard makes a repeat call a
+ * no-op) so instrumentation is present even if the client entry didn't run for
+ * some reason.
+ *
+ * Crucially it does NOT stop the instrument on unmount: the instrument's
+ * lifetime is the whole tab/page session, and a React effect cleanup (which
+ * StrictMode double-invokes in dev) must never detach react-scan's commit hook
+ * — doing so was silently killing all post-mount capture (~300ms in), which is
+ * exactly the switch data we need. See plans/community-switch-perf-diagnosis.md.
+ *
+ * Renders nothing and does nothing when the perf gate is off, so it is inert in
+ * every real build.
+ */
+export function PerfTraceBootstrap() {
+  useEffect(() => {
+    if (!perfTraceEnabled()) return
+    void installReactScan().catch(() => {})
+    // No cleanup: the instrument lives for the page session, not the effect.
+  }, [])
+
+  return null
+}

--- a/src/web/src/instrumentation-client.ts
+++ b/src/web/src/instrumentation-client.ts
@@ -1,0 +1,15 @@
+// Next.js client instrumentation entry — runs before the app hydrates, i.e.
+// before react-dom installs its DevTools global hook. This is the ONLY place
+// early enough to register react-scan's instrument() and capture the initial
+// mount (see plans/community-switch-perf-diagnosis.md).
+//
+// Distinct from the server-side `instrumentation.ts` `register()` hook — do not
+// conflate them. This file is diagnosis-only and self-noops unless
+// NEXT_PUBLIC_PERF_TRACE=1 in a non-production build.
+
+import { installReactScan } from "@/lib/perf/react-scan-install"
+
+// Fire-and-forget: the guard inside is synchronous, only the dynamic
+// react-scan import is async. Any failure is swallowed so instrumentation can
+// never break app boot.
+void installReactScan().catch(() => {})

--- a/src/web/src/lib/perf/perf-gate.test.ts
+++ b/src/web/src/lib/perf/perf-gate.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, afterEach } from "vitest"
+import { perfTraceEnabled } from "./perf-gate"
+
+const origFlag = process.env.NEXT_PUBLIC_PERF_TRACE
+const origNodeEnv = process.env.NODE_ENV
+
+function setEnv(flag: string | undefined, nodeEnv: string): void {
+  if (flag === undefined) delete process.env.NEXT_PUBLIC_PERF_TRACE
+  else process.env.NEXT_PUBLIC_PERF_TRACE = flag
+  // NODE_ENV is readonly in the types but writable at runtime under vitest.
+  ;(process.env as Record<string, string>).NODE_ENV = nodeEnv
+}
+
+afterEach(() => {
+  setEnv(origFlag, origNodeEnv ?? "test")
+})
+
+describe("perfTraceEnabled — double gate", () => {
+  it("is on only when flag=1 AND not production", () => {
+    setEnv("1", "development")
+    expect(perfTraceEnabled()).toBe(true)
+  })
+
+  it("is off when the flag is unset even in dev", () => {
+    setEnv(undefined, "development")
+    expect(perfTraceEnabled()).toBe(false)
+  })
+
+  it("is off in production even when the flag is 1 (hard backstop)", () => {
+    setEnv("1", "production")
+    expect(perfTraceEnabled()).toBe(false)
+  })
+
+  it("is off for any non-'1' flag value", () => {
+    setEnv("true", "development")
+    expect(perfTraceEnabled()).toBe(false)
+  })
+})

--- a/src/web/src/lib/perf/perf-gate.ts
+++ b/src/web/src/lib/perf/perf-gate.ts
@@ -1,0 +1,21 @@
+/**
+ * Single source of truth for whether local perf instrumentation is armed.
+ *
+ * Double-gated on purpose (see plans/community-switch-perf-diagnosis.md):
+ * - `NEXT_PUBLIC_PERF_TRACE === "1"` — opt-in flag, off by default.
+ * - `NODE_ENV !== "production"` — a hard backstop so a stray flag in a prod
+ *   env can never arm the instrument or pull `react-scan` into a live build.
+ *
+ * `NEXT_PUBLIC_*` is inlined to a string literal by Next at build time, so in a
+ * production bundle this collapses to `false` and every guarded body is
+ * dead-code-eliminated.
+ *
+ * This is a function, not a module-level const, so unit tests can flip
+ * `process.env` between cases and observe the gate.
+ */
+export function perfTraceEnabled(): boolean {
+  return (
+    process.env.NEXT_PUBLIC_PERF_TRACE === "1" &&
+    process.env.NODE_ENV !== "production"
+  )
+}

--- a/src/web/src/lib/perf/perf-globals.test.ts
+++ b/src/web/src/lib/perf/perf-globals.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest"
+import { pushPerfEvent, PERF_RING_MAX, type PerfEventRecord } from "./perf-globals"
+
+function makeEvent(ts: number): PerfEventRecord {
+  return { kind: "commit", ts }
+}
+
+describe("pushPerfEvent — bounded ring buffer", () => {
+  it("allocates the buffer on first push", () => {
+    const target: { __ALOOK_PERF__?: PerfEventRecord[] } = {}
+    pushPerfEvent(target, makeEvent(1))
+    expect(target.__ALOOK_PERF__).toHaveLength(1)
+  })
+
+  it("clamps to the max size, dropping oldest", () => {
+    const target: { __ALOOK_PERF__?: PerfEventRecord[] } = {}
+    for (let i = 0; i < 5; i++) pushPerfEvent(target, makeEvent(i), 3)
+    const buf = target.__ALOOK_PERF__!
+    expect(buf).toHaveLength(3)
+    // oldest (ts 0,1) dropped; newest three retained in order.
+    expect(buf.map((e) => e.ts)).toEqual([2, 3, 4])
+  })
+
+  it("defaults to PERF_RING_MAX", () => {
+    const target: { __ALOOK_PERF__?: PerfEventRecord[] } = {}
+    for (let i = 0; i < PERF_RING_MAX + 10; i++) pushPerfEvent(target, makeEvent(i))
+    expect(target.__ALOOK_PERF__).toHaveLength(PERF_RING_MAX)
+  })
+})

--- a/src/web/src/lib/perf/perf-globals.ts
+++ b/src/web/src/lib/perf/perf-globals.ts
@@ -1,0 +1,77 @@
+import type { LiteEvent } from "react-scan/lite"
+
+/**
+ * Shape of a single captured perf event pushed onto the ring buffer. A trimmed
+ * projection of react-scan's `LiteEvent` plus a wall-clock-free monotonic `ts`
+ * (browser `performance.now()`), so everything the report correlates —
+ * commits, unmounts, switch marks, resource timings — shares one clock.
+ */
+export interface PerfEventRecord {
+  kind: LiteEvent["kind"]
+  /** performance.now() at capture time (browser monotonic clock). */
+  ts: number
+  /** commit priority name, when present. */
+  priorityName?: string
+  /** true when react-dom flagged a commit error. */
+  didError?: boolean
+  /** per-fiber summaries for `commit` events (already trimmed by react-scan). */
+  fibers?: PerfFiberRecord[]
+  /** componentName on per-component mark events / fiber-unmount. */
+  componentName?: string
+  /** profiling-hooks-status availability. */
+  available?: boolean
+}
+
+export interface PerfFiberRecord {
+  name: string
+  depth: number
+  fiberId?: number
+  actualDuration: number
+  ownerName?: string | null
+  /** null for host nodes; carries the re-render reason otherwise. */
+  isFirstMount?: boolean
+  changedProps?: string[] | null
+  changedState?: boolean
+  changedContext?: boolean
+  changedHooks?: number[]
+  changedByParent?: boolean
+}
+
+/** A switch anchor (`t=0`) recorded at the click site. */
+export interface PerfSwitchMark {
+  kind: "server" | "channel"
+  id: string
+  ts: number
+  markName: string
+}
+
+declare global {
+  interface Window {
+    /** Bounded ring buffer of captured render/commit events. */
+    __ALOOK_PERF__?: PerfEventRecord[]
+    /** Switch-click anchors, in click order. */
+    __ALOOK_PERF_MARKS__?: PerfSwitchMark[]
+    /** Set true if react-scan's profiling hooks are unavailable. */
+    __ALOOK_PERF_DEGRADED__?: boolean
+    /** Set once when instrument() has been installed, to guard double-install. */
+    __ALOOK_PERF_INSTALLED__?: boolean
+  }
+}
+
+/** Max events retained; oldest are dropped so a long session can't OOM the tab. */
+export const PERF_RING_MAX = 5000
+
+/**
+ * Push an event onto the ring buffer, allocating it on first use and clamping
+ * to `PERF_RING_MAX` (drop-oldest). Kept pure/DOM-free so it unit-tests against
+ * a plain object standing in for `window`.
+ */
+export function pushPerfEvent(
+  target: { __ALOOK_PERF__?: PerfEventRecord[] },
+  record: PerfEventRecord,
+  max: number = PERF_RING_MAX,
+): void {
+  const buf = target.__ALOOK_PERF__ ?? (target.__ALOOK_PERF__ = [])
+  buf.push(record)
+  if (buf.length > max) buf.splice(0, buf.length - max)
+}

--- a/src/web/src/lib/perf/react-scan-install.test.ts
+++ b/src/web/src/lib/perf/react-scan-install.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest"
+
+const instrumentSpy = vi.fn(() => ({ stop: vi.fn(), isActive: () => true, subscribe: vi.fn() }))
+
+vi.mock("react-scan/lite", () => ({ instrument: instrumentSpy }))
+vi.mock("@/lib/logger", () => ({ log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }))
+
+const origFlag = process.env.NEXT_PUBLIC_PERF_TRACE
+const origNodeEnv = process.env.NODE_ENV
+
+interface TestWindow {
+  __ALOOK_PERF_INSTALLED__?: boolean
+  __ALOOK_PERF__?: unknown[]
+  __ALOOK_PERF_DEGRADED__?: boolean
+}
+
+function setGate(flag: string | undefined, nodeEnv: string): void {
+  if (flag === undefined) delete process.env.NEXT_PUBLIC_PERF_TRACE
+  else process.env.NEXT_PUBLIC_PERF_TRACE = flag
+  ;(process.env as Record<string, string>).NODE_ENV = nodeEnv
+}
+
+beforeEach(() => {
+  instrumentSpy.mockClear()
+  ;(globalThis as unknown as { window: TestWindow }).window = {}
+})
+
+afterEach(() => {
+  setGate(origFlag, origNodeEnv ?? "test")
+  delete (globalThis as unknown as { window?: TestWindow }).window
+})
+
+describe("installReactScan — gating", () => {
+  it("no-ops (does not import/instrument) when the flag is off", async () => {
+    setGate(undefined, "development")
+    const { installReactScan } = await import("./react-scan-install")
+    const handle = await installReactScan()
+    expect(handle).toBeNull()
+    expect(instrumentSpy).not.toHaveBeenCalled()
+  })
+
+  it("no-ops in production even with the flag on (double-gate)", async () => {
+    setGate("1", "production")
+    const { installReactScan } = await import("./react-scan-install")
+    const handle = await installReactScan()
+    expect(handle).toBeNull()
+    expect(instrumentSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe("installReactScan — single-install guard", () => {
+  it("instruments exactly once across repeated calls", async () => {
+    setGate("1", "development")
+    const { installReactScan, stopReactScan } = await import("./react-scan-install")
+
+    await installReactScan()
+    await installReactScan()
+    await installReactScan()
+
+    expect(instrumentSpy).toHaveBeenCalledTimes(1)
+    const win = (globalThis as unknown as { window: TestWindow }).window
+    expect(win.__ALOOK_PERF_INSTALLED__).toBe(true)
+
+    // stop releases the guard so a later session can re-arm.
+    stopReactScan()
+    expect(win.__ALOOK_PERF_INSTALLED__).toBe(false)
+    await installReactScan()
+    expect(instrumentSpy).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/web/src/lib/perf/react-scan-install.ts
+++ b/src/web/src/lib/perf/react-scan-install.ts
@@ -1,0 +1,108 @@
+import { log } from "@/lib/logger"
+import { perfTraceEnabled } from "./perf-gate"
+import { pushPerfEvent, type PerfEventRecord, type PerfFiberRecord } from "./perf-globals"
+import type { LiteEvent, LiteFiberSummary, LiteHandle } from "react-scan/lite"
+
+/**
+ * Local render instrumentation install. Diagnosis-only (see
+ * plans/community-switch-perf-diagnosis.md) — NEVER runs in a real build.
+ *
+ * Must run before react-dom installs its DevTools global hook, so this is
+ * imported from `instrumentation-client.ts` (Next's pre-hydration client
+ * entry), NOT a component mount effect. `instrument()` monkey-patches the
+ * renderer; registering late loses the initial mount and possibly early
+ * commits, and the `profiling-hooks-status.available` flag does not detect
+ * that (it only reports whether the React build exposes the mark hooks).
+ */
+
+function toFiberRecord(f: LiteFiberSummary): PerfFiberRecord {
+  const cd = f.changeDescription
+  return {
+    name: f.name,
+    depth: f.depth,
+    fiberId: f.fiberId,
+    actualDuration: f.actualDuration,
+    ownerName: f.ownerName,
+    isFirstMount: cd?.isFirstMount,
+    changedProps: cd?.props ?? null,
+    changedState: cd?.state,
+    changedContext: cd?.context,
+    changedHooks: cd?.hooks,
+    changedByParent: cd?.parent,
+  }
+}
+
+function toRecord(event: LiteEvent): PerfEventRecord {
+  return {
+    kind: event.kind,
+    ts: event.timestamp,
+    priorityName: event.priorityName,
+    didError: event.didError,
+    componentName: event.componentName,
+    available: event.available,
+    fibers: event.tree?.map(toFiberRecord),
+  }
+}
+
+/**
+ * Install the react-scan lite instrument exactly once. No-ops when the perf
+ * gate is off or when already installed (a shell/layout remount must not
+ * double-`instrument()` and double every commit event).
+ *
+ * Returns the handle when it installed, or null when it no-op'd — the caller
+ * (bootstrap component) uses the handle to stop on unmount.
+ */
+export async function installReactScan(): Promise<LiteHandle | null> {
+  // Build-time exclusion FIRST. Next inlines `process.env.NODE_ENV` to the
+  // string literal "production" in a prod build and runs dead-code elimination
+  // on it, so this becomes `if (true) return null` and everything after —
+  // including `import("react-scan/lite")` — is unreachable and dropped from the
+  // graph, keeping the library (and its bippy core) out of the production
+  // client bundle. Verified by build inspection (see plan finding-7): a runtime
+  // `perfTraceEnabled()` / NEXT_PUBLIC_PERF_TRACE check alone does NOT DCE the
+  // dynamic import — only the NODE_ENV literal does.
+  if (process.env.NODE_ENV === "production") return null
+  if (!perfTraceEnabled()) return null
+  if (typeof window === "undefined") return null
+  if (window.__ALOOK_PERF_INSTALLED__) return null
+  window.__ALOOK_PERF_INSTALLED__ = true
+
+  const { instrument } = await import("react-scan/lite")
+
+  const handle = instrument({
+    recordChangeDescriptions: true,
+    includeFiberSource: true,
+    includeFiberIdentity: true,
+    onEvent: (event) => {
+      if (event.kind === "profiling-hooks-status" && event.available === false) {
+        window.__ALOOK_PERF_DEGRADED__ = true
+        log.warn(
+          "[perf] react-scan profiling hooks unavailable — render data will be incomplete",
+          { reason: event.reason },
+        )
+      }
+      pushPerfEvent(window, toRecord(event))
+    },
+  })
+
+  log.info("[perf] react-scan instrument installed (NEXT_PUBLIC_PERF_TRACE=1)")
+  activeHandle = handle
+  return handle
+}
+
+/**
+ * The live handle from the most recent install, so a component mounted later
+ * in the tree (PerfTraceBootstrap) can stop it on unmount even though the
+ * install itself happens pre-hydration in instrumentation-client.
+ */
+let activeHandle: LiteHandle | null = null
+
+/**
+ * Stop the active instrument (idempotent) and release the install guard so a
+ * later flag-on session can re-arm cleanly.
+ */
+export function stopReactScan(): void {
+  activeHandle?.stop()
+  activeHandle = null
+  if (typeof window !== "undefined") window.__ALOOK_PERF_INSTALLED__ = false
+}

--- a/src/web/src/lib/perf/switch-mark.test.ts
+++ b/src/web/src/lib/perf/switch-mark.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, afterEach, vi } from "vitest"
+import { markSwitch } from "./switch-mark"
+import type { PerfSwitchMark } from "./perf-globals"
+
+const origFlag = process.env.NEXT_PUBLIC_PERF_TRACE
+const origNodeEnv = process.env.NODE_ENV
+
+interface TestWindow {
+  __ALOOK_PERF_MARKS__?: PerfSwitchMark[]
+}
+
+function withGlobals(flag: string | undefined, fn: (markSpy: () => void) => void): void {
+  if (flag === undefined) delete process.env.NEXT_PUBLIC_PERF_TRACE
+  else process.env.NEXT_PUBLIC_PERF_TRACE = flag
+  ;(process.env as Record<string, string>).NODE_ENV = "development"
+
+  const g = globalThis as unknown as { window?: TestWindow; performance?: { mark: () => void; now: () => number } }
+  const prevWindow = g.window
+  const prevPerf = g.performance
+  const markSpy = vi.fn()
+  const win: TestWindow = {}
+  g.window = win
+  g.performance = { mark: markSpy, now: () => 123 }
+  try {
+    fn(markSpy)
+  } finally {
+    g.window = prevWindow
+    g.performance = prevPerf
+  }
+}
+
+afterEach(() => {
+  if (origFlag === undefined) delete process.env.NEXT_PUBLIC_PERF_TRACE
+  else process.env.NEXT_PUBLIC_PERF_TRACE = origFlag
+  ;(process.env as Record<string, string>).NODE_ENV = origNodeEnv ?? "test"
+})
+
+describe("markSwitch", () => {
+  it("is a no-op when the flag is unset (no mark, no window mutation)", () => {
+    withGlobals(undefined, (markSpy) => {
+      markSwitch("channel", "chan-1")
+      expect(markSpy).not.toHaveBeenCalled()
+      const win = (globalThis as unknown as { window: TestWindow }).window
+      expect(win.__ALOOK_PERF_MARKS__).toBeUndefined()
+    })
+  })
+
+  it("writes a structured mark + buffer entry when the flag is on", () => {
+    withGlobals("1", (markSpy) => {
+      markSwitch("server", "srv-9")
+      expect(markSpy).toHaveBeenCalledWith("alook:switch:server:srv-9")
+      const win = (globalThis as unknown as { window: TestWindow }).window
+      expect(win.__ALOOK_PERF_MARKS__).toHaveLength(1)
+      expect(win.__ALOOK_PERF_MARKS__![0]).toMatchObject({
+        kind: "server",
+        id: "srv-9",
+        markName: "alook:switch:server:srv-9",
+      })
+    })
+  })
+})

--- a/src/web/src/lib/perf/switch-mark.ts
+++ b/src/web/src/lib/perf/switch-mark.ts
@@ -1,0 +1,22 @@
+import { perfTraceEnabled } from "./perf-gate"
+import type { PerfSwitchMark } from "./perf-globals"
+
+/**
+ * Record a `t=0` anchor at a server/channel switch click site. The Playwright
+ * perf spec correlates the following network + render events against this mark
+ * to compute perceived latency (see plans/community-switch-perf-diagnosis.md).
+ *
+ * Guarded no-op when the perf gate is off, so the two hot-path call sites
+ * (`setActiveChannel`, `onRailServerNavigate`) add zero cost in real builds.
+ */
+export function markSwitch(kind: "server" | "channel", id: string): void {
+  if (!perfTraceEnabled()) return
+  if (typeof window === "undefined" || typeof performance === "undefined") return
+
+  const markName = `alook:switch:${kind}:${id}`
+  performance.mark(markName)
+
+  const entry: PerfSwitchMark = { kind, id, ts: performance.now(), markName }
+  const buf = window.__ALOOK_PERF_MARKS__ ?? (window.__ALOOK_PERF_MARKS__ = [])
+  buf.push(entry)
+}

--- a/src/web/src/test/e2e-ui/perf/perf-capture-types.ts
+++ b/src/web/src/test/e2e-ui/perf/perf-capture-types.ts
@@ -1,0 +1,77 @@
+// Shared schema between the Playwright perf spec (producer) and the report
+// generator (consumer). All timestamps are the BROWSER monotonic clock
+// (performance.now()) so network, marks, renders, and layout shifts correlate
+// without cross-clock skew. See plans/community-switch-perf-diagnosis.md.
+
+export type CacheState = "cold" | "memory-warm" | "disk-warm"
+export type SwitchKind = "server" | "channel"
+
+/** One `/api/community/*` request, from the in-page resource observer. */
+export interface CapturedResource {
+  name: string
+  /** performance.now() at fetchStart. */
+  startTime: number
+  /** performance.now() at responseEnd. */
+  responseEnd: number
+}
+
+/** One render commit, projected from the react-scan ring buffer. */
+export interface CapturedCommit {
+  ts: number
+  kind: string
+  /** fibers that mounted this commit (isFirstMount). */
+  mounts: CapturedFiber[]
+  /** fibers that re-rendered (not first mount). */
+  rerenders: CapturedFiber[]
+}
+
+export interface CapturedFiber {
+  name: string
+  fiberId?: number
+  actualDuration: number
+  /** compact re-render reason, e.g. "props:[x]", "parent", "hooks". */
+  reason?: string
+}
+
+/** A single switch, fully captured across one cache state. */
+export interface CapturedSwitch {
+  kind: SwitchKind
+  targetId: string
+  cacheState: CacheState
+  /** performance.now() of the click mark (t=0). */
+  clickTs: number
+  /** performance.now() when the first skeleton for the target appeared. */
+  skeletonTs: number | null
+  /** performance.now() when the first message row painted. */
+  paintedTs: number | null
+  /** performance.now() of the last ResizeObserver settle on the list. */
+  contentStableTs: number | null
+  resources: CapturedResource[]
+  commits: CapturedCommit[]
+  /** fiber-unmount events during the switch, by component name. */
+  unmounts: string[]
+  /** layout-shift values kept INCLUDING hadRecentInput (click-triggered). */
+  layoutShifts: Array<{ ts: number; value: number; hadRecentInput: boolean }>
+  /** true if react-scan reported profiling hooks degraded. */
+  degraded: boolean
+}
+
+export interface CaptureFile {
+  owner: { email: string; userId: string }
+  createdAt: string
+  switches: CapturedSwitch[]
+}
+
+// In-page globals installed by the perf spec's PerformanceObserver setup.
+// Declared here so the spec's page.evaluate callbacks typecheck under tsc.
+declare global {
+  interface Window {
+    __PERF_RESOURCES__?: Array<{ name: string; startTime: number; responseEnd: number }>
+    __PERF_SHIFTS__?: Array<{ ts: number; value: number; hadRecentInput: boolean }>
+    __PERF_RESIZES__?: number[]
+    __PERF_RESIZE_ATTACHED__?: boolean
+    __PERF_ATTACH_RESIZE__?: () => void
+    __PERF_SKELETON_TS__?: number | null
+    __PERF_PAINTED_TS__?: number | null
+  }
+}

--- a/src/web/src/test/e2e-ui/perf/switch.perf.ts
+++ b/src/web/src/test/e2e-ui/perf/switch.perf.ts
@@ -1,0 +1,357 @@
+/**
+ * Perf-diagnosis harness for community server/channel switching.
+ *
+ * ## Perf diagnosis (workflow)
+ *   1. pnpm --filter @alook/web seed:stress          # heavy local dataset
+ *   2. NEXT_PUBLIC_PERF_TRACE=1 pnpm --filter @alook/web dev
+ *   3. pnpm --filter @alook/web perf:switch          # this spec + report
+ *   → perf-artifacts/switch-report.md
+ *
+ * Caveats:
+ *   - NEXT_PUBLIC_MOCK_NETWORK must be UNSET (it injects a ~300ms dev delay
+ *     per apiFetch that would poison every network measurement).
+ *   - NOT in CI and never shipped to prod: this config matches *.perf.ts,
+ *     the CI e2e-ui workflow matches *.spec.ts, and the instrument is
+ *     double-gated on NEXT_PUBLIC_PERF_TRACE + NODE_ENV.
+ *   - Against a live dev build each switch is slow (full API fan-out + paint +
+ *     reflow settle), so the matrix defaults SMALL and is env-tunable:
+ *     PERF_CHANNEL_SWITCHES (default 3), PERF_SERVER_SWITCHES (default 3).
+ *   - The capture is flushed to switch-events.json after EVERY switch, and the
+ *     `perf:switch` script runs the report with `;` (not `&&`), so even a
+ *     timed-out run still produces switch-report.md from the partial capture.
+ *
+ * See plans/community-switch-perf-diagnosis.md. LOCAL-ONLY — runs via
+ * playwright.perf.config.ts, which has NO global-setup, so the stress-seeded
+ * DB is preserved and this spec drives as the STABLE seed identity recorded in
+ * the manifest.
+ *
+ * It measures PERCEIVED latency (click → content stable), not raw request ms,
+ * across three cache states (cold / memory-warm / disk-warm). All timing is
+ * captured in-page via one browser clock. Raw capture is written to
+ * perf-artifacts/switch-events.json for scripts/perf-report.ts to consume.
+ */
+import { test, expect, type Page, type BrowserContext } from "@playwright/test"
+import { readFileSync, mkdirSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { DEV_PASSWORD } from "@alook/shared"
+import type {
+  CacheState,
+  CaptureFile,
+  CapturedSwitch,
+  SwitchKind,
+} from "./perf-capture-types"
+
+const BASE_URL = process.env.ALOOK_SERVER_URL || "http://localhost:3000"
+const ARTIFACTS_DIR = resolve(__dirname, "..", "..", "..", "..", "perf-artifacts")
+const SEED_MANIFEST = resolve(ARTIFACTS_DIR, "seed-manifest.json")
+const CAPTURE_OUT = resolve(ARTIFACTS_DIR, "switch-events.json")
+
+interface SeedManifest {
+  owner: { email: string; userId: string }
+  servers: Array<{ id: string; name: string; channels: Array<{ id: string; name: string }> }>
+}
+
+function loadManifest(): SeedManifest {
+  try {
+    return JSON.parse(readFileSync(SEED_MANIFEST, "utf8")) as SeedManifest
+  } catch {
+    throw new Error(
+      `Missing ${SEED_MANIFEST}. Run \`pnpm --filter @alook/web seed:stress\` first.`,
+    )
+  }
+}
+
+/** Sign in (or up) the stable seed identity over HTTP and inject cookies. */
+async function authenticateAs(context: BrowserContext, email: string): Promise<void> {
+  const api = context.request
+  let res = await api.post(`${BASE_URL}/api/auth/sign-in/email`, {
+    data: { email, password: DEV_PASSWORD },
+  })
+  if (!res.ok()) {
+    res = await api.post(`${BASE_URL}/api/auth/sign-up/email`, {
+      data: { name: email.split("@")[0], email, password: DEV_PASSWORD },
+    })
+  }
+  if (!res.ok()) {
+    throw new Error(`Could not authenticate seed identity ${email} (${res.status()})`)
+  }
+}
+
+// In-page instrumentation installed before each measured switch. Reads the
+// react-scan ring buffer + performance marks + resource timings + a
+// ResizeObserver on the message scroll container, all on the browser clock.
+const INPAGE_SETUP = `
+(() => {
+  window.__PERF_RESOURCES__ = [];
+  window.__PERF_SHIFTS__ = [];
+  window.__PERF_RESIZES__ = [];
+  const ro = new PerformanceObserver((list) => {
+    for (const e of list.getEntries()) {
+      if (e.name.includes('/api/community/')) {
+        window.__PERF_RESOURCES__.push({ name: e.name, startTime: e.startTime, responseEnd: e.responseEnd });
+      }
+    }
+  });
+  ro.observe({ type: 'resource', buffered: true });
+  const lo = new PerformanceObserver((list) => {
+    for (const e of list.getEntries()) {
+      // KEEP hadRecentInput entries — the click-triggered reflow is exactly what
+      // standard CLS filtering drops, and it's what we're measuring.
+      window.__PERF_SHIFTS__.push({ ts: e.startTime, value: e.value, hadRecentInput: e.hadRecentInput });
+    }
+  });
+  try { lo.observe({ type: 'layout-shift', buffered: true }); } catch (_) {}
+  window.__PERF_ATTACH_RESIZE__ = () => {
+    const root = document.querySelector('.thin-scrollbar');
+    if (!root || window.__PERF_RESIZE_ATTACHED__) return;
+    window.__PERF_RESIZE_ATTACHED__ = true;
+    const rz = new ResizeObserver(() => { window.__PERF_RESIZES__.push(performance.now()); });
+    rz.observe(root);
+  };
+})()
+`
+
+interface DrainedSwitch {
+  clickTs: number
+  skeletonTs: number | null
+  paintedTs: number | null
+  contentStableTs: number | null
+  resources: CapturedSwitch["resources"]
+  commits: CapturedSwitch["commits"]
+  unmounts: string[]
+  layoutShifts: CapturedSwitch["layoutShifts"]
+  degraded: boolean
+}
+
+async function drainSwitch(page: Page, sinceTs: number, markName: string): Promise<DrainedSwitch> {
+  return page.evaluate(
+    ({ sinceTs, markName }) => {
+      const marks = performance.getEntriesByName(markName, "mark")
+      const clickTs = marks.length ? marks[marks.length - 1].startTime : sinceTs
+
+      const events = (window.__ALOOK_PERF__ || []).filter((e) => e.ts >= clickTs)
+      const commits = events
+        .filter((e) => e.kind === "commit")
+        .map((e) => {
+          const fibers = e.fibers || []
+          const mkReason = (f: {
+            changedProps?: string[] | null
+            changedByParent?: boolean
+            changedHooks?: number[]
+            changedState?: boolean
+            changedContext?: boolean
+          }) => {
+            const parts: string[] = []
+            if (f.changedProps && f.changedProps.length) parts.push("props:[" + f.changedProps.join(",") + "]")
+            if (f.changedByParent) parts.push("parent")
+            if (f.changedHooks && f.changedHooks.length) parts.push("hooks")
+            if (f.changedState) parts.push("state")
+            if (f.changedContext) parts.push("context")
+            return parts.join("+") || undefined
+          }
+          const proj = (f: NonNullable<typeof e.fibers>[number]) => ({
+            name: f.name,
+            fiberId: f.fiberId,
+            actualDuration: f.actualDuration,
+            reason: mkReason(f),
+          })
+          return {
+            ts: e.ts,
+            kind: e.kind,
+            mounts: fibers.filter((f) => f.isFirstMount === true).map(proj),
+            rerenders: fibers.filter((f) => f.isFirstMount === false).map(proj),
+          }
+        })
+      const unmounts = events
+        .filter((e) => e.kind === "fiber-unmount")
+        .map((e) => e.componentName || "unknown")
+
+      const resources = (window.__PERF_RESOURCES__ || []).filter((r) => r.startTime >= clickTs)
+      const layoutShifts = (window.__PERF_SHIFTS__ || []).filter((s) => s.ts >= clickTs)
+      const resizes = (window.__PERF_RESIZES__ || []).filter((t) => t >= clickTs)
+      const contentStableTs = resizes.length ? resizes[resizes.length - 1] : null
+
+      return {
+        clickTs,
+        skeletonTs: window.__PERF_SKELETON_TS__ ?? null,
+        paintedTs: window.__PERF_PAINTED_TS__ ?? null,
+        contentStableTs,
+        resources,
+        commits,
+        unmounts,
+        layoutShifts,
+        degraded: window.__ALOOK_PERF_DEGRADED__ === true,
+      }
+    },
+    { sinceTs, markName },
+  )
+}
+
+test("community switch perceived-latency capture", async ({ browser }) => {
+  const manifest = loadManifest()
+  expect(manifest.servers.length, "seed manifest has servers").toBeGreaterThan(0)
+  const targetServer = manifest.servers.find((s) => s.channels.length >= 5) ?? manifest.servers[0]
+  const channels = targetServer.channels.slice(0, 6)
+  expect(channels.length, "target server has channels").toBeGreaterThan(1)
+
+  const context = await browser.newContext()
+  await authenticateAs(context, manifest.owner.email)
+  const page = await context.newPage()
+
+  // Precondition guards.
+  expect(process.env.NEXT_PUBLIC_MOCK_NETWORK, "mock-network must be off").not.toBe("true")
+
+  await page.goto(`${BASE_URL}/c/channels/${targetServer.id}`, { waitUntil: "commit" })
+  // Prove the react-scan hook registered early enough: commit events must
+  // actually arrive (not merely that hooks are "available").
+  await page.waitForFunction(() => Array.isArray(window.__ALOOK_PERF__) && window.__ALOOK_PERF__.length > 0, {
+    timeout: 20_000,
+  })
+  const degraded = await page.evaluate(() => window.__ALOOK_PERF_DEGRADED__ === true)
+  expect(degraded, "react-scan profiling hooks live").toBe(false)
+
+  // Warm the LEAF routes (channel + server) so first-hit dev compile isn't
+  // misattributed to a measured switch.
+  await page.goto(`${BASE_URL}/c/channels/${targetServer.id}/${channels[0].id}`, { waitUntil: "commit" })
+  await page.waitForSelector("[data-msg-id]", { timeout: 20_000 }).catch(() => {})
+
+  const captured: CapturedSwitch[] = []
+  const startedAt = new Date().toISOString()
+
+  async function measureSwitch(
+    kind: SwitchKind,
+    targetId: string,
+    cacheState: CacheState,
+    navigate: () => Promise<void>,
+  ): Promise<void> {
+    await page.evaluate(INPAGE_SETUP)
+    await page.evaluate(() => {
+      window.__PERF_SKELETON_TS__ = null
+      window.__PERF_PAINTED_TS__ = null
+      window.__PERF_ATTACH_RESIZE__?.()
+    })
+    const markName = `alook:switch:${kind}:${targetId}`
+    const t0 = await page.evaluate(() => performance.now())
+
+    await navigate()
+
+    // Record skeleton + painted anchors as they appear.
+    await page
+      .waitForFunction(
+        () => {
+          const painted = document.querySelector("[data-msg-id]")
+          if (painted && window.__PERF_PAINTED_TS__ == null) {
+            window.__PERF_PAINTED_TS__ = performance.now()
+          }
+          return window.__PERF_PAINTED_TS__ != null
+        },
+        { timeout: 25_000 },
+      )
+      .catch(() => {})
+
+    // Let reflow settle so the ResizeObserver captures content-stable.
+    await page.waitForTimeout(600)
+
+    const drained = await drainSwitch(page, t0, markName)
+    captured.push({ kind, targetId, cacheState, ...drained })
+    // Write incrementally so a timed-out / interrupted run still yields a
+    // usable capture the report generator can consume (dev-build latency can
+    // blow any single wall-clock budget — see the harness header).
+    flushCapture()
+  }
+
+  function flushCapture(): void {
+    const out: CaptureFile = {
+      owner: manifest.owner,
+      createdAt: startedAt,
+      switches: captured,
+    }
+    mkdirSync(ARTIFACTS_DIR, { recursive: true })
+    writeFileSync(CAPTURE_OUT, JSON.stringify(out, null, 2))
+  }
+
+  // Force a cold pass by clearing the persister's IndexedDB. Do NOT
+  // `deleteDatabase` — the app holds an open connection to `keyval-store`, so
+  // the delete request fires `onblocked` and can hang indefinitely. Instead
+  // clear the object store's CONTENTS (a transaction that doesn't need the DB
+  // closed), with a hard timeout so a switch can never wedge the whole run.
+  async function clearIdb(): Promise<void> {
+    await page.evaluate(
+      () =>
+        new Promise<void>((res) => {
+          const done = setTimeout(res, 3000) // never wedge the run
+          const open = indexedDB.open("keyval-store")
+          open.onerror = () => {
+            clearTimeout(done)
+            res()
+          }
+          open.onsuccess = () => {
+            const db = open.result
+            if (!db.objectStoreNames.contains("keyval")) {
+              db.close()
+              clearTimeout(done)
+              res()
+              return
+            }
+            const tx = db.transaction("keyval", "readwrite")
+            tx.objectStore("keyval").clear()
+            tx.oncomplete = tx.onerror = () => {
+              db.close()
+              clearTimeout(done)
+              res()
+            }
+          }
+        }),
+    )
+  }
+
+  // Matrix size is env-configurable and defaults SMALL: against a live Next dev
+  // build each switch costs full API fan-out + paint + reflow settle (often
+  // 1-3s), so a big matrix blows any practical timeout. The incremental
+  // flushCapture() means even a partial run yields a report; bump these when
+  // pointing at a faster (prod) build. See the harness header.
+  const N_CHANNEL = Number(process.env.PERF_CHANNEL_SWITCHES ?? 3)
+  const N_SERVER = Number(process.env.PERF_SERVER_SWITCHES ?? 3)
+
+  // --- Channel switches: cold, then memory-warm (immediate repeat) ---
+  for (let i = 1; i < Math.min(channels.length, N_CHANNEL + 1); i++) {
+    const ch = channels[i]
+    await clearIdb()
+    await measureSwitch("channel", ch.id, "cold", async () => {
+      await page.getByTestId(`community-channel-row-${ch.id}`).click()
+    })
+    // memory-warm: click away and back within staleTime.
+    const prev = channels[i - 1]
+    await page.getByTestId(`community-channel-row-${prev.id}`).click()
+    await page.waitForTimeout(200)
+    await measureSwitch("channel", ch.id, "memory-warm", async () => {
+      await page.getByTestId(`community-channel-row-${ch.id}`).click()
+    })
+  }
+
+  // --- disk-warm channel pass: let the app persist to IDB, reload preserving
+  // it, then measure the first switch (messages paint from disk, read-state
+  // still refetches). ---
+  await page.waitForTimeout(1500) // let the throttled persist settle
+  await page.reload({ waitUntil: "commit" })
+  await page.waitForSelector("[data-msg-id]", { timeout: 20_000 }).catch(() => {})
+  {
+    const ch = channels[1]
+    await measureSwitch("channel", ch.id, "disk-warm", async () => {
+      await page.getByTestId(`community-channel-row-${ch.id}`).click()
+    })
+  }
+
+  // --- Server switches (cold) ---
+  const otherServers = manifest.servers.filter((s) => s.id !== targetServer.id).slice(0, N_SERVER)
+  for (const srv of otherServers) {
+    await clearIdb()
+    await measureSwitch("server", srv.id, "cold", async () => {
+      await page.getByTestId(`community-server-icon-${srv.id}`).click()
+    })
+  }
+
+  flushCapture() // final flush (measureSwitch already flushes incrementally)
+  expect(captured.length, "captured at least one switch").toBeGreaterThan(0)
+  await context.close()
+})

--- a/src/web/vitest.config.ts
+++ b/src/web/vitest.config.ts
@@ -11,7 +11,7 @@ export default mergeConfig(shared, defineConfig({
   test: {
     testTimeout: 30_000,
     hookTimeout: 30_000,
-    include: ["src/**/*.test.ts"],
-    exclude: ["src/test/e2e/**"],
+    include: ["src/**/*.test.ts", "scripts/**/*.test.ts"],
+    exclude: ["src/test/e2e/**", "src/test/e2e-ui/**"],
   },
 }))


### PR DESCRIPTION
## What

Diagnosis-only instrumentation to measure **why switching community server/channel shows a perceived-long loading on local** (where network latency is ~0, so a visible loading spell is itself the anomaly). **No behavior change to `/c` when the flag is off** — every path is double-gated on `NEXT_PUBLIC_PERF_TRACE` + `NODE_ENV`.

## What's in it

- **react-scan** (devDependency) installed pre-hydration via `instrumentation-client.ts`, feeding a bounded ring buffer on `window.__ALOOK_PERF__`. Verified **excluded from the production client bundle** by build inspection (needed a `NODE_ENV` literal guard to actually DCE the dynamic import — a runtime flag check alone shipped ~27KB).
- **`markSwitch()`** at the two switch click sites (`setActiveChannel`, `onRailServerNavigate`) — a guarded no-op in prod.
- **`seed:stress`** script — breadth-heavy, identity-pinned, idempotent (slug-aware), rate-limit-paced local dataset + manifest.
- **`perf:switch`** — Playwright capture (in-page one-clock, three cache states cold/memory-warm/disk-warm, incremental flush) + report generator → `switch-report.md` with perceived-latency breakdown, StrictMode-adjusted render counts, network waterfall, and a render-vs-network verdict.
- Unit tests for gate / ring-buffer / mark / install-guard / cookie-jar / rate-pacer / 429-retry / report correlation.

## Verification

- `typecheck` ✅ · full web suite **3232 tests** ✅ · `lint` ✅ · `knip` ✅
- Prod-bundle exclusion verified (0 `react-scan` refs in prod client chunks).
- `alook-c-qa`: flag-off parity, flag-on capture, heavy-data pipeline, and report generation all PASS.

## Notes

- `perf-artifacts/` is gitignored (local outputs).
- **Not wired into CI** — the harness matches `*.perf.ts`; the e2e-ui workflow matches `*.spec.ts`, so it's never picked up. Run on demand.
- First real finding it produced: a cold channel switch is **NOT network-bound** — the perceived loading is render/remount/reflow (~23k re-renders, full `ChannelView` remount), plus a serialized `read-state → messages` round-trip. A follow-up optimization plan targets those.