### PR TITLE
fix(web): noindex sign-in and fix templates heading outline

### DIFF
--- a/src/web/src/app/(auth)/layout.test.ts
+++ b/src/web/src/app/(auth)/layout.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { metadata } from "./layout";
+
+describe("(auth) layout metadata", () => {
+  it("noindexes sign-in and other auth pages", () => {
+    expect(metadata.robots).toEqual({ index: false, follow: true });
+  });
+});

--- a/src/web/src/app/(auth)/layout.tsx
+++ b/src/web/src/app/(auth)/layout.tsx
@@ -5,6 +5,7 @@ import { getSession } from "@/lib/session";
 export const metadata: Metadata = {
   title: "Sign In",
   description: "Rooms for people and agents.",
+  robots: { index: false, follow: true },
   openGraph: {
     images: [{ url: "/og?title=Sign In", width: 1200, height: 630 }],
   },

--- a/src/web/src/app/templates/client.test.ts
+++ b/src/web/src/app/templates/client.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest"
+import React from "react"
+import TestRenderer, { act } from "react-test-renderer"
+import { TemplatesClient } from "./client"
+import { devopsMonitor } from "@/lib/templates/presets/devops-monitor"
+
+vi.mock("@/lib/analytics", () => ({
+  trackTemplatesBrowsed: vi.fn(),
+  trackTemplateUsed: vi.fn(),
+}))
+
+vi.mock("@/components/public-layout", () => ({
+  PublicLayout: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement("div", { "data-mock": "layout" }, children),
+}))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children?: React.ReactNode
+    href: string
+  }) => React.createElement("a", { href }, children),
+}))
+
+function collectHeadingLevels(node: TestRenderer.ReactTestInstance): number[] {
+  const levels: number[] = []
+  const walk = (n: TestRenderer.ReactTestInstance) => {
+    if (typeof n.type === "string" && /^h[1-6]$/.test(n.type)) {
+      levels.push(Number(n.type.slice(1)))
+    }
+    for (const child of n.children) {
+      if (typeof child !== "string") walk(child)
+    }
+  }
+  walk(node)
+  return levels
+}
+
+describe("TemplatesClient heading outline", () => {
+  it("steps H1 → H2 → H3 without skipping a level", () => {
+    let renderer!: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(
+        React.createElement(TemplatesClient, {
+          templates: [devopsMonitor],
+          categories: ["Developer"],
+          isLoggedIn: false,
+        }),
+      )
+    })
+
+    const levels = collectHeadingLevels(renderer.root)
+    expect(levels).toEqual([1, 2, 3])
+    for (let i = 1; i < levels.length; i++) {
+      expect(levels[i]! - levels[i - 1]!).toBeLessThanOrEqual(1)
+    }
+  })
+})

--- a/src/web/src/app/templates/client.tsx
+++ b/src/web/src/app/templates/client.tsx
@@ -107,6 +107,9 @@ export function TemplatesClient({
 
       {/* Grid */}
       <div className="mx-auto max-w-4xl px-6 pb-20">
+        <h2 className="mb-3 text-xs uppercase tracking-widest font-mono text-muted-foreground">
+          {activeCategory === "All" ? "All templates" : activeCategory}
+        </h2>
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           {filtered.map((template) => (
             <TemplateCard


### PR DESCRIPTION
## Summary
- Add `robots: { index: false, follow: true }` on `(auth)` layout so `/sign-in` and `?redirect=` variants are not indexed (SEO audit 2026-08-06).
- Add an H2 section label on `/templates` so heading outline is H1 → H2 → H3 (no skip).

## Test plan
- [x] `vitest` `(auth)/layout.test.ts` + `templates/client.test.ts`
- [x] Diff is SEO-only (preserves signed-in redirect to `/c/me`)
- [ ] After deploy: view-source `/sign-in` includes noindex
- [ ] After deploy: `/templates` heading outline H1 → H2 → H3


Made with [Cursor](https://cursor.com)