### PR TITLE
ci: stabilize daemon tests across platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,8 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Run daemon tests in isolation
+        env:
+          VITEST_MAX_WORKERS: 1
         run: pnpm --filter @alook/daemon test
       - name: Run remaining workspace tests
         run: pnpm turbo run test --filter='!@alook/daemon'
@@ -133,6 +135,8 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Run daemon tests in isolation
+        env:
+          VITEST_MAX_WORKERS: 1
         run: pnpm --filter @alook/daemon test
       - name: Run remaining workspace tests
         run: pnpm turbo run test --filter='!@alook/daemon'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,12 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm test
+      - name: Run daemon tests in isolation
+        run: pnpm --filter @alook/daemon test
+      - name: Run remaining workspace tests
+        run: pnpm turbo run test --filter='!@alook/daemon'
+      - name: Run CI script tests
+        run: pnpm vitest run --project ci-scripts
 
   test-windows:
     name: Tests (windows-latest)
@@ -127,7 +132,12 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm test
+      - name: Run daemon tests in isolation
+        run: pnpm --filter @alook/daemon test
+      - name: Run remaining workspace tests
+        run: pnpm turbo run test --filter='!@alook/daemon'
+      - name: Run CI script tests
+        run: pnpm vitest run --project ci-scripts
 
   e2e:
     name: E2E Tests

--- a/src/daemon/src/cli/daemonLifecycle.real.test.ts
+++ b/src/daemon/src/cli/daemonLifecycle.real.test.ts
@@ -4,11 +4,11 @@ import * as fs from "node:fs";
 import { createRequire } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { daemonStart } from "./daemonStart";
 
 const packageRoot = fileURLToPath(new URL("../..", import.meta.url));
-const tsxLoader = createRequire(import.meta.url).resolve("tsx");
+const tsxLoader = pathToFileURL(createRequire(import.meta.url).resolve("tsx")).href;
 const cli = path.join(packageRoot, "src", "cli", "index.ts");
 const secret = "cmk_B0_REAL_PROCESS_SECRET";
 const machineId = "cm_machine_real_123456";

--- a/src/daemon/src/cli/daemonLifecycle.real.test.ts
+++ b/src/daemon/src/cli/daemonLifecycle.real.test.ts
@@ -221,15 +221,16 @@ describe("daemon lifecycle real processes", () => {
     const contender = await runCli(cliArgs(baseDir));
     expect(contender.output).toContain("already running");
     expect(readOwner(baseDir)).toEqual(owner);
-    foreground.kill("SIGTERM");
+    await stop(baseDir);
     const completed = await foregroundResult;
     expect(completed.output).toContain("daemon startup");
     expect(completed.output).toContain("daemon up");
-    expect(daemonLogRecords(baseDir).map((record) => record.message)).toEqual(expect.arrayContaining([
+    const expectedRecords = [
       "daemon startup",
       "daemon up",
-      "shutting down…",
-    ]));
+      ...(process.platform === "win32" ? [] : ["shutting down…"]),
+    ];
+    expect(daemonLogRecords(baseDir).map((record) => record.message)).toEqual(expect.arrayContaining(expectedRecords));
     await waitFor(() => !fs.existsSync(pidfile(baseDir)));
   }, 60_000);
 
@@ -253,7 +254,7 @@ describe("daemon lifecycle real processes", () => {
     await waitFor(() => daemonIsReady(foregroundBase));
     const foregroundOwner = readOwner(foregroundBase);
     expect([first.pid, second.pid]).toContain(foregroundOwner.pid);
-    process.kill(foregroundOwner.pid, "SIGTERM");
+    await stop(foregroundBase);
     const results = await Promise.all([firstResult, secondResult]);
     expect(results.filter((result) => result.output.includes("already") || result.output.includes("in progress"))).toHaveLength(1);
     await waitFor(() => !fs.existsSync(pidfile(foregroundBase)));
@@ -270,7 +271,9 @@ describe("daemon lifecycle real processes", () => {
       ALOOK_DAEMON_TEST_SHUTDOWN_MARKER: shutdownMarker,
     });
     const firstResult = collect(first);
-    await waitFor(() => fs.existsSync(shutdownMarker));
+    await waitFor(() => process.platform === "win32"
+      ? fs.existsSync(pidfile(baseDir)) && alive(readOwner(baseDir).pid)
+      : fs.existsSync(shutdownMarker));
     const oldOwner = readOwner(baseDir);
     expect(alive(oldOwner.pid)).toBe(true);
 

--- a/src/daemon/src/cli/daemonLifecycle.real.test.ts
+++ b/src/daemon/src/cli/daemonLifecycle.real.test.ts
@@ -95,11 +95,29 @@ function readOwner(baseDir: string): { pid: number; machineId: string; ownerToke
   return JSON.parse(fs.readFileSync(pidfile(baseDir), "utf8"));
 }
 
+function readCheckpoint(checkpointFile: string): { parentPid: number; childPid: number } | undefined {
+  try {
+    return JSON.parse(fs.readFileSync(checkpointFile, "utf8"));
+  } catch {
+    return undefined;
+  }
+}
+
 function daemonLogRecords(baseDir: string): Array<{ message: string; fields: Record<string, unknown> }> {
   return fs.readFileSync(path.join(path.dirname(pidfile(baseDir)), "daemon.log"), "utf8")
     .trimEnd()
     .split("\n")
     .map((line) => JSON.parse(line));
+}
+
+function daemonIsReady(baseDir: string): boolean {
+  const logPath = path.join(path.dirname(pidfile(baseDir)), "daemon.log");
+  if (!fs.existsSync(pidfile(baseDir)) || !fs.existsSync(logPath)) return false;
+  try {
+    return daemonLogRecords(baseDir).some((record) => record.message === "daemon up");
+  } catch {
+    return false;
+  }
 }
 
 function alive(pid: number): boolean {
@@ -197,7 +215,7 @@ describe("daemon lifecycle real processes", () => {
     const baseDir = makeBaseDir();
     const foreground = spawnCli(cliArgs(baseDir, true));
     const foregroundResult = collect(foreground);
-    await waitFor(() => fs.existsSync(pidfile(baseDir)) && fs.existsSync(path.join(path.dirname(pidfile(baseDir)), "daemon.log")));
+    await waitFor(() => daemonIsReady(baseDir));
     const owner = readOwner(baseDir);
     expect(owner.pid).toBe(foreground.pid);
     const contender = await runCli(cliArgs(baseDir));
@@ -232,7 +250,7 @@ describe("daemon lifecycle real processes", () => {
     const second = spawnCli(cliArgs(foregroundBase, true));
     const firstResult = collect(first);
     const secondResult = collect(second);
-    await waitFor(() => fs.existsSync(pidfile(foregroundBase)));
+    await waitFor(() => daemonIsReady(foregroundBase));
     const foregroundOwner = readOwner(foregroundBase);
     expect([first.pid, second.pid]).toContain(foregroundOwner.pid);
     process.kill(foregroundOwner.pid, "SIGTERM");
@@ -316,8 +334,9 @@ describe("daemon lifecycle real processes", () => {
         ALOOK_DAEMON_TEST_CHECKPOINT_FILE: checkpointFile,
       });
       const parentResult = collect(parent);
-      await waitFor(() => fs.existsSync(checkpointFile));
-      const state = JSON.parse(fs.readFileSync(checkpointFile, "utf8")) as { parentPid: number; childPid: number };
+      await waitFor(() => readCheckpoint(checkpointFile) !== undefined);
+      const state = readCheckpoint(checkpointFile);
+      if (!state) throw new Error("checkpoint was not readable after becoming ready");
       process.kill(state.parentPid, "SIGKILL");
       await parentResult;
 

--- a/src/daemon/src/cli/daemonLifecycle.real.test.ts
+++ b/src/daemon/src/cli/daemonLifecycle.real.test.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 import { daemonStart } from "./daemonStart";
 
 const packageRoot = fileURLToPath(new URL("../..", import.meta.url));
-const tsxCli = createRequire(import.meta.url).resolve("tsx/cli");
+const tsxLoader = createRequire(import.meta.url).resolve("tsx");
 const cli = path.join(packageRoot, "src", "cli", "index.ts");
 const secret = "cmk_B0_REAL_PROCESS_SECRET";
 const machineId = "cm_machine_real_123456";
@@ -52,7 +52,7 @@ function cliArgs(baseDir: string, foreground = false): string[] {
 }
 
 function spawnCli(args: string[], env: NodeJS.ProcessEnv = {}): ChildProcess {
-  const child = spawn(process.execPath, [tsxCli, ...args], {
+  const child = spawn(process.execPath, ["--import", tsxLoader, ...args], {
     cwd: packageRoot,
     env: { ...process.env, ...env },
     stdio: ["ignore", "pipe", "pipe"],
@@ -105,6 +105,11 @@ function daemonLogRecords(baseDir: string): Array<{ message: string; fields: Rec
 function alive(pid: number): boolean {
   try {
     process.kill(pid, 0);
+  } catch {
+    return false;
+  }
+  if (process.platform === "win32") return true;
+  try {
     const state = execFileSync("ps", ["-p", String(pid), "-o", "stat="], { encoding: "utf8" }).trim();
     return state.length > 0 && !state.startsWith("Z");
   } catch {
@@ -112,19 +117,16 @@ function alive(pid: number): boolean {
   }
 }
 
-function isDescendant(pid: number, ancestor: number): boolean {
-  let current = pid;
-  for (let depth = 0; depth < 8; depth++) {
-    if (current === ancestor) return true;
-    try {
-      const parent = Number(execFileSync("ps", ["-p", String(current), "-o", "ppid="], { encoding: "utf8" }).trim());
-      if (!Number.isInteger(parent) || parent <= 1) return false;
-      current = parent;
-    } catch {
-      return false;
-    }
+function processDescription(pid: number): string {
+  if (process.platform === "win32") {
+    return execFileSync("powershell.exe", [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      `(Get-CimInstance Win32_Process -Filter 'ProcessId = ${pid}').CommandLine`,
+    ], { encoding: "utf8" });
   }
-  return false;
+  return execFileSync("ps", ["eww", "-p", String(pid), "-o", "command="], { encoding: "utf8" });
 }
 
 async function stop(baseDir: string): Promise<void> {
@@ -161,7 +163,7 @@ describe("daemon lifecycle real processes", () => {
     expect(alive(owner.pid)).toBe(true);
     expect(owner).toMatchObject({ machineId });
     expect(JSON.stringify(owner)).not.toContain(secret);
-    expect(execFileSync("ps", ["eww", "-p", String(owner.pid), "-o", "command="], { encoding: "utf8" })).not.toContain(secret);
+    expect(processDescription(owner.pid)).not.toContain(secret);
     const daemonDir = path.dirname(pidfile(baseDir));
     const logPath = path.join(daemonDir, "daemon.log");
     expect(fs.readFileSync(logPath, "utf8")).not.toContain(secret);
@@ -197,7 +199,7 @@ describe("daemon lifecycle real processes", () => {
     const foregroundResult = collect(foreground);
     await waitFor(() => fs.existsSync(pidfile(baseDir)) && fs.existsSync(path.join(path.dirname(pidfile(baseDir)), "daemon.log")));
     const owner = readOwner(baseDir);
-    expect(isDescendant(owner.pid, foreground.pid!)).toBe(true);
+    expect(owner.pid).toBe(foreground.pid);
     const contender = await runCli(cliArgs(baseDir));
     expect(contender.output).toContain("already running");
     expect(readOwner(baseDir)).toEqual(owner);
@@ -232,10 +234,7 @@ describe("daemon lifecycle real processes", () => {
     const secondResult = collect(second);
     await waitFor(() => fs.existsSync(pidfile(foregroundBase)));
     const foregroundOwner = readOwner(foregroundBase);
-    expect([
-      isDescendant(foregroundOwner.pid, first.pid!),
-      isDescendant(foregroundOwner.pid, second.pid!),
-    ].filter(Boolean)).toHaveLength(1);
+    expect([first.pid, second.pid]).toContain(foregroundOwner.pid);
     process.kill(foregroundOwner.pid, "SIGTERM");
     const results = await Promise.all([firstResult, secondResult]);
     expect(results.filter((result) => result.output.includes("already") || result.output.includes("in progress"))).toHaveLength(1);

--- a/src/daemon/src/cli/daemonLifecycle.real.test.ts
+++ b/src/daemon/src/cli/daemonLifecycle.real.test.ts
@@ -1,13 +1,14 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import * as fs from "node:fs";
+import { createRequire } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { daemonStart } from "./daemonStart";
 
 const packageRoot = fileURLToPath(new URL("../..", import.meta.url));
-const tsx = path.join(packageRoot, "node_modules", ".bin", "tsx");
+const tsxCli = createRequire(import.meta.url).resolve("tsx/cli");
 const cli = path.join(packageRoot, "src", "cli", "index.ts");
 const secret = "cmk_B0_REAL_PROCESS_SECRET";
 const machineId = "cm_machine_real_123456";
@@ -51,7 +52,7 @@ function cliArgs(baseDir: string, foreground = false): string[] {
 }
 
 function spawnCli(args: string[], env: NodeJS.ProcessEnv = {}): ChildProcess {
-  const child = spawn(tsx, args, {
+  const child = spawn(process.execPath, [tsxCli, ...args], {
     cwd: packageRoot,
     env: { ...process.env, ...env },
     stdio: ["ignore", "pipe", "pipe"],

--- a/src/daemon/src/cli/daemonStart.ts
+++ b/src/daemon/src/cli/daemonStart.ts
@@ -150,6 +150,16 @@ function ensurePrivateDir(dir: string): void {
   fs.chmodSync(dir, 0o700);
 }
 
+function syncDirectory(dir: string): void {
+  if (process.platform === "win32") return;
+  const fd = fs.openSync(dir, "r");
+  try {
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
 function writeExclusive(filePath: string, value: Record<string, unknown>): void {
   const dir = path.dirname(filePath);
   ensurePrivateDir(dir);
@@ -165,12 +175,7 @@ function writeExclusive(filePath: string, value: Record<string, unknown>): void 
     fd = null;
     fs.chmodSync(tempPath, 0o600);
     fs.linkSync(tempPath, filePath);
-    const dirFd = fs.openSync(dir, "r");
-    try {
-      fs.fsyncSync(dirFd);
-    } finally {
-      fs.closeSync(dirFd);
-    }
+    syncDirectory(dir);
   } finally {
     if (fd !== null) {
       try { fs.closeSync(fd); } catch { /* best effort */ }
@@ -619,12 +624,7 @@ function writeCredentialFile(filePath: string, credential: string, machineId: st
     fd = null;
     fs.chmodSync(tempPath, 0o600);
     fs.renameSync(tempPath, filePath);
-    const dirFd = fs.openSync(dir, "r");
-    try {
-      fs.fsyncSync(dirFd);
-    } finally {
-      fs.closeSync(dirFd);
-    }
+    syncDirectory(dir);
   } finally {
     if (fd !== null) {
       try { fs.closeSync(fd); } catch { /* best effort */ }

--- a/src/daemon/vitest.config.ts
+++ b/src/daemon/vitest.config.ts
@@ -8,5 +8,6 @@ export default defineConfig({
     include: ["src/**/*.test.ts"],
     environment: "node",
     testTimeout: 10_000,
+    maxWorkers: process.env.CI ? 1 : undefined,
   },
 });

--- a/src/daemon/vitest.config.ts
+++ b/src/daemon/vitest.config.ts
@@ -8,6 +8,5 @@ export default defineConfig({
     include: ["src/**/*.test.ts"],
     environment: "node",
     testTimeout: 10_000,
-    maxWorkers: process.env.CI ? 1 : undefined,
   },
 });


### PR DESCRIPTION
# Why we need this PR?
> No linked issue. PR #454's merge ref exposed daemon CI failures already present on `main`: hosted-runner contention caused lifecycle/timeline timeouts, and Windows hit platform-specific process-launch, process-inspection, signal-cleanup, and directory-`fsync` behavior.

## What changed
- Launch the real-process daemon CLI with `process.execPath --import <resolved tsx loader file URL>`, avoiding platform-specific pnpm shims, Windows ESM path errors, and an extra CLI-wrapper process.
- Use portable liveness/process-description checks and direct foreground owner PID assertions.
- Wait for `daemon up` before foreground test cleanup and for checkpoint JSON to be readable before parsing it.
- Exercise the public daemon-stop path for foreground cleanup so pidfile removal follows owner-checked production behavior on both POSIX and Windows; retain the full ownership/timeout/cleanup/replacement chain while only observing graceful-delay markers on POSIX.
- Keep file `fsync` durability while skipping unsupported directory `fsync` on Windows.
- Run daemon tests in an isolated Ubuntu/Windows step with CI-only `VITEST_MAX_WORKERS=1`, then run the remaining workspaces in parallel and CI-script tests separately.
- Validation: focused lifecycle suite passed repeated CI-shaped runs (including independent repeated rounds); daemon suite passed 60 files / 1056 tests; repository typecheck, lint, full tests, WS-event lint, and knip passed.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [x] Other: `@alook/daemon`

