### PR TITLE
blog: refresh human-AI collaboration for small teams

### DIFF
--- a/src/web/src/content/ai-agent-orchestration.mdx
+++ b/src/web/src/content/ai-agent-orchestration.mdx
@@ -169,4 +169,4 @@ Not necessarily. Building your own orchestration means writing code. A platform 
 **When is orchestration overkill?**
 For a one-off task, or anything a single agent handles well on its own, orchestration adds complexity you don't need. It pays off when work is repetitive, multi-step, and runs on a schedule.
 
-Want to see orchestration applied to a whole business? Read how a [personal AI company](/blog/personal-ai-company) runs on coordinated agents.
+Want to see orchestration applied to a whole business? Read how a [personal AI company](/blog/personal-ai-company) runs on coordinated agents. For the people-and-agents framing, start with [human-AI collaboration for small teams](/blog/human-ai-collaboration-small-teams).

--- a/src/web/src/content/human-ai-collaboration-small-teams.mdx
+++ b/src/web/src/content/human-ai-collaboration-small-teams.mdx
@@ -1,64 +1,120 @@
 export const metadata = {
   slug: "human-ai-collaboration-small-teams",
-  title: "Human-AI Collaboration for Small Teams: From Single Agent to AI Workforce",
+  title: "Human-AI Collaboration for Small Teams: Humans and AI Working Together",
   date: "2026-06-30",
+  dateModified: "2026-08-11",
   author: "Donia",
   excerpt:
-    "Human-AI collaboration for small teams evolves from command-and-response tools to coordinated agents, shared context, parallel work, and human approval.",
-  readingTime: "7 min read",
+    "Human-AI collaboration for small teams means humans and AI working together across roles, shared channels, and approval nodes, not one chat at a time.",
+  readingTime: "8 min read",
+  image: "/blog/human-ai-collaboration-small-teams/hero.webp",
 };
+
+export const jsonLd = [
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "What is human-AI collaboration?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Human-AI collaboration is humans and AI working together in the same workflow: people set direction and approve high-impact moves, while agents execute parallel work under clear roles and boundaries.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "What does it look like when humans and AI work together?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "In practice, a founder or small team runs several specialized agents at once. Agents share status in a common workspace or channel, and the human reviews decisions twice a day instead of typing every prompt in sequence.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "How do humans and AI agents work together on a small team?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Give each agent a role, keep work visible in shared channels or boards, define what needs human sign-off, and let agents hand off context without you copying every message between sessions.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Is human-AI collaboration the same as using ChatGPT?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "No. Chatting with one model is co-creation with a single partner. Human-AI collaboration at team scale means multiple agents, parallel work, shared visibility, and human approval nodes.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "What's the difference between human-AI collaboration and AI automation?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Automation tries to remove the person from the loop. Collaboration keeps humans on judgment, relationships, and irreversible decisions while agents carry volume and repeatable execution.",
+        },
+      },
+    ],
+  },
+];
 
 ![Human-AI Collaboration for Small Teams - Evolution from single AI agent to coordinated AI workforce with humans and agents working together](/blog/human-ai-collaboration-small-teams/hero.webp)
 
 "Human-AI collaboration" used to mean asking ChatGPT a question and getting an answer back. In 2026, that definition feels almost quaint. Like calling a phone call "human-telephone collaboration."
 
-If you're a solo founder or running a small team, the collaboration landscape looks different now. You're not working with one AI anymore. You're probably managing several. And the skills that matter have changed with it. Less prompt engineering, more team design.
+Human-AI collaboration, in practice, is humans and AI working together in the same workflow: people set direction and approve what matters, while agents run specialized work in parallel. For a solo founder, human and AI working together often means one person directing several agents instead of living in a single chat. If you're running a small team, you're rarely dealing with one assistant anymore. You're managing several. The skill that matters shifts from prompt engineering toward team design.
 
-Here's where we've been, where most teams actually are, and where the leverage is for small teams right now.
+Here's where we've been, where most teams actually are, and where the leverage is right now.
 
-## Four generations of working with AI
+## From lookup tools to mixed human-agent rooms
 
-The way humans work with AI has gone through distinct phases. Most people are stuck in generation two without realizing generation three already exists.
+The way people work with AI has changed in stages. Most teams still live in one chat window, even though coordinated agent teams and shared rooms already exist.
 
-**Generation 1: Command and response.**
-You type a query. The AI returns an answer. No memory between sessions, no context carried forward. Google Search, Siri, early Alexa. The AI is a lookup tool. This is where it started.
+**Lookup.** You type a query. The AI returns an answer. No memory between sessions, no context carried forward. Google Search, Siri, early Alexa. The AI is a search box with better language.
 
-**Generation 2: Co-creation.**
-You and one AI work together on a task. It remembers what you said five minutes ago. You iterate on a document, debug code together, brainstorm ideas back and forth. ChatGPT, Claude, GitHub Copilot live here. Most knowledge workers in 2026 operate at this level.
+**One chat partner.** You and one AI work together on a task. It remembers what you said five minutes ago. You iterate on a document, debug code together, brainstorm ideas back and forth. ChatGPT, Claude, GitHub Copilot live here. Most knowledge workers in 2026 operate at this level.
 
 The ceiling: you're still the only operator. One task at a time. While you're co-creating a blog post with Claude, your customer emails pile up. While you're debugging with Copilot, nobody's working on tomorrow's feature. You do everything sequentially because you only have one AI partner and one attention span.
 
-**Generation 3: Orchestration.**
-One person, multiple specialized agents running in parallel. You set direction, agents execute. A content agent writes while a research agent gathers data while a support agent handles tickets. They share context with each other. You review output twice a day instead of managing every keystroke.
+**A coordinated agent team.** One person, multiple specialized agents running in parallel. You set direction, agents execute. A content agent writes while a research agent gathers data while a support agent handles tickets. They stay aligned through shared status and handoffs. You review output twice a day instead of managing every keystroke.
 
 Your role shifts from operator to manager. The bottleneck moves from "how fast can I type prompts" to "how well have I designed my team."
 
-This is where tools like [Alook](https://alook.ai) sit today. Not replacing Claude Code or any single agent, but giving multiple agents a place to coordinate as a team.
+This is where coordination layers like [Alook](https://alook.ai) sit today. Alook does not replace Claude Code or any single agent. It gives multiple agents a place to coordinate as a team. For the mechanics of that layer, see [AI orchestration](/blog/ai-agent-orchestration).
 
-**Generation 4: Mixed teams.**
-Multiple humans and multiple agents in the same workspace. Your engineering team of three people works alongside four AI agents. The PM briefs an agent directly. The designer reviews agent output in a shared channel. The developer pairs with an AI dev agent while another AI runs tests.
+**Mixed human-agent rooms.** Multiple humans and multiple agents in the same workspace. Your engineering team of three people works alongside four AI agents. The PM briefs an agent directly. The designer reviews agent output in a shared channel. The developer pairs with an AI dev agent while another AI runs tests.
 
 Human and agent become roles, not categories. The question shifts from "who is AI and who isn't" to "who owns this outcome."
 
-This is where the industry is heading. Early platforms are exploring it now. For [Alook](https://alook.ai), it's the next step on the roadmap.
+![How human-AI collaboration evolves from one chat partner to a coordinated agent team and a mixed human-agent room](/blog/human-ai-collaboration-small-teams/evolution.webp)
 
-![The Evolution of Human-AI Collaboration - Four generations from Command to Co-create to Orchestrate to Mixed Team](/blog/human-ai-collaboration-small-teams/evolution.webp)
+## What human-AI collaboration means for small teams
 
-## Why most teams are still stuck at Generation 2
+Skip the abstract partnership language. For a small team, human-AI collaboration shows up as a few concrete habits:
 
-If you're using Claude or ChatGPT for work, you feel productive. And you are. Generation 2 is a real improvement over search-and-copy.
+- Agents have named roles instead of one catch-all chat
+- Work stays visible in a shared place people and agents can both read
+- High-impact actions wait for a human, while repeatable work keeps moving
+- You check the board or channel on a schedule, not after every keystroke
+
+That is what humans and AI working together looks like when the day has more than one job. A single model session can still help you write a paragraph. It will not finish research, support triage, and a docs refresh while you take a customer call.
+
+## Why one chat still traps small teams
+
+If you're using Claude or ChatGPT for work, you feel productive. And you are. One strong chat partner beats search-and-copy.
 
 But notice the pattern. You open one AI session. Work on one task. Finish (or get interrupted). Open the same AI for a different task. Repeat all day.
 
 This is like having one employee who's good at everything but does tasks one after another. Works for a freelancer. Doesn't scale when you have ten things that need to happen today and half of them don't depend on each other.
 
-The analogy that makes this click: sending an email to a freelancer is not the same as having a team. A team works in parallel. A team has shared context. A team coordinates without you routing every piece of information between people.
+The analogy that makes this click: sending an email to a freelancer is not the same as having a team. Parallel work, shared context, and coordination that does not route through you are what separate the two.
 
-## What Generation 3 collaboration requires
+## What a multi-agent team needs before it works
 
-Moving from one AI partner to an AI workforce takes four things. Miss any one of them and you end up with chaos instead of coordination.
+Moving from one AI partner to several specialized agents takes more than opening extra tabs. Miss any of these and you get chaos instead of coordination.
 
-![Four requirements for Generation 3 AI collaboration - Defined Roles, Shared Context, Human Decisions, and Visibility](/blog/human-ai-collaboration-small-teams/gen3-requirements.webp)
+![Four requirements for multi-agent collaboration: defined roles, shared context, human decisions, and visibility](/blog/human-ai-collaboration-small-teams/gen3-requirements.webp)
 
 **Defined roles.** Each agent owns a domain. Your content agent doesn't touch code. Your dev agent doesn't write marketing copy. Specialization creates depth. It also prevents the "one agent trying to do everything, mediocre at all of it" problem.
 
@@ -66,48 +122,76 @@ Moving from one AI partner to an AI workforce takes four things. Miss any one of
 
 [Jen Stave, Ryan Kurt, and John Winsor (HBR, June 25, 2026)](https://hbr.org/2026/06/teach-your-ai-how-you-make-decisions) argue that companies need to translate tacit decision principles into structured guidance for agents. When multiple agents operate on the same project, those shared principles keep them aligned.
 
-**Human decision nodes.** Not everything should run on autopilot. Customer-facing messages, pricing changes, architectural decisions, anything with legal or reputational weight needs human sign-off. The agents propose and execute within boundaries. You approve what matters.
+**Human decision nodes.** Not everything should run on autopilot. Customer-facing messages, pricing changes, architectural decisions, anything with legal or reputational weight needs human sign-off. The agents propose and execute within boundaries. You approve what matters. For a practical method, see [how to delegate tasks to AI agents](/blog/how-to-delegate-tasks-to-ai-agents).
 
 There's good reason for this. [Ben Rand (HBR, June 24, 2026)](https://hbr.org/2026/06/employees-arent-questioning-ai-advice-enough) describes research by Alex Chan showing that people often don't question AI recommendations enough. With multiple agents running in parallel, approval nodes are your safeguard against compounding errors.
 
 **Visibility.** You need to see what all agents are doing without micromanaging each one. A dashboard, a feed, an activity log. If you can't see the state of your AI workforce at a glance, you'll either over-control it (defeating the purpose) or under-control it (missing problems until they compound).
 
-## The next frontier: mixed human-AI teams
+## Humans and AI working together in one workspace
 
-Generation 3 solves a specific problem well: one person scaling their output through multiple agents. Solo founders, indie hackers, small agency owners. (If you're building a [one-person company with an AI team](/blog/personal-ai-company), this is where you start.)
+A coordinated agent team solves a specific problem well: one person scaling their output through multiple agents. Solo founders, indie hackers, small agency owners. (If you're building a [one-person company with an AI team](/blog/personal-ai-company), this is where you start.)
 
-But real companies have multiple people. And the next question is natural: what happens when your human team and your AI team occupy the same workspace?
+Real companies also have multiple people. The next question is natural: what happens when your human team and your AI team occupy the same workspace?
 
 Picture a startup with four humans and six AI agents. The product manager assigns tasks to both human engineers and AI dev agents in the same project board. The designer reviews output from AI content agents and human copywriters in the same queue. Stand-ups include status updates from agents alongside human check-ins.
 
-The coordination gets interesting here. Not just agent-to-agent communication, but human-to-agent, agent-to-human, and the whole mesh in between.
+The coordination gets interesting here. Not just agent-to-agent communication, but human-to-agent, agent-to-human, and the whole mesh in between. The protocol for multi-human, multi-agent rooms is in [humans and AI agents in one room](/blog/humans-and-ai-agents-in-one-room). Usability details for that shared surface are covered in [what makes a shared AI workspace usable](/blog/what-makes-a-shared-ai-workspace-usable).
 
-This is early. But for small teams especially, the multiplier matters. A five-person startup with ten AI agents operates with the capacity of a much larger company. The humans handle judgment, relationships, and creative direction. The agents handle volume, consistency, and parallel execution.
+For small teams especially, the multiplier matters. A five-person startup with ten AI agents operates with the capacity of a much larger company. The humans handle judgment, relationships, and creative direction. The agents handle volume, consistency, and parallel execution.
 
-## Moving your workflow from Gen 2 to Gen 3
+## Move off one chat and into parallel agent work
 
 If you're a solo founder or small team still working with one AI at a time, here's the practical shift:
 
 **Step 1:** List the tasks you repeat-dispatch every day. The things where you open Claude, explain context, wait for output, then move to the next thing.
 
-**Step 2:** Group them into two or three roles. Content work. Operations work. Research work. Customer work. Whatever matches your business.
+**Step 2:** Group them into two or four roles. Content work. Operations work. Research work. Customer work. Whatever matches your business.
 
-**Step 3:** Set up dedicated agents for each role. Give them persistent memory so you don't re-explain context daily. Give them access to each other's output so they stay aligned.
+**Step 3:** Set up dedicated agents for each role. Give them persistent context so you don't re-explain the company daily. Give them a place to read each other's status so they stay aligned.
 
 **Step 4:** Define your approval nodes. What can agents ship without asking? What needs your sign-off? Get this wrong in either direction and you'll either bottleneck yourself or let mistakes through.
 
 **Step 5:** Check in twice a day instead of managing every prompt. Review decisions, redirect if needed, and spend the rest of your time on work that only you can do.
 
-We built [Alook](https://alook.ai) to make this transition straightforward. Your agents get roles, shared memory, and communication channels. You get the CEO seat instead of the dispatcher seat.
+## Put people and agents in one Discord-like room
 
-## Where this is going
+The industry shape for mixed human-agent work is getting familiar. Products such as [Buzz](https://buzz.xyz) put humans and agents in Discord-like servers and channels: one place to talk, assign work, and see who (or which agent) replied.
 
-Human-AI collaboration is no longer about one person chatting with one AI. That era lasted about two years. For small teams, the real leverage now comes from coordinating multiple agents into something that resembles a workforce.
+[Alook](https://alook.ai) is deploying that same kind of collaboration surface. Your team opens a shared room. People and local coding agents show up as participants. Mentions, threads, and channel history replace the tab-hopping between private chats. Roles, email inboxes, boards, and calendars still sit underneath so work does not evaporate when a thread moves on.
 
-Today: you manage an AI team. Soon: your human team and AI team work together in the same space. The companies that figure this out early will operate at a scale that their headcount shouldn't allow.
+That mix is what small teams need for human and AI working together without giving up local runtimes. You can self-host from [GitHub](https://github.com/alookai/alook), or register at [alook.ai](https://alook.ai) and connect the agents on your machine.
 
-The tools exist. The question is whether you're still typing one prompt at a time, or building a team that works while you think.
+For small teams, the leverage comes from coordinating multiple agents, then inviting more humans into the same room when the company grows. One person chatting with one AI was the starting point. Shared channels are the next operating surface.
 
----
+The tools exist. The open question is whether you're still typing one prompt at a time, or sitting in a channel where your people and your agents can see the same work.
 
-*[Alook](https://alook.ai) helps small teams build and manage an AI workforce. Shared context, parallel agents, human oversight. Move from chatting with AI to managing an AI team.*
+## FAQ
+
+### What is human-AI collaboration?
+
+Human-AI collaboration is humans and AI working together in the same workflow. People set direction and approve high-impact moves. Agents execute parallel work under clear roles and boundaries.
+
+### What does it look like when humans and AI work together?
+
+A founder or small team runs several specialized agents at once. Status lives in a shared workspace or channel. The human reviews decisions on a schedule instead of typing every prompt in sequence.
+
+### How do humans and AI agents work together on a small team?
+
+Give each agent a role, keep work visible, define approval nodes, and let agents hand off context without you copying every message between sessions.
+
+### Is human-AI collaboration the same as using ChatGPT?
+
+No. Chatting with one model is co-creation with a single partner. Team-scale collaboration means multiple agents, parallel work, shared visibility, and human approval.
+
+### What's the difference between human-AI collaboration and AI automation?
+
+Automation tries to remove the person from the loop. Collaboration keeps humans on judgment and irreversible decisions while agents carry volume and repeatable execution.
+
+## Related
+
+- [AI Orchestration: How Multiple Agents Work Together](/blog/ai-agent-orchestration)
+- [How to Delegate Tasks to AI Agents](/blog/how-to-delegate-tasks-to-ai-agents)
+- [Humans and AI Agents in One Room](/blog/humans-and-ai-agents-in-one-room)
+- [What Makes a Shared AI Workspace Usable](/blog/what-makes-a-shared-ai-workspace-usable)
+- [Personal AI Company](/blog/personal-ai-company)

--- a/src/web/src/content/human-ai-collaboration-small-teams.mdx
+++ b/src/web/src/content/human-ai-collaboration-small-teams.mdx
@@ -1,6 +1,6 @@
 export const metadata = {
   slug: "human-ai-collaboration-small-teams",
-  title: "Human-AI Collaboration for Small Teams: Humans and AI Working Together",
+  title: "Human-AI Collaboration for Small Teams",
   date: "2026-06-30",
   dateModified: "2026-08-11",
   author: "Donia",

--- a/src/web/src/content/humans-and-ai-agents-in-one-room.mdx
+++ b/src/web/src/content/humans-and-ai-agents-in-one-room.mdx
@@ -164,5 +164,5 @@ Coding runtimes continue to run on their owners’ machines, and machine presenc
 
 - [What Makes a Shared AI Workspace Actually Usable](/blog/what-makes-a-shared-ai-workspace-usable)
 - [How to Run an AI Agent Team That Stays on Track](/blog/run-ai-agent-team-that-stays-on-track)
-- [Human-AI Collaboration for Small Teams: Humans and AI Working Together](/blog/human-ai-collaboration-small-teams)
+- [Human-AI Collaboration for Small Teams](/blog/human-ai-collaboration-small-teams)
 - [How to Build an AI Agent Team](/blog/ai-agent-team)

--- a/src/web/src/content/humans-and-ai-agents-in-one-room.mdx
+++ b/src/web/src/content/humans-and-ai-agents-in-one-room.mdx
@@ -2,6 +2,7 @@ export const metadata = {
   slug: "humans-and-ai-agents-in-one-room",
   title: "Humans and AI Agents in One Room",
   date: "2026-08-10",
+  dateModified: "2026-08-11",
   author: "Alook Team",
   excerpt:
     "See how several people can bring multiple AI agents into one room while keeping identity, authority, attention, and memory boundaries clear.",
@@ -66,7 +67,7 @@ Picture Amara, Chen, and Kai entering a project channel with seven agents betwee
 
 ## The collaboration unit is no longer one person
 
-Private AI use keeps a simple shape. One person opens an agent session, gives instructions, and carries the useful result back to the team.
+Private AI use keeps a simple shape. One person opens an agent session, gives instructions, and carries the useful result back to the team. That path still matters for [human-AI collaboration on small teams](/blog/human-ai-collaboration-small-teams), where one person often starts by coordinating several agents alone.
 
 A shared room changes the route. Chen can ask Amara’s research agent a follow-up directly. Kai’s review agent can challenge an output from Amara’s builder. Two agents owned by different people may continue a thread while both humans are away.
 
@@ -157,11 +158,11 @@ The workspace should show that the agent or its machine is unavailable. Mentions
 
 [Alook](https://alook.ai) provides a Discord-like `/c` surface with servers, categories, channels, forums, threads, DMs, and real-time messaging. Agents appear under distinct identities and remain associated with their owners. Channel membership controls where they participate; notification levels can wake them for all messages, mentions, or nothing.
 
-Coding runtimes continue to run on their owners’ machines, and machine presence shows whether they are online. When a machine reconnects, it can ask for unread catch-up so pending work is not silently dropped. Use the open-source, self-hosted path or register online and connect local runtimes. For roles and handoffs inside one person’s agent team, see [How to Build an AI Agent Team](/blog/ai-agent-team).
+Coding runtimes continue to run on their owners’ machines, and machine presence shows whether they are online. When a machine reconnects, it can ask for unread catch-up so pending work is not silently dropped. Use the open-source, self-hosted path or register online and connect local runtimes. For roles and handoffs inside one person’s agent team, see [How to Build an AI Agent Team](/blog/ai-agent-team). For the broader shift from one chat to humans and AI working together, see [Human-AI Collaboration for Small Teams](/blog/human-ai-collaboration-small-teams).
 
 ## Related
 
 - [What Makes a Shared AI Workspace Actually Usable](/blog/what-makes-a-shared-ai-workspace-usable)
 - [How to Run an AI Agent Team That Stays on Track](/blog/run-ai-agent-team-that-stays-on-track)
-- [Human-AI Collaboration for Small Teams: From Single Agent to AI Workforce](/blog/human-ai-collaboration-small-teams)
+- [Human-AI Collaboration for Small Teams: Humans and AI Working Together](/blog/human-ai-collaboration-small-teams)
 - [How to Build an AI Agent Team](/blog/ai-agent-team)

--- a/src/web/src/content/what-makes-a-shared-ai-workspace-usable.mdx
+++ b/src/web/src/content/what-makes-a-shared-ai-workspace-usable.mdx
@@ -199,4 +199,4 @@ Yes. A coordination layer can keep roles, tasks, messages, and decisions visible
 
 - [How to Keep Context Across Multiple Coding Agent Sessions](/blog/keep-context-across-coding-agent-sessions)
 - [When AI Agents Don't Share Context or Memory](/blog/shared-context-between-agents)
-- [Human-AI Collaboration for Small Teams: From Single Agent to AI Workforce](/blog/human-ai-collaboration-small-teams)
+- [Human-AI Collaboration for Small Teams: Humans and AI Working Together](/blog/human-ai-collaboration-small-teams)

--- a/src/web/src/content/what-makes-a-shared-ai-workspace-usable.mdx
+++ b/src/web/src/content/what-makes-a-shared-ai-workspace-usable.mdx
@@ -199,4 +199,4 @@ Yes. A coordination layer can keep roles, tasks, messages, and decisions visible
 
 - [How to Keep Context Across Multiple Coding Agent Sessions](/blog/keep-context-across-coding-agent-sessions)
 - [When AI Agents Don't Share Context or Memory](/blog/shared-context-between-agents)
-- [Human-AI Collaboration for Small Teams: Humans and AI Working Together](/blog/human-ai-collaboration-small-teams)
+- [Human-AI Collaboration for Small Teams](/blog/human-ai-collaboration-small-teams)


### PR DESCRIPTION
## Summary
- Refresh `human-ai-collaboration-small-teams` for `human-AI collaboration` / `humans and AI working together` (FAQ + jsonLd, clearer H2s, no Generation framing).
- Close on Alook’s Discord-like room surface, with Buzz as the only morph peer; Soft CTA for self-host + alook.ai + local runtime.
- Cross-link with `humans-and-ai-agents-in-one-room`, plus light inbound links from orchestration and shared-workspace posts.

## Test plan
- [x] `pnpm --filter @alook/web validate:blog`
- [x] `pnpm typecheck`
- [ ] Spot-check `/blog/human-ai-collaboration-small-teams` and `/blog/humans-and-ai-agents-in-one-room` after deploy (title, FAQ, Related links)
- [ ] Confirm no Raft mentions; Buzz link only in collaboration close


Made with [Cursor](https://cursor.com)