### PR TITLE
blog: land coordination and approvals cluster on main

### DIFF
--- a/src/web/src/content/ai-agent-orchestration.mdx
+++ b/src/web/src/content/ai-agent-orchestration.mdx
@@ -1,11 +1,11 @@
 export const metadata = {
   slug: "ai-agent-orchestration",
-  title: "AI Orchestration: How Multiple Agents Work Together",
+  title: "AI Agent Coordination: How Orchestration Works",
   date: "2026-06-03",
-  dateModified: "2026-08-10",
+  dateModified: "2026-08-11",
   author: "Alook Team",
   excerpt:
-    "AI orchestration (agent coordination) routes specialized agents with roles, handoffs, retries, and shared context.",
+    "AI agent coordination keeps agents aligned on roles, handoffs, and shared state. Orchestration is the system layer that makes that reliable.",
   readingTime: "6 min read",
   image: "/blog/ai-agent-orchestration/hero.webp",
 };
@@ -15,6 +15,22 @@ export const jsonLd = [
     "@context": "https://schema.org",
     "@type": "FAQPage",
     mainEntity: [
+      {
+        "@type": "Question",
+        name: "What is AI agent coordination?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "AI agent coordination is how multiple agents stay aligned on roles, handoffs, current state, and the next action. AI agent orchestration is the system layer that makes that coordination reliable by sequencing steps, passing outputs forward, and retrying failed work.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Is AI agent coordination the same as AI agent orchestration?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Teams often use the terms interchangeably. Coordination emphasizes alignment between agents. Orchestration emphasizes the system that routes work, sequences steps, and handles retries. In practice, orchestration is usually how coordination gets enforced.",
+        },
+      },
       {
         "@type": "Question",
         name: "What is AI agent orchestration?",
@@ -69,7 +85,7 @@ export const jsonLd = [
 
 ![Hand-drawn diagram of AI orchestration as a coordination layer connecting data, analysis, writing, and delivery agents around a shared goal](/blog/ai-agent-orchestration/hero.webp)
 
-**AI agent orchestration** is how multiple specialized agents finish one job together: who runs, in what order, what each step returns, and how a failed step retries, without you forwarding every message. Teams also search for **AI agent coordination** when they mean the same layer.
+**AI agent coordination** is how multiple specialized agents stay aligned on one job: who owns which step, what each handoff returns, what state stays current, and who acts next. **AI agent orchestration** is the system layer that makes that coordination reliable, without you forwarding every message by hand.
 
 One agent does step one. Another picks up step two. A third closes it out. You set the roles once. The orchestration layer keeps the work moving.
 
@@ -80,6 +96,16 @@ AI orchestration is the coordination layer above your individual agents. It deci
 A single agent answers one prompt at a time. Orchestration turns a set of agents into something closer to a team, where each one owns a narrow job and the handoffs happen on their own. You describe the roles and the sequence. The layer keeps the work flowing.
 
 For named pattern catalogs (fan-out, review gates, and similar), see [multi-agent workflow patterns](/blog/multi-agent-workflow-patterns). This page stays on the coordination layer itself.
+
+## AI agent coordination vs orchestration
+
+Teams often use these terms interchangeably. That is usually fine. The difference is mostly about emphasis.
+
+**Coordination** points at alignment between agents: shared status, clean handoffs, current decisions, and a visible next step.
+
+**Orchestration** points at the system that enforces that alignment: roles, sequencing, retries, state passing, and approval gates.
+
+In practice, coordination is the job you want. Orchestration is the mechanism that makes it happen. If one agent investigates, another writes the patch, and a third reviews it, coordination is the fact that they do not trip over each other. Orchestration is the layer that moves the diagnosis forward, routes the patch to review, and pauses before merge when a human decision is required.
 
 ## Why one agent isn't enough
 
@@ -150,6 +176,12 @@ Buying a platform flips that around. You describe the roles and the sequence, an
 The future of this work isn't one super-intelligent model doing everything. It's teams of specialized agents, each good at a narrow task, passing work between each other. Like a company, minus the meetings.
 
 ## AI orchestration FAQ
+
+**What is AI agent coordination?**
+AI agent coordination is how multiple agents stay aligned on roles, handoffs, current state, and the next action. **AI agent orchestration** is the system layer that makes that coordination reliable.
+
+**Is AI agent coordination the same as AI agent orchestration?**
+Most teams use the terms almost interchangeably. Coordination emphasizes alignment between agents. Orchestration emphasizes the system that sequences work, passes outputs forward, and handles retries.
 
 **What is AI agent orchestration?**
 AI agent orchestration is the coordination layer above individual agents. It decides which agent runs, in what order, how outputs pass between steps, and how failed steps retry. **AI agent coordination** usually points at the same job.

--- a/src/web/src/content/how-to-delegate-tasks-to-ai-agents.mdx
+++ b/src/web/src/content/how-to-delegate-tasks-to-ai-agents.mdx
@@ -2,7 +2,7 @@ export const metadata = {
   slug: "how-to-delegate-tasks-to-ai-agents",
   title: "How to Delegate Tasks to AI Agents",
   date: "2026-06-03",
-  dateModified: "2026-08-10",
+  dateModified: "2026-08-11",
   author: "Alook Team",
   excerpt:
     "Delegate tasks to AI agents with a clear method for stable work, multi-day coding jobs, authority boundaries, supervised runs, and human review.",
@@ -37,6 +37,14 @@ export const jsonLd = [
         acceptedAnswer: {
           "@type": "Answer",
           text: "Separate addressing from authority. Teammates may request work from an agent when the room allows it, but the agent's tools, credentials, and approval rules stay with the owner of the runtime. A request should never silently expand what the agent can do.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "What needs human approval when you delegate tasks to AI agents?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Keep human approval for merges that change production behavior, published release notes, customer commitments, payments, legal language, and anything that sends, spends, or changes another person's expectations. The agent can prepare the work, but approval is still a separate step.",
         },
       },
       {
@@ -227,11 +235,30 @@ Do not hand over a week of work as one vague prompt. Slice it.
 
 Multi-day work fails when the agent optimizes for activity instead of checkpoints. Approvals, exceptions, and handoffs to people belong in the stop conditions. For team-level operating rules, see [how to run an AI agent team that stays on track](/blog/run-ai-agent-team-that-stays-on-track).
 
+## What needs human approval when you delegate tasks?
+
+Keep the approval line explicit before the work starts.
+
+- Merges that change production behavior
+- Releases, public changelogs, and customer-facing notes
+- Messages that make commitments on timing, pricing, or support
+- Anything that sends, spends, publishes, or changes legal expectations
+
+The agent can prepare the draft, collect evidence, and tee up the decision. Approval is still a separate step. If the boundary lives only in your head, the handoff is incomplete.
+
 ## How do you delegate user authority to AI agents?
 
-**Addressing** is who may ask an agent for work. **Authority** is what the agent is allowed to do with tools and credentials.
+**Addressing** is who may ask an agent for work. **Authority** is what the agent is allowed to do with tools and credentials. **Approval** is the last gate for actions that should pause before they affect another person or system.
 
 A teammate can @mention your agent in a shared room without inheriting your local secrets. The request does not expand permissions. The agent may answer, draft, refuse, or ask you to approve. Keep owner-defined tools and approval boundaries intact. The room-protocol view of that split is in [humans and AI agents in one room](/blog/humans-and-ai-agents-in-one-room).
+
+In practice, those three lines should stay separate:
+
+- who can ask
+- what the agent is permitted to do
+- which outcomes still stop for human approval
+
+When those lines blur, teams think delegation failed. Usually the method failed first.
 
 ## Instruction patterns that hold up
 
@@ -288,6 +315,10 @@ Break the job into checkpoint-sized slices with a written definition of done for
 **How do you delegate user authority to AI agents?**
 
 Separate addressing from authority. Others may request work when the room allows it; tools, credentials, and approvals stay with the runtime owner. A request should not silently expand what the agent can do.
+
+**What needs human approval when you delegate tasks to AI agents?**
+
+Keep human approval for merges that change production behavior, published release notes, customer commitments, payments, legal language, and anything that sends, spends, or changes another person's expectations. The agent can prepare the work, but approval is still a separate step.
 
 **What makes a task good for AI agent delegation?**
 

--- a/src/web/src/content/humans-and-ai-agents-in-one-room.mdx
+++ b/src/web/src/content/humans-and-ai-agents-in-one-room.mdx
@@ -98,7 +98,7 @@ This creates a useful distinction:
 
 ![Chen addresses @amara-builder while authority stays with Amara, and the agent may answer, draft, refuse, or ask Amara](/blog/humans-and-ai-agents-in-one-room/addressing-vs-authority.png)
 
-An outside request might produce an answer, a draft for the owner, a refusal, or an approval request. The sender does not choose the agent’s authority. That boundary stays with the person operating the runtime.
+An outside request might produce an answer, a draft for the owner, a refusal, or an approval request. That last outcome matters. In a mixed room, "please approve this before I act" is often the correct response, not a failure of autonomy. The sender does not choose the agent’s authority. That boundary stays with the person operating the runtime.
 
 Scope the room itself. A project channel should include only the participants and history needed for that collaboration. Joining it should not reveal unrelated DMs or private channels. “Agents will behave” is not an access model.
 
@@ -140,7 +140,7 @@ Yes. Every agent should appear as a separate participant with its own identity, 
 
 ### Can another person give instructions to my agent?
 
-They can make a request when the room permits it. The request does not expand the agent’s tools or permissions. Your runtime settings still determine whether it answers, drafts, refuses, or asks you to approve.
+They can make a request when the room permits it. The request does not expand the agent’s tools or permissions. Your runtime settings still determine whether it answers, drafts, refuses, or asks you to approve. Approval requests are part of the room protocol, not a sign that the agent ignored the ask.
 
 ### Should every agent receive every message?
 


### PR DESCRIPTION
## Summary
- Land the stranded [#444](https://github.com/alookai/alook/pull/444) coordination/approvals cluster onto `main` (it previously merged only into the already-merged #443 branch).
- Includes orchestration (coordination vs orchestration), delegation (approval/authority), and room (approval-request wording).
- Shortens the orchestration excerpt to ≤155 chars.
- `run-ai-agent-team-that-stays-on-track` handoff/exception/proof/always-on coverage is already in [#449](https://github.com/alookai/alook/pull/449); omitted here to avoid overlap.

## Test plan
- [ ] `pnpm --filter @alook/web validate:blog`
- [ ] Spot-check `/blog/ai-agent-orchestration`, `/blog/how-to-delegate-tasks-to-ai-agents`, `/blog/humans-and-ai-agents-in-one-room`
- [ ] Confirm orchestration title/FAQ use coordination framing and FAQ ↔ jsonLd match
- [ ] Merge after or with #449 so stays-on-track and this cluster both land


Made with [Cursor](https://cursor.com)