### PR TITLE
fix(web): prerender /llms.txt and blog feed (CF 500)

### DIFF
--- a/src/web/src/app/blog/feed.xml/route.test.ts
+++ b/src/web/src/app/blog/feed.xml/route.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/blog/posts", () => ({
+  getAllPosts: vi.fn(),
+}));
+
+import { getAllPosts } from "@/lib/blog/posts";
+import { dynamic, GET } from "./route";
+
+describe("GET /blog/feed.xml", () => {
+  beforeEach(() => {
+    vi.mocked(getAllPosts).mockReset();
+  });
+
+  it("is prerendered for Cloudflare Workers", () => {
+    expect(dynamic).toBe("force-static");
+  });
+
+  it("returns RSS with blog posts and correct content type", async () => {
+    vi.mocked(getAllPosts).mockResolvedValue([
+      {
+        slug: "why-we-built-alook",
+        title: "Why We Built Alook",
+        date: "2026-05-15",
+        author: "Gus",
+        excerpt: "Origin story excerpt.",
+        readingTime: "5 min read",
+      },
+    ]);
+
+    const res = await GET();
+    const body = await res.text();
+
+    expect(res.headers.get("Content-Type")).toBe("application/rss+xml");
+    expect(body).toContain("<title>Alook Blog</title>");
+    expect(body).toContain("https://alook.ai/blog/why-we-built-alook");
+    expect(body).toContain("Why We Built Alook");
+  });
+});

--- a/src/web/src/app/blog/feed.xml/route.ts
+++ b/src/web/src/app/blog/feed.xml/route.ts
@@ -1,5 +1,7 @@
 import { getAllPosts } from "@/lib/blog/posts";
 
+export const dynamic = "force-static";
+
 export async function GET() {
   const posts = await getAllPosts();
   const siteUrl = "https://alook.ai";

--- a/src/web/src/app/llms.txt/route.ts
+++ b/src/web/src/app/llms.txt/route.ts
@@ -1,6 +1,8 @@
 import { getAllPosts } from "@/lib/blog/posts";
 import { buildLlmsTxt, LLMS_TXT_SITE_URL } from "@/lib/blog/llms-txt";
 
+export const dynamic = "force-static";
+
 export async function GET() {
   const posts = await getAllPosts();
   const body = buildLlmsTxt(posts, LLMS_TXT_SITE_URL);


### PR DESCRIPTION
## Summary
- Live `https://alook.ai/llms.txt` and `/blog/feed.xml` return **500** (empty body).
- Both routes call `getAllPosts()`, which uses Node `readdirSync` + dynamic MDX imports — fine at **build** (`/blog`, sitemap), broken at **Worker runtime**.
- Mark both handlers `dynamic = "force-static"` so OpenNext prerenders them.

## Test plan
- [x] `vitest` llms.txt route test
- [ ] After deploy: `curl -sI https://alook.ai/llms.txt` → 200 + markdown body
- [ ] `curl -sI https://alook.ai/blog/feed.xml` → 200


Made with [Cursor](https://cursor.com)