### PR TITLE
fix: distinguish sent invite cards

### DIFF
--- a/src/web/src/components/community/_types.ts
+++ b/src/web/src/components/community/_types.ts
@@ -20,6 +20,7 @@ export type Presence = "online" | "offline"
 export type RightPanel = "members" | "pinned" | "search" | "threads" | null
 export type MobileZone = "nav" | "messages"
 export type View = "server" | "dm" | "settings"
+export type MessagePerspective = "sender" | "recipient" | "neutral"
 export type SettingsSection =
   | "overview"
   | "members"

--- a/src/web/src/components/community/community-invite-card.test.ts
+++ b/src/web/src/components/community/community-invite-card.test.ts
@@ -51,6 +51,6 @@ describe("invite-card perspective wiring", () => {
   it("keeps Share as Image explicitly neutral", () => {
     const shareDialog = readComponent("message-share-dialog.tsx")
 
-    expect(shareDialog).toContain('invitePerspective="neutral"')
+    expect(shareDialog).toContain('perspective="neutral"')
   })
 })

--- a/src/web/src/components/community/community-invite-card.test.ts
+++ b/src/web/src/components/community/community-invite-card.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+import { resolveInviteCardPresentation } from "./community-invite-card"
+
+const componentDirectory = dirname(fileURLToPath(import.meta.url))
+const readComponent = (name: string) =>
+  readFileSync(resolve(componentDirectory, name), "utf8")
+
+describe("resolveInviteCardPresentation", () => {
+  it("keeps sender state stable and non-interactive", () => {
+    expect(resolveInviteCardPresentation("sender", false)).toEqual({
+      eyebrow: "Invite sent",
+      action: null,
+    })
+    expect(resolveInviteCardPresentation("sender", true)).toEqual({
+      eyebrow: "Invite sent",
+      action: null,
+    })
+  })
+
+  it("keeps the existing recipient actions", () => {
+    expect(resolveInviteCardPresentation("recipient", false)).toEqual({
+      eyebrow: "You've been invited to join",
+      action: "join",
+    })
+    expect(resolveInviteCardPresentation("recipient", true)).toEqual({
+      eyebrow: "You've been invited to join",
+      action: "open",
+    })
+  })
+
+  it("keeps shared images neutral and non-interactive", () => {
+    expect(resolveInviteCardPresentation("neutral", false)).toEqual({
+      eyebrow: "Server invite",
+      action: null,
+    })
+  })
+})
+
+describe("invite-card perspective wiring", () => {
+  it("derives sender perspective from the message author and viewer", () => {
+    const message = readComponent("message.tsx")
+
+    expect(message).toContain("m.authorId === viewerUserId ? \"sender\" : \"recipient\"")
+    expect(message).toContain("a.authorId !== b.authorId")
+    expect(message).toContain("prev.viewerUserId === next.viewerUserId")
+  })
+
+  it("keeps Share as Image explicitly neutral", () => {
+    const shareDialog = readComponent("message-share-dialog.tsx")
+
+    expect(shareDialog).toContain('invitePerspective="neutral"')
+  })
+})

--- a/src/web/src/components/community/community-invite-card.tsx
+++ b/src/web/src/components/community/community-invite-card.tsx
@@ -11,6 +11,21 @@ import { useServers } from "@/hooks/community/use-servers"
 import { useJoinServer } from "@/hooks/community/mutations/servers"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
+import { tid } from "@/lib/community/testids"
+
+export type InviteCardPerspective = "sender" | "recipient" | "neutral"
+
+export function resolveInviteCardPresentation(
+  perspective: InviteCardPerspective,
+  alreadyMember: boolean,
+): { eyebrow: string; action: "join" | "open" | null } {
+  if (perspective === "sender") return { eyebrow: "Invite sent", action: null }
+  if (perspective === "neutral") return { eyebrow: "Server invite", action: null }
+  return {
+    eyebrow: "You've been invited to join",
+    action: alreadyMember ? "open" : "join",
+  }
+}
 
 type InviteInfo = {
   serverId: string
@@ -25,7 +40,13 @@ type InviteInfo = {
  * mount so the card stays live (revoked/expired invites render an error
  * state instead of showing stale info from a snapshot).
  */
-export function CommunityInviteCard({ token }: { token: string }) {
+export function CommunityInviteCard({
+  token,
+  perspective,
+}: {
+  token: string
+  perspective: InviteCardPerspective
+}) {
   const router = useRouter()
   const { servers } = useServers()
   const joinServer = useJoinServer()
@@ -40,6 +61,10 @@ export function CommunityInviteCard({ token }: { token: string }) {
   const alreadyMemberServerId = data
     ? servers.find((s) => s.id === data.serverId)?.id
     : undefined
+  const presentation = resolveInviteCardPresentation(
+    perspective,
+    !!alreadyMemberServerId,
+  )
 
   const onJoin = async () => {
     try {
@@ -62,27 +87,39 @@ export function CommunityInviteCard({ token }: { token: string }) {
 
   if (isLoading) {
     return (
-      <div className={cardBase}>
+      <div
+        className={cardBase}
+        data-testid={tid.inviteCard(token)}
+        data-perspective={perspective}
+      >
         <Skeleton className="size-12 shrink-0 rounded-lg" />
         <div className="min-w-0 flex-1 space-y-2">
           <Skeleton className="h-3 w-24 rounded" />
           <Skeleton className="h-3 w-16 rounded" />
         </div>
-        <Skeleton className="h-8 w-16 rounded-md" />
+        {perspective === "recipient" && <Skeleton className="h-8 w-16 rounded-md" />}
       </div>
     )
   }
 
   if (isError || !data) {
     return (
-      <div className={`${cardBase} text-sm text-muted-foreground`}>
+      <div
+        className={`${cardBase} text-sm text-muted-foreground`}
+        data-testid={tid.inviteCard(token)}
+        data-perspective={perspective}
+      >
         This invite has expired or is no longer valid.
       </div>
     )
   }
 
   return (
-    <div className={cardBase}>
+    <div
+      className={cardBase}
+      data-testid={tid.inviteCard(token)}
+      data-perspective={perspective}
+    >
       <ServerIcon
         id={data.serverId}
         name={data.serverName}
@@ -93,25 +130,31 @@ export function CommunityInviteCard({ token }: { token: string }) {
       />
       <div className="min-w-0 flex-1">
         <div className="text-xs font-medium text-muted-foreground">
-          You&apos;ve been invited to join
+          {presentation.eyebrow}
         </div>
         <div className="truncate font-medium">{data.serverName}</div>
         <div className="text-xs text-muted-foreground">
           {data.memberCount} {data.memberCount === 1 ? "member" : "members"}
         </div>
       </div>
-      {alreadyMemberServerId ? (
+      {presentation.action === "open" && alreadyMemberServerId ? (
         <Button
           size="sm"
+          data-testid={tid.inviteCardAction(token)}
           onClick={() => router.push(`/c/channels/${alreadyMemberServerId}`)}
         >
           Go to Server
         </Button>
-      ) : (
-        <Button size="sm" onClick={onJoin} disabled={joinServer.isPending}>
+      ) : presentation.action === "join" ? (
+        <Button
+          size="sm"
+          data-testid={tid.inviteCardAction(token)}
+          onClick={onJoin}
+          disabled={joinServer.isPending}
+        >
           {joinServer.isPending ? "Joining…" : "Join"}
         </Button>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/src/web/src/components/community/community-invite-card.tsx
+++ b/src/web/src/components/community/community-invite-card.tsx
@@ -12,11 +12,10 @@ import { useJoinServer } from "@/hooks/community/mutations/servers"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { tid } from "@/lib/community/testids"
-
-export type InviteCardPerspective = "sender" | "recipient" | "neutral"
+import type { MessagePerspective } from "./_types"
 
 export function resolveInviteCardPresentation(
-  perspective: InviteCardPerspective,
+  perspective: MessagePerspective,
   alreadyMember: boolean,
 ): { eyebrow: string; action: "join" | "open" | null } {
   if (perspective === "sender") return { eyebrow: "Invite sent", action: null }
@@ -45,7 +44,7 @@ export function CommunityInviteCard({
   perspective,
 }: {
   token: string
-  perspective: InviteCardPerspective
+  perspective: MessagePerspective
 }) {
   const router = useRouter()
   const { servers } = useServers()

--- a/src/web/src/components/community/community-panel-sheet.tsx
+++ b/src/web/src/components/community/community-panel-sheet.tsx
@@ -34,6 +34,7 @@ export function CommunityPanelSheet({
   myRole,
   onJumpToMessage,
   onSearch,
+  viewerUserId,
 }: {
   open: boolean
   onOpenChange: (v: boolean) => void
@@ -59,6 +60,7 @@ export function CommunityPanelSheet({
   myRole?: Role
   onJumpToMessage?: (seq: number) => void
   onSearch?: (query: string) => void
+  viewerUserId?: string
 }) {
   const { width, onPointerDown, onPointerMove, onPointerUp } = useSheetResize({
     defaultWidth: 380,
@@ -100,6 +102,7 @@ export function CommunityPanelSheet({
           myRole={myRole}
           onJumpToMessage={onJumpToMessage}
           onSearch={onSearch}
+          viewerUserId={viewerUserId}
         />
       </SheetContent>
     </Sheet>

--- a/src/web/src/components/community/forum-channel-surface.tsx
+++ b/src/web/src/components/community/forum-channel-surface.tsx
@@ -142,6 +142,7 @@ export function ForumChannelSurface({
           open
           onOpenChange={(open) => { if (!open) setPanelState({ channelId, panel: null }) }}
           kind={rightPanel}
+          viewerUserId={viewer.id}
           {...memberPanelProps}
           pinned={[]}
           searchResults={[]}

--- a/src/web/src/components/community/message-body.tsx
+++ b/src/web/src/components/community/message-body.tsx
@@ -13,7 +13,10 @@ import {
   MD_LITERAL_TAGS,
   buildMdComponents,
 } from "./message-markdown"
-import { CommunityInviteCard } from "./community-invite-card"
+import {
+  CommunityInviteCard,
+  type InviteCardPerspective,
+} from "./community-invite-card"
 import type { OpenProfile } from "./_types"
 
 // The sanitize schema Streamdown builds internally when `allowedTags` is
@@ -94,9 +97,11 @@ const REHYPE_PLUGINS: PluggableList = [
 function MessageBodyImpl({
   text,
   onOpenProfile,
+  invitePerspective = "neutral",
 }: {
   text: string
   onOpenProfile?: OpenProfile
+  invitePerspective?: InviteCardPerspective
 }) {
   const inviteTokens = useMemo(() => extractInviteTokens(text), [text])
   const components = useMemo(
@@ -135,7 +140,11 @@ function MessageBodyImpl({
         // padding area.
         <div className="flex flex-col gap-2 pb-2">
           {inviteTokens.map((token) => (
-            <CommunityInviteCard key={token} token={token} />
+            <CommunityInviteCard
+              key={token}
+              token={token}
+              perspective={invitePerspective}
+            />
           ))}
         </div>
       )}

--- a/src/web/src/components/community/message-body.tsx
+++ b/src/web/src/components/community/message-body.tsx
@@ -13,11 +13,8 @@ import {
   MD_LITERAL_TAGS,
   buildMdComponents,
 } from "./message-markdown"
-import {
-  CommunityInviteCard,
-  type InviteCardPerspective,
-} from "./community-invite-card"
-import type { OpenProfile } from "./_types"
+import { CommunityInviteCard } from "./community-invite-card"
+import type { MessagePerspective, OpenProfile } from "./_types"
 
 // The sanitize schema Streamdown builds internally when `allowedTags` is
 // left at its default merge path (verified against Streamdown 2.5.0's
@@ -97,11 +94,11 @@ const REHYPE_PLUGINS: PluggableList = [
 function MessageBodyImpl({
   text,
   onOpenProfile,
-  invitePerspective = "neutral",
+  perspective = "neutral",
 }: {
   text: string
   onOpenProfile?: OpenProfile
-  invitePerspective?: InviteCardPerspective
+  perspective?: MessagePerspective
 }) {
   const inviteTokens = useMemo(() => extractInviteTokens(text), [text])
   const components = useMemo(
@@ -143,7 +140,7 @@ function MessageBodyImpl({
             <CommunityInviteCard
               key={token}
               token={token}
-              perspective={invitePerspective}
+              perspective={perspective}
             />
           ))}
         </div>

--- a/src/web/src/components/community/message-context-sheet.tsx
+++ b/src/web/src/components/community/message-context-sheet.tsx
@@ -417,6 +417,7 @@ export function MessageContextSheet({
           {!query.isLoading && !query.isError && query.data && !query.data.notFound && (
             <ContextRows
               rows={renderRows}
+              viewerUserId={currentUser.id}
               anchorId={anchorId}
               pinnedIds={pinnedIds}
               onOpenProfile={onOpenProfile}
@@ -441,6 +442,7 @@ export function MessageContextSheet({
 
 function ContextRows({
   rows,
+  viewerUserId,
   anchorId,
   pinnedIds,
   onOpenProfile,
@@ -457,6 +459,7 @@ function ContextRows({
   onDownloadFile,
 }: {
   rows: RenderMsg[]
+  viewerUserId: string
   anchorId: string | null
   pinnedIds?: Set<string>
   onOpenProfile?: OpenProfile
@@ -500,6 +503,7 @@ function ContextRows({
             <div data-anchor-row={isTarget ? "1" : undefined}>
               <MessageRow
                 m={m}
+                viewerUserId={viewerUserId}
                 pinned={pinnedIds?.has(m.id)}
                 highlighted={isTarget}
                 onOpenThread={onOpenThread ?? (() => {})}

--- a/src/web/src/components/community/message-list.tsx
+++ b/src/web/src/components/community/message-list.tsx
@@ -451,6 +451,7 @@ export function MessageList({
                         <div data-msg-id={item.m.id} data-testid={tid.message(item.m.id)}>
                           <MessageRow
                             m={item.m}
+                            viewerUserId={viewerUserId}
                             pinned={pinnedIds?.has(item.m.id)}
                             highlighted={jumped === item.m.id}
                             onOpenThread={onOpenThread}

--- a/src/web/src/components/community/message-row.tsx
+++ b/src/web/src/components/community/message-row.tsx
@@ -17,6 +17,7 @@ import type { RenderMsg, OpenProfile } from "./_types"
 // plans/community-switch-perf-optimization.md (WS3).
 export interface MessageRowProps {
   m: RenderMsg
+  viewerUserId?: string
   pinned?: boolean
   highlighted?: boolean
   onOpenThread: (id: string) => void
@@ -50,7 +51,7 @@ export interface MessageRowProps {
 
 function MessageRowImpl(props: MessageRowProps) {
   const {
-    m, pinned, highlighted, onOpenThread, onOpenProfile,
+    m, viewerUserId, pinned, highlighted, onOpenThread, onOpenProfile,
     onToggleReactionId, onReactId, onReplyId, onPinId, onMarkId, onCreateThreadId,
     onCopyId, onEditId, onRetryId, onDismissId, onJumpToId, onPreviewImage, onDownloadFile,
     resolveUserName, onImageLoad,
@@ -88,6 +89,7 @@ function MessageRowImpl(props: MessageRowProps) {
   return (
     <Message
       m={m}
+      viewerUserId={viewerUserId}
       pinned={pinned}
       highlighted={highlighted}
       onOpenThread={onOpenThread}

--- a/src/web/src/components/community/message-share-dialog.tsx
+++ b/src/web/src/components/community/message-share-dialog.tsx
@@ -201,7 +201,7 @@ export function MessageShareDialog({ m, open, onClose }: {
                       onMouseUp={() => onBodyMouseUp(msg.id)}
                       className="max-h-164 overflow-hidden line-clamp-32 [&_mark[data-hl]]:rounded-xs [&_mark[data-hl]]:bg-[rgba(255,208,92,0.5)] [&_mark[data-hl]]:p-[0_1px] [&_mark[data-hl]]:[box-decoration-break:clone] [&_mark[data-hl]]:[-webkit-box-decoration-break:clone] [&_mark[data-hl]]:text-inherit"
                     >
-                      <MessageBody text={msg.content} invitePerspective="neutral" />
+                      <MessageBody text={msg.content} perspective="neutral" />
                     </div>
                   )}
                 </div>

--- a/src/web/src/components/community/message-share-dialog.tsx
+++ b/src/web/src/components/community/message-share-dialog.tsx
@@ -201,7 +201,7 @@ export function MessageShareDialog({ m, open, onClose }: {
                       onMouseUp={() => onBodyMouseUp(msg.id)}
                       className="max-h-164 overflow-hidden line-clamp-32 [&_mark[data-hl]]:rounded-xs [&_mark[data-hl]]:bg-[rgba(255,208,92,0.5)] [&_mark[data-hl]]:p-[0_1px] [&_mark[data-hl]]:[box-decoration-break:clone] [&_mark[data-hl]]:[-webkit-box-decoration-break:clone] [&_mark[data-hl]]:text-inherit"
                     >
-                      <MessageBody text={msg.content} />
+                      <MessageBody text={msg.content} invitePerspective="neutral" />
                     </div>
                   )}
                 </div>

--- a/src/web/src/components/community/message.tsx
+++ b/src/web/src/components/community/message.tsx
@@ -42,6 +42,7 @@ function MessageImpl({
   onToggleReaction, onReact, onReply, onPin, onMark, onCreateThread, onCopy, onEdit, onRetry, onDismiss,
   onPreviewImage, onDownloadFile, highlighted, resolveUserName, onImageLoad,
   selectMode, selected, onToggleSelect, onEnterSelect, onShareSingle,
+  viewerUserId,
 }: {
   m: RenderMsg
   compact?: boolean
@@ -81,6 +82,7 @@ function MessageImpl({
   onToggleSelect?: () => void
   onEnterSelect?: () => void
   onShareSingle?: () => void
+  viewerUserId?: string
 }) {
   // keep the hover toolbar pinned open while its ⋯ dropdown is open
   const [toolbarOpen, setToolbarOpen] = useState(false)
@@ -241,7 +243,15 @@ function MessageImpl({
             <BotApprovalCard approval={m.approval} />
           ) : (
             m.content && (
-              <MessageBody text={m.content} onOpenProfile={onOpenProfile} />
+              <MessageBody
+                text={m.content}
+                onOpenProfile={onOpenProfile}
+                invitePerspective={
+                  viewerUserId
+                    ? m.authorId === viewerUserId ? "sender" : "recipient"
+                    : "neutral"
+                }
+              />
             )
           )}
 
@@ -472,6 +482,7 @@ function messagePropsEqual(prev: MessageProps, next: MessageProps): boolean {
       a.content !== b.content ||
       a.grouped !== b.grouped ||
       a.failed !== b.failed ||
+      a.authorId !== b.authorId ||
       a.authorName !== b.authorName ||
       a.authorAvatar !== b.authorAvatar ||
       a.color !== b.color ||
@@ -490,6 +501,7 @@ function messagePropsEqual(prev: MessageProps, next: MessageProps): boolean {
     prev.compact === next.compact &&
     prev.pinned === next.pinned &&
     prev.highlighted === next.highlighted &&
+    prev.viewerUserId === next.viewerUserId &&
     prev.onOpenThread === next.onOpenThread &&
     prev.onOpenProfile === next.onOpenProfile &&
     prev.onJumpReply === next.onJumpReply &&

--- a/src/web/src/components/community/message.tsx
+++ b/src/web/src/components/community/message.tsx
@@ -246,7 +246,7 @@ function MessageImpl({
               <MessageBody
                 text={m.content}
                 onOpenProfile={onOpenProfile}
-                invitePerspective={
+                perspective={
                   viewerUserId
                     ? m.authorId === viewerUserId ? "sender" : "recipient"
                     : "neutral"

--- a/src/web/src/components/community/right-panel.tsx
+++ b/src/web/src/components/community/right-panel.tsx
@@ -21,7 +21,7 @@ export function RightPanelContent({
   onAddMember, manageContext,
   pinned, pinnedLoading, searchResults, searchQuery,
   threads, threadsLoading, showSearchInput = true, onOpenThread, onOpenProfile,
-  onSetRole, onKickMember, myRole, onJumpToMessage, onSearch,
+  onSetRole, onKickMember, myRole, onJumpToMessage, onSearch, viewerUserId,
 }: {
   kind: Exclude<RightPanel, null>
   members: Member[]
@@ -49,6 +49,7 @@ export function RightPanelContent({
   // sheet), so a click always gives feedback even for an out-of-window pin.
   onJumpToMessage?: (seq: number) => void
   onSearch?: (query: string) => void
+  viewerUserId?: string
 }) {
   if (kind === "members")
     return (
@@ -100,7 +101,16 @@ export function RightPanelContent({
       </PanelShell>
     )
   if (kind === "search")
-    return <SearchPanel searchResults={searchResults} initialQuery={searchQuery} showSearchInput={showSearchInput} onOpenProfile={onOpenProfile} onSearch={onSearch} />
+    return (
+      <SearchPanel
+        searchResults={searchResults}
+        initialQuery={searchQuery}
+        showSearchInput={showSearchInput}
+        onOpenProfile={onOpenProfile}
+        onSearch={onSearch}
+        viewerUserId={viewerUserId}
+      />
+    )
   return (
     <PanelShell icon={MessagesSquare} title="Threads">
       {threadsLoading && threads.length === 0 ? (
@@ -170,8 +180,20 @@ function ThreadListSkeleton() {
   )
 }
 
-function SearchPanel({ searchResults, initialQuery, showSearchInput, onOpenProfile, onSearch }: {
-  searchResults: Msg[]; initialQuery?: string; showSearchInput?: boolean; onOpenProfile?: OpenProfile; onSearch?: (query: string) => void
+function SearchPanel({
+  searchResults,
+  initialQuery,
+  showSearchInput,
+  onOpenProfile,
+  onSearch,
+  viewerUserId,
+}: {
+  searchResults: Msg[]
+  initialQuery?: string
+  showSearchInput?: boolean
+  onOpenProfile?: OpenProfile
+  onSearch?: (query: string) => void
+  viewerUserId?: string
 }) {
   const [query, setQuery] = useState(initialQuery ?? "")
   const submit = () => { const q = query.trim(); if (q) onSearch?.(q) }
@@ -192,7 +214,16 @@ function SearchPanel({ searchResults, initialQuery, showSearchInput, onOpenProfi
       <div className="mb-2 text-xs text-muted-foreground">{searchResults.length} results</div>
       {searchResults.map((m) => {
         const renderMsg: RenderMsg = { ...m, grouped: false }
-        return <Message key={m.id} m={renderMsg} compact onOpenThread={() => {}} onOpenProfile={onOpenProfile} />
+        return (
+          <Message
+            key={m.id}
+            m={renderMsg}
+            compact
+            viewerUserId={viewerUserId}
+            onOpenThread={() => {}}
+            onOpenProfile={onOpenProfile}
+          />
+        )
       })}
     </PanelShell>
   )

--- a/src/web/src/components/community/text-channel-surface.tsx
+++ b/src/web/src/components/community/text-channel-surface.tsx
@@ -155,6 +155,7 @@ export function TextChannelSurface({
               open
               onOpenChange={(open) => { if (!open) setRightPanel(null) }}
               kind={rightPanel}
+              viewerUserId={viewer.id}
               {...memberPanelProps}
               pinned={feed.pinned}
               pinnedLoading={feed.pinnedLoading}

--- a/src/web/src/components/community/thread-channel-surface.test.ts
+++ b/src/web/src/components/community/thread-channel-surface.test.ts
@@ -228,6 +228,7 @@ describe("ThreadChannelSurface ownership", () => {
     expect(opener.type).toBe(ThreadOpener)
     expect(opener.props).toEqual(expect.objectContaining({
       parentMessageId: "opener_1",
+      viewerUserId: "viewer_1",
       onOpenProfile: props.onOpenProfile,
     }))
     act(() => opener.props.onJump?.())

--- a/src/web/src/components/community/thread-channel-surface.tsx
+++ b/src/web/src/components/community/thread-channel-surface.tsx
@@ -153,6 +153,7 @@ export function ThreadChannelSurface({
   const opener = parentMessageId && !parentIsForum ? (
     <ThreadOpener
       parentMessageId={parentMessageId}
+      viewerUserId={viewer.id}
       onOpenProfile={onOpenProfile}
       onPreviewImage={(url) => uiHandlers.previewImage?.(url)}
       onDownloadFile={(url) => {
@@ -256,6 +257,7 @@ export function ThreadChannelSurface({
               open
               onOpenChange={(open) => { if (!open) setRightPanel(null) }}
               kind={rightPanel}
+              viewerUserId={viewer.id}
               {...memberPanelProps}
               pinned={controller.feed.pinned}
               pinnedLoading={controller.feed.pinnedLoading}

--- a/src/web/src/components/community/thread-opener.test.ts
+++ b/src/web/src/components/community/thread-opener.test.ts
@@ -40,7 +40,10 @@ describe("ThreadOpener image attachment layout", () => {
     let renderer: TestRenderer.ReactTestRenderer
     act(() => {
       renderer = TestRenderer.create(
-        React.createElement(ThreadOpener, { parentMessageId: "opener_1" }),
+        React.createElement(ThreadOpener, {
+          parentMessageId: "opener_1",
+          viewerUserId: "viewer_1",
+        }),
         { createNodeMock: () => genericMock },
       )
     })

--- a/src/web/src/components/community/thread-opener.tsx
+++ b/src/web/src/components/community/thread-opener.tsx
@@ -107,7 +107,7 @@ export function ThreadOpener({
             <MessageBody
               text={msg.content}
               onOpenProfile={onOpenProfile}
-              invitePerspective={msg.authorId === viewerUserId ? "sender" : "recipient"}
+              perspective={msg.authorId === viewerUserId ? "sender" : "recipient"}
             />
           )}
 

--- a/src/web/src/components/community/thread-opener.tsx
+++ b/src/web/src/components/community/thread-opener.tsx
@@ -27,12 +27,14 @@ import type { OpenProfile } from "./_types"
 // reflect here without a page reload once the mutation invalidates this key.
 export function ThreadOpener({
   parentMessageId,
+  viewerUserId,
   onOpenProfile,
   onPreviewImage,
   onDownloadFile,
   onJump,
 }: {
   parentMessageId: string
+  viewerUserId: string
   onOpenProfile?: OpenProfile
   onPreviewImage?: (url: string) => void
   onDownloadFile?: (url: string) => void
@@ -101,7 +103,13 @@ export function ThreadOpener({
             </span>
           </div>
 
-          {msg.content && <MessageBody text={msg.content} onOpenProfile={onOpenProfile} />}
+          {msg.content && (
+            <MessageBody
+              text={msg.content}
+              onOpenProfile={onOpenProfile}
+              invitePerspective={msg.authorId === viewerUserId ? "sender" : "recipient"}
+            />
+          )}
 
           {msg.attachments && msg.attachments.length > 0 && (
             <div className="mt-2 flex flex-col gap-2 pb-2">

--- a/src/web/src/lib/community/testids.test.ts
+++ b/src/web/src/lib/community/testids.test.ts
@@ -7,6 +7,13 @@ describe("community QA selectors", () => {
     expect(tid.channelRefPill("post_1")).toBe("community-channel-ref-pill-post_1")
   })
 
+  it("keys invite-card surfaces by their token", () => {
+    expect(tid.inviteCard("invite_1")).toBe("community-invite-card-invite_1")
+    expect(tid.inviteCardAction("invite_1")).toBe(
+      "community-invite-card-action-invite_1",
+    )
+  })
+
   it("exposes only the four stable My Bots bug-report flow selectors", () => {
     expect(tid.botReportProblemItem).toBe("bot-report-problem-item")
     expect(tid.botReportProblemDialog).toBe("bot-report-problem-dialog")

--- a/src/web/src/lib/community/testids.ts
+++ b/src/web/src/lib/community/testids.ts
@@ -15,6 +15,8 @@ export const tid = {
   statusPill: "community-status-pill",
   inviteToken: "community-invite-token",
   inviteCopy: "community-invite-copy",
+  inviteCard: (token: string) => `community-invite-card-${token}`,
+  inviteCardAction: (token: string) => `community-invite-card-action-${token}`,
   machinePairOpen: "community-machine-pair-open",
   machinePairCommand: "community-machine-pair-command",
   machinePairCopy: "community-machine-pair-copy",


### PR DESCRIPTION
# Why we need this PR?
> Closes: N/A

Invite cards currently show actions based only on the viewer’s server membership, so the author of an invite message can see Join or a redundant Go to Server action on their own sent message.

## What changed
- Derive invite-card perspective from the message author and current viewer.
- Show senders a stable Invite sent state with no action button, independent of membership.
- Preserve recipient Join / Go to Server behavior and the shared invalid state.
- Apply the same perspective to main messages, thread openers, search results, and message-context previews; keep Share as Image neutral and non-interactive.
- Add stable invite-card selectors and focused regression coverage.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (@alook/shared)
- [x] Web app (@alook/web)
- [ ] CLI (@alook/cli)
- [ ] Email Worker (@alook/email-worker)
- [ ] WebSocket DO (@alook/ws-do)
- [ ] CI/CD
- [x] Other: community invite-card UX

Validation: focused invite/thread tests 10/10 and selector/invite tests 8/8 passed; typecheck and lint passed; real Chromium /c QA passed with D1, network, web-log, and WebSocket correlation. Full local test ran 4,278/4,279; the sole failure was the known unrelated concurrent preflight-bug-reports stdout race, which passed 18/18 in isolation. GitHub CI, UI E2E, and Codecov patch coverage are green.