### PR TITLE
fix: align avatar shapes and restore pnpm dev

### DIFF
--- a/scripts/ci/dev-registry-isolation.test.ts
+++ b/scripts/ci/dev-registry-isolation.test.ts
@@ -34,7 +34,7 @@ describe("local Wrangler registry isolation", () => {
   })
 
   it("executes native package-manager launchers directly", () => {
-    const launcher = readFileSync(launcherPath, "utf8")
+    const launcher = readFileSync(launcherPath, "utf8").replaceAll("\r\n", "\n")
 
     expect(launcher).toContain('spawn(\n  packageManagerCli,\n  ["exec", command, ...args]')
     expect(launcher).not.toContain("process.execPath")

--- a/scripts/ci/dev-registry-isolation.test.ts
+++ b/scripts/ci/dev-registry-isolation.test.ts
@@ -33,6 +33,13 @@ describe("local Wrangler registry isolation", () => {
     expect(launcher).toContain("WRANGLER_REGISTRY_PATH: resolve(process.cwd(), registryPath)")
   })
 
+  it("executes native package-manager launchers directly", () => {
+    const launcher = readFileSync(launcherPath, "utf8")
+
+    expect(launcher).toContain('spawn(\n  packageManagerCli,\n  ["exec", command, ...args]')
+    expect(launcher).not.toContain("process.execPath")
+  })
+
   it("uses one shared registry inside the current worktree for every dev entrypoint", () => {
     const paths = packagePaths.map((packagePath) => resolvedRegistryPath(repositoryRoot, packagePath))
 

--- a/scripts/dev-with-wrangler-registry.mjs
+++ b/scripts/dev-with-wrangler-registry.mjs
@@ -9,8 +9,8 @@ if (!registryPath || !command || !packageManagerCli) {
 }
 
 const child = spawn(
-  process.execPath,
-  [packageManagerCli, "exec", command, ...args],
+  packageManagerCli,
+  ["exec", command, ...args],
   {
     stdio: "inherit",
     env: {

--- a/src/web/src/components/avatar/avatar-picker-dialog.tsx
+++ b/src/web/src/components/avatar/avatar-picker-dialog.tsx
@@ -30,7 +30,11 @@ export function AvatarPickerDialog({ value, onChange }: AvatarPickerDialogProps)
 
   return (
     <div className="flex flex-col items-center gap-3">
-      <div className="rounded-2xl bg-background p-2 shadow-sm border border-border">
+      <div
+        aria-label="Workspace agent avatar preview"
+        data-testid="workspace-agent-avatar-preview"
+        className="rounded-2xl bg-background p-2 shadow-sm border border-border"
+      >
         <span className="block size-20 overflow-hidden rounded-2xl">
           <GeneratedAvatar seed={seed} size={80} className="size-full" />
         </span>

--- a/src/web/src/components/avatar/bot-avatar-picker-dialog.tsx
+++ b/src/web/src/components/avatar/bot-avatar-picker-dialog.tsx
@@ -18,6 +18,7 @@ import { type AvatarDraft } from "@/lib/avatar/model";
 import { GeneratedAvatar } from "./generated-avatar";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useAvatarDraftPicker, type AvatarPickerTab } from "./use-avatar-draft-picker";
+import { tid } from "@/lib/community/testids";
 
 interface BotAvatarPickerDialogProps {
   image: string | null;
@@ -56,14 +57,16 @@ export function BotAvatarPickerDialog({ image, onChange }: BotAvatarPickerDialog
             render={
               <button
                 type="button"
-                className="rounded-2xl bg-background p-2 shadow-sm border border-border hover:border-primary/40 transition-colors cursor-pointer"
+                aria-label="Choose bot avatar"
+                data-testid={tid.botAvatarPickerTrigger}
+                className="rounded-full bg-background p-2 shadow-sm border border-border hover:border-primary/40 transition-colors cursor-pointer"
               />
             }
           >
             {triggerPreview ? (
-              <img src={triggerPreview} alt="" className="size-20 rounded-2xl object-cover" />
+              <img src={triggerPreview} alt="" className="size-20 rounded-full object-cover" />
             ) : (
-              <span className="block size-20 overflow-hidden rounded-2xl">
+              <span className="block size-20 overflow-hidden rounded-full">
                 <GeneratedAvatar seed={picker.seed} size={80} className="size-full" />
               </span>
             )}

--- a/src/web/src/components/community/community-avatar-shape.contract.test.ts
+++ b/src/web/src/components/community/community-avatar-shape.contract.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+const componentDirectory = dirname(fileURLToPath(import.meta.url))
+const webRoot = resolve(componentDirectory, "../../..")
+const readWeb = (path: string) => readFileSync(resolve(webRoot, path), "utf8")
+
+describe("community avatar shape contract", () => {
+  it("keeps My Profile preview and crop circular", () => {
+    const profile = readWeb("src/components/community/edit-profile-dialog.tsx")
+    const shell = readWeb("src/components/community/shell-frame.tsx")
+
+    expect(profile).toContain(
+      'className="block size-24 overflow-hidden rounded-full ring-1 ring-border/50"',
+    )
+    expect(shell).toMatch(/pendingAvatarCrop[\s\S]*maskShape="circle"/)
+  })
+
+  it("keeps every bot picker preview and crop circular", () => {
+    const picker = readWeb("src/components/avatar/bot-avatar-picker-dialog.tsx")
+
+    expect(picker).not.toContain("rounded-2xl")
+    expect(picker.match(/rounded-full/g)).toHaveLength(5)
+    expect(picker).toContain('maskShape="circle"')
+    expect(picker).toContain("data-testid={tid.botAvatarPickerTrigger}")
+    expect(picker).toContain('aria-label="Choose bot avatar"')
+  })
+
+  it("leaves the workspace agent picker rounded-square", () => {
+    const picker = readWeb("src/components/avatar/avatar-picker-dialog.tsx")
+
+    expect(picker).toContain('className="block size-20 overflow-hidden rounded-2xl"')
+    expect(picker).not.toContain("rounded-full")
+    expect(picker).toContain('data-testid="workspace-agent-avatar-preview"')
+  })
+})

--- a/src/web/src/components/community/edit-profile-dialog.tsx
+++ b/src/web/src/components/community/edit-profile-dialog.tsx
@@ -214,7 +214,7 @@ export function UserSettings({ onClose, userId, userName, aboutMe, avatar, statu
                   pill button beneath (matches the bot create/edit sheet; a stock
                   secondary Button reads as the old square style). */}
               <div className="flex flex-col items-center gap-3">
-                <span className="block size-24 overflow-hidden rounded-2xl ring-1 ring-border/50">
+                <span className="block size-24 overflow-hidden rounded-full ring-1 ring-border/50">
                   <Avatar label={avatar} seed={userId ?? undefined} size={96} />
                 </span>
                 <button

--- a/src/web/src/lib/community/testids.ts
+++ b/src/web/src/lib/community/testids.ts
@@ -24,6 +24,7 @@ export const tid = {
   botReportProblemDialog: "bot-report-problem-dialog",
   botReportProblemSubmit: "bot-report-problem-submit",
   botReportProblemStatus: "bot-report-problem-status",
+  botAvatarPickerTrigger: "community-bot-avatar-picker-trigger",
 
   forumTagDialog: "community-forum-tag-dialog",
 


### PR DESCRIPTION
# Why we need this PR?
> Closes: N/A

Community identity avatars had inconsistent preview shapes, and the local Wrangler launcher passed native pnpm executables to Node as JavaScript, preventing `pnpm dev` from starting on standalone pnpm installations.

## What changed
- Make My Profile and Community bot avatar previews circular while keeping Workspace agent avatars rounded-square.
- Add stable avatar QA selectors and focused shape contracts.
- Execute `npm_execpath` directly so native pnpm launchers work with the shared worktree-local Wrangler registry.
- Add a focused registry launcher contract with cross-platform line-ending normalization.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [x] Other: local development launcher

Validation: typecheck, lint, Ubuntu and Windows tests, build, coverage, E2E, five UI shards and gates, focused avatar contract (3/3), focused launcher contract (4/4), full CI scripts (41/41), real Chromium avatar QA, and independent four-service `pnpm dev` startup. All GitHub Actions checks pass, including Tests (windows-latest) and CI Gate.