### PR TITLE
fix(web): unify profile avatar rendering

### DIFF
--- a/src/web/src/app/(app)/w/[slug]/home/_components/team-access.test.ts
+++ b/src/web/src/app/(app)/w/[slug]/home/_components/team-access.test.ts
@@ -1,0 +1,63 @@
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+import type { WorkspaceOverview } from "@/lib/api"
+import { serializeBeamSeed } from "@/lib/avatar/seed-url"
+import { TeamAccess } from "./team-access"
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }))
+vi.mock("@/contexts/workspace-context", () => ({ useWorkspace: () => ({ slug: "demo" }) }))
+
+function overview(): WorkspaceOverview {
+  return {
+    email_stats: { inbound: 0, outbound: 0, unread: 0, rejected: 0 },
+    task_stats: { completed: 0, failed: 0, cancelled: 0, queued: 0, stale: 0 },
+    recent_tasks: [],
+    conversation_counts: {},
+    pending_invites: 0,
+    calendar_events: [],
+    members: [
+      {
+        id: "membership_1",
+        user_id: "user_beam",
+        role: "owner",
+        name: "Beam User",
+        email: "beam@example.com",
+        image: serializeBeamSeed("stored-face"),
+        created_at: "2026-08-14T00:00:00Z",
+      },
+      {
+        id: "membership_2",
+        user_id: "user_photo",
+        role: "member",
+        name: "Photo User",
+        email: "photo@example.com",
+        image: "https://cdn.example.com/photo.png",
+        created_at: "2026-08-14T00:00:00Z",
+      },
+      {
+        id: "membership_3",
+        user_id: "user_generated",
+        role: "member",
+        name: "Generated User",
+        email: "generated@example.com",
+        image: null,
+        created_at: "2026-08-14T00:00:00Z",
+      },
+    ],
+  }
+}
+
+describe("TeamAccess avatars", () => {
+  it("renders photo, stored beam, and stable-id avatars at the existing row size", () => {
+    const html = renderToStaticMarkup(createElement(TeamAccess, { overview: overview() }))
+
+    expect(html).toContain('data-testid="team-access-avatar-user_beam"')
+    expect(html).toContain('data-testid="team-access-avatar-user_photo"')
+    expect(html).toContain('data-testid="team-access-avatar-user_generated"')
+    expect(html.match(/data-avatar-kind="beam"/g)).toHaveLength(2)
+    expect(html).toContain('data-avatar-kind="photo"')
+    expect(html).not.toContain('src="avatar:beam:stored-face"')
+    expect(html).toContain("width:28px;height:28px")
+  })
+})

--- a/src/web/src/app/(app)/w/[slug]/home/_components/team-access.tsx
+++ b/src/web/src/app/(app)/w/[slug]/home/_components/team-access.tsx
@@ -7,7 +7,7 @@ import { useWorkspace } from "@/contexts/workspace-context";
 import { ArrowUpRight } from "lucide-react";
 import type { WorkspaceOverview } from "@/lib/api";
 import { displayName } from "@/lib/community/display-name";
-import { avatarInitial } from "@/lib/community/avatar";
+import { ProfileAvatar } from "@/components/avatar";
 
 interface TeamAccessProps {
   overview: WorkspaceOverview;
@@ -43,17 +43,13 @@ export function TeamAccess({ overview }: TeamAccessProps) {
         <div className="divide-y divide-border/50">
           {[...members].sort((a, b) => (a.role === "owner" ? -1 : b.role === "owner" ? 1 : 0)).map((m) => (
             <div key={m.id} className="flex items-center gap-3 px-4 py-2">
-              {m.image ? (
-                <img
-                  src={m.image}
-                  alt={m.name}
-                  className="size-7 rounded-full shrink-0"
-                />
-              ) : (
-                <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-secondary text-xs font-medium">
-                  {avatarInitial(displayName(m))}
-                </div>
-              )}
+              <ProfileAvatar
+                label={displayName(m)}
+                seed={m.user_id}
+                src={m.image}
+                size={28}
+                data-testid={`team-access-avatar-${m.user_id}`}
+              />
               <div className="flex-1 min-w-0">
                 <span className="text-sm font-medium truncate block">
                   {displayName(m)}

--- a/src/web/src/app/(app)/w/[slug]/settings/members-tab.test.ts
+++ b/src/web/src/app/(app)/w/[slug]/settings/members-tab.test.ts
@@ -1,0 +1,89 @@
+import React from "react"
+import TestRenderer, { act } from "react-test-renderer"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { ProfileAvatar } from "@/components/avatar"
+import { serializeBeamSeed } from "@/lib/avatar/seed-url"
+import { MembersTab } from "./members-tab"
+
+const mocks = vi.hoisted(() => ({
+  listMembers: vi.fn(),
+  listInvites: vi.fn(),
+}))
+
+vi.mock("@/contexts/workspace-context", () => ({
+  useWorkspace: () => ({ workspaceId: "workspace_1" }),
+}))
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => ({ data: { user: { id: "user_beam" } } }),
+}))
+
+vi.mock("@/lib/api", () => ({
+  listMembers: mocks.listMembers,
+  listInvites: mocks.listInvites,
+  removeMember: vi.fn(),
+  createInvite: vi.fn(),
+  revokeInvite: vi.fn(),
+}))
+
+vi.mock("@/lib/analytics", () => ({ trackTeamMemberInvited: vi.fn() }))
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: React.PropsWithChildren) => React.createElement("div", null, children),
+  TooltipTrigger: ({ children }: React.PropsWithChildren) => React.createElement("div", null, children),
+  TooltipContent: ({ children }: React.PropsWithChildren) => React.createElement("span", null, children),
+}))
+
+describe("MembersTab avatars", () => {
+  beforeEach(() => {
+    mocks.listInvites.mockResolvedValue([])
+    mocks.listMembers.mockResolvedValue([
+      {
+        id: "membership_1",
+        user_id: "user_beam",
+        role: "owner",
+        name: "Beam User",
+        email: "beam@example.com",
+        image: serializeBeamSeed("stored-face"),
+      },
+      {
+        id: "membership_2",
+        user_id: "user_photo",
+        role: "member",
+        name: "Photo User",
+        email: "photo@example.com",
+        image: "https://cdn.example.com/photo.png",
+      },
+      {
+        id: "membership_3",
+        user_id: "user_generated",
+        role: "member",
+        name: "Generated User",
+        email: "generated@example.com",
+        image: null,
+      },
+    ])
+  })
+
+  it("passes each member image and stable id through ProfileAvatar", async () => {
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(React.createElement(MembersTab))
+    })
+
+    const avatars = renderer.root.findAllByType(ProfileAvatar)
+    expect(avatars.map((avatar) => ({
+      src: avatar.props.src,
+      seed: avatar.props.seed,
+      size: avatar.props.size,
+    }))).toEqual([
+      { src: serializeBeamSeed("stored-face"), seed: "user_beam", size: 28 },
+      { src: "https://cdn.example.com/photo.png", seed: "user_photo", size: 28 },
+      { src: null, seed: "user_generated", size: 28 },
+    ])
+
+    const html = JSON.stringify(renderer.toJSON())
+    expect(html.match(/data-avatar-kind\":\"beam/g)).toHaveLength(2)
+    expect(html).toContain('data-avatar-kind\":\"photo')
+  })
+})

--- a/src/web/src/app/(app)/w/[slug]/settings/members-tab.tsx
+++ b/src/web/src/app/(app)/w/[slug]/settings/members-tab.tsx
@@ -20,6 +20,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip
 import { cn } from "@/lib/utils";
 import { trackTeamMemberInvited } from "@/lib/analytics";
 import { displayName } from "@/lib/community/display-name";
+import { ProfileAvatar } from "@/components/avatar";
 
 function getInviteLink(token: string) {
   return `${window.location.origin}/invite/${token}`;
@@ -199,26 +200,19 @@ export function MembersTab() {
         <div className="space-y-2">
           {members.map((member) => {
             const isSelf = member.user_id === currentUserId;
-            const initials = displayName(member)
-              .split(" ")
-              .map((n) => n[0])
-              .join("")
-              .slice(0, 2)
-              .toUpperCase();
 
             return (
               <div
                 key={member.id}
                 className="flex items-center gap-3 rounded-md border border-border/50 px-3 py-2"
               >
-                {/* Avatar */}
-                <div className="size-7 rounded-full bg-muted flex items-center justify-center text-xs font-medium text-muted-foreground shrink-0 overflow-hidden">
-                  {member.image ? (
-                    <img src={member.image} alt={member.name} className="size-full object-cover" />
-                  ) : (
-                    initials
-                  )}
-                </div>
+                <ProfileAvatar
+                  label={displayName(member)}
+                  seed={member.user_id}
+                  src={member.image}
+                  size={28}
+                  data-testid={`members-avatar-${member.user_id}`}
+                />
 
                 {/* Name / email */}
                 <div className="min-w-0 flex-1">

--- a/src/web/src/components/avatar/index.ts
+++ b/src/web/src/components/avatar/index.ts
@@ -6,3 +6,4 @@ export { AnimatedAvatar } from "./animated-avatar";
 export { AvatarPickerDialog } from "./avatar-picker-dialog";
 export { BotAvatarPickerDialog } from "./bot-avatar-picker-dialog";
 export { AgentAvatar } from "./agent-avatar";
+export { ProfileAvatar } from "./profile-avatar";

--- a/src/web/src/components/avatar/profile-avatar.test.ts
+++ b/src/web/src/components/avatar/profile-avatar.test.ts
@@ -1,0 +1,89 @@
+import { Children, createElement, type ReactElement, type ReactNode } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import { serializeBeamSeed } from "@/lib/avatar/seed-url"
+import { ProfileAvatar, type ProfileAvatarProps } from "./profile-avatar"
+
+function normalize(html: string): string {
+  return html.replace(/_R_[0-9a-z]+_/g, "_ID_").replace(/#[0-9a-z]+_ID_/g, "#_ID_")
+}
+
+function render(props: ProfileAvatarProps): string {
+  return renderToStaticMarkup(createElement(ProfileAvatar, props))
+}
+
+function resolvedImageProps(props: ProfileAvatarProps): { src: string; alt: string } {
+  const root = ProfileAvatar(props) as ReactElement<{ children: ReactNode }>
+  const branch = Children.toArray(root.props.children)[0] as ReactElement<{ children: ReactNode }>
+  const image = Children.toArray(branch.props.children)[0] as ReactElement<{
+    src: string
+    alt: string
+  }>
+  return image.props
+}
+
+describe("ProfileAvatar", () => {
+  it("renders a photo with the requested label, size, and caller class", () => {
+    const html = render({
+      label: "Ada",
+      src: "https://cdn.example.com/ada.png",
+      seed: "user_1",
+      size: 40,
+      className: "ring-2",
+      "data-testid": "profile-avatar",
+    })
+
+    expect(html).toContain('data-testid="profile-avatar"')
+    expect(html).toContain('data-avatar-kind="photo"')
+    expect(resolvedImageProps({
+      label: "Ada",
+      src: "https://cdn.example.com/ada.png",
+    })).toMatchObject({ src: "https://cdn.example.com/ada.png", alt: "Ada" })
+    expect(html).toContain("width:40px;height:40px")
+    expect(html).toContain("ring-2")
+  })
+
+  it("renders a stored beam seed without emitting an image or fallback", () => {
+    const html = render({
+      label: "Ada",
+      src: serializeBeamSeed("stored-seed"),
+      seed: "user_1",
+    })
+
+    expect(html).toContain("<svg")
+    expect(html).not.toContain("<img")
+    expect(html).not.toContain('data-slot="avatar-fallback"')
+    expect(html).toContain('role="img"')
+    expect(html).toContain('aria-label="Ada"')
+  })
+
+  it("uses the stable id for a missing avatar and stays unchanged across rename", () => {
+    const before = normalize(render({ label: "Ada", src: null, seed: "user_1" }))
+    const after = normalize(render({ label: "Adelaide", src: null, seed: "user_1" }))
+
+    expect(before).toContain("<svg")
+    expect(after.replace('aria-label="Adelaide"', 'aria-label="Ada"')).toBe(before)
+  })
+
+  it("uses one letter only when neither avatar nor stable id is available", () => {
+    const html = render({ label: "Ada", src: null })
+
+    expect(html).toContain('data-slot="avatar-fallback"')
+    expect(html).toContain(">A<")
+    expect(html).not.toContain("<svg")
+  })
+
+  it("honors decorative alt text and dimming", () => {
+    const html = render({
+      label: "Ada",
+      src: "/api/avatar",
+      seed: "user_1",
+      alt: "",
+      dim: true,
+    })
+
+    expect(html).toContain('data-avatar-kind="photo"')
+    expect(resolvedImageProps({ label: "Ada", src: "/api/avatar", alt: "" }).alt).toBe("")
+    expect(html).toContain("opacity:0.4")
+  })
+})

--- a/src/web/src/components/avatar/profile-avatar.test.ts
+++ b/src/web/src/components/avatar/profile-avatar.test.ts
@@ -84,6 +84,19 @@ describe("ProfileAvatar", () => {
 
     expect(html).toContain('data-avatar-kind="photo"')
     expect(resolvedImageProps({ label: "Ada", src: "/api/avatar", alt: "" }).alt).toBe("")
+    expect(html).toContain('aria-hidden="true"')
+    expect(html).not.toContain('role="img"')
+    expect(html).not.toContain("aria-label")
     expect(html).toContain("opacity:0.4")
+  })
+
+  it("makes generated avatars decorative without exposing their source", () => {
+    const source = serializeBeamSeed("private-seed")
+    const html = render({ label: source, src: source, seed: "user_1", alt: "" })
+
+    expect(html).toContain('aria-hidden="true"')
+    expect(html).not.toContain('role="img"')
+    expect(html).not.toContain("aria-label")
+    expect(html).not.toContain(source)
   })
 })

--- a/src/web/src/components/avatar/profile-avatar.tsx
+++ b/src/web/src/components/avatar/profile-avatar.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import type { ReactNode } from "react"
+import {
+  Avatar as UiAvatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/components/ui/avatar"
+import { resolveAvatar } from "@/lib/avatar/resolve"
+import { avatarInitial } from "@/lib/community/avatar"
+import { cn } from "@/lib/utils"
+import { GeneratedAvatar } from "./generated-avatar"
+
+export type ProfileAvatarProps = {
+  label: string
+  src?: string | null
+  seed?: string | null
+  size?: number
+  dim?: boolean
+  alt?: string
+  className?: string
+  children?: ReactNode
+  "data-testid"?: string
+}
+
+export function ProfileAvatar({
+  label,
+  src,
+  seed,
+  size = 32,
+  dim = false,
+  alt,
+  className,
+  children,
+  "data-testid": testId,
+}: ProfileAvatarProps) {
+  const safeLabel = label || "?"
+  const resolved = resolveAvatar(src || safeLabel, seed || undefined)
+  const accessibleLabel = alt ?? safeLabel
+
+  return (
+    <UiAvatar
+      data-testid={testId}
+      data-avatar-kind={resolved.kind}
+      className={cn(resolved.kind === "beam" ? "after:hidden" : "bg-muted", className)}
+      style={{ width: size, height: size, opacity: dim ? 0.4 : 1 }}
+      role={resolved.kind === "photo" ? undefined : "img"}
+      aria-label={resolved.kind === "photo" ? undefined : accessibleLabel}
+    >
+      {resolved.kind === "photo" ? (
+        <>
+          <AvatarImage src={resolved.url} alt={accessibleLabel} />
+          <AvatarFallback className="font-medium" style={{ fontSize: size * 0.4 }}>
+            {avatarInitial(safeLabel)}
+          </AvatarFallback>
+        </>
+      ) : resolved.kind === "beam" ? (
+        <span className="size-full overflow-hidden rounded-full">
+          <GeneratedAvatar seed={resolved.seed} size={size} className="size-full rounded-full" />
+        </span>
+      ) : (
+        <AvatarFallback className="font-medium" style={{ fontSize: size * 0.4 }}>
+          {avatarInitial(safeLabel)}
+        </AvatarFallback>
+      )}
+      {children}
+    </UiAvatar>
+  )
+}

--- a/src/web/src/components/avatar/profile-avatar.tsx
+++ b/src/web/src/components/avatar/profile-avatar.tsx
@@ -37,6 +37,7 @@ export function ProfileAvatar({
   const safeLabel = label || "?"
   const resolved = resolveAvatar(src || safeLabel, seed || undefined)
   const accessibleLabel = alt ?? safeLabel
+  const decorative = accessibleLabel === ""
 
   return (
     <UiAvatar
@@ -44,8 +45,9 @@ export function ProfileAvatar({
       data-avatar-kind={resolved.kind}
       className={cn(resolved.kind === "beam" ? "after:hidden" : "bg-muted", className)}
       style={{ width: size, height: size, opacity: dim ? 0.4 : 1 }}
-      role={resolved.kind === "photo" ? undefined : "img"}
-      aria-label={resolved.kind === "photo" ? undefined : accessibleLabel}
+      role={resolved.kind === "photo" || decorative ? undefined : "img"}
+      aria-label={resolved.kind === "photo" || decorative ? undefined : accessibleLabel}
+      aria-hidden={decorative ? true : undefined}
     >
       {resolved.kind === "photo" ? (
         <>

--- a/src/web/src/components/community/avatar.test.ts
+++ b/src/web/src/components/community/avatar.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest"
 import { createElement } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 import { Avatar } from "./avatar"
+import { ProfileAvatar } from "@/components/avatar"
 import { serializeBeamSeed } from "@/lib/avatar/seed-url"
 
 function normalize(html: string): string {
@@ -36,6 +37,23 @@ describe("Avatar seed contract", () => {
     const html = render({ label: serializeBeamSeed("beam-xyz") })
     expect(html).toContain("<svg")
     expect(html).not.toContain('data-slot="avatar-fallback"')
+  })
+
+  it("keeps stored avatar sources out of the accessibility tree", () => {
+    for (const source of [
+      serializeBeamSeed("private-seed"),
+      "https://cdn.example.com/private-avatar.png",
+    ]) {
+      const element = Avatar({ label: source, seed: "usr_1" })
+      const html = render({ label: source, seed: "usr_1" })
+
+      expect(element.type).toBe(ProfileAvatar)
+      expect(element.props.alt).toBe("")
+      expect(html).toContain('aria-hidden="true"')
+      expect(html).not.toContain('role="img"')
+      expect(html).not.toContain("aria-label")
+      expect(html).not.toContain(source)
+    }
   })
 
   it("is stable for the same seed", () => {

--- a/src/web/src/components/community/avatar.test.ts
+++ b/src/web/src/components/community/avatar.test.ts
@@ -47,12 +47,26 @@ describe("Avatar seed contract", () => {
   it("keeps the same avatar when the display name changes but the seed is stable", () => {
     const before = normalize(render({ label: "Ada", seed: "usr_1" }))
     const afterRename = normalize(render({ label: "Adelaide", seed: "usr_1" }))
-    expect(afterRename).toBe(before)
+    expect(afterRename.replace('aria-label="Adelaide"', 'aria-label="Ada"')).toBe(before)
   })
 
   it("produces different avatars for different seeds", () => {
     const a = normalize(render({ label: "Ada", seed: "usr_1" }))
     const b = normalize(render({ label: "Ada", seed: "usr_2" }))
     expect(a).not.toBe(b)
+  })
+
+  it("preserves the community presence badge and caller ring surface", () => {
+    const html = render({
+      label: "Ada",
+      seed: "usr_1",
+      size: 64,
+      presence: "online",
+      ringColor: "var(--popover)",
+    })
+
+    expect(html).toContain('data-presence="online"')
+    expect(html).toContain("background:var(--status-online)")
+    expect(html).toContain("var(--popover)")
   })
 })

--- a/src/web/src/components/community/avatar.tsx
+++ b/src/web/src/components/community/avatar.tsx
@@ -1,8 +1,6 @@
 import type React from "react"
-import { Avatar as UiAvatar, AvatarImage, AvatarFallback, AvatarBadge } from "@/components/ui/avatar"
-import { GeneratedAvatar } from "@/components/avatar"
-import { resolveAvatar } from "@/lib/avatar/resolve"
-import { avatarInitial } from "@/lib/community/avatar"
+import { AvatarBadge } from "@/components/ui/avatar"
+import { ProfileAvatar } from "@/components/avatar"
 import type { Presence } from "./_types"
 
 const STATUS_COLOR: Record<Presence, string> = {
@@ -23,7 +21,7 @@ export function Avatar({ label, seed, src, size = 40, dim = false, presence, rin
   // shape avatars must not shift on rename. When absent, we drop to a plain
   // single-letter fallback instead of synthesising a shape from `label`.
   seed?: string
-  src?: string
+  src?: string | null
   size?: number
   dim?: boolean
   presence?: Presence
@@ -34,44 +32,8 @@ export function Avatar({ label, seed, src, size = 40, dim = false, presence, rin
   // e.g. `ringColor="var(--popover)"`.
   ringColor?: string
 }) {
-  const safeLabel = label || "?"
-  // `label` historically also carried stored avatar values, so keep it as the
-  // fallback input when `src` is absent. The shared resolver owns URL/generated
-  // precedence and returns a plain-letter fallback when there is no stable id.
-  const resolved = resolveAvatar(src || safeLabel, seed || undefined)
-
-  // Priority: image URL > beam (from stored seed or id) > single letter. Radix
-  // `AvatarFallback` renders whenever no `AvatarImage` is present, so we must
-  // NOT emit it when we've already drawn a beam via `<span><GeneratedAvatar/></span>`
-  // — otherwise both stack on top of each other (the "two-avatar-in-one-place" bug).
   return (
-    <UiAvatar
-      className={resolved.kind === "beam" ? "after:hidden" : "bg-muted"}
-      style={{ width: size, height: size, opacity: dim ? 0.4 : 1 }}
-    >
-      {resolved.kind === "photo" ? (
-        <>
-          <AvatarImage src={resolved.url} alt={safeLabel} />
-          <AvatarFallback className="font-medium" style={{ fontSize: size * 0.4 }}>
-            {avatarInitial(safeLabel)}
-          </AvatarFallback>
-        </>
-      ) : resolved.kind === "beam" ? (
-        <span className="size-full rounded-full overflow-hidden">
-          {/* rounded-full must live on GeneratedAvatar's OWN wrapper (which carries
-              overflow-hidden), not only on this outer span: the beam SVG has a
-              `<g transform>`, and WebKit/Safari does not clip a transformed
-              descendant to an ancestor's border-radius — so an outer-only
-              radius leaks the beam's square background as a rounded-square
-              (the pinned-panel "clipped avatar" bug, WebKit-only). Every other
-              GeneratedAvatar caller co-locates the radius on it for this reason. */}
-          <GeneratedAvatar seed={resolved.seed} size={size} className="size-full rounded-full" />
-        </span>
-      ) : (
-        <AvatarFallback className="font-medium" style={{ fontSize: size * 0.4 }}>
-          {avatarInitial(safeLabel)}
-        </AvatarFallback>
-      )}
+    <ProfileAvatar label={label} seed={seed} src={src} size={size} dim={dim}>
       {presence && (
         <AvatarBadge
           data-presence={presence}
@@ -93,6 +55,6 @@ export function Avatar({ label, seed, src, size = 40, dim = false, presence, rin
           } as React.CSSProperties}
         />
       )}
-    </UiAvatar>
+    </ProfileAvatar>
   )
 }

--- a/src/web/src/components/community/avatar.tsx
+++ b/src/web/src/components/community/avatar.tsx
@@ -33,7 +33,7 @@ export function Avatar({ label, seed, src, size = 40, dim = false, presence, rin
   ringColor?: string
 }) {
   return (
-    <ProfileAvatar label={label} seed={seed} src={src} size={size} dim={dim}>
+    <ProfileAvatar label={label} seed={seed} src={src} size={size} dim={dim} alt="">
       {presence && (
         <AvatarBadge
           data-presence={presence}

--- a/src/web/src/components/community/bot-approval-card.test.ts
+++ b/src/web/src/components/community/bot-approval-card.test.ts
@@ -3,6 +3,7 @@ import { createElement } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { FriendApprovalPayload } from "@alook/shared"
+import { serializeBeamSeed } from "@/lib/avatar/seed-url"
 import { BotApprovalCard } from "./bot-approval-card"
 
 const OTHER = { id: "u_alice", name: "Alice", discriminator: "0042", image: null }
@@ -76,5 +77,27 @@ describe("BotApprovalCard states", () => {
   it("never renders any isBot marker", () => {
     const html = render(base({ status: "pending", waitingOn: "you" }))
     expect(html).not.toContain("isBot")
+  })
+
+  it("renders a stored beam avatar without treating it as an image URL", () => {
+    const html = render(base({
+      otherProfile: { ...OTHER, image: serializeBeamSeed("alice-face") },
+    }))
+
+    expect(html).toContain('data-testid="bot-approval-avatar"')
+    expect(html).toContain("<svg")
+    expect(html).not.toContain('src="avatar:beam:alice-face"')
+  })
+
+  it("renders a photo and uses the profile id when the image is absent", () => {
+    const photo = render(base({
+      otherProfile: { ...OTHER, image: "https://cdn.example.com/alice.png" },
+    }))
+    const generated = render(base({ otherProfile: OTHER }))
+
+    expect(photo).toContain('data-avatar-kind="photo"')
+    expect(generated).toContain('data-avatar-kind="beam"')
+    expect(generated).toContain("<svg")
+    expect(generated).not.toContain('data-slot="avatar-fallback"')
   })
 })

--- a/src/web/src/components/community/bot-approval-card.tsx
+++ b/src/web/src/components/community/bot-approval-card.tsx
@@ -2,9 +2,9 @@
 
 import { toast } from "sonner"
 import type { FriendApprovalPayload } from "@alook/shared"
-import { avatarInitial } from "@/lib/community/avatar"
 import { useOwnerDecision } from "@/hooks/community/mutations/friends"
 import { Button } from "@/components/ui/button"
+import { ProfileAvatar } from "@/components/avatar"
 
 /**
  * Inline friend-approval card, rendered in a bot owner's DM with their bot when
@@ -35,17 +35,13 @@ export function BotApprovalCard({ approval }: { approval: FriendApprovalPayload 
   // Header — who wants to friend whom. Symmetric wording; no isBot leak.
   const header = (
     <div className="flex items-center gap-3">
-      {other.image ? (
-        <img
-          src={other.image}
-          alt={other.name}
-          className="size-10 shrink-0 rounded-full object-cover"
-        />
-      ) : (
-        <div className="grid size-10 shrink-0 place-items-center rounded-full bg-primary text-sm font-semibold text-primary-foreground">
-          {avatarInitial(other.name)}
-        </div>
-      )}
+      <ProfileAvatar
+        label={other.name}
+        seed={other.id}
+        src={other.image}
+        size={40}
+        data-testid="bot-approval-avatar"
+      />
       <div className="min-w-0 flex-1">
         <div className="truncate font-medium">{otherHandle}</div>
         <div className="text-xs text-muted-foreground">

--- a/src/web/src/components/nav-user.test.ts
+++ b/src/web/src/components/nav-user.test.ts
@@ -1,0 +1,64 @@
+import React from "react"
+import TestRenderer, { act } from "react-test-renderer"
+import { describe, expect, it, vi } from "vitest"
+import { ProfileAvatar } from "@/components/avatar"
+import { NavUser } from "./nav-user"
+
+const mocks = vi.hoisted(() => ({
+  routerPush: vi.fn(),
+  session: {
+    data: {
+      user: {
+        id: "user_1",
+        name: "Ada",
+        discriminator: "0042",
+        email: "ada@example.com",
+        image: "https://cdn.example.com/ada.png",
+      },
+    },
+    isPending: false,
+  },
+}))
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: mocks.routerPush }) }))
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => mocks.session,
+  signOut: vi.fn(),
+}))
+vi.mock("@/lib/chat-cache", () => ({ clearAllCache: vi.fn() }))
+vi.mock("@/lib/query-persister", () => ({ clearPersistedCache: vi.fn() }))
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: React.PropsWithChildren) => React.createElement("div", null, children),
+  DropdownMenuContent: ({ children }: React.PropsWithChildren) => React.createElement("div", null, children),
+  DropdownMenuGroup: ({ children }: React.PropsWithChildren) => React.createElement("div", null, children),
+  DropdownMenuItem: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) =>
+    React.createElement("button", props, children),
+  DropdownMenuLabel: ({ children }: React.PropsWithChildren) => React.createElement("div", null, children),
+  DropdownMenuSeparator: () => React.createElement("hr"),
+  DropdownMenuTrigger: ({ children, render }: React.PropsWithChildren<{ render: React.ReactElement }>) =>
+    React.cloneElement(render, {}, children),
+}))
+
+describe("NavUser avatar", () => {
+  it("uses the session photo in both the trigger and open menu identity", async () => {
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(React.createElement(NavUser))
+    })
+
+    const avatars = renderer.root.findAllByType(ProfileAvatar)
+    expect(avatars).toHaveLength(2)
+    expect(avatars.map((avatar) => ({
+      src: avatar.props.src,
+      seed: avatar.props.seed,
+      size: avatar.props.size,
+    }))).toEqual([
+      { src: "https://cdn.example.com/ada.png", seed: "user_1", size: 28 },
+      { src: "https://cdn.example.com/ada.png", seed: "user_1", size: 28 },
+    ])
+
+    const trigger = renderer.root.findByProps({ "data-testid": "nav-user-trigger" })
+    expect(trigger.props["aria-label"]).toBe("Open user menu for Ada")
+    expect(JSON.stringify(renderer.toJSON()).match(/data-avatar-kind\":\"photo/g)).toHaveLength(2)
+  })
+})

--- a/src/web/src/components/nav-user.tsx
+++ b/src/web/src/components/nav-user.tsx
@@ -18,9 +18,9 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
-import { LogOut, User } from "lucide-react";
+import { LogOut } from "lucide-react";
 import { displayName } from "@/lib/community/display-name";
-import { avatarInitial } from "@/lib/community/avatar";
+import { ProfileAvatar } from "@/components/avatar";
 
 export function NavUser() {
   const { data: session, isPending } = useSession();
@@ -35,7 +35,7 @@ export function NavUser() {
   if (!mounted || isPending || !user)
     return <Skeleton className="size-10 rounded-xl" />;
 
-  const firstLetter = avatarInitial(displayName(user));
+  const userDisplayName = displayName(user);
 
   return (
     <DropdownMenu>
@@ -44,11 +44,20 @@ export function NavUser() {
           <button
             type="button"
             title={user.name}
+            aria-label={`Open user menu for ${userDisplayName}`}
+            data-testid="nav-user-trigger"
             className="flex items-center justify-center size-10 rounded-xl text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-200 cursor-pointer"
           />
         }
       >
-        <User className="size-4" />
+        <ProfileAvatar
+          label={userDisplayName}
+          seed={user.id}
+          src={user.image}
+          size={28}
+          alt=""
+          data-testid="nav-user-trigger-avatar"
+        />
       </DropdownMenuTrigger>
       <DropdownMenuContent
         className="min-w-52 rounded-lg"
@@ -59,12 +68,16 @@ export function NavUser() {
         <DropdownMenuGroup>
           <DropdownMenuLabel className="p-0 font-normal">
             <div className="flex items-center gap-2 px-2 py-2 text-left text-sm">
-              <div className="flex items-center justify-center size-7 rounded-full bg-primary text-primary-foreground text-xs font-medium shrink-0">
-                {firstLetter}
-              </div>
+              <ProfileAvatar
+                label={userDisplayName}
+                seed={user.id}
+                src={user.image}
+                size={28}
+                data-testid="nav-user-menu-avatar"
+              />
               <div className="grid flex-1 text-left text-sm leading-tight">
                 <span className="truncate font-medium">
-                  {displayName(user)}
+                  {userDisplayName}
                 </span>
                 <span className="truncate text-xs text-muted-foreground">
                   {user.email}


### PR DESCRIPTION
# Why we need this PR?
> No linked issue.

Profile avatars were rendered through several separate handwritten image/initial branches. Those branches disagreed on stored `avatar:beam:*` values, stable fallbacks, session photos, and accessibility semantics, which could produce broken images or expose serialized avatar sources to assistive technology.

## What changed
- Added a shared `ProfileAvatar` renderer for photo URLs, stored Beam avatars, stable-id Beam fallbacks, and single-letter fallback when no stable id exists.
- Layered community presence badges on the shared renderer without changing status, ring, sizing, or dimming behavior.
- Migrated bot approval cards, workspace TeamAccess, workspace Members, and NavUser trigger/menu identities to the shared contract.
- Made decorative avatars consistently `aria-hidden`; meaningful avatars expose only display names, never stored Beam seeds or URLs.
- Added focused coverage for photo/Beam/fallback resolution, community presence, approval cards, TeamAccess, Members, and NavUser.

Validation:
- Focused avatar/component suite: 6 files, 28 tests passed.
- Repository typecheck, lint, tests, WS event lint, and knip passed.
- Web production build passed.
- Independent live QA passed on exact HEAD `5c4021eb27efaf548c045545071d363f8891e240`, including owner-DM API/D1/WS hydration, TeamAccess, Members, NavUser keyboard behavior, light/dark themes, 390px mobile layout, accessibility semantics, and teardown.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: none
