### PR TITLE
fix(ci): make daemon packaging tests portable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.11
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
@@ -129,6 +132,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.11
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
@@ -227,6 +233,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.11
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22

--- a/scripts/ci/workflow-contract.test.ts
+++ b/scripts/ci/workflow-contract.test.ts
@@ -8,6 +8,13 @@ const ciWorkflow = readFileSync(resolve(workflowRoot, "ci.yml"), "utf8")
 const publishWorkflows = ["publish-app.yml", "publish-cli.yml", "publish-daemon.yml"]
   .map((name) => readFileSync(resolve(workflowRoot, name), "utf8"))
 
+function ciJob(name: string): string {
+  const start = ciWorkflow.indexOf(`\n  ${name}:\n`)
+  if (start < 0) throw new Error(`missing CI job: ${name}`)
+  const next = ciWorkflow.slice(start + 1).search(/\n  [a-z][a-z0-9-]*:\n/)
+  return next < 0 ? ciWorkflow.slice(start) : ciWorkflow.slice(start, start + 1 + next)
+}
+
 describe("E2E UI workflow", () => {
   it("runs before merge without running on main pushes", () => {
     expect(workflow).toMatch(/^  pull_request:/m)
@@ -25,9 +32,13 @@ describe("E2E UI workflow", () => {
 })
 
 describe("Bun workflow setup", () => {
-  it("installs Bun only in the CI build job and pins every retained setup", () => {
-    expect(ciWorkflow.match(/oven-sh\/setup-bun/g)).toHaveLength(1)
-    expect(ciWorkflow).toContain("bun-version: 1.3.11")
+  it("installs pinned Bun in every CI job that builds a daemon package fixture", () => {
+    const bunJobs = ["test-linux", "test-windows", "build", "coverage"]
+    expect(ciWorkflow.match(/oven-sh\/setup-bun/g)).toHaveLength(bunJobs.length)
+    for (const job of bunJobs) {
+      expect(ciJob(job)).toContain("oven-sh/setup-bun")
+      expect(ciJob(job)).toContain("bun-version: 1.3.11")
+    }
     for (const publishWorkflow of publishWorkflows) {
       expect(publishWorkflow).toContain("oven-sh/setup-bun")
       expect(publishWorkflow).toContain("bun-version: 1.3.11")

--- a/scripts/ci/workflow-contract.test.ts
+++ b/scripts/ci/workflow-contract.test.ts
@@ -3,10 +3,14 @@ import { resolve } from "node:path"
 import { describe, expect, it } from "vitest"
 
 const workflowRoot = resolve(import.meta.dirname, "../../.github/workflows")
-const workflow = readFileSync(resolve(workflowRoot, "e2e-ui.yml"), "utf8")
-const ciWorkflow = readFileSync(resolve(workflowRoot, "ci.yml"), "utf8")
+function normalizeWorkflow(text: string): string {
+  return text.replace(/\r\n/g, "\n")
+}
+
+const workflow = normalizeWorkflow(readFileSync(resolve(workflowRoot, "e2e-ui.yml"), "utf8"))
+const ciWorkflow = normalizeWorkflow(readFileSync(resolve(workflowRoot, "ci.yml"), "utf8"))
 const publishWorkflows = ["publish-app.yml", "publish-cli.yml", "publish-daemon.yml"]
-  .map((name) => readFileSync(resolve(workflowRoot, name), "utf8"))
+  .map((name) => normalizeWorkflow(readFileSync(resolve(workflowRoot, name), "utf8")))
 
 function ciJob(name: string): string {
   const start = ciWorkflow.indexOf(`\n  ${name}:\n`)
@@ -32,6 +36,10 @@ describe("E2E UI workflow", () => {
 })
 
 describe("Bun workflow setup", () => {
+  it("normalizes Windows checkout line endings before locating jobs", () => {
+    expect(normalizeWorkflow("jobs:\r\n  test-linux:\r\n")).toBe("jobs:\n  test-linux:\n")
+  })
+
   it("installs pinned Bun in every CI job that builds a daemon package fixture", () => {
     const bunJobs = ["test-linux", "test-windows", "build", "coverage"]
     expect(ciWorkflow.match(/oven-sh\/setup-bun/g)).toHaveLength(bunJobs.length)

--- a/src/daemon/src/cli/daemonSelfUpdate.real.test.ts
+++ b/src/daemon/src/cli/daemonSelfUpdate.real.test.ts
@@ -6,6 +6,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { WebSocket, WebSocketServer } from "ws";
+import { execPackageManagerSync } from "../test-package-manager.js";
 
 const packageRoot = fileURLToPath(new URL("../..", import.meta.url));
 const machineId = "cm_self_update_real_123456";
@@ -223,7 +224,7 @@ async function waitForUpdateSettled(baseDir: string, timeoutMs = 45_000): Promis
 }
 
 beforeAll(() => {
-  execFileSync("pnpm", ["run", "build"], { cwd: packageRoot, stdio: "pipe" });
+  execPackageManagerSync(["run", "build"], { cwd: packageRoot, stdio: "pipe" });
   oldTgz = packFixture("9.9.0");
   newTgz = packFixture("9.9.1");
 }, 120_000);

--- a/src/daemon/src/cli/daemonSelfUpdate.real.test.ts
+++ b/src/daemon/src/cli/daemonSelfUpdate.real.test.ts
@@ -6,7 +6,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { WebSocket, WebSocketServer } from "ws";
-import { execPackageManagerSync } from "../test-package-manager.js";
+import { commandShimShell, execPackageManagerSync } from "../test-package-manager.js";
 
 const packageRoot = fileURLToPath(new URL("../..", import.meta.url));
 const machineId = "cm_self_update_real_123456";
@@ -49,7 +49,11 @@ function packFixture(version: string): string {
     "--ignore-scripts",
     "--pack-destination",
     fixtureRoot,
-  ], { cwd: dir, encoding: "utf8" })) as Array<{ filename: string }>;
+  ], {
+    cwd: dir,
+    encoding: "utf8",
+    shell: commandShimShell(),
+  })) as Array<{ filename: string }>;
   return path.join(fixtureRoot, packed[0]!.filename);
 }
 
@@ -62,6 +66,7 @@ function runNpmPackage(
     execFile("npm", ["exec", "--yes", `--package=${tgz}`, "--", "alook-daemon", ...args], {
       env: { ...process.env, ...env },
       maxBuffer: 10 * 1024 * 1024,
+      shell: commandShimShell(),
     }, (error, stdout, stderr) => {
       if (error && typeof (error as NodeJS.ErrnoException & { code?: unknown }).code !== "number") {
         reject(error);

--- a/src/daemon/src/test-package-manager.test.ts
+++ b/src/daemon/src/test-package-manager.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { resolvePackageManagerCommand } from "./test-package-manager.js";
+
+describe("resolvePackageManagerCommand", () => {
+  it("runs a JavaScript lifecycle entrypoint through Node", () => {
+    expect(resolvePackageManagerCommand(
+      ["run", "build"],
+      { npm_execpath: "C:\\tools\\pnpm.cjs" },
+      "C:\\tools\\node.exe",
+      "win32",
+    )).toEqual({
+      file: "C:\\tools\\node.exe",
+      args: ["C:\\tools\\pnpm.cjs", "run", "build"],
+    });
+  });
+
+  it("uses the Windows command shell for a pnpm cmd shim", () => {
+    expect(resolvePackageManagerCommand(
+      ["pack"],
+      { npm_execpath: "C:\\tools\\pnpm.cmd" },
+      "C:\\tools\\node.exe",
+      "win32",
+    )).toEqual({
+      file: "C:\\tools\\pnpm.cmd",
+      args: ["pack"],
+      shell: true,
+    });
+  });
+
+  it("runs a native lifecycle executable directly", () => {
+    expect(resolvePackageManagerCommand(
+      ["pack"],
+      { npm_execpath: "/tools/pnpm" },
+      "/tools/node",
+      "linux",
+    )).toEqual({
+      file: "/tools/pnpm",
+      args: ["pack"],
+    });
+  });
+
+  it("uses a shell-backed PATH fallback on Windows", () => {
+    expect(resolvePackageManagerCommand(["pack"], {}, "C:\\tools\\node.exe", "win32")).toEqual({
+      file: "pnpm",
+      args: ["pack"],
+      shell: true,
+    });
+  });
+
+  it("uses a direct PATH fallback on POSIX", () => {
+    expect(resolvePackageManagerCommand(["pack"], {}, "/tools/node", "linux")).toEqual({
+      file: "pnpm",
+      args: ["pack"],
+    });
+  });
+});

--- a/src/daemon/src/test-package-manager.test.ts
+++ b/src/daemon/src/test-package-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolvePackageManagerCommand } from "./test-package-manager.js";
+import { commandShimShell, resolvePackageManagerCommand } from "./test-package-manager.js";
 
 describe("resolvePackageManagerCommand", () => {
   it("runs a JavaScript lifecycle entrypoint through Node", () => {
@@ -52,5 +52,10 @@ describe("resolvePackageManagerCommand", () => {
       file: "pnpm",
       args: ["pack"],
     });
+  });
+
+  it("shell-enables command shims only on Windows", () => {
+    expect(commandShimShell("win32")).toBe(true);
+    expect(commandShimShell("linux")).toBeUndefined();
   });
 });

--- a/src/daemon/src/test-package-manager.ts
+++ b/src/daemon/src/test-package-manager.ts
@@ -7,6 +7,10 @@ export interface PackageManagerCommand {
   shell?: true;
 }
 
+export function commandShimShell(platform = process.platform): true | undefined {
+  return platform === "win32" ? true : undefined;
+}
+
 export function resolvePackageManagerCommand(
   args: string[],
   env: NodeJS.ProcessEnv = process.env,
@@ -15,8 +19,9 @@ export function resolvePackageManagerCommand(
 ): PackageManagerCommand {
   const npmExecPath = env.npm_execpath;
   if (!npmExecPath) {
-    return platform === "win32"
-      ? { file: "pnpm", args, shell: true }
+    const shell = commandShimShell(platform);
+    return shell
+      ? { file: "pnpm", args, shell }
       : { file: "pnpm", args };
   }
 
@@ -25,7 +30,7 @@ export function resolvePackageManagerCommand(
     return { file: nodeExecutable, args: [npmExecPath, ...args] };
   }
   if (platform === "win32" && [".bat", ".cmd"].includes(extension)) {
-    return { file: npmExecPath, args, shell: true };
+    return { file: npmExecPath, args, shell: commandShimShell(platform) };
   }
   return { file: npmExecPath, args };
 }

--- a/src/daemon/src/test-package-manager.ts
+++ b/src/daemon/src/test-package-manager.ts
@@ -1,0 +1,42 @@
+import { execFileSync, type ExecFileSyncOptions } from "node:child_process";
+import { extname } from "node:path";
+
+export interface PackageManagerCommand {
+  file: string;
+  args: string[];
+  shell?: true;
+}
+
+export function resolvePackageManagerCommand(
+  args: string[],
+  env: NodeJS.ProcessEnv = process.env,
+  nodeExecutable = process.execPath,
+  platform = process.platform,
+): PackageManagerCommand {
+  const npmExecPath = env.npm_execpath;
+  if (!npmExecPath) {
+    return platform === "win32"
+      ? { file: "pnpm", args, shell: true }
+      : { file: "pnpm", args };
+  }
+
+  const extension = extname(npmExecPath).toLowerCase();
+  if ([".js", ".cjs", ".mjs"].includes(extension)) {
+    return { file: nodeExecutable, args: [npmExecPath, ...args] };
+  }
+  if (platform === "win32" && [".bat", ".cmd"].includes(extension)) {
+    return { file: npmExecPath, args, shell: true };
+  }
+  return { file: npmExecPath, args };
+}
+
+export function execPackageManagerSync(
+  args: string[],
+  options: ExecFileSyncOptions,
+): Buffer | string {
+  const command = resolvePackageManagerCommand(args);
+  return execFileSync(command.file, command.args, {
+    ...options,
+    shell: command.shell,
+  });
+}

--- a/src/daemon/src/version.packed.test.ts
+++ b/src/daemon/src/version.packed.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
+import { execPackageManagerSync } from "./test-package-manager.js";
 
 const execFileAsync = promisify(execFile);
 const packageRoot = fileURLToPath(new URL("../", import.meta.url));
@@ -24,12 +25,8 @@ describe("packed daemon version", () => {
   it("reports the root package version from the real dist/cli bin", { timeout: 120_000 }, async () => {
     const root = mkdtempSync(join(tmpdir(), "alook-daemon-version-pack-"));
     tempRoots.push(root);
-    const npmExecPath = process.env.npm_execpath;
-    if (!npmExecPath) throw new Error("npm_execpath is required to build the packed daemon fixture");
-
-    await execFileAsync(
-      process.execPath,
-      [npmExecPath, "pack", "--pack-destination", root],
+    execPackageManagerSync(
+      ["pack", "--pack-destination", root],
       { cwd: packageRoot, maxBuffer: 10 * 1024 * 1024 },
     );
     const tarball = readdirSync(root).find((name) => name.endsWith(".tgz"));


### PR DESCRIPTION
# Why we need this PR?
The daemon's new real packaging tests run package build and pack steps inside the Linux, Windows, and Coverage jobs. Those jobs did not all provision Bun, and the tests assumed either a directly executable `pnpm` command or a JavaScript-only `npm_execpath`. On GitHub Actions that produced `bun: not found`, Windows `spawnSync pnpm ENOENT`, and Coverage `npm_execpath is required` failures.

## What changed
- install the existing pinned Bun 1.3.11 setup in Linux tests, Windows tests, and Coverage, matching the Build job
- route both daemon real-package build and pack fixtures through one test-only package-manager resolver
- support JavaScript lifecycle entrypoints through Node, native executables directly, Windows `.cmd`/`.bat` shims through the command shell, and platform-appropriate PATH fallbacks
- apply the Windows-only command-shell rule to the fixtures' direct `npm pack` and `npm exec` calls
- add Windows-shaped resolver tests and strengthen the CI workflow contract so all four Bun-dependent jobs remain pinned, including CRLF checkout coverage

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm --filter @alook/daemon test` — 71 files / 1196 tests
- direct Vitest with `npm_execpath` removed for the resolver, packed-version fixture, and real self-update fixture — 3 files / 10 tests
- `pnpm vitest run --project ci-scripts` — 8 files / 42 tests
- exact Coverage command produced `coverage/coverage-final.json`
- root `pnpm test` reaches one existing concurrent-only `scripts/preflight-bug-reports.test.ts` failure; the same test passes 18/18 in isolation
- GitHub Actions `Tests (ubuntu-latest)` — passed in 5m28s
- GitHub Actions `Tests (windows-latest)` — passed in 9m34s, including isolated daemon packaging, remaining workspace tests, and CI-script tests
- GitHub Actions `Coverage` — passed in 4m16s; Codecov patch passed
- GitHub Actions `CI Gate`, all five UI shards, and `UI E2E Gate` — passed (UI shard 2's first attempt hit an unrelated Miniflare `SQLITE_BUSY` lock and passed on failed-job rerun)

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [x] Other: daemon test infrastructure
