### PR TITLE
fix(web): preserve query refs through OpenNext

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
     "wrangler": "^4.119.0"
   },
   "pnpm": {
+    "patchedDependencies": {
+      "@opennextjs/aws@4.1.0": "patches/@opennextjs__aws@4.1.0.patch"
+    },
     "onlyBuiltDependencies": [
       "better-sqlite3",
       "esbuild",

--- a/patches/@opennextjs__aws@4.1.0.patch
+++ b/patches/@opennextjs__aws@4.1.0.patch
@@ -1,24 +1,16 @@
-diff --git a/dist/core/routing/util.js b/dist/core/routing/util.js
---- a/dist/core/routing/util.js
-+++ b/dist/core/routing/util.js
-@@ -118,16 +118,16 @@ export function convertRes(res) {
-  * @__PURE__
+diff --git a/dist/overrides/converters/utils.js b/dist/overrides/converters/utils.js
+--- a/dist/overrides/converters/utils.js
++++ b/dist/overrides/converters/utils.js
+@@ -24,5 +24,11 @@ export function extractHostFromHeaders(headers) {
+  * @returns
   */
- export function convertToQueryString(query) {
--    const queryStrings = [];
-+    const searchParams = new URLSearchParams();
-     Object.entries(query).forEach(([key, value]) => {
-         if (Array.isArray(value)) {
--            value.forEach((entry) => queryStrings.push(`${key}=${entry}`));
-+            value.forEach((entry) => searchParams.append(key, entry));
-         }
-         else {
--            queryStrings.push(`${key}=${value}`);
-+            searchParams.append(key, value);
-         }
-     });
--    return queryStrings.length > 0 ? `?${queryStrings.join("&")}` : "";
-+    return searchParams.size > 0 ? `?${searchParams.toString()}` : "";
+ export function getQueryFromSearchParams(searchParams) {
+-    return getQueryFromIterator(searchParams.entries());
++    const querystring = searchParams.toString();
++    if (querystring === "")
++        return {};
++    return getQueryFromIterator(querystring.split("&").map((part) => {
++        const [key, value] = part.split("=");
++        return [key, value];
++    }));
  }
- /**
-  * Given a raw query string, returns a record with key value-array pairs

--- a/patches/@opennextjs__aws@4.1.0.patch
+++ b/patches/@opennextjs__aws@4.1.0.patch
@@ -1,0 +1,24 @@
+diff --git a/dist/core/routing/util.js b/dist/core/routing/util.js
+--- a/dist/core/routing/util.js
++++ b/dist/core/routing/util.js
+@@ -118,16 +118,16 @@ export function convertRes(res) {
+  * @__PURE__
+  */
+ export function convertToQueryString(query) {
+-    const queryStrings = [];
++    const searchParams = new URLSearchParams();
+     Object.entries(query).forEach(([key, value]) => {
+         if (Array.isArray(value)) {
+-            value.forEach((entry) => queryStrings.push(`${key}=${entry}`));
++            value.forEach((entry) => searchParams.append(key, entry));
+         }
+         else {
+-            queryStrings.push(`${key}=${value}`);
++            searchParams.append(key, value);
+         }
+     });
+-    return queryStrings.length > 0 ? `?${queryStrings.join("&")}` : "";
++    return searchParams.size > 0 ? `?${searchParams.toString()}` : "";
+ }
+ /**
+  * Given a raw query string, returns a record with key value-array pairs

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@opennextjs/aws@4.1.0':
+    hash: b331be37cd299643f7c746838fd1169124addcdda37808ce899028379e37ef0a
+    path: patches/@opennextjs__aws@4.1.0.patch
+
 importers:
 
   .:
@@ -11218,7 +11223,7 @@ snapshots:
   '@open-draft/until@2.1.0':
     optional: true
 
-  '@opennextjs/aws@4.1.0(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@25.9.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@opennextjs/aws@4.1.0(patch_hash=b331be37cd299643f7c746838fd1169124addcdda37808ce899028379e37ef0a)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@25.9.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@aws-sdk/client-cloudfront': 3.984.0
@@ -11245,7 +11250,7 @@ snapshots:
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@dotenvx/dotenvx': 1.31.0
-      '@opennextjs/aws': 4.1.0(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@25.9.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@opennextjs/aws': 4.1.0(patch_hash=b331be37cd299643f7c746838fd1169124addcdda37808ce899028379e37ef0a)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@25.9.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       ci-info: 4.4.0
       cloudflare: 4.5.0
       comment-json: 4.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@opennextjs/aws@4.1.0':
-    hash: b331be37cd299643f7c746838fd1169124addcdda37808ce899028379e37ef0a
+    hash: 6a1b801adbed4307cde86c12f701bc354047783b077e836f58af1e362e244b9e
     path: patches/@opennextjs__aws@4.1.0.patch
 
 importers:
@@ -11223,7 +11223,7 @@ snapshots:
   '@open-draft/until@2.1.0':
     optional: true
 
-  '@opennextjs/aws@4.1.0(patch_hash=b331be37cd299643f7c746838fd1169124addcdda37808ce899028379e37ef0a)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@25.9.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@opennextjs/aws@4.1.0(patch_hash=6a1b801adbed4307cde86c12f701bc354047783b077e836f58af1e362e244b9e)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@25.9.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@aws-sdk/client-cloudfront': 3.984.0
@@ -11250,7 +11250,7 @@ snapshots:
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@dotenvx/dotenvx': 1.31.0
-      '@opennextjs/aws': 4.1.0(patch_hash=b331be37cd299643f7c746838fd1169124addcdda37808ce899028379e37ef0a)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@25.9.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@opennextjs/aws': 4.1.0(patch_hash=6a1b801adbed4307cde86c12f701bc354047783b077e836f58af1e362e244b9e)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@25.9.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       ci-info: 4.4.0
       cloudflare: 4.5.0
       comment-json: 4.6.2

--- a/scripts/ci/open-next-query-encoding.test.ts
+++ b/scripts/ci/open-next-query-encoding.test.ts
@@ -3,46 +3,96 @@ import { readFileSync } from "node:fs"
 import { dirname, resolve } from "node:path"
 import { describe, expect, it } from "vitest"
 
+type Query = Record<string, string | string[]>
+
 const repoRoot = resolve(import.meta.dirname, "../..")
 const requireFromWeb = createRequire(resolve(repoRoot, "src/web/package.json"))
 const cloudflareEntry = requireFromWeb.resolve("@opennextjs/cloudflare")
-const awsUtil = resolve(dirname(cloudflareEntry), "../../../aws/dist/core/routing/util.js")
-const source = readFileSync(awsUtil, "utf8")
-const start = source.indexOf("export function convertToQueryString")
-const end = source.indexOf("/**\n * Given a raw query string", start)
-const functionSource = source.slice(start, end).replace(/^export /, "")
-const convertToQueryString = Function(`${functionSource}; return convertToQueryString`)() as (
-  query: Record<string, string | string[]>,
+const awsDist = resolve(dirname(cloudflareEntry), "../../../aws/dist")
+
+function extractFunction(file: string, name: string, nextMarker?: string) {
+  const source = readFileSync(file, "utf8")
+  const start = source.indexOf(`export function ${name}`)
+  const end = nextMarker ? source.indexOf(nextMarker, start) : source.length
+  if (start < 0 || end <= start) throw new Error(`Unable to extract OpenNext function ${name}`)
+  return source.slice(start, end).replace(/^export /, "")
+}
+
+const httpUtil = resolve(awsDist, "http/util.js")
+const routingUtil = resolve(awsDist, "core/routing/util.js")
+const converterUtil = resolve(awsDist, "overrides/converters/utils.js")
+const iteratorSource = extractFunction(httpUtil, "getQueryFromIterator")
+const getQueryFromIterator = Function(`${iteratorSource}; return getQueryFromIterator`)() as (
+  entries: Iterable<[string, string]>,
+) => Query
+const parserSource = extractFunction(converterUtil, "getQueryFromSearchParams")
+const getQueryFromSearchParams = Function(
+  "getQueryFromIterator",
+  `${parserSource}; return getQueryFromSearchParams`,
+)(getQueryFromIterator) as (searchParams: URLSearchParams) => Query
+const fromQuerySource = extractFunction(routingUtil, "convertFromQueryString", "/**")
+const convertFromQueryString = Function(
+  "getQueryFromIterator",
+  `${fromQuerySource}; return convertFromQueryString`,
+)(getQueryFromIterator) as (query: string) => Query
+const toQuerySource = extractFunction(
+  routingUtil,
+  "convertToQueryString",
+  "/**\n * Given a raw query string",
+)
+const convertToQueryString = Function(`${toQuerySource}; return convertToQueryString`)() as (
+  query: Query,
 ) => string
 
-function roundTrip(value: string) {
-  const query = convertToQueryString({ ref: value })
+function roundTrip(rawQuery: string, key = "ref") {
+  const internalQuery = getQueryFromSearchParams(new URLSearchParams(rawQuery))
+  const query = convertToQueryString(internalQuery)
   const url = new URL(`https://example.test/api${query}`)
-  return { query, url, value: url.searchParams.get("ref") }
+  return { internalQuery, query, url, value: url.searchParams.get(key) }
 }
 
 describe("OpenNext query encoding patch", () => {
   it.each([
-    "/Gener#9879/fix/#1",
-    "/.dm/Audrie#4069",
-    "Gener#9879",
-    "/设计 team/a&b=c/%23literal",
-  ])("round-trips %s as query data", (input) => {
-    const result = roundTrip(input)
+    ["%2FGener%239879%2Ffix%2F%231", "/Gener#9879/fix/#1"],
+    ["%2F.dm%2FAudrie%234069", "/.dm/Audrie#4069"],
+    ["Gener%239879", "Gener#9879"],
+    ["%2F%E8%AE%BE%E8%AE%A1+team%2Fa%26b%3Dc%2F%2523literal", "/设计 team/a&b=c/%23literal"],
+  ])("round-trips encoded query data %s", (encoded, expected) => {
+    const result = roundTrip(`ref=${encoded}`)
 
-    expect(result.value).toBe(input)
+    expect(result.value).toBe(expected)
     expect(result.url.hash).toBe("")
     expect(result.query).not.toContain("#")
+    expect(result.internalQuery.ref).toBe(encoded)
   })
 
-  it("preserves repeated values and their order", () => {
-    const query = convertToQueryString({ ref: ["/a#0001/x", "/b#0002/y/#3"] })
-    const values = new URL(`https://example.test/api${query}`).searchParams.getAll("ref")
+  it("preserves repeated encoded values and their order", () => {
+    const first = "%2Fa%230001%2Fx"
+    const second = "%2Fb%230002%2Fy%2F%233"
+    const result = roundTrip(`ref=${first}&ref=${second}`)
 
-    expect(values).toEqual(["/a#0001/x", "/b#0002/y/#3"])
+    expect(result.internalQuery.ref).toEqual([first, second])
+    expect(result.url.searchParams.getAll("ref")).toEqual(["/a#0001/x", "/b#0002/y/#3"])
+  })
+
+  it("keeps source and rewrite-destination values in one encoded representation", () => {
+    const source = getQueryFromSearchParams(
+      new URLSearchParams("ref=%2FGener%239879%2Ffix%2F%231"),
+    )
+    const destination = convertFromQueryString("returnTo=%2Ffoo%3Fa%3D1%26b%3D2")
+    const query = convertToQueryString({ ...source, ...destination })
+    const url = new URL(`https://example.test/api${query}`)
+
+    expect(query).toContain("returnTo=%2Ffoo%3Fa%3D1%26b%3D2")
+    expect(query).not.toContain("%252Ffoo")
+    expect(url.searchParams.get("ref")).toBe("/Gener#9879/fix/#1")
+    expect(url.searchParams.get("returnTo")).toBe("/foo?a=1&b=2")
   })
 
   it("returns no suffix for an empty query", () => {
-    expect(convertToQueryString({})).toBe("")
+    const result = roundTrip("")
+
+    expect(result.internalQuery).toEqual({})
+    expect(result.query).toBe("")
   })
 })

--- a/scripts/ci/open-next-query-encoding.test.ts
+++ b/scripts/ci/open-next-query-encoding.test.ts
@@ -1,0 +1,48 @@
+import { createRequire } from "node:module"
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { describe, expect, it } from "vitest"
+
+const repoRoot = resolve(import.meta.dirname, "../..")
+const requireFromWeb = createRequire(resolve(repoRoot, "src/web/package.json"))
+const cloudflareEntry = requireFromWeb.resolve("@opennextjs/cloudflare")
+const awsUtil = resolve(dirname(cloudflareEntry), "../../../aws/dist/core/routing/util.js")
+const source = readFileSync(awsUtil, "utf8")
+const start = source.indexOf("export function convertToQueryString")
+const end = source.indexOf("/**\n * Given a raw query string", start)
+const functionSource = source.slice(start, end).replace(/^export /, "")
+const convertToQueryString = Function(`${functionSource}; return convertToQueryString`)() as (
+  query: Record<string, string | string[]>,
+) => string
+
+function roundTrip(value: string) {
+  const query = convertToQueryString({ ref: value })
+  const url = new URL(`https://example.test/api${query}`)
+  return { query, url, value: url.searchParams.get("ref") }
+}
+
+describe("OpenNext query encoding patch", () => {
+  it.each([
+    "/Gener#9879/fix/#1",
+    "/.dm/Audrie#4069",
+    "Gener#9879",
+    "/设计 team/a&b=c/%23literal",
+  ])("round-trips %s as query data", (input) => {
+    const result = roundTrip(input)
+
+    expect(result.value).toBe(input)
+    expect(result.url.hash).toBe("")
+    expect(result.query).not.toContain("#")
+  })
+
+  it("preserves repeated values and their order", () => {
+    const query = convertToQueryString({ ref: ["/a#0001/x", "/b#0002/y/#3"] })
+    const values = new URL(`https://example.test/api${query}`).searchParams.getAll("ref")
+
+    expect(values).toEqual(["/a#0001/x", "/b#0002/y/#3"])
+  })
+
+  it("returns no suffix for an empty query", () => {
+    expect(convertToQueryString({})).toBe("")
+  })
+})


### PR DESCRIPTION
## What changed

- patch `@opennextjs/aws@4.1.0` at the query parse boundary so `URLSearchParams` values stay percent-encoded in OpenNext's internal query record
- keep the existing raw serializer contract, avoiding double encoding when source params are merged with encoded rewrite-destination params
- preserve `#`, spaces, Unicode, `&`, `=`, literal percent escapes, repeated keys, and key order
- add a CI regression against the exact installed patched parser and serializer, including the mixed rewrite case

## Root cause

The OpenNext production adapter decoded request query values, then rebuilt the query string with raw `key=value` concatenation. A channel or DM ref containing `#` was therefore interpreted as a URL fragment and truncated before reaching the Next.js route. Development bypasses this adapter, which is why the bug appeared only in production-style builds.

This is an upstream OpenNext issue, not an Alook-specific edge case: opennextjs/opennextjs-aws#1187, #1179, and #1133 track the same contract mismatch, with the parse-side fix proposed in opennextjs/opennextjs-aws#1197.

## Impact

Query-based CLI routes now preserve channel, thread, DM, server, and Unicode/space-bearing refs consistently with development. JSON-body message-send and emoji paths are unchanged. Rewrite-destination query values retain their existing encoding rather than being encoded twice.

## Validation

- `pnpm install --frozen-lockfile --offline`
- targeted installed-adapter regression: 7/7
- OpenNext production build; generated server and middleware bundles verified
- `pnpm typecheck`
- `pnpm test` (web: 4,062 tests; CI scripts: 37 tests)
- `pnpm lint`
- `pnpm typegrep:ws`
- `pnpm knip`
- production-adapter QA: 69/69 assertions, 20/20 HTTP 200, exact D1 rows and successful WS fanouts across top-level channel, thread, and DM journeys
- live production redirect plus nested encoded URL checks showed no double encoding; D1/R2 cleanup and service teardown clean
