### PR TITLE
blog: refresh personal AI company, agent team, and ops guides

### DIFF
--- a/src/web/src/content/ai-agent-team.mdx
+++ b/src/web/src/content/ai-agent-team.mdx
@@ -2,11 +2,11 @@ export const metadata = {
   slug: "ai-agent-team",
   title: "How to Build an AI Agent Team: Roles, Handoffs, and Oversight",
   date: "2026-06-08",
-  dateModified: "2026-07-23",
+  dateModified: "2026-08-12",
   author: "Alook Team",
   excerpt:
-    "Build an AI agent team around one reliable workflow with defined roles, structured handoffs, recorded decisions, failure paths, and human approval.",
-  readingTime: "7 min read",
+    "Build an AI agent team with roles, agent email, structured handoffs, and human approval around one reliable workflow.",
+  readingTime: "8 min read",
   image: "/blog/ai-agent-team/hero.webp",
 };
 
@@ -29,6 +29,30 @@ export const jsonLd = [
         acceptedAnswer: {
           "@type": "Answer",
           text: "Use multiple agents when a workflow has distinct stages that need different instructions, tools, context, or review. Keep one agent when the task is short, self-contained, and does not benefit from a handoff.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "What is agent email?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Agent email is a durable inbox for an AI agent, separate from a chat session. It lets people and other agents send instructions, handoffs, and replies that stay attached to the work after a session closes.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Why do AI agents need their own email address?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "A dedicated address makes the agent addressable, keeps human-to-agent and agent-to-agent work in one thread, and preserves decisions after a chat window closes. Without it, the founder becomes the copy-paste layer between sessions.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Are AI agent departments the same as AI agent roles?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Not exactly. Departments are grouping labels such as research, engineering, or ops. Roles are the actual jobs inside those groups. Start with roles and handoffs. Add department labels only when several agents share a reporting line.",
         },
       },
       {
@@ -61,13 +85,11 @@ export const jsonLd = [
 
 ![AI agent team workflow: Owner, Orchestrator, Specialists, handoff artifact, Reviewer, and human approval](/blog/ai-agent-team/hero.webp)
 
-*Clear roles, structured handoffs, and human oversight — a conceptual workflow, not a product screenshot.*
+*Clear roles, structured handoffs, and human oversight. A conceptual workflow, not a product screenshot.*
 
-An AI agent team is a group of agents with defined roles working on one shared workflow. One agent might investigate an issue. Another prepares a change. A review step checks the result before anything moves forward.
+An AI agent team is a group of agents with defined roles on one shared workflow. Each role owns a stage, passes a structured result to the next step, and stays inside access and approval boundaries set by a person.
 
-Clear ownership and reliable handoffs matter more than stacking agents.
-
-You still set the goal, control access, and approve the decisions that can hurt customers or production. The agents handle scoped work inside those boundaries. If those boundaries stay fuzzy, more agents only multiply the mess.
+One agent might investigate an issue. Another prepares a change. A review step checks the result before anything moves forward. Clear ownership and reliable handoffs matter more than stacking agents. If those boundaries stay fuzzy, more agents only multiply the mess.
 
 ## What is an AI agent team?
 
@@ -83,6 +105,39 @@ Take a bug that needs a draft pull request. One useful shape looks like this:
 These are workflow roles, not job titles. The same agent can own more than one role when the work is simple. Separate agents help when stages need different permissions, instructions, or review standards.
 
 Want a harder test? Ask whether two stages would still make sense if each one used a different tool set.
+
+## AI agent departments vs roles
+
+Search language sometimes calls this an **agent company** with departments: research, engineering, growth, ops. That map can help later. It is a poor first design.
+
+A department is a grouping label. A role is a job with inputs, outputs, and limits. "Engineering" is too broad to evaluate. "Prepare a draft PR from this reproducible bug report" is not.
+
+If you want a small org chart, keep it tiny:
+
+- one owner or CEO-facing lead that receives briefs
+- one specialist that does the work
+- one reviewer or ops role that checks the result
+
+Add another department only when several agents already share a reporting line and a recurring handoff. Until then, inventing a C-suite does not make the company more real. It just multiplies places for work to disappear.
+
+For the one-person / 0-person company shape around this team, see [how to build a one-person company with AI agents](/blog/personal-ai-company).
+
+## What is agent email?
+
+Agent email is a durable inbox for an AI agent, separate from a chat session.
+
+A chat window is useful for one turn. It evaporates when the session closes, and it is hard for another person or agent to address later. A dedicated inbox gives the agent an address, a thread, and a record. People can send work. Other agents can hand off findings. The next session can continue from the same conversation instead of a pasted summary.
+
+That is why agent email matters in an agent company. It is not a novelty inbox. It is how instructions, decisions, and replies stay attached to the work after the runtime sleeps. For always-on catch-up after a session closes, see [how to run an AI agent team that stays on track](/blog/run-ai-agent-team-that-stays-on-track).
+
+Use it for:
+
+- human-to-agent briefs
+- agent-to-agent handoffs
+- approval requests that need a visible pause
+- recap threads that should survive more than one day
+
+Do not use it as a dump for every internal thought. The inbox should carry work, not chatter.
 
 ## AI agent team vs single agent
 
@@ -118,18 +173,18 @@ One agent may cover several of those jobs at first. Split them when different to
 
 A handoff needs more than a message that says “continue.” The next agent needs a contract.
 
-- **Scope** — what the current agent owns, and what it must leave alone
-- **Input** — source material, earlier decisions, and constraints the agent should use
-- **Output** — the artifact the next step expects: research brief, issue analysis, patch, test report, or approval request
-- **Completion criteria** — how the team knows the stage is finished; if a check can be written down, write it down
-- **Failure path** — what happens when information is missing, a tool fails, or review rejects the result (silent retries are not always right)
-- **Approval boundary** — which actions may proceed automatically, and which must wait for a person
+- **Scope:** what the current agent owns, and what it must leave alone
+- **Input:** source material, earlier decisions, and constraints the agent should use
+- **Output:** the artifact the next step expects: research brief, issue analysis, patch, test report, or approval request
+- **Completion criteria:** how the team knows the stage is finished; if a check can be written down, write it down
+- **Failure path:** what happens when information is missing, a tool fails, or review rejects the result (silent retries are not always right)
+- **Approval boundary:** which actions may proceed automatically, and which must wait for a person
 
 Recorded decisions help the next role, but only when that role knows how to apply them. Contracts still come first.
 
 ![Handoff contract: Scope, Input, Output, Completion criteria, Failure path, Approval boundary](/blog/ai-agent-team/handoff-contract.webp)
 
-*A handoff needs a contract — not a message that only says “continue.”*
+*A handoff needs a contract, not a message that only says “continue.”*
 
 For a deeper explanation of this coordination layer, read the guide to [AI orchestration](/blog/ai-agent-orchestration).
 
@@ -228,13 +283,19 @@ That list is incomplete on purpose.
 
 **What is an AI agent team?** It is a group of agents with defined roles that work on one shared workflow. Each role owns a stage and passes a structured result to the next step.
 
-**When should you use multiple AI agents instead of one?** Use multiple agents when stages need different instructions, tools, permissions, context, or review. Keep one agent when the task is short and self-contained — especially when a handoff would only add delay.
+**When should you use multiple AI agents instead of one?** Use multiple agents when stages need different instructions, tools, permissions, context, or review. Keep one agent when the task is short and self-contained, especially when a handoff would only add delay.
 
-**How many agents should a team have?** Start with the fewest roles needed for one reliable workflow, then add an agent only when a real handoff requires it.
+**What is agent email?** It is a durable inbox for an AI agent, separate from a chat session. People and other agents can send instructions, handoffs, and replies that stay attached to the work after a session closes.
+
+**Why do AI agents need their own email address?** A dedicated address makes the agent addressable and keeps decisions in a thread instead of a disappearing chat. Without it, the founder becomes the copy-paste layer between sessions.
+
+**Are AI agent departments the same as AI agent roles?** Not exactly. Departments are grouping labels such as research, engineering, or ops. Roles are the actual jobs. Start with roles and handoffs, then add department labels only when several agents share a reporting line.
+
+**How many agents should an AI team have?** Start with the fewest roles needed for one reliable workflow, then add an agent only when a real handoff requires it.
 
 **Which AI agents does Alook support?** Claude Code, Codex, and OpenCode are available today. Cursor, Hermes, and OpenClaw are listed as coming soon.
 
-**Does an AI agent team need human oversight?** Yes. People should approve customer commitments, financial actions, legal decisions, pricing changes, and high-risk production work. Design those gates before the agents start acting.
+**Does an AI agent team still need human oversight?** Yes. People should approve customer commitments, financial actions, legal decisions, pricing changes, and high-risk production work. Design those gates before the agents start acting.
 
 ## Start with one handoff
 
@@ -243,3 +304,10 @@ Name the artifact first.
 Choose a workflow you already understand. Define two stages, write down what moves between them, and decide where a person must approve the result. If you cannot name that artifact yet, stay on a single agent.
 
 To set up Alook for your local coding agents, run `npx @alook/app onboard`. You can also review the project on [GitHub](https://github.com/alookai/alook) or browse the current [Alook templates](https://alook.ai/templates).
+
+## Related
+
+- [How to Build a One-Person Company With AI Agents](/blog/personal-ai-company)
+- [How to Run an AI Agent Team That Stays on Track](/blog/run-ai-agent-team-that-stays-on-track)
+- [AI Orchestration: How Multiple Agents Work Together](/blog/ai-agent-orchestration)
+- [How to Delegate Tasks to AI Agents](/blog/how-to-delegate-tasks-to-ai-agents)

--- a/src/web/src/content/personal-ai-company.mdx
+++ b/src/web/src/content/personal-ai-company.mdx
@@ -2,11 +2,11 @@ export const metadata = {
   slug: "personal-ai-company",
   title: "How to Build a One-Person Company With AI Agents",
   date: "2026-06-10",
-  dateModified: "2026-07-23",
+  dateModified: "2026-08-12",
   author: "Alook Team",
   excerpt:
-    "Build a one-person company with AI agents through repeatable workflows, defined handoffs, limited access, and human approval for high-impact work.",
-  readingTime: "7 min read",
+    "A personal AI company, or 0-person company, runs with AI agents, scoped workflows, and founder approval instead of a full headcount.",
+  readingTime: "8 min read",
   image: "/blog/personal-ai-company/hero.webp",
 };
 
@@ -20,7 +20,23 @@ export const jsonLd = [
         name: "What is a personal AI company?",
         acceptedAnswer: {
           "@type": "Answer",
-          text: "A personal AI company is a one-person company where the founder uses AI agents for defined workflows while keeping responsibility for goals, approvals, and important decisions.",
+          text: "A personal AI company is a one-person company, sometimes called a 0-person company or agent company, where the founder uses AI agents for defined workflows while keeping responsibility for goals, approvals, and important decisions.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "What is a 0-person company?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "A 0-person company is a one-person business that uses AI agents for scoped work instead of hiring a traditional team. The founder still sets direction and approves high-impact actions. Agents do not replace accountability.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "What is an agent company?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "An agent company is a business operated through AI agents with roles, handoffs, and review boundaries. In Alook's framing, it is still a one-person or small-team company: local agents run the work, and the founder stays responsible for outcomes.",
         },
       },
       {
@@ -59,9 +75,9 @@ export const jsonLd = [
   },
 ];
 
-A one-person company does not need an AI version of every department. It needs a few reliable workflows that keep moving when you are heads-down elsewhere.
+A personal AI company is a one-person business, also called a 0-person company or agent company, where AI agents run scoped workflows while the founder keeps goals, access, and high-impact approvals. You do not need an AI version of every department. A few reliable workflows that keep moving when you are heads-down elsewhere are enough.
 
-That is the practical idea behind a personal AI company — what many founders also call a one-person business. You stay responsible for the company. Agents take ownership of defined work, use only the tools you allow, and return results for review. When more than one agent is involved, an orchestration layer keeps roles, tasks, schedules, and communication connected.
+Agents take ownership of defined work, use only the tools you allow, and return results for review. When more than one agent is involved, an orchestration layer keeps roles, tasks, schedules, and communication connected.
 
 ![Founder at the center of a personal AI company with scoped agent roles and an approval gate](/blog/personal-ai-company/hero.webp)
 
@@ -69,14 +85,16 @@ That is the practical idea behind a personal AI company — what many founders a
 
 ## What is a personal AI company?
 
-Bingran You’s [2026 working definition](https://bingran.ai/one-person-company) puts it plainly: a one-person company is not “a founder with a chatbot.” It is a founder running several agentic surfaces, each with a specific job, glued together by orchestration and rails. In practice the setup has a few moving parts:
+Bingran You’s [2026 working definition](https://bingran.ai/one-person-company) puts it plainly: a one-person company is not “a founder with a chatbot.” It is a founder running several agentic surfaces, each with a specific job, glued together by orchestration and rails. **0-person company** and **agent company** point at the same shape. Those labels still describe a founder-led business, not a company with zero accountability.
+
+In practice the setup has a few moving parts:
 
 - **A founder who sets direction.** You choose priorities, define boundaries, and approve decisions with financial, legal, or reputational impact.
 - **Agents with narrow roles.** Each agent gets a clear responsibility, the context needed to do the work, and access only to relevant tools.
 - **An orchestration layer.** This coordinates assignments, handoffs, recurring work, and records so the operation does not depend on you forwarding every message.
 - **A review habit.** Someone human still checks the outputs that can hurt customers or production.
 
-The point is narrower than “AI employees.” Make repeatable work easier to delegate and inspect. Useful starting workflows include a morning brief, turning a bug report into a draft pull request, organizing release notes, researching a lead, or drafting a follow-up for approval — tasks with visible inputs and outputs you can check before they reach a customer or change production.
+The point is narrower than “AI employees.” Make repeatable work easier to delegate and inspect. Useful starting workflows include a morning brief, turning a bug report into a draft pull request, organizing release notes, researching a lead, or drafting a follow-up for approval: tasks with visible inputs and outputs you can check before they reach a customer or change production.
 
 ## Start from the workflow, not the job title
 
@@ -104,7 +122,7 @@ Name the trigger, inputs, steps, output, and approval point. “Handle content�
 
 ### 2. Give one agent a narrow inbox and tool set
 
-Assign a role and only the tools that workflow needs. A research brief may need approved sources and a document destination — not billing or production access.
+Assign a role and only the tools that workflow needs. A research brief may need approved sources and a document destination, not billing or production access.
 
 ### 3. Say where the draft goes next
 
@@ -116,7 +134,7 @@ Use representative inputs first. Then test missing data, tool errors, ambiguous 
 
 ### 5. Put it on the calendar only after review
 
-Once the unscheduled version produces useful results, add a schedule or trigger. Review history when the underlying business process changes. Add another agent only when the next handoff is clear — team size is a poor measure of progress.
+Once the unscheduled version produces useful results, add a schedule or trigger. Review history when the underlying business process changes. Add another agent only when the next handoff is clear. Team size is a poor measure of progress.
 
 ![Workflow maturity for a personal AI company: one founder, first workflow, handoffs, then scheduled routines](/blog/personal-ai-company/timeline.webp)
 
@@ -148,9 +166,9 @@ Vendor tooling inside one product can help peers coordinate. Anthropic’s [Clau
 
 [AI orchestration](/blog/ai-agent-orchestration) is the shared requirement across solopreneur stacks. Consultants, open-source maintainers, and retailers use different tools, yet they still need roles, assignments, context, and handoffs that do not collapse into manual copy-paste.
 
-A **one-person company** is the shape of the business: one founder stays accountable. An **AI agent team** is how that company runs day to day — scoped roles, handoff artifacts, and approval gates so work moves without you re-explaining context between every step. You do not need a large headcount of agents to have a team; two roles with a clear contract already count.
+A **one-person company** is the shape of the business: one founder stays accountable. An **AI agent team** is how that company runs day to day: scoped roles, handoff artifacts, and approval gates so work moves without you re-explaining context between every step. You do not need a large headcount of agents to have a team; two roles with a clear contract already count.
 
-For the roles, contracts, and failure modes in detail, read **[How to Build an AI Agent Team](/blog/ai-agent-team)**. Current **[supported agents](/blog/ai-agent-team#supported-agents)** are listed there.
+For the roles, agent email, and failure modes in detail, read **[How to Build an AI Agent Team](/blog/ai-agent-team)**. Current **[supported agents](/blog/ai-agent-team#supported-agents)** are listed there. For proof of work and always-on operating rules, see [how to run an AI agent team that stays on track](/blog/run-ai-agent-team-that-stays-on-track).
 
 ## Building this with Alook
 
@@ -160,7 +178,11 @@ That describes Alook’s current availability. It is not a claim about the total
 
 ## Personal AI company FAQ
 
-**What is a personal AI company?** It is a one-person company where AI agents handle defined workflows while the founder controls goals, access, and important approvals.
+**What is a personal AI company?** It is a one-person company, sometimes called a 0-person company or agent company, where AI agents handle defined workflows while the founder controls goals, access, and important approvals.
+
+**What is a 0-person company?** It is a one-person business that uses AI agents for scoped work instead of hiring a traditional team. The founder still sets direction and approves high-impact actions.
+
+**What is an agent company?** It is a business operated through AI agents with roles, handoffs, and review boundaries. In this guide, that still means a founder-led company, not a fully unsupervised machine.
 
 **How is an AI agent team different from a one-person company?** The company is the business shape. The agent team is the operating pattern inside it: roles, handoffs, and approval gates. A solo founder can run a small agent team without pretending they hired a C-suite.
 
@@ -172,8 +194,14 @@ That describes Alook’s current availability. It is not a claim about the total
 
 ## Run one Friday loop before you hire titles
 
-Pick a recurring job you already do alone — the Friday newsletter, the morning brief, or the bug-to-draft-PR path.
+Pick a recurring job you already do alone: the Friday newsletter, the morning brief, or the bug-to-draft-PR path.
 
 Write the artifact you expect, the tools the agent may touch, and the moment you must approve before anything reaches a customer. When that loop is boring in a good way, add the next handoff. Until then, one reliable workflow beats a pretend org chart.
 
 To connect local coding agents under Alook, run `npx @alook/app onboard`. Templates and product details live at [alook.ai](https://alook.ai).
+
+## Related
+
+- [How to Build an AI Agent Team](/blog/ai-agent-team)
+- [How to Run an AI Agent Team That Stays on Track](/blog/run-ai-agent-team-that-stays-on-track)
+- [AI Orchestration: How Multiple Agents Work Together](/blog/ai-agent-orchestration)

--- a/src/web/src/content/run-ai-agent-team-that-stays-on-track.mdx
+++ b/src/web/src/content/run-ai-agent-team-that-stays-on-track.mdx
@@ -2,10 +2,11 @@ export const metadata = {
   slug: "run-ai-agent-team-that-stays-on-track",
   title: "How to Run an AI Agent Team That Stays on Track",
   date: "2026-07-29",
+  dateModified: "2026-08-12",
   author: "Alook Team",
   excerpt:
-    "More agents help only when jobs stay clear, ownership stays named, and results stay easy to review. These operating rules keep a team usable day after day.",
-  readingTime: "6 min read",
+    "Keep an AI agent team on track with clear jobs, proof of work, approval gates, and an always-on runtime that still waits for human review.",
+  readingTime: "7 min read",
   image: "/blog/run-ai-agent-team-that-stays-on-track/hero.webp",
 };
 
@@ -32,6 +33,38 @@ export const jsonLd = [
       },
       {
         "@type": "Question",
+        name: "What counts as proof of work for an AI agent?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Proof of work is a reviewable artifact: a pull request, test output, screenshot, dated note, or deploy link that shows what changed and what remains open. A long chat thread is activity, not proof.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "What is an always-on AI agent runtime?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "An always-on runtime keeps agents available across hours and days so scheduled work, email, and catch-up can continue after a chat session closes. Always-on does not mean unsupervised. High-impact actions still wait for approval.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "What should an AI agent handoff include?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "A useful handoff names the objective, the current state, the artifact produced so far, the checks already run, the open questions, and the requested next action. The next owner should not have to reconstruct a thread to know what to do.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "What should happen when an AI agent hits an exception?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "The workflow should pause, return the exception with context, and route it to the person or role that owns the decision. Silent guessing is worse than a visible stop.",
+        },
+      },
+      {
+        "@type": "Question",
         name: "Do I need Alook to use these rules?",
         acceptedAnswer: {
           "@type": "Answer",
@@ -42,11 +75,11 @@ export const jsonLd = [
   },
 ];
 
-You give three agents the same project on Monday. By Wednesday, one has drafted a plan, another has started a different version, and a third has reopened a question the group settled on Monday afternoon. The work is moving. Nobody can say where it is going.
+An AI agent team stays on track when each role has one clear job, handoffs leave proof of work a person can review, high-impact actions wait for approval, and an always-on runtime does not become unsupervised work. The fix is usually a short set of operating rules, not another agent.
 
-This is a common second-stage problem with agent teams. The first problem is getting useful work out of an agent. The next one is keeping several pieces of useful work from becoming a pile of drafts, old conclusions, and unanswered requests.
+You can see the failure mode quickly. Give three agents the same project on Monday. By Wednesday, one has drafted a plan, another has started a different version, and a third has reopened a question the group settled on Monday afternoon. The work is moving. Nobody can say where it is going.
 
-The answer is rarely another agent. It is a few operating rules that keep the team clear, owned, and easy to review.
+That second-stage mess is common once agents start producing useful drafts. Useful output without ownership, reviewable artifacts, and a stop path turns into old conclusions and unanswered requests.
 
 ![Agent team workflow moving from noisy drafts to clear jobs, named ownership, and easy review](/blog/run-ai-agent-team-that-stays-on-track/hero.webp)
 
@@ -123,6 +156,40 @@ Require a short verification path. Depending on the work, that might be:
 
 The next reviewer should not have to reconstruct a day of chat to work out whether the task is complete. If they do, the handoff is still unfinished.
 
+## What counts as proof of work for an AI agent
+
+That is the difference between activity and **proof of work**. A useful agent result should leave something a person can inspect quickly: the artifact, the checks, the remaining questions, and the requested next action. "Still working" is not proof. Neither is a transcript dump.
+
+Proof can be small. A pull request with checks run. A screenshot. A dated note with sources. A deploy link plus what remains open. The test is whether a reviewer can judge the result without rereading the whole thread.
+
+## Always-on runtime is not unsupervised runtime
+
+An always-on AI agent runtime keeps the team available after a chat window closes. Scheduled checks can fire. Agent email can wait in the inbox. A local daemon can pick work back up when the machine is online.
+
+That is useful. It is not the same as letting agents spend, publish, or merge without you.
+
+Keep the distinction explicit:
+
+- **Always-on** means the runtime can continue work across hours and days.
+- **Unsupervised** means high-impact actions proceed without a human gate.
+
+Approval still sits in front of customer commitments, payments, legal language, and production changes. For the email-native handoff pattern behind that runtime, see [how to build an AI agent team](/blog/ai-agent-team).
+
+## Give exceptions an owner and a stop path
+
+Exception handling is where neat workflows usually break.
+
+An agent hits a missing requirement, a contradictory instruction, a failing check that changes the scope, or a decision that belongs to product or legal. That is not the moment to "be helpful" and guess through it.
+
+Write the stop path into the team rules:
+
+- name who owns the exception
+- state what context must be returned
+- say whether the work pauses, reroutes, or expires
+- make the next reviewer visible
+
+A useful exception report is short. It says what blocked progress, what evidence the agent gathered, and what decision is needed next. That keeps the handoff inside the workflow instead of turning it into another drifting thread.
+
 ## Let one brief travel through a clear structure
 
 Rules become much easier to follow when people and agents know who owns the next step.
@@ -133,7 +200,7 @@ Rules become much easier to follow when people and agents know who owns the next
 
 The full walkthrough, including the org chart and screenshots, is in [How to Build an AI Agent Team](/blog/ai-agent-team). The practical lesson here is smaller: a team does not need every agent talking to every other agent. Clear reporting lines reduce the number of places a task can disappear.
 
-That is the kind of structure Alook is built to hold for agents that run on your own machine: roles, email-native threads, task handoffs, and a history you can inspect later. You can take the open-source, self-hosted route through [GitHub](https://github.com/alookai/alook). Or register at [alook.ai](https://alook.ai), then connect the local agents and runtime you already use. In both paths, the agents continue to run in your environment.
+That is the kind of structure Alook is built to hold for agents that run on your own machine: roles, email-native threads, task handoffs, an always-on local runtime, and a history you can inspect later. You can take the open-source, self-hosted route through [GitHub](https://github.com/alookai/alook). Or register at [alook.ai](https://alook.ai), then connect the local agents and runtime you already use. In both paths, the agents continue to run in your environment.
 
 ## Keep the team usable
 
@@ -148,7 +215,7 @@ An agent team stays on track when you can answer six questions without reading e
 
 More agents can give you more coverage. They also create more places for a decision to blur. Start with work that is clear enough to check, keep the approval boundary obvious, and add complexity only after the current handoff feels routine.
 
-Related: [How to Build an AI Agent Team](/blog/ai-agent-team) · [How to Keep Context Across Multiple Coding Agent Sessions](/blog/keep-context-across-coding-agent-sessions) · [How to Delegate Tasks to AI Agents](/blog/how-to-delegate-tasks-to-ai-agents)
+Related: [How to Build an AI Agent Team](/blog/ai-agent-team) · [How to Build a One-Person Company With AI Agents](/blog/personal-ai-company) · [How to Keep Context Across Multiple Coding Agent Sessions](/blog/keep-context-across-coding-agent-sessions) · [How to Delegate Tasks to AI Agents](/blog/how-to-delegate-tasks-to-ai-agents)
 
 ## FAQ
 
@@ -157,6 +224,18 @@ Start with two to four roles that have clear jobs. Add another role when a real 
 
 **What should always stay behind human approval?**  
 Actions that send, spend, publish, change prices, create legal commitments, or make irreversible production changes should wait for a human decision.
+
+**What counts as proof of work for an AI agent?**  
+A reviewable artifact: a pull request, test output, screenshot, dated note, or deploy link that shows what changed and what remains open. A long chat thread is activity, not proof.
+
+**What is an always-on AI agent runtime?**  
+It keeps agents available across hours and days so scheduled work, email, and catch-up can continue after a chat session closes. Always-on does not mean unsupervised. High-impact actions still wait for approval.
+
+**What should an AI agent handoff include?**  
+Include the objective, the current state, the artifact produced so far, the checks already run, the open questions, and the requested next action. The next owner should not have to reconstruct a thread to know what to do.
+
+**What should happen when an AI agent hits an exception?**  
+Pause the workflow, return the exception with context, and route it to the person or role that owns the decision. Silent guessing is worse than a visible stop.
 
 **Do I need Alook to use these rules?**  
 No. These rules work with any agent stack. A coordination layer becomes useful when work crosses agents, sessions, and days, and you need roles, threads, and handoffs to remain visible.


### PR DESCRIPTION
## Summary
- Refresh `personal-ai-company`, `ai-agent-team`, and `run-ai-agent-team-that-stays-on-track` for Matrix keyword gaps: 0-person / agent company, agent email, departments vs roles, proof of work, and always-on vs unsupervised runtime.
- Add answer-first openings (AEO), FAQPage parity, Related links, and `dateModified: 2026-08-12`.
- Keep product facts accurate (local runtime, self-host + alook.ai signup); no ROI/cost claims; product mentions stay out of the opening.

## Test plan
- [ ] `pnpm --filter @alook/web validate:blog`
- [ ] Spot-check three posts render: `/blog/personal-ai-company`, `/blog/ai-agent-team`, `/blog/run-ai-agent-team-that-stays-on-track`
- [ ] Confirm FAQ body questions match `jsonLd` FAQPage names on each post
- [ ] Confirm openings have extractable definitions before narrative/product copy


Made with [Cursor](https://cursor.com)