### PR TITLE
fix: unify profile card context

### DIFF
--- a/src/web/src/components/community/_types.ts
+++ b/src/web/src/components/community/_types.ts
@@ -277,7 +277,7 @@ export type Profile = {
   // in @alook/shared.
   discriminator?: string
   avatar: string
-  role: string
+  contextLabel?: string
   about: string
   mutual: number
   // Live online/offline dot on the card's avatar — undefined when no

--- a/src/web/src/components/community/message.render.test.ts
+++ b/src/web/src/components/community/message.render.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import React from "react"
 import TestRenderer, { act } from "react-test-renderer"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { Message } from "./message"
+import { Message, shouldActivateMessageOverlays } from "./message"
 import type { RenderMsg } from "./_types"
 
 // WS3 render-behavior tests (see plans/community-switch-perf-optimization.md):
@@ -178,6 +178,48 @@ describe("Message image attachment layout", () => {
 })
 
 describe("Message lazy overlays", () => {
+  it("does not remount the row when the pointer enters an author button", () => {
+    const interactiveTarget = { closest: vi.fn(() => ({})) }
+    const rowTarget = { closest: vi.fn(() => null) }
+
+    expect(shouldActivateMessageOverlays(interactiveTarget as unknown as EventTarget)).toBe(false)
+    expect(shouldActivateMessageOverlays(rowTarget as unknown as EventTarget)).toBe(true)
+  })
+
+  it("keeps the first author click live while lazy overlays are inactive", () => {
+    const onOpenProfile = vi.fn()
+    let renderer: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(
+        makeTree({
+          m: baseMsg(),
+          onOpenThread: vi.fn(),
+          onOpenProfile,
+          onReply: vi.fn(),
+        }),
+        { createNodeMock: () => genericMock },
+      )
+    })
+    const row = renderer!.root.find(
+      (node) => typeof node.props.className === "string"
+        && node.props.className.includes("group relative -mx-2"),
+    )
+    const authorButton = renderer!.root.findAllByType("button").find((button) =>
+      button.children.includes("Alice"),
+    )
+    const target = { closest: () => authorButton }
+
+    act(() => row.props.onPointerEnter({ target }))
+    expect(renderer!.root.findAll(
+      (node) => node.props["data-slot"] === "context-menu-trigger",
+    )).toHaveLength(0)
+
+    const event = { clientX: 10, clientY: 20 }
+    act(() => authorButton!.props.onClick(event))
+    expect(onOpenProfile).toHaveBeenCalledOnce()
+    expect(onOpenProfile).toHaveBeenCalledWith("Alice", event, undefined, "u1")
+  })
+
   it("does not mount the ContextMenu root until the row is activated", () => {
     const onOpenThread = vi.fn()
     let renderer: TestRenderer.ReactTestRenderer

--- a/src/web/src/components/community/message.tsx
+++ b/src/web/src/components/community/message.tsx
@@ -37,6 +37,11 @@ export function messageCanShare(m: RenderMsg, compact?: boolean): boolean {
   return !compact && !m.approval && !!m.content
 }
 
+export function shouldActivateMessageOverlays(target: EventTarget | null): boolean {
+  const element = target as { closest?: (selector: string) => unknown } | null
+  return !element?.closest?.("button, a, input, textarea, select, [role=button]")
+}
+
 function MessageImpl({
   m, compact, pinned, onOpenThread, onOpenProfile, onJumpReply,
   onToggleReaction, onReact, onReply, onPin, onMark, onCreateThread, onCopy, onEdit, onRetry, onDismiss,
@@ -131,7 +136,11 @@ function MessageImpl({
   }
   const showMenu = hasMessageMenu(menuHandlers)
   const interactive = !compact && !m.failed && showMenu
-  const activate = interactive && !activated ? () => setActivated(true) : undefined
+  const activate = interactive && !activated
+    ? (event: React.SyntheticEvent<HTMLElement>) => {
+        if (shouldActivateMessageOverlays(event.target)) setActivated(true)
+      }
+    : undefined
   // In select mode (multi-share), the whole row is a big toggle target and gets
   // a leading checkbox overlay + a tint when picked. `canShare` rows only —
   // approval/attachment-only rows aren't selectable (nothing to put on the card).

--- a/src/web/src/components/community/profile-card.test.ts
+++ b/src/web/src/components/community/profile-card.test.ts
@@ -1,6 +1,51 @@
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
 import { describe, it, expect } from "vitest"
 import { resolveCardStatus, resolveProfileBackdropSeed } from "./profile-card"
+import { ProfileCard } from "./profile-card"
 import { serializeBeamSeed } from "@/lib/avatar/seed-url"
+import type { Profile } from "./_types"
+
+function renderProfile(overrides: Partial<Profile> = {}) {
+  return renderToStaticMarkup(createElement(ProfileCard, {
+    embedded: true,
+    data: {
+      name: "Ren",
+      userId: "user_1",
+      avatar: "R",
+      about: "",
+      mutual: 0,
+      ...overrides,
+    },
+    x: 0,
+    y: 0,
+    bp: "desktop",
+    onClose: () => undefined,
+  }))
+}
+
+describe("ProfileCard contextual metadata", () => {
+  it("omits the badge when no context label exists", () => {
+    const html = renderProfile()
+
+    expect(html).not.toContain("community-profile-context-badge")
+    expect(html).not.toContain(">Member<")
+  })
+
+  it("renders an explicit context label", () => {
+    const html = renderProfile({ contextLabel: "Admin" })
+
+    expect(html).toContain('data-testid="community-profile-context-badge"')
+    expect(html).toContain("Admin")
+  })
+
+  it("keeps mutual-server metadata without a context label", () => {
+    const html = renderProfile({ mutual: 2 })
+
+    expect(html).not.toContain("community-profile-context-badge")
+    expect(html).toContain("2 mutual servers")
+  })
+})
 
 describe("resolveProfileBackdropSeed", () => {
   it("uses the stored generated seed so Shuffle changes face and backdrop together", () => {

--- a/src/web/src/components/community/profile-card.tsx
+++ b/src/web/src/components/community/profile-card.tsx
@@ -178,10 +178,16 @@ export function ProfileCard({ data, x, y, bp, onClose, onMessage, isSelf, onUpda
               (a step past DESIGN.md's 16px between-groups token) rather than
               just tighter line spacing off the bio above it. */}
           <p className="mt-2 text-[15px] text-muted-foreground">{data.about || "No bio yet."}</p>
-          <div className="mt-6 flex items-center gap-2 text-xs text-muted-foreground">
-            <Badge variant="secondary" className="h-5 gap-1 text-xs"><Shield className="size-3" /> {data.role}</Badge>
-            {data.mutual > 0 && <span>{data.mutual} mutual server{data.mutual > 1 ? "s" : ""}</span>}
-          </div>
+          {(data.contextLabel || data.mutual > 0) && (
+            <div className="mt-6 flex items-center gap-2 text-xs text-muted-foreground">
+              {data.contextLabel && (
+                <Badge data-testid={tid.profileContextBadge} variant="secondary" className="h-5 gap-1 text-xs">
+                  <Shield className="size-3" /> {data.contextLabel}
+                </Badge>
+              )}
+              {data.mutual > 0 && <span>{data.mutual} mutual server{data.mutual > 1 ? "s" : ""}</span>}
+            </div>
+          )}
           {!isSelf && (
             <div className="mt-4 flex h-9 items-center gap-2 rounded-md bg-secondary px-2">
               <input

--- a/src/web/src/components/community/profile-lookup.test.ts
+++ b/src/web/src/components/community/profile-lookup.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest"
-import { resolveProfileTarget, buildSelfProfile } from "./profile-lookup"
+import {
+  resolveProfileContextLabel,
+  resolveProfileServerId,
+  resolveProfileTarget,
+  resolveProfileUserId,
+  buildSelfProfile,
+} from "./profile-lookup"
 import type { Member, Friend } from "./_types"
 import type { CurrentUser } from "@/contexts/community/current-user"
 
@@ -48,6 +54,40 @@ describe("resolveProfileTarget", () => {
   })
 })
 
+describe("profile context", () => {
+  it("uses the shell view as the synchronous context boundary", () => {
+    expect(resolveProfileServerId("server", "server_1")).toBe("server_1")
+    expect(resolveProfileServerId("dm", "stale_server")).toBeNull()
+    expect(resolveProfileServerId("settings", "stale_server")).toBeNull()
+  })
+
+  it.each([
+    ["owner", "Owner"],
+    ["admin", "Admin"],
+    ["member", "Member"],
+  ] as const)("shows the real %s role only in a server", (role, label) => {
+    const target = member({ role })
+
+    expect(resolveProfileContextLabel("server_1", target)).toBe(label)
+    expect(resolveProfileContextLabel(null, target)).toBeUndefined()
+  })
+
+  it("does not turn a friend row into a server member badge", () => {
+    const friend: Friend = { id: "friend_1", userId: "user_1", name: "Ren", discriminator: "0001", avatar: "R", status: "online", sub: "" }
+
+    expect(resolveProfileContextLabel("server_1", friend)).toBeUndefined()
+  })
+
+  it("keeps the caller user id when no cached member or friend resolves", () => {
+    expect(resolveProfileUserId(undefined, "user_uncached")).toBe("user_uncached")
+  })
+
+  it("prefers the resolved row user id over the caller fallback", () => {
+    expect(resolveProfileUserId(member({ userId: "user_resolved" }), "user_fallback"))
+      .toBe("user_resolved")
+  })
+})
+
 function currentUser(overrides: Partial<CurrentUser> = {}): CurrentUser {
   return {
     id: overrides.id ?? "user_self",
@@ -70,7 +110,7 @@ describe("buildSelfProfile", () => {
     expect(profile.name).toBe("Ren")
     expect(profile.discriminator).toBe("0001")
     expect(profile.about).toBe("hi")
-    expect(profile.role).toBe("You")
+    expect(profile.contextLabel).toBeUndefined()
   })
 
   it("always resolves self presence to online, even when the viewer's id is absent from the online set", () => {
@@ -81,5 +121,11 @@ describe("buildSelfProfile", () => {
   it("falls back to an avatar initial when the viewer has no avatar", () => {
     const profile = buildSelfProfile(currentUser({ name: "alice", avatar: "" }), new Set())
     expect(profile.avatar).toBe("A")
+  })
+
+  it("uses the viewer's real server role when the caller provides one", () => {
+    const profile = buildSelfProfile(currentUser(), new Set(), "Admin")
+
+    expect(profile.contextLabel).toBe("Admin")
   })
 })

--- a/src/web/src/components/community/profile-lookup.ts
+++ b/src/web/src/components/community/profile-lookup.ts
@@ -1,4 +1,4 @@
-import type { Member, Friend, Profile } from "./_types"
+import type { Member, Friend, Profile, View } from "./_types"
 import type { CurrentUser } from "@/contexts/community/current-user"
 import { resolveProfilePresence } from "@/lib/community/presence"
 import { avatarInitial } from "@/lib/community/avatar"
@@ -16,17 +16,40 @@ import { avatarInitial } from "@/lib/community/avatar"
 export function buildSelfProfile(
   currentUser: CurrentUser,
   onlineUserIds: ReadonlySet<string>,
+  contextLabel?: string,
 ): Profile {
   return {
     name: currentUser.name,
     userId: currentUser.id,
     discriminator: currentUser.discriminator,
     avatar: currentUser.avatar || avatarInitial(currentUser.name),
-    role: "You",
+    contextLabel,
     about: currentUser.aboutMe ?? "",
     mutual: 0,
     presence: resolveProfilePresence(true, undefined, onlineUserIds),
   }
+}
+
+export function resolveProfileContextLabel(
+  currentServerId: string | null | undefined,
+  target: Member | Friend | undefined,
+): string | undefined {
+  if (!currentServerId || !target || !("role" in target)) return undefined
+  return target.role.charAt(0).toUpperCase() + target.role.slice(1)
+}
+
+export function resolveProfileServerId(
+  view: View,
+  activeServerId: string | undefined,
+): string | null {
+  return view === "server" ? (activeServerId ?? null) : null
+}
+
+export function resolveProfileUserId(
+  target: Member | Friend | undefined,
+  targetUserId?: string,
+): string | undefined {
+  return target?.userId ?? targetUserId
 }
 
 /**

--- a/src/web/src/components/community/shell-frame.tsx
+++ b/src/web/src/components/community/shell-frame.tsx
@@ -29,7 +29,13 @@ import { ImageLightbox } from "./image-lightbox"
 import { ImageCropDialog } from "./image-crop-dialog"
 import { validateIconSourceFile } from "@/lib/community/image-crop"
 import type { ImagePreview, Marked, MobileZone, Profile, View } from "./_types"
-import { resolveProfileTarget, buildSelfProfile } from "./profile-lookup"
+import {
+  resolveProfileContextLabel,
+  resolveProfileServerId,
+  resolveProfileTarget,
+  resolveProfileUserId,
+  buildSelfProfile,
+} from "./profile-lookup"
 import { resolveProfilePresence } from "@/lib/community/presence"
 import { avatarInitial } from "@/lib/community/avatar"
 import { signOut } from "@/lib/auth-client"
@@ -122,7 +128,8 @@ export function ShellFrame({
   const { folders } = useFolders()
   const { friends } = useFriends()
   const currentServerId = useCommunityStore((s) => s.currentServerId)
-  const membersHook = useServerMembers(currentServerId)
+  const profileServerId = resolveProfileServerId(view, activeServerId)
+  const membersHook = useServerMembers(profileServerId)
   const members = membersHook.members
 
   // Inbox pair — the shell reads both to drive the bell badge.
@@ -346,8 +353,15 @@ export function ShellFrame({
     (name: string, e: React.MouseEvent, discriminator?: string, targetUserId?: string) => {
       const isSelf = !!targetUserId && targetUserId === currentUser.id
       if (isSelf) {
+        const selfMember = profileServerId
+          ? members.find((member) => member.userId === currentUser.id)
+          : undefined
         setProfile({
-          data: buildSelfProfile(currentUser, onlineUserIds),
+          data: buildSelfProfile(
+            currentUser,
+            onlineUserIds,
+            resolveProfileContextLabel(profileServerId, selfMember),
+          ),
           x: e.clientX,
           y: e.clientY,
           initialStatusEmoji: currentUser.statusEmoji ?? null,
@@ -356,19 +370,17 @@ export function ShellFrame({
         return
       }
       const member = resolveProfileTarget(members, friends, { name, discriminator, userId: targetUserId })
-      const role: string = member && "role" in member ? (member as { role: string }).role : "member"
-      const about: string = member && "sub" in member && (member as { sub: string }).sub ? (member as { sub: string }).sub : ""
-      const displayRole = role.charAt(0).toUpperCase() + role.slice(1)
+      const about = member?.sub ?? ""
       // Hoisted above `data` (was previously computed after `setProfile`,
       // only for the async fetch below) so the same value can also feed
       // `resolveProfilePresence`.
-      const userId = member && "userId" in member ? (member as { userId: string }).userId : member?.id
+      const userId = resolveProfileUserId(member, targetUserId)
       const data: Profile = {
         name,
         userId,
         // discriminator is undefined until the /profile fetch below hydrates it.
         avatar: member?.avatar ?? avatarInitial(name),
-        role: displayRole,
+        contextLabel: resolveProfileContextLabel(profileServerId, member),
         about,
         mutual: 0,
         presence: resolveProfilePresence(false, userId, onlineUserIds),
@@ -423,7 +435,7 @@ export function ShellFrame({
           .catch((e) => toastApiError(e, "Failed to load profile"))
       }
     },
-    [currentUser, members, friends, queryClient, onlineUserIds],
+    [currentUser, profileServerId, members, friends, queryClient, onlineUserIds],
   )
 
   const previewImage = useCallback((image: ImagePreview) => setPreview(image), [])

--- a/src/web/src/components/home/landing-page.tsx
+++ b/src/web/src/components/home/landing-page.tsx
@@ -107,7 +107,7 @@ const LANDING_PROFILE = {
   name: "Maya",
   userId: "maya",
   avatar: "Maya",
-  role: "Agent",
+  contextLabel: "Agent",
   about: "I keep the same account, identity, and relationships across every room.",
   mutual: 0,
   presence: "online" as const,

--- a/src/web/src/lib/community/testids.test.ts
+++ b/src/web/src/lib/community/testids.test.ts
@@ -14,6 +14,11 @@ describe("community QA selectors", () => {
     )
   })
 
+  it("exposes the profile context badge independently from the card", () => {
+    expect(tid.profileCard).toBe("community-profile-card")
+    expect(tid.profileContextBadge).toBe("community-profile-context-badge")
+  })
+
   it("exposes only the four stable My Bots bug-report flow selectors", () => {
     expect(tid.botReportProblemItem).toBe("bot-report-problem-item")
     expect(tid.botReportProblemDialog).toBe("bot-report-problem-dialog")

--- a/src/web/src/lib/community/testids.ts
+++ b/src/web/src/lib/community/testids.ts
@@ -12,6 +12,7 @@ export const tid = {
   typingIndicator: "community-typing-indicator",
   dmBlockedNotice: "community-dm-blocked-notice",
   profileCard: "community-profile-card",
+  profileContextBadge: "community-profile-context-badge",
   statusPill: "community-status-pill",
   inviteToken: "community-invite-token",
   inviteCopy: "community-invite-copy",

--- a/src/web/src/lib/time.test.ts
+++ b/src/web/src/lib/time.test.ts
@@ -41,12 +41,15 @@ describe("relativeTime", () => {
 
   it("returns formatted date for 7+ days", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-06-10T12:00:00Z"));
-    const result = relativeTime("2026-05-20T12:00:00Z");
-    expect(result).not.toContain("ago");
-    expect(result).not.toBe("just now");
-    expect(result).not.toBe("");
-    expect(result.length).toBeGreaterThan(0);
+    vi.setSystemTime(new Date("2026-08-13T12:00:00Z"));
+    const localeSpy = vi.spyOn(Date.prototype, "toLocaleDateString");
+    const result = relativeTime("2026-08-06T04:20:00Z");
+    expect(result).toBe("Aug 6");
+    expect(localeSpy).toHaveBeenCalledWith("en-US", {
+      month: "short",
+      day: "numeric",
+      timeZone: "UTC",
+    });
     vi.useRealTimers();
   });
 });

--- a/src/web/src/lib/time.ts
+++ b/src/web/src/lib/time.ts
@@ -10,7 +10,11 @@ export function relativeTime(dateStr: string): string {
   if (diffHrs < 24) return `${diffHrs}h ago`;
   const diffDays = Math.floor(diffHrs / 24);
   if (diffDays < 7) return `${diffDays}d ago`;
-  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
 }
 
 export function timeAgo(dateStr: string | null): string {


### PR DESCRIPTION
# Why we need this PR?
> Closes: N/A

DM and friend profile cards currently inherit a fake Member badge, while uncached message authors can lose their user id and fail to open a usable profile/DM flow. Fast server-to-DM navigation can also briefly retain the previous server role. The landing machine preview also formats old dates with environment defaults, producing a server/browser locale hydration mismatch.

## What changed
- Make the shared profile-card context label optional and render badges only for real server membership roles.
- Derive profile context synchronously from the active shell view, preserving self and server role behavior without stale DM badges.
- Preserve caller-supplied user ids for uncached targets so profile loading and Message-to-DM flows remain usable.
- Keep the first author click live by avoiding lazy message-overlay remounts from interactive targets.
- Stabilize machine last-seen absolute dates with an explicit English locale and UTC time zone.
- Add focused regression coverage and stable QA selectors; live profile QA passed all five DM/server/self/uncached/navigation journeys.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (@alook/shared)
- [x] Web app (@alook/web)
- [ ] CLI (@alook/cli)
- [ ] Email Worker (@alook/email-worker)
- [ ] WebSocket DO (@alook/ws-do)
- [ ] CI/CD
- [ ] Other: ...