### PR TITLE
fix(web): stop forum sidebar route query loop

### DIFF
--- a/src/web/src/hooks/community/use-forum-sidebar-threads.test.ts
+++ b/src/web/src/hooks/community/use-forum-sidebar-threads.test.ts
@@ -6,6 +6,7 @@ import { communityKeys } from "@/lib/query-keys"
 import {
   deriveForumSidebarProjection,
   grantForumSidebarChild,
+  hasForumSidebarOwnershipEvidence,
   invalidateForumSidebarBaseExact,
   patchForumSidebarActivityExact,
   patchForumSidebarTitleExact,
@@ -538,6 +539,113 @@ describe("forum sidebar Stage B resources", () => {
     expect(resolveForumSidebarRouteCandidate("general", ["general", "forum"])).toBeNull()
     expect(resolveForumSidebarRouteCandidate("post-1", ["general", "forum"])).toBe("post-1")
     expect(resolveForumSidebarRouteCandidate("post-1", null)).toBeNull()
+  })
+
+  it("requires positive forum ownership evidence", () => {
+    const queryClient = new QueryClient()
+    expect(hasForumSidebarOwnershipEvidence(queryClient, "server-1", "child-1"))
+      .toBe(false)
+
+    const detail = serverDetail(false)
+    detail.categories[0]!.channels.push({
+      id: "general-1",
+      name: "General",
+      type: "text",
+      active: false,
+      unread: false,
+      muted: false,
+    })
+    queryClient.setQueryData(communityKeys.server("server-1"), detail)
+    queryClient.setQueryData(communityKeys.channelMeta("server-1", "child-1"), {
+      id: "child-1",
+      serverId: "server-1",
+      name: "Thread",
+      type: "thread",
+      parentChannelId: "general-1",
+      parentMessageId: "message-1",
+      creatorId: "user-1",
+      archived: false,
+      activityAt: "2026-08-08T00:00:00.000Z",
+      verifiedEpoch: 0,
+    })
+    queryClient.setQueryData(
+      communityKeys.forumSidebarRetained("server-1", "child-1"),
+      projectForumSidebarThreads(envelope(["child-1"]))[0],
+    )
+    expect(hasForumSidebarOwnershipEvidence(queryClient, "server-1", "child-1"))
+      .toBe(false)
+
+    queryClient.setQueryData(communityKeys.channelMeta("server-1", "child-1"), {
+      ...queryClient.getQueryData<ChildChannelMeta>(
+        communityKeys.channelMeta("server-1", "child-1"),
+      )!,
+      parentChannelId: "forum-1",
+    })
+    expect(hasForumSidebarOwnershipEvidence(queryClient, "server-1", "child-1"))
+      .toBe(true)
+  })
+
+  it("settles an omitted text-thread candidate without deleting exact metadata", async () => {
+    apiFetchMock.mockResolvedValue({
+      ...envelope([]),
+      canonicalChannels: [],
+      retainedChannel: null,
+    })
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const detail = serverDetail(false)
+    detail.categories[0]!.channels.push({
+      id: "general-1",
+      name: "General",
+      type: "text",
+      active: false,
+      unread: false,
+      muted: false,
+    })
+    queryClient.setQueryData(communityKeys.server("server-1"), detail)
+    let renderer: TestRenderer.ReactTestRenderer
+    const tree = (retainId: string | null) => React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(Capture, { retainId, onRender: () => undefined }),
+    )
+    await act(async () => {
+      renderer = TestRenderer.create(tree(null))
+    })
+    await waitFor(() => queryClient.getQueryState(
+      communityKeys.forumSidebarThreads("server-1"),
+    )?.status === "success")
+    const meta: ChildChannelMeta = {
+      id: "thread-1",
+      serverId: "server-1",
+      name: "Thread",
+      type: "thread",
+      parentChannelId: "general-1",
+      parentMessageId: "message-1",
+      creatorId: "user-1",
+      archived: false,
+      activityAt: "2026-08-08T00:00:00.000Z",
+      verifiedEpoch: 0,
+    }
+    queryClient.setQueryData(communityKeys.channelMeta("server-1", "thread-1"), meta)
+
+    await act(async () => {
+      renderer!.update(tree("thread-1"))
+    })
+    await waitFor(() => queryClient.getQueryState(
+      communityKeys.forumSidebarRetained("server-1", "thread-1"),
+    )?.status === "success")
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 25))
+    })
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(2)
+    expect(queryClient.getQueryData(
+      communityKeys.channelMeta("server-1", "thread-1"),
+    )).toEqual(meta)
+    expect(queryClient.getQueryData(
+      communityKeys.forumSidebarRetained("server-1", "thread-1"),
+    )).toBeNull()
+    renderer!.unmount()
   })
 
   it("uses one cold combined request and seeds sibling resources before base settles", async () => {

--- a/src/web/src/hooks/community/use-forum-sidebar-threads.ts
+++ b/src/web/src/hooks/community/use-forum-sidebar-threads.ts
@@ -531,6 +531,24 @@ export function isForumSidebarParent(
     )) ?? false
 }
 
+export function hasForumSidebarOwnershipEvidence(
+  queryClient: QueryClient,
+  serverId: string,
+  childId: string,
+) {
+  if (isKnownNonForumSidebarChannel(queryClient, serverId, childId)) return false
+  if (hasForumSidebarThread(getForumSidebarBase(queryClient, serverId), childId)) return true
+  if (getForumSidebarRetained(queryClient, serverId, childId)) return true
+  const server = queryClient.getQueryData<ServerDetail>(communityKeys.server(serverId))
+  if (Object.values(server?.forumUnreadState ?? {}).some(
+    (state) => state.childIds.includes(childId),
+  )) return true
+  const meta = queryClient.getQueryData<ChildChannelMeta>(
+    communityKeys.channelMeta(serverId, childId),
+  )
+  return !!meta && isForumSidebarParent(queryClient, serverId, meta.parentChannelId)
+}
+
 function patchRetained(
   queryClient: QueryClient,
   serverId: string,
@@ -853,7 +871,8 @@ function seedForumSidebarResources(
   if (
     retainId &&
     !normalized.retained &&
-    !hasForumSidebarThread(normalized.base, retainId)
+    !hasForumSidebarThread(normalized.base, retainId) &&
+    hasForumSidebarOwnershipEvidence(queryClient, serverId, retainId)
   ) {
     removeForumSidebarUnreadChild(queryClient, serverId, retainId)
     removeForumSidebarThreadExact(queryClient, serverId, retainId)

--- a/src/web/src/test/e2e-ui/09-forum-thread.spec.ts
+++ b/src/web/src/test/e2e-ui/09-forum-thread.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "./_fixtures/community-fixture"
-import { sendMessage } from "./_fixtures/actions"
+import { composerEditable, sendMessage } from "./_fixtures/actions"
 import { seedServer, seedChannel, seedMessage } from "./_fixtures/seed"
 
 // Journey 9 — threads. Creating a thread from a message surfaces a thread
@@ -22,12 +22,23 @@ test.describe.serial("threads", () => {
 
   test("creating a thread from a message shows a thread indicator on the parent", async ({ asUser }) => {
     const { page } = await asUser("alice")
+    const requests: string[] = []
+    page.on("request", (request) => requests.push(request.url()))
     await page.goto(`/c/channels/${serverId}/${channelId}`)
     await page.waitForURL(new RegExp(channelId), { timeout: 20_000 , waitUntil: "commit" })
 
     // The seeded parent message renders (real id, not a racy optimistic row).
     const row = page.getByText("thread parent", { exact: false }).first()
     await expect(row).toBeVisible({ timeout: 20_000 })
+
+    const threadMessagesLoaded = page.waitForResponse((response) => {
+      const url = new URL(response.url())
+      return response.request().method() === "GET" &&
+        url.pathname.startsWith("/api/community/channels/") &&
+        url.pathname.endsWith("/messages") &&
+        url.pathname !== `/api/community/channels/${channelId}/messages` &&
+        response.ok()
+    })
 
     // Open the message's more-menu → Create Thread. Retry the open since the
     // hover toolbar can close between the hover and the menu click.
@@ -39,11 +50,31 @@ test.describe.serial("threads", () => {
 
     // Thread creation navigates off the parent channel into the thread child.
     await page.waitForURL((url) => !url.pathname.endsWith(`/${channelId}`), { timeout: 20_000, waitUntil: "commit" })
+    const threadId = new URL(page.url()).pathname.split("/").at(-1)!
+    const threadMessagesResponse = await threadMessagesLoaded
+    expect(new URL(threadMessagesResponse.url()).pathname).toBe(`/api/community/channels/${threadId}/messages`)
+    await expect(composerEditable(page)).toBeVisible()
 
     // The thread is usable: a reply posts and appears in the thread view.
     const reply = `first reply ${Date.now()}`
     await sendMessage(page, reply)
     await expect(page.getByText(reply, { exact: false }).first()).toBeVisible({ timeout: 15_000 })
+
+    const exactChannelRequests = requests.filter((requestUrl) =>
+      new URL(requestUrl).pathname === `/api/community/channels/${threadId}`
+    ).length
+    const retainedSidebarRequests = requests.filter((requestUrl) => {
+      const url = new URL(requestUrl)
+      return url.pathname === `/api/community/servers/${serverId}/channels` &&
+        url.searchParams.get("retainId") === threadId
+    }).length
+    await test.info().attach("thread-route-request-counts", {
+      body: JSON.stringify({ exactChannelRequests, retainedSidebarRequests }),
+      contentType: "application/json",
+    })
+    console.log(`thread-route requests exact=${exactChannelRequests} retained=${retainedSidebarRequests}`)
+    expect(exactChannelRequests).toBeLessThanOrEqual(3)
+    expect(retainedSidebarRequests).toBeLessThanOrEqual(3)
 
     // Back on the parent channel, the message now carries a thread indicator.
     await page.goto(`/c/channels/${serverId}/${channelId}`)


### PR DESCRIPTION
# Why we need this PR?
> The forum sidebar's seed cleanup can mistake an ordinary text-thread route for a revoked forum child. It then deletes the active retained route query and exact metadata, causing a refetch loop that leaves the route on its loading skeleton. This is also the pre-existing failure blocking the otherwise-green WebSocket security hotfix in #433.

## What changed
- require positive forum-sidebar ownership evidence before omission cleanup
- keep unknown and known text-thread candidates out of forum cleanup while preserving unauthorized forum-child cleanup
- add unit coverage for the ownership predicate and omitted text-thread convergence
- make the thread E2E await the composer and assert bounded exact/retained request counts

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...
