### PR TITLE
fix(ci): extend Windows test job budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
     needs: scope
     if: needs.scope.outputs.run_windows == 'true'
     runs-on: windows-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6

--- a/scripts/ci/workflow-contract.test.ts
+++ b/scripts/ci/workflow-contract.test.ts
@@ -81,6 +81,12 @@ describe("Bun workflow setup", () => {
   })
 })
 
+describe("CI test budgets", () => {
+  it("gives the slower Windows workspace suite enough job time", () => {
+    expect(ciJob("test-windows")).toContain("timeout-minutes: 15")
+  })
+})
+
 describe("Desktop updater release", () => {
   it("uploads assets without replacing the auto-tag title or changelog", () => {
     expect(autoTagReleaseWorkflow).toContain('--title "$TAG"')


### PR DESCRIPTION
## What changed

- increase the Windows test job timeout from 10 to 15 minutes
- add a workflow contract test that locks the Windows-specific budget

## Why

The CI run for `cf0ffc77` showed that the original flaky-test fixes are sound: Ubuntu completed successfully, and the Windows daemon tests—including the reduced rotating-file-sink workload—also passed. The Windows job was then canceled by its job-level 10-minute timeout while the remaining workspace tests were still passing.

## Root cause and impact

This was a CI budget issue rather than a test assertion failure. Giving the Windows runner five additional minutes lets the full workspace suite finish without relaxing the Linux budget or changing product behavior.

## Validation

- `pnpm exec vitest run scripts/ci/workflow-contract.test.ts` (11/11)
- full pre-commit checks: typecheck, lint, tests, `typegrep:ws`, and knip
- source run: https://github.com/alookai/alook/actions/runs/31881492366
