### PR TITLE
fix(ci): resolve shared subpath in integration tests

### DIFF
--- a/tests/integration/cli/vitest.config.ts
+++ b/tests/integration/cli/vitest.config.ts
@@ -9,6 +9,7 @@ export default mergeConfig(shared, defineConfig({
   resolve: {
     alias: {
       "@alook/shared/community-cli-contract": resolve(root, "src/shared/src/community-cli-contract.ts"),
+      "@alook/shared/lib/discriminator": resolve(root, "src/shared/src/lib/discriminator.ts"),
       "@alook/test-utils": resolve(root, "tests/utils/src/index.ts"),
       "@alook/shared": resolve(root, "src/shared/src/index.ts"),
     },

--- a/tests/integration/daemon/vitest.config.ts
+++ b/tests/integration/daemon/vitest.config.ts
@@ -14,6 +14,7 @@ export default mergeConfig(shared, defineConfig({
   resolve: {
     alias: {
       "@alook/shared/community-cli-contract": resolve(root, "src/shared/src/community-cli-contract.ts"),
+      "@alook/shared/lib/discriminator": resolve(root, "src/shared/src/lib/discriminator.ts"),
       "@alook/test-utils": resolve(root, "tests/utils/src/index.ts"),
       "@alook/shared": resolve(root, "src/shared/src/index.ts"),
     },


### PR DESCRIPTION
# Why we need this PR?
> Closes #

The daemon local-message-reminder change introduced a shared-package subpath import that the daemon and CLI integration Vitest configs incorrectly rewrote through their broad shared barrel alias. As a result, the CI E2E job failed during module collection with `ENOTDIR` before the credential-chain tests could run.

## What changed
- add an exact `@alook/shared/lib/discriminator` source alias to the daemon integration Vitest config
- mirror the exact alias in the CLI integration Vitest config so both integration environments preserve the same shared import contract
- keep the existing broad shared barrel and community-contract aliases unchanged

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [ ] Other: ...

Validation: daemon credential-chain integration 2/2; complete daemon integration exits 0; CLI integration 15 passed / 1 skipped; repository typecheck and lint pass. Repository test reaches 4,475/4,476 web tests with only the known concurrent-only `preflight-bug-reports` fixture failing; that fixture passes 18/18 in isolation. Exact-head GitHub CI is fully green, including E2E 359/359 and daemon integration 6/6. Independent read-only QA reproduced the base `ENOTDIR` failure and verified it disappears on exact head `07fc66007aa7cd073cfd5f245eb87242b200901e`.
