### PR TITLE
fix(web): contain community navigation scrolling

### DIFF
--- a/src/web/src/app/globals.css
+++ b/src/web/src/app/globals.css
@@ -1436,6 +1436,13 @@ body.community-onboarding-active.driver-active :is(
   display: none;
 }
 
+/* Preserve the thin-scrollbar overflow contract while allowing shell lists to
+   opt into a zero-gutter hidden scrollbar. This later, more-specific rule wins
+   over .thin-scrollbar's Firefox width without changing other thin scrollers. */
+.thin-scrollbar.scrollbar-none {
+  scrollbar-width: none;
+}
+
 /* Backdrop scrollbar: takes same space as thin-scrollbar but invisible */
 .mention-backdrop.thin-scrollbar {
   scrollbar-color: transparent transparent;

--- a/src/web/src/components/community/channels/channel-sidebar.crumb.test.ts
+++ b/src/web/src/components/community/channels/channel-sidebar.crumb.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest"
+import { readFileSync } from "node:fs"
 import { createElement } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 
@@ -88,6 +89,17 @@ const renderForum = (muted = false) => renderToStaticMarkup(
 )
 
 describe("ChannelSidebar header", () => {
+  it("keeps the channel list scrollable without reserving scrollbar width", () => {
+    const html = render()
+    expect(html).toContain('data-testid="community-channel-sidebar-scroll"')
+    expect(html).toContain(
+      "min-h-0 flex-1 overflow-y-auto px-2 py-4 thin-scrollbar scrollbar-none",
+    )
+    const css = readFileSync(new URL("../../../app/globals.css", import.meta.url), "utf8")
+    expect(css).toContain(".thin-scrollbar.scrollbar-none")
+    expect(css).toContain("scrollbar-width: none")
+  })
+
   it("renders the server name as the sole header identity marker (no duplicate ServerCrumb icon)", () => {
     const html = render()
     expect(html).toContain("Alpha")

--- a/src/web/src/components/community/channels/channel-sidebar.tsx
+++ b/src/web/src/components/community/channels/channel-sidebar.tsx
@@ -292,7 +292,7 @@ export const ChannelSidebar = memo(function ChannelSidebar({
   )
 
   return (
-    <aside className="flex min-w-0 flex-1 flex-col">
+    <aside className="flex min-h-0 min-w-0 flex-1 flex-col">
       {!noHeader && (
         <header className="flex h-12 items-center gap-1 border-b border-border/40 px-2">
           {serverName && onOpenSettings ? (
@@ -338,7 +338,12 @@ export const ChannelSidebar = memo(function ChannelSidebar({
       {isAdmin ? (
       <ContextMenu>
         <ContextMenuTrigger
-          render={<div className="flex-1 overflow-y-auto thin-scrollbar px-2 py-4" />}
+          render={(
+            <div
+              data-testid={tid.channelSidebarScroll}
+              className="min-h-0 flex-1 overflow-y-auto px-2 py-4 thin-scrollbar scrollbar-none"
+            />
+          )}
         >
           {channelTree}
         </ContextMenuTrigger>
@@ -348,7 +353,12 @@ export const ChannelSidebar = memo(function ChannelSidebar({
         </ContextMenuContent>
       </ContextMenu>
       ) : (
-        <div className="flex-1 overflow-y-auto thin-scrollbar px-2 py-4">{channelTree}</div>
+        <div
+          data-testid={tid.channelSidebarScroll}
+          className="min-h-0 flex-1 overflow-y-auto px-2 py-4 thin-scrollbar scrollbar-none"
+        >
+          {channelTree}
+        </div>
       )}
 
       {dialog?.kind === "create-channel" && (

--- a/src/web/src/components/community/shell/server-rail-brand.test.ts
+++ b/src/web/src/components/community/shell/server-rail-brand.test.ts
@@ -12,9 +12,22 @@ describe("ServerRail Home brand mark", () => {
     expect(source).toContain('<TooltipContent side="right" sideOffset={8}>Home</TooltipContent>')
     expect(source).not.toContain('>Direct Messages</TooltipContent>')
     expect(source).toContain("group/alook grid size-10")
-    expect(source).toContain("gap-2 pt-2 pb-2")
+    expect(source).toContain("flex min-h-0 w-14 shrink-0 flex-col items-center overflow-hidden pt-2")
     expect(source).not.toContain("hover:scale-110")
     expect(source).not.toContain('src="/alook.svg"')
     expect(source).not.toContain("alook-dark.svg")
+  })
+
+  it("keeps Home and Add fixed while only the server list scrolls", () => {
+    const source = readFileSync(new URL("./server-rail.tsx", import.meta.url), "utf8")
+
+    expect(source).toContain("data-testid={tid.serverRailScroll}")
+    expect(source).toContain(
+      'className="min-h-0 w-full flex-1 overflow-y-auto overflow-x-clip py-2 thin-scrollbar scrollbar-none"',
+    )
+    expect(source).toContain(
+      'className="flex w-full shrink-0 justify-center" style={{ paddingBottom: bottomInset ?? 8 }}',
+    )
+    expect(source).not.toContain("pb-2 overflow-y-auto overflow-x-clip thin-scrollbar")
   })
 })

--- a/src/web/src/components/community/shell/server-rail-brand.test.ts
+++ b/src/web/src/components/community/shell/server-rail-brand.test.ts
@@ -18,16 +18,19 @@ describe("ServerRail Home brand mark", () => {
     expect(source).not.toContain("alook-dark.svg")
   })
 
-  it("keeps Home and Add fixed while only the server list scrolls", () => {
+  it("lets Add follow short lists while only the server list shrinks on overflow", () => {
     const source = readFileSync(new URL("./server-rail.tsx", import.meta.url), "utf8")
 
+    const scrollViewport =
+      'className="min-h-0 w-full shrink overflow-y-auto overflow-x-clip py-2 thin-scrollbar scrollbar-none"'
+    const addRegion =
+      'className="flex w-full shrink-0 justify-center" style={{ paddingBottom: bottomInset ?? 8 }}'
+
     expect(source).toContain("data-testid={tid.serverRailScroll}")
-    expect(source).toContain(
-      'className="min-h-0 w-full flex-1 overflow-y-auto overflow-x-clip py-2 thin-scrollbar scrollbar-none"',
-    )
-    expect(source).toContain(
-      'className="flex w-full shrink-0 justify-center" style={{ paddingBottom: bottomInset ?? 8 }}',
-    )
+    expect(source).toContain(scrollViewport)
+    expect(source).toContain(addRegion)
+    expect(source.indexOf(scrollViewport)).toBeLessThan(source.indexOf(addRegion))
+    expect(scrollViewport).not.toContain("flex-1")
     expect(source).not.toContain("pb-2 overflow-y-auto overflow-x-clip thin-scrollbar")
   })
 })

--- a/src/web/src/components/community/shell/server-rail.tsx
+++ b/src/web/src/components/community/shell/server-rail.tsx
@@ -114,7 +114,7 @@ export const ServerRail = memo(function ServerRail({
 
       <div
         data-testid={tid.serverRailScroll}
-        className="min-h-0 w-full flex-1 overflow-y-auto overflow-x-clip py-2 thin-scrollbar scrollbar-none"
+        className="min-h-0 w-full shrink overflow-y-auto overflow-x-clip py-2 thin-scrollbar scrollbar-none"
       >
         {serversLoading && servers.length === 0 && folders.length === 0 ? (
           <ServerRailSkeleton />

--- a/src/web/src/components/community/shell/server-rail.tsx
+++ b/src/web/src/components/community/shell/server-rail.tsx
@@ -88,34 +88,41 @@ export const ServerRail = memo(function ServerRail({
   }, [folders])
 
   return (
-    <nav aria-label="Server navigation" className="flex w-14 shrink-0 flex-col items-center gap-2 pt-2 pb-2 overflow-y-auto overflow-x-clip thin-scrollbar" style={bottomInset ? { paddingBottom: bottomInset } : undefined}>
-      <Tooltip>
-        <TooltipTrigger render={<div className="group relative flex w-full justify-center" />}>
-          <span className={[
-            "absolute left-0 top-1/2 w-1 -translate-y-1/2 rounded-r-full bg-foreground transition-all duration-150",
-            view === "dm" ? "h-8" : "h-0 group-hover:h-5",
-          ].join(" ")} />
-          <button
-            onClick={onHome}
-            onPointerEnter={onHomePrefetch}
-            onFocus={onHomePrefetch}
-            aria-label="Home"
-            data-testid={tid.homeButton}
-            className="group/alook grid size-10 shrink-0 place-items-center rounded-[20px] focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
-          >
-            <AnimatedAlookLogo className="size-10" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="right" sideOffset={8}>Home</TooltipContent>
-      </Tooltip>
-      <div className="w-6 border-t border-border/50 my-1" />
-      {serversLoading && servers.length === 0 && folders.length === 0 ? (
-        <ServerRailSkeleton />
-      ) : (
-      <DndContext id="d-rail" sensors={sensors} collisionDetection={closestCenter} modifiers={[restrictToVerticalAxis]} onDragStart={onDragStart} onDragOver={onDragOver} onDragEnd={onDragEnd} onDragCancel={() => setDragActiveId(null)}>
-        <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
-          <div className="flex w-full flex-col items-center gap-2">
-            {(() => {
+    <nav aria-label="Server navigation" className="flex min-h-0 w-14 shrink-0 flex-col items-center overflow-hidden pt-2">
+      <div className="flex w-full shrink-0 flex-col items-center gap-2">
+        <Tooltip>
+          <TooltipTrigger render={<div className="group relative flex w-full justify-center" />}>
+            <span className={[
+              "absolute left-0 top-1/2 w-1 -translate-y-1/2 rounded-r-full bg-foreground transition-all duration-150",
+              view === "dm" ? "h-8" : "h-0 group-hover:h-5",
+            ].join(" ")} />
+            <button
+              onClick={onHome}
+              onPointerEnter={onHomePrefetch}
+              onFocus={onHomePrefetch}
+              aria-label="Home"
+              data-testid={tid.homeButton}
+              className="group/alook grid size-10 shrink-0 place-items-center rounded-[20px] focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+            >
+              <AnimatedAlookLogo className="size-10" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right" sideOffset={8}>Home</TooltipContent>
+        </Tooltip>
+        <div className="my-1 w-6 border-t border-border/50" />
+      </div>
+
+      <div
+        data-testid={tid.serverRailScroll}
+        className="min-h-0 w-full flex-1 overflow-y-auto overflow-x-clip py-2 thin-scrollbar scrollbar-none"
+      >
+        {serversLoading && servers.length === 0 && folders.length === 0 ? (
+          <ServerRailSkeleton />
+        ) : (
+          <DndContext id="d-rail" sensors={sensors} collisionDetection={closestCenter} modifiers={[restrictToVerticalAxis]} onDragStart={onDragStart} onDragOver={onDragOver} onDragEnd={onDragEnd} onDragCancel={() => setDragActiveId(null)}>
+            <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+              <div className="flex w-full flex-col items-center gap-2">
+              {(() => {
               const elements: ReactNode[] = []
               let i = 0
               while (i < visibleItems.length) {
@@ -199,12 +206,12 @@ export const ServerRail = memo(function ServerRail({
                 }
               }
               return elements
-            })()}
-          </div>
-        </SortableContext>
-        <DragOverlay dropAnimation={null}>
-          {dragActiveId && (() => {
-            if (isFolderKey(dragActiveId)) {
+              })()}
+              </div>
+            </SortableContext>
+            <DragOverlay dropAnimation={null}>
+              {dragActiveId && (() => {
+              if (isFolderKey(dragActiveId)) {
               const fId = extractFolderId(dragActiveId)
               const folder = folderById.get(fId)
               if (!folder) return null
@@ -229,36 +236,40 @@ export const ServerRail = memo(function ServerRail({
                 </div>
               )
             }
-            const s = serverById.get(dragActiveId) ?? folderServerMap.get(dragActiveId)
-            if (!s) return null
-            const icon = s.icon
-            return (
-              <div
-                className={[
-                  "relative grid size-10 place-items-center overflow-hidden rounded-xl font-brand text-xl font-bold shadow-(--e2)",
-                  icon ? "bg-secondary text-foreground" : "text-white [text-shadow:0_1px_2px_rgb(0_0_0/0.35)]",
-                ].join(" ")}
-              >
-                {icon ? <img src={icon} alt={s.name} className="size-full object-cover" /> : <><SeededBackdrop seed={s.id} /><span className="relative -translate-x-0.5 [-webkit-text-stroke:0.5px_currentColor]">{s.initial}</span></>}
-              </div>
-            )
-          })()}
-        </DragOverlay>
-      </DndContext>
-      )}
-      <RailIcon
-        label={<Plus className="size-6" />}
-        round
-        accent
-        tooltip="Add a Server"
-        testId={tid.serverAdd}
-        onboardingTarget="add-server"
-        onClick={() => {
-          const guided = isCommunityOnboardingStage("server")
-          setCreateOpen(true)
-          if (guided) completeCommunityOnboarding()
-        }}
-      />
+              const s = serverById.get(dragActiveId) ?? folderServerMap.get(dragActiveId)
+              if (!s) return null
+              const icon = s.icon
+              return (
+                <div
+                  className={[
+                    "relative grid size-10 place-items-center overflow-hidden rounded-xl font-brand text-xl font-bold shadow-(--e2)",
+                    icon ? "bg-secondary text-foreground" : "text-white [text-shadow:0_1px_2px_rgb(0_0_0/0.35)]",
+                  ].join(" ")}
+                >
+                  {icon ? <img src={icon} alt={s.name} className="size-full object-cover" /> : <><SeededBackdrop seed={s.id} /><span className="relative -translate-x-0.5 [-webkit-text-stroke:0.5px_currentColor]">{s.initial}</span></>}
+                </div>
+              )
+              })()}
+            </DragOverlay>
+          </DndContext>
+        )}
+      </div>
+
+      <div className="flex w-full shrink-0 justify-center" style={{ paddingBottom: bottomInset ?? 8 }}>
+        <RailIcon
+          label={<Plus className="size-6" />}
+          round
+          accent
+          tooltip="Add a Server"
+          testId={tid.serverAdd}
+          onboardingTarget="add-server"
+          onClick={() => {
+            const guided = isCommunityOnboardingStage("server")
+            setCreateOpen(true)
+            if (guided) completeCommunityOnboarding()
+          }}
+        />
+      </div>
 
       {createOpen && (
         <CreateServerDialog

--- a/src/web/src/components/community/shell/shell-frame-view.test.ts
+++ b/src/web/src/components/community/shell/shell-frame-view.test.ts
@@ -101,6 +101,7 @@ describe("ShellFrameView", () => {
     expect(group.props.orientation).toBe("horizontal")
     const [sidebarPanel, mainPanel] = renderer.root.findAllByType("panel")
     expect(sidebarPanel.props).toMatchObject({ id: "sidebar", defaultSize: "24%", minSize: 160, maxSize: 360 })
+    expect(sidebarPanel.props.className).toContain("pb-15")
     expect(mainPanel.props).toMatchObject({ id: "main", defaultSize: "76%" })
     expect(renderer.root.findByType("shell-overlays").props.profileStatusSeeds).toEqual({
       initialStatusEmoji: "🌱",

--- a/src/web/src/components/community/shell/shell-frame-view.tsx
+++ b/src/web/src/components/community/shell/shell-frame-view.tsx
@@ -80,7 +80,7 @@ export function ShellFrameView({
                 defaultSize="24%"
                 minSize={160}
                 maxSize={360}
-                className="flex flex-col pb-14 bg-sidebar"
+                className="flex flex-col bg-sidebar pb-15"
               >
                 <div ref={sidebarPanelRef} className="flex min-h-0 flex-1 flex-col">
                   {sidebar()}

--- a/src/web/src/lib/community/testids.ts
+++ b/src/web/src/lib/community/testids.ts
@@ -6,6 +6,8 @@ export const tid = {
   composerSend: "community-composer-send",
   composerAttach: "community-composer-attach",
   serverAdd: "community-server-add",
+  serverRailScroll: "community-server-rail-scroll",
+  channelSidebarScroll: "community-channel-sidebar-scroll",
   createServerSubmit: "community-create-server-submit",
   createChannelSubmit: "community-create-channel-submit",
   newDivider: "community-new-divider",


### PR DESCRIPTION
# Why we need this PR?
> No linked issue.

Long server and channel lists could scroll the wrong navigation container. In the server rail, overflow moved Home and Add Server together with the list. In the channel sidebar, the desktop shell reserved 56px for a 60px user bar, so the final rows could sit beneath the overlay. Visible thin scrollbars could also reserve horizontal layout space on platforms without overlay scrollbars.

This fix keeps the permanent navigation controls stable, makes each middle list own its scrolling, and preserves the full usable width on desktop and mobile.

## What changed
- Split the server rail into a fixed Home header, an adaptive scrollable server/folder list, and an Add Server control that follows short lists but stays at the bottom when the list overflows.
- Made the channel list the sidebar's only scroll owner while keeping the channel header and 60px user bar fixed.
- Hid both navigation scrollbars without reserving a gutter, while retaining the repository-required `thin-scrollbar` class.
- Added stable test IDs and regression coverage for both scroll containers, fixed controls, and the corrected desktop inset.

Validation:
- GitHub CI, UI E2E gate, all five Playwright shards, build, typecheck/lint, tests, coverage, knip, and Codecov patch checks pass.
- Authenticated live QA passed 50/50 desktop/mobile geometry, independent-scroll, fixed-control, last-row, navigation, HTTP, WebSocket, and D1 assertions for the original navigation fix.
- The Add Server follow/overflow delta was manually accepted by the owner; its focused 6/6 tests, ESLint, repository typecheck (9/9 tasks), and repository tests (9/9 tasks, including 4,827 web tests and 55 CI-script tests) passed. The separate follow-up geometry run was stopped after owner acceptance and is correctly recorded as partial/superseded.

The pre-existing `RailFolder` accessible-name / `aria-expanded` gap is outside this scoped fix and remains unchanged.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...
