### PR TITLE
fix(web): chunk large broadcast audiences

### DIFF
--- a/src/web/src/lib/broadcast.test.ts
+++ b/src/web/src/lib/broadcast.test.ts
@@ -247,55 +247,250 @@ describe("broadcastToUser", () => {
 })
 
 describe("broadcastToUsers", () => {
-  it("sends one bulk service-binding request with the exact shared payload and exclusion", async () => {
-    const bindingFetch = vi.fn(async () =>
-      new Response(JSON.stringify({ sent: 2 }), { status: 200 }),
-    )
-    const env = makeEnv(bindingFetch)
+  function setBinding(bindingFetch: (...args: unknown[]) => Promise<Response>): void {
     mockGetCloudflareContext.mockReturnValue({
-      env,
+      env: makeEnv(bindingFetch),
       ctx: { waitUntil: mockCtxWaitUntil },
     })
-    const message = { type: "community:message.create", channelId: "c1" } as any
+  }
 
-    await broadcastToUsers(["u1", "u2", "u3"], message, "u1")
+  function bodiesOf(bindingFetch: ReturnType<typeof vi.fn>): Array<{
+    userIds: string[]
+    message: Record<string, unknown>
+    excludeUserId?: string
+  }> {
+    return bindingFetch.mock.calls.map((call) => JSON.parse(String(call[1]?.body)))
+  }
 
-    expect(bindingFetch).toHaveBeenCalledTimes(1)
+  function deferred<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void
+    let reject!: (reason?: unknown) => void
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise
+      reject = rejectPromise
+    })
+    return { promise, resolve, reject }
+  }
+
+  it("does not call transport for an empty post-filter audience and logs zero completion", async () => {
+    const bindingFetch = vi.fn(async () => new Response("unused"))
+    setBinding(bindingFetch)
+
+    await expect(broadcastToUsers(["u1", "u1"], { type: "community:member.update" } as any, "u1"))
+      .resolves.toBeUndefined()
+
+    expect(bindingFetch).not.toHaveBeenCalled()
     expect(mockFetch).not.toHaveBeenCalled()
-    expect(String(bindingFetch.mock.calls[0]?.[0])).toBe("http://internal/broadcast/users")
-    expect(bindingFetch.mock.calls[0]?.[1]).toEqual(expect.objectContaining({
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ userIds: ["u1", "u2", "u3"], message, excludeUserId: "u1" }),
-    }))
+    expect(mockCtxWaitUntil).toHaveBeenCalledTimes(1)
+    expect(mockInfo).toHaveBeenCalledWith(
+      "broadcast_users_complete",
+      expect.objectContaining({
+        inputCount: 2,
+        uniqueCount: 1,
+        excludedCount: 1,
+        targetCount: 0,
+        chunkCount: 0,
+        transportSuccessChunkCount: 0,
+        transportFailureChunkCount: 0,
+        sent: 0,
+        maxActive: 0,
+        durationMs: expect.any(Number),
+      }),
+    )
   })
 
-  it("omits excludeUserId from the body when it is absent", async () => {
-    const bindingFetch = vi.fn(async () =>
-      new Response(JSON.stringify({ sent: 1 }), { status: 200 }),
-    )
-    const env = makeEnv(bindingFetch)
-    mockGetCloudflareContext.mockReturnValue({
-      env,
-      ctx: { waitUntil: mockCtxWaitUntil },
+  it.each([
+    [1, [1]],
+    [1000, [1000]],
+    [1001, [1000, 1]],
+    [2001, [1000, 1000, 1]],
+  ])("chunks %i targets into valid ordered requests", async (targetCount, expectedSizes) => {
+    const bindingFetch = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { userIds: string[] }
+      return Response.json({ sent: body.userIds.length })
     })
-    const message = { type: "community:member.update" } as any
+    setBinding(bindingFetch)
+    const userIds = Array.from({ length: targetCount }, (_, index) => `u${index}`)
+    const message = { type: "community:member.update", serverId: "s1" } as any
 
-    await broadcastToUsers(["u1"], message)
+    await broadcastToUsers(userIds, message)
 
-    const body = JSON.parse(String(bindingFetch.mock.calls[0]?.[1]?.body))
-    expect(body).toEqual({ userIds: ["u1"], message })
-    expect(body).not.toHaveProperty("excludeUserId")
+    const bodies = bodiesOf(bindingFetch)
+    expect(bodies.map((body) => body.userIds.length)).toEqual(expectedSizes)
+    expect(bodies.flatMap((body) => body.userIds)).toEqual(userIds)
+    expect(bodies.every((body) => body.excludeUserId === undefined)).toBe(true)
+    expect(bindingFetch.mock.calls.every((call) => (
+      String(call[0]) === "http://internal/broadcast/users"
+      && call[1]?.method === "POST"
+      && JSON.stringify(call[1]?.headers) === JSON.stringify({ "Content-Type": "application/json" })
+    ))).toBe(true)
+    expect(mockInfo).toHaveBeenCalledWith(
+      "broadcast_users_complete",
+      expect.objectContaining({
+        target: `users:${targetCount}`,
+        targetCount,
+        chunkCount: expectedSizes.length,
+        transportSuccessChunkCount: expectedSizes.length,
+        transportFailureChunkCount: 0,
+        sent: targetCount,
+        maxActive: Math.min(expectedSizes.length, 3),
+        durationMs: expect.any(Number),
+      }),
+    )
+  })
+
+  it("dedupes in first-seen order before exclusion and never reintroduces excluded duplicates across chunks", async () => {
+    const bindingFetch = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { userIds: string[] }
+      return Response.json({ sent: body.userIds.length })
+    })
+    setBinding(bindingFetch)
+    const expected = Array.from({ length: 1001 }, (_, index) => `target-${index}`)
+    const userIds = [
+      expected[0],
+      "excluded-user",
+      expected[0],
+      ...expected.slice(1, 1000),
+      "excluded-user",
+      expected[500],
+      expected[1000],
+      "excluded-user",
+    ]
+    const message = { type: "community:channel.update" } as any
+
+    await broadcastToUsers(userIds, message, "excluded-user")
+
+    const bodies = bodiesOf(bindingFetch)
+    expect(bodies.map((body) => body.userIds.length)).toEqual([1000, 1])
+    expect(bodies.flatMap((body) => body.userIds)).toEqual(expected)
+    expect(bodies.every((body) => body.excludeUserId === "excluded-user")).toBe(true)
+    expect(bodies.flatMap((body) => body.userIds)).not.toContain("excluded-user")
+  })
+
+  it("starts at most three chunks and registers the whole aggregate lifetime", async () => {
+    const gates = Array.from({ length: 5 }, () => deferred<Response>())
+    let started = 0
+    let active = 0
+    let observedMaxActive = 0
+    const bindingFetch = vi.fn(async () => {
+      const index = started
+      started += 1
+      active += 1
+      observedMaxActive = Math.max(observedMaxActive, active)
+      const response = await gates[index].promise
+      active -= 1
+      return response
+    })
+    setBinding(bindingFetch)
+    const work = broadcastToUsers(
+      Array.from({ length: 4001 }, (_, index) => `u${index}`),
+      { type: "community:server.update" } as any,
+    )
+    const lifetime = mockCtxWaitUntil.mock.calls[0]?.[0] as Promise<void>
+    let lifetimeSettled = false
+    void lifetime.then(() => {
+      lifetimeSettled = true
+    })
+
+    expect(started).toBe(3)
+    expect(observedMaxActive).toBe(3)
+    expect(lifetimeSettled).toBe(false)
+
+    gates[1].resolve(Response.json({ sent: 1000 }))
+    await vi.waitFor(() => expect(started).toBe(4))
+    expect(observedMaxActive).toBe(3)
+    expect(lifetimeSettled).toBe(false)
+
+    gates[0].resolve(Response.json({ sent: 1000 }))
+    await vi.waitFor(() => expect(started).toBe(5))
+    expect(observedMaxActive).toBe(3)
+
+    gates[2].resolve(Response.json({ sent: 1000 }))
+    gates[3].resolve(Response.json({ sent: 1000 }))
+    gates[4].resolve(Response.json({ sent: 1 }))
+    await expect(work).resolves.toBeUndefined()
+    await expect(lifetime).resolves.toBeUndefined()
+    expect(lifetimeSettled).toBe(true)
+  })
+
+  it("isolates a failed chunk, continues later chunks, logs transport counts, then rejects", async () => {
+    let callIndex = 0
+    const bindingFetch = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      const index = callIndex
+      callIndex += 1
+      if (index === 1) return new Response("bad request", { status: 400 })
+      const body = JSON.parse(String(init?.body)) as { userIds: string[] }
+      return Response.json({ sent: body.userIds.length })
+    })
+    setBinding(bindingFetch)
+    const work = broadcastToUsers(
+      Array.from({ length: 4001 }, (_, index) => `u${index}`),
+      { type: "community:server.update" } as any,
+    )
+
+    await expect(work).rejects.toThrow("broadcast failed for 1 of 5 chunks")
+
+    expect(bindingFetch).toHaveBeenCalledTimes(5)
+    expect(bodiesOf(bindingFetch).map((body) => body.userIds.length)).toEqual([1000, 1000, 1000, 1000, 1])
+    expect(mockWarn).toHaveBeenCalledWith(
+      "broadcast_users_chunk_complete",
+      expect.objectContaining({
+        target: "users:4001",
+        chunkNumber: 2,
+        chunkCount: 5,
+        chunkSize: 1000,
+        transportStatus: "failure",
+        durationMs: expect.any(Number),
+      }),
+    )
+    expect(mockInfo).toHaveBeenCalledWith(
+      "broadcast_users_complete",
+      expect.objectContaining({
+        transportSuccessChunkCount: 4,
+        transportFailureChunkCount: 1,
+        sent: 3001,
+        maxActive: 3,
+      }),
+    )
+  })
+
+  it("logs only safe target and chunk metadata, not user ids or message secrets", async () => {
+    const bindingFetch = vi.fn(async () => Response.json({ sent: 1 }))
+    setBinding(bindingFetch)
+
+    await broadcastToUsers(
+      ["sensitive-user-id"],
+      { type: "community:server.update", token: "private-token-value" } as any,
+    )
+
+    const newLogCalls = [...mockInfo.mock.calls, ...mockWarn.mock.calls]
+      .filter(([message]) => String(message).startsWith("broadcast_users_"))
+    const serialized = JSON.stringify(newLogCalls)
+    expect(serialized).not.toContain("sensitive-user-id")
+    expect(serialized).not.toContain("private-token-value")
+    expect(serialized).not.toContain("userIds")
+    expect(newLogCalls).toEqual(expect.arrayContaining([
+      ["broadcast_users_chunk_complete", expect.objectContaining({
+        target: "users:1",
+        chunkNumber: 1,
+        chunkCount: 1,
+        chunkSize: 1,
+        transportStatus: "success",
+        sent: 1,
+        durationMs: expect.any(Number),
+      })],
+      ["broadcast_users_complete", expect.objectContaining({
+        target: "users:1",
+        transportSuccessChunkCount: 1,
+        transportFailureChunkCount: 0,
+      })],
+    ]))
   })
 
   it("falls back exactly once after one binding 5xx", async () => {
     const bindingFetch = vi.fn(async () => new Response("boom", { status: 502 }))
     mockFetch.mockResolvedValue(new Response(JSON.stringify({ sent: 2 }), { status: 200 }))
-    const env = makeEnv(bindingFetch)
-    mockGetCloudflareContext.mockReturnValue({
-      env,
-      ctx: { waitUntil: mockCtxWaitUntil },
-    })
+    setBinding(bindingFetch)
 
     await broadcastToUsers(["u1", "u2"], { type: "community:member.update" } as any)
 
@@ -309,11 +504,7 @@ describe("broadcastToUsers", () => {
       throw new Error("binding down")
     })
     mockFetch.mockResolvedValue(new Response(JSON.stringify({ sent: 2 }), { status: 200 }))
-    const env = makeEnv(bindingFetch)
-    mockGetCloudflareContext.mockReturnValue({
-      env,
-      ctx: { waitUntil: mockCtxWaitUntil },
-    })
+    setBinding(bindingFetch)
 
     await broadcastToUsers(["u1", "u2"], { type: "community:member.update" } as any)
 

--- a/src/web/src/lib/broadcast.ts
+++ b/src/web/src/lib/broadcast.ts
@@ -4,6 +4,8 @@ import { DEV_WS_DO_URL, createLogger } from "@alook/shared"
 import { fetchViaBindingOrDevFallback } from "./dev-binding-fetch"
 
 const log = createLogger({ service: "broadcast" })
+const bulkBroadcastMaxUserIds = 1000
+const bulkBroadcastMaxActive = 3
 
 /**
  * Fetch against the WS DO worker.
@@ -67,6 +69,135 @@ function sendBroadcast(url: string, body: string, opts: { label: string; type: s
   return promise.then(() => { })
 }
 
+type BroadcastChunkResult = { sent: number }
+
+async function settleBroadcastChunks(
+  chunks: readonly string[][],
+  run: (chunk: string[], index: number) => Promise<BroadcastChunkResult>,
+): Promise<{
+  results: PromiseSettledResult<BroadcastChunkResult>[]
+  maxActive: number
+}> {
+  const results = new Array<PromiseSettledResult<BroadcastChunkResult>>(chunks.length)
+  let nextIndex = 0
+  let active = 0
+  let maxActive = 0
+
+  const workers = Array.from(
+    { length: Math.min(bulkBroadcastMaxActive, chunks.length) },
+    async () => {
+      while (nextIndex < chunks.length) {
+        const index = nextIndex
+        nextIndex += 1
+        active += 1
+        maxActive = Math.max(maxActive, active)
+        try {
+          results[index] = { status: "fulfilled", value: await run(chunks[index], index) }
+        } catch (reason) {
+          results[index] = { status: "rejected", reason }
+        } finally {
+          active -= 1
+        }
+      }
+    },
+  )
+
+  await Promise.all(workers)
+  return { results, maxActive }
+}
+
+function safeLog(write: () => void): void {
+  try {
+    write()
+  } catch {}
+}
+
+async function runBroadcastToUsers(
+  userIds: string[],
+  message: WsMessage,
+  excludeUserId?: string,
+): Promise<void> {
+  const startedAt = Date.now()
+  const uniqueUserIds = [...new Set(userIds)]
+  const targetUserIds = excludeUserId === undefined
+    ? uniqueUserIds
+    : uniqueUserIds.filter((userId) => userId !== excludeUserId)
+  const chunks: string[][] = []
+
+  for (let start = 0; start < targetUserIds.length; start += bulkBroadcastMaxUserIds) {
+    chunks.push(targetUserIds.slice(start, start + bulkBroadcastMaxUserIds))
+  }
+
+  const target = `users:${targetUserIds.length}`
+  const { results, maxActive } = await settleBroadcastChunks(
+    chunks,
+    async (chunk, index) => {
+      const chunkStartedAt = Date.now()
+      const chunkNumber = index + 1
+      try {
+        const result = await doSend(
+          "/broadcast/users",
+          JSON.stringify({ userIds: chunk, message, ...(excludeUserId === undefined ? {} : { excludeUserId }) }),
+          { label: `${target}:chunk:${chunkNumber}/${chunks.length}`, type: message.type },
+        )
+        safeLog(() => log.info("broadcast_users_chunk_complete", {
+          target,
+          type: message.type,
+          chunkNumber,
+          chunkCount: chunks.length,
+          chunkSize: chunk.length,
+          transportStatus: "success",
+          sent: result.sent,
+          durationMs: Date.now() - chunkStartedAt,
+        }))
+        return result
+      } catch (reason) {
+        safeLog(() => log.warn("broadcast_users_chunk_complete", {
+          target,
+          type: message.type,
+          chunkNumber,
+          chunkCount: chunks.length,
+          chunkSize: chunk.length,
+          transportStatus: "failure",
+          durationMs: Date.now() - chunkStartedAt,
+        }))
+        throw reason
+      }
+    },
+  )
+
+  let transportSuccessChunkCount = 0
+  let transportFailureChunkCount = 0
+  let sent = 0
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      transportSuccessChunkCount += 1
+      sent += result.value.sent
+    } else {
+      transportFailureChunkCount += 1
+    }
+  }
+
+  safeLog(() => log.info("broadcast_users_complete", {
+    target,
+    type: message.type,
+    inputCount: userIds.length,
+    uniqueCount: uniqueUserIds.length,
+    excludedCount: uniqueUserIds.length - targetUserIds.length,
+    targetCount: targetUserIds.length,
+    chunkCount: chunks.length,
+    transportSuccessChunkCount,
+    transportFailureChunkCount,
+    sent,
+    maxActive,
+    durationMs: Date.now() - startedAt,
+  }))
+
+  if (transportFailureChunkCount > 0) {
+    throw new Error(`broadcast failed for ${transportFailureChunkCount} of ${chunks.length} chunks`)
+  }
+}
+
 export function broadcastToUser(userId: string, message: WsMessage): Promise<void> {
   return sendBroadcast(
     `/broadcast/user/${userId}`,
@@ -80,11 +211,12 @@ export function broadcastToUsers(
   message: WsMessage,
   excludeUserId?: string,
 ): Promise<void> {
-  return sendBroadcast(
-    "/broadcast/users",
-    JSON.stringify({ userIds, message, excludeUserId }),
-    { label: `users:${userIds.length}`, type: message.type },
-  )
+  const work = runBroadcastToUsers(userIds, message, excludeUserId)
+  try {
+    const { ctx } = getCloudflareContext()
+    ctx.waitUntil(work.catch(() => {}))
+  } catch {}
+  return work
 }
 
 


### PR DESCRIPTION
# Why we need this PR?
> Reliability fix; no linked issue.

Web broadcast producers sent an entire server audience in one `/broadcast/users` request while ws-do rejects payloads with more than 1,000 raw user IDs. The business mutation could succeed while every client silently missed the event for large servers.

## What changed
- Deduplicate recipients in first-seen order, exclude the requested user, and split the remaining audience into chunks of at most 1,000 before calling ws-do.
- Run at most three chunk transports concurrently and isolate failures so every chunk is attempted before the aggregate preserves the existing rejection signal.
- Record safe per-chunk and aggregate transport counts, sent totals, maximum concurrency, and duration without logging user lists, messages, tokens, or secrets.
- Add boundary and failure coverage for 0/1/1000/1001/2001 recipients, ordering, exclusion, tail chunks, bounded concurrency, aggregate lifetime, and partial failure.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...
