### PR TITLE
Fix message menu click anchor

### DIFF
--- a/src/web/src/components/community/messages/message.render.test.ts
+++ b/src/web/src/components/community/messages/message.render.test.ts
@@ -4,6 +4,7 @@ import React from "react"
 import TestRenderer, { act } from "react-test-renderer"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import {
+  createMessageMenuPointAnchor,
   Message,
   shouldActivateMessageOverlays,
   shouldSuppressTouchMenuOpen,
@@ -60,6 +61,7 @@ beforeEach(() => {
 })
 afterEach(() => {
   vi.restoreAllMocks()
+  vi.unstubAllGlobals()
 })
 
 describe("Message memo comparator", () => {
@@ -128,6 +130,21 @@ describe("Message memo comparator", () => {
 })
 
 describe("Message touch action menu", () => {
+  it("creates a zero-size virtual anchor at the viewport click coordinates", () => {
+    const rect = createMessageMenuPointAnchor(123, 456).getBoundingClientRect()
+
+    expect(rect).toMatchObject({
+      x: 123,
+      y: 456,
+      top: 456,
+      right: 123,
+      bottom: 456,
+      left: 123,
+      width: 0,
+      height: 0,
+    })
+  })
+
   it("uses row taps with an invisible dropdown anchor and no persistent ellipsis", async () => {
     let renderer: TestRenderer.ReactTestRenderer | undefined
     await act(async () => {
@@ -164,6 +181,53 @@ describe("Message touch action menu", () => {
     expect(row.props.className).not.toContain("select-none")
     expect(row.props.role).toBeUndefined()
     expect(row.props.tabIndex).toBeUndefined()
+    act(() => renderer!.unmount())
+  })
+
+  it("anchors an accepted row tap to its viewport coordinates", async () => {
+    vi.stubGlobal("window", { getSelection: () => null })
+    let renderer: TestRenderer.ReactTestRenderer | undefined
+    await act(async () => {
+      renderer = TestRenderer.create(
+        makeTree({
+          m: baseMsg({ content: "long message\n".repeat(200) }),
+          hoverCapable: false,
+          onOpenThread: vi.fn(),
+          onReply: vi.fn(),
+          onCopy: vi.fn(),
+        }),
+        { createNodeMock: () => genericMock },
+      )
+    })
+
+    const row = renderer!.root.find(
+      (node) => typeof node.props.className === "string"
+        && node.props.className.includes("group relative -mx-2"),
+    )
+    await act(async () => {
+      row.props.onClick({
+        clientX: 271,
+        clientY: 603,
+        currentTarget: { contains: () => false },
+        target: { closest: () => null },
+      })
+    })
+
+    const positioner = renderer!.root.find(
+      (node) => node.props.positionMethod === "fixed" && node.props.anchor,
+    )
+    expect(positioner.props.anchor.getBoundingClientRect()).toMatchObject({
+      x: 271,
+      y: 603,
+      width: 0,
+      height: 0,
+    })
+    expect(positioner.props.collisionPadding).toBe(8)
+    expect(positioner.props.collisionAvoidance).toEqual({
+      side: "flip",
+      align: "shift",
+      fallbackAxisSide: "none",
+    })
     act(() => renderer!.unmount())
   })
 

--- a/src/web/src/components/community/messages/message.tsx
+++ b/src/web/src/components/community/messages/message.tsx
@@ -58,6 +58,31 @@ export function shouldSuppressTouchMenuOpen({
   return nestedControl || selectionInsideRow || longPress
 }
 
+export function createMessageMenuPointAnchor(clientX: number, clientY: number) {
+  const rect = {
+    x: clientX,
+    y: clientY,
+    top: clientY,
+    right: clientX,
+    bottom: clientY,
+    left: clientX,
+    width: 0,
+    height: 0,
+    toJSON: () => ({
+      x: clientX,
+      y: clientY,
+      top: clientY,
+      right: clientX,
+      bottom: clientY,
+      left: clientX,
+      width: 0,
+      height: 0,
+    }),
+  } satisfies DOMRect
+
+  return { getBoundingClientRect: () => rect }
+}
+
 function MessageImpl({
   m, compact, pinned, onOpenThread, onOpenProfile, onJumpReply,
   onToggleReaction, onReact, onReply, onPin, onMark, onCreateThread, onCopy, onEdit, onRetry, onDismiss,
@@ -119,6 +144,7 @@ function MessageImpl({
   // Touch devices use a normal tap-triggered dropdown. Long-press is left to
   // the browser so message text keeps native selection/copy behavior.
   const [touchMenuOpen, setTouchMenuOpen] = useState(false)
+  const [touchMenuAnchor, setTouchMenuAnchor] = useState<ReturnType<typeof createMessageMenuPointAnchor> | null>(null)
   const touchStartedAt = useRef<number | null>(null)
   const suppressLongPressClick = useRef(false)
   // The Mark/Unmark label needs to know if THIS message is already in the
@@ -226,6 +252,7 @@ function MessageImpl({
             // short tap on its non-control body opens the controlled menu;
             // nested buttons/links and native long-press selection stay intact.
             if (!suppress) {
+              setTouchMenuAnchor(createMessageMenuPointAnchor(event.clientX, event.clientY))
               setTouchMenuOpen(true)
             }
           }
@@ -537,7 +564,15 @@ function MessageImpl({
             )}
           />
         </div>
-        <DropdownMenuContent align="end" className="w-48 select-none">
+        <DropdownMenuContent
+          anchor={touchMenuAnchor ?? undefined}
+          positionMethod="fixed"
+          side="bottom"
+          align="start"
+          collisionPadding={8}
+          collisionAvoidance={{ side: "flip", align: "shift", fallbackAxisSide: "none" }}
+          className="w-48 select-none"
+        >
           <MessageDropdownItems {...menuHandlers} touch />
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/web/src/components/ui/dropdown-menu.tsx
+++ b/src/web/src/components/ui/dropdown-menu.tsx
@@ -23,12 +23,23 @@ function DropdownMenuContent({
   alignOffset = 0,
   side = "bottom",
   sideOffset = 4,
+  anchor,
+  positionMethod,
+  collisionPadding,
+  collisionAvoidance,
   className,
   ...props
 }: MenuPrimitive.Popup.Props &
   Pick<
     MenuPrimitive.Positioner.Props,
-    "align" | "alignOffset" | "side" | "sideOffset"
+    | "align"
+    | "alignOffset"
+    | "side"
+    | "sideOffset"
+    | "anchor"
+    | "positionMethod"
+    | "collisionPadding"
+    | "collisionAvoidance"
   >) {
   return (
     <MenuPrimitive.Portal>
@@ -38,6 +49,10 @@ function DropdownMenuContent({
         alignOffset={alignOffset}
         side={side}
         sideOffset={sideOffset}
+        anchor={anchor}
+        positionMethod={positionMethod}
+        collisionPadding={collisionPadding}
+        collisionAvoidance={collisionAvoidance}
       >
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"


### PR DESCRIPTION
## What changed

- anchor the touch message action menu to the accepted tap's viewport coordinates
- keep the menu visible near viewport edges with Base UI collision flipping and shifting
- expose the needed Positioner props through the shared dropdown wrapper
- add regression coverage for the virtual point anchor and long-message tap path

## Why

The mobile menu used an invisible zero-size trigger at the start of the message row. On a long message, tapping far down the body still positioned the menu near the row start, often outside the visible viewport.

The touch path now supplies a fixed virtual anchor at `clientX`/`clientY`. Desktop right-click and ellipsis behavior are unchanged.

## Validation

- `pnpm --filter @alook/web exec vitest run src/components/community/messages/message.render.test.ts` — 17 passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — web 566 files / 4,888 tests; CI scripts 9 files / 55 tests
- `pnpm typegrep:ws`
- `pnpm knip`
- independent alook-c-qa: middle, bottom-right, and top-left long-message taps stayed within the 8px viewport collision margin; desktop context menu and ellipsis anchors passed; long-press and nested attachment-control suppression passed; no writes or page errors
