### PR TITLE
fix(test): daemon IT addresses channels by name, not id

### DIFF
--- a/tests/integration/daemon/control-plane.test.ts
+++ b/tests/integration/daemon/control-plane.test.ts
@@ -181,7 +181,7 @@ describe("daemon control plane — real ws-do wake round-trip", () => {
     const sendRes = await fetchWithRetry(`${APP_URL}/api/community/agent/send`, {
       method: "POST",
       headers: { Authorization: `Bearer ${runnerKey}`, "content-type": "application/json" },
-      body: JSON.stringify({ channel: `/${fixture.serverId}/${fixture.channelId}`, content: { text: replyText } }),
+      body: JSON.stringify({ channel: `/${fixture.serverId}/${fixture.channelName}`, content: { text: replyText } }),
     })
     expect(sendRes.ok).toBe(true)
     const sendBody = (await sendRes.json()) as { state: string }
@@ -290,7 +290,7 @@ describe("daemon control plane — real ws-do wake round-trip", () => {
         const sendRes = await fetchWithRetry(`${APP_URL}/api/community/agent/send`, {
           method: "POST",
           headers: { Authorization: `Bearer ${runnerKey}`, "content-type": "application/json" },
-          body: JSON.stringify({ channel: `/${fixture.serverId}/${fixture.channelId}`, content: { text: replyText } }),
+          body: JSON.stringify({ channel: `/${fixture.serverId}/${fixture.channelName}`, content: { text: replyText } }),
         })
         expect(sendRes.ok).toBe(true)
         const sendBody = (await sendRes.json()) as { state: string }

--- a/tests/integration/daemon/credential-chain.test.ts
+++ b/tests/integration/daemon/credential-chain.test.ts
@@ -59,7 +59,7 @@ describe("daemon credential chain — real local proxy against the real web app"
 
     const page = await api.read({
       agentId: fixture.bot.botUserId,
-      channel: `/${fixture.serverId}/${fixture.channelId}`,
+      channel: `/${fixture.serverId}/${fixture.channelName}`,
     })
     expect(Array.isArray(page.items)).toBe(true)
     expect(typeof page.hasMore).toBe("boolean")
@@ -69,7 +69,7 @@ describe("daemon credential chain — real local proxy against the real web app"
     const res = await fetch(`${proxy.url}/api/read`, {
       method: "POST",
       headers: { Authorization: "Bearer vch_this_was_never_minted", "content-type": "application/json" },
-      body: JSON.stringify({ channel: `/${fixture.serverId}/${fixture.channelId}` }),
+      body: JSON.stringify({ channel: `/${fixture.serverId}/${fixture.channelName}` }),
     })
     expect(res.status).toBe(401)
     const body = (await res.json()) as { error: string; code: string }

--- a/tests/integration/daemon/seed-helpers.ts
+++ b/tests/integration/daemon/seed-helpers.ts
@@ -23,6 +23,15 @@ export function nanoid() {
 export interface DaemonItFixture {
   serverId: string
   channelId: string
+  /**
+   * Top-level channel NAME — the only way agent surfaces address a channel.
+   * `resolveChannelByNameForMember` is name-only (migration 0057's partial
+   * unique index; agent refs never accept ids), so agent-facing routes
+   * (`/api/community/agent/*`) must build the ref as `/serverId/channelName`,
+   * while the `/c` UI REST routes (`/api/community/channels/:id/*`) still key
+   * on `channelId`.
+   */
+  channelName: string
   paired: PairedMachine
   bot: SeededCommunityBot
 }
@@ -31,6 +40,7 @@ export async function seedPairedBot(seed: TestSeed, cookie: string): Promise<Dae
   const now = new Date().toISOString()
   const serverId = `srv_${nanoid()}`
   const channelId = `chn_${nanoid()}`
+  const channelName = "general"
   sqlRun(
     `INSERT INTO community_server (id, name, description, owner_id, created_at) VALUES (?, ?, ?, ?, ?)`,
     serverId,
@@ -51,7 +61,7 @@ export async function seedPairedBot(seed: TestSeed, cookie: string): Promise<Dae
     `INSERT INTO community_channel (id, server_id, name, type, position, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
     channelId,
     serverId,
-    "general",
+    channelName,
     "text",
     0,
     now,
@@ -60,7 +70,7 @@ export async function seedPairedBot(seed: TestSeed, cookie: string): Promise<Dae
   const paired = await pairAndActivateMachine(cookie)
   const bot = seedCommunityBot({ ownerUserId: seed.userId, serverId, machineId: paired.machineId, runtime: "claude" })
 
-  return { serverId, channelId, paired, bot }
+  return { serverId, channelId, channelName, paired, bot }
 }
 
 export function cleanupPairedBot(seed: TestSeed, fixture: DaemonItFixture): void {


### PR DESCRIPTION
## What

Fixes the deterministically-failing **E2E Tests** job on `main` (the daemon integration suite: `tests/integration/daemon/`).

## Root cause

The agent-facing routes (`/api/community/agent/*`) resolve a channel ref by **name only** — `resolveChannelByNameForMember` matches on the per-server unique channel name (migration 0057's partial-unique index `idx_channel_server_name`), never on the `chn_` id.

The daemon integration fixtures built the ref as `/${serverId}/${channelId}`, passing a `chn_` **id** where a **name** is expected. So `resolveTargetForMember` returned `channel not found: chn_...`, which failed:

- `credential-chain.test.ts` — the real `read` call (`Error: channel not found: chn_...`)
- `control-plane.test.ts` — both wake round-trips on the `send` step (`expect(sendRes.ok).toBe(true)` → `false`)

`main` is red on this today (verified via a re-run of CI on #409 — 3/5 daemon IT tests fail identically on a clean base). It's unrelated to any web change.

## Fix

Add `channelName` to `DaemonItFixture` and build every agent ref as `/${serverId}/${channelName}`. The `/c` UI REST routes (`/api/community/channels/:id/*`) still key on `channelId`, so those refs are unchanged.

## Verification

Booted the full local stack (web + ws-do + wake-worker + email-worker) and ran the suite:

```
pnpm --filter @alook/daemon run test:integration
 Test Files  2 passed (2)
      Tests  5 passed (5)
```