### PR TITLE
feat(web): refresh homepage copy

### DIFF
--- a/src/web/src/app/page.tsx
+++ b/src/web/src/app/page.tsx
@@ -1,10 +1,13 @@
 import type { Metadata } from "next";
+import {
+  LANDING_META_DESCRIPTION,
+  LANDING_META_TITLE,
+} from "@/components/home/landing-content";
 import { LandingPage } from "@/components/home/landing-page";
-import { BRAND_DESCRIPTION, BRAND_TITLE } from "@/lib/brand-copy";
 import { getSession } from "@/lib/session";
 
-const title = BRAND_TITLE;
-const description = BRAND_DESCRIPTION;
+const title = LANDING_META_TITLE;
+const description = LANDING_META_DESCRIPTION;
 const image = "/og?title=Share%20your%20agents%20with%20people%20you%20trust";
 
 export const metadata: Metadata = {

--- a/src/web/src/components/home/homepage-faq.test.ts
+++ b/src/web/src/components/home/homepage-faq.test.ts
@@ -45,6 +45,19 @@ describe("HomepageFaq", () => {
     expect(source).toContain("dangerouslySetInnerHTML")
   })
 
+  it("uses the approved canonical answers", () => {
+    expect(HOME_FAQS.map(({ answer }) => answer)).toEqual([
+      "Alook is where people and AI agents share the same rooms. Your local coding agents get persistent identities — a handle, inbox, and memberships — so your team can address them in servers, channels, and DMs the same way you'd reach a person.",
+      "A machine running Node.js 20.9+ and a supported coding agent. Run the daemon pairing command, and your agent joins the room. No extra AI subscription through Alook — you bring the runtime you already pay for.",
+      "Yes. Alook connects to the coding agents already on your machine. It does not supply or host its own models. Your existing Claude Code or Codex installation keeps its tools, credentials, and codebase access — Alook gives it a way to be reached.",
+      "Discord and Slack are built for people messaging each other. Bots are add-ons. In Alook, agents are first-class participants with their own handles, inboxes, and memberships. Work can wait in an agent's inbox, handoffs stay visible, and the daemon keeps the agent reachable without an interactive terminal session.",
+      "Buzz centers a sovereign Nostr relay and signed-event stack — workflows, voice, Git, broader infrastructure. Alook offers a hosted room layer (also self-hostable) focused on the coding agents you already run. Same Apache-2.0 license, different operating model and surface area.",
+      "Managed workspaces like Oasis can supply cloud-hosted agents and connect outside services. Alook does not supply models or route them. Instead, it gives your existing local agents persistent account handles, an inbox, server/channel/DM memberships, and daemon wake semantics — the agent stays a participant even after a session ends.",
+      "Agents stay reachable and can advance work between sessions, but you control what they can do. Bot-owner consent gates who can friend your agent or add it to a server. Membership determines who can address it — a mention never silently expands the agent's permissions.",
+      "The agent process runs on your machine. Room and account data follow Alook's hosted model. “Local” means where the runtime executes — not that all data stays on disk. You can also self-host the full room layer from the open-source repo.",
+    ])
+  })
+
   it("keeps the landing interaction and responsive spacing contracts", () => {
     const styles = stylesSource()
 

--- a/src/web/src/components/home/landing-content.test.ts
+++ b/src/web/src/components/home/landing-content.test.ts
@@ -3,6 +3,8 @@ import path from "node:path"
 import { describe, expect, it } from "vitest"
 import { BRAND_DESCRIPTION, BRAND_SLOGAN, BRAND_TITLE } from "@/lib/brand-copy"
 import {
+  LANDING_META_DESCRIPTION,
+  LANDING_META_TITLE,
   LANDING_AGENT,
   LANDING_CONTINUITY,
   LANDING_GALLERY,
@@ -31,8 +33,9 @@ describe("landing content contract", () => {
       loggedInCta: "Open Alook",
       secondaryCta: "See how it works",
     })
-    expect(LANDING_HERO.subline).toContain("agents you already use")
-    expect(LANDING_HERO.subline).toContain("everyone can talk and work together")
+    expect(LANDING_HERO.subline).toBe(
+      "Bring AI agents running on your machine into a shared room, give your team a way to collaborate with them directly — a Discord-style workspace.",
+    )
     expect(hero).not.toContain("Local runtimes")
     expect(hero.toLowerCase()).not.toContain("your people")
     expect(hero.toLowerCase()).not.toContain("personal company")
@@ -65,10 +68,11 @@ describe("landing content contract", () => {
     expect(LANDING_AGENT).toMatchObject({ name: "Alli", handle: "Alli#8145" })
     expect(LANDING_CONTINUITY).toMatchObject({
       kicker: "Memory with initiative",
-      headline: "Agents keep things moving",
+      headline: "AI agents with memory that keep work moving",
     })
-    expect(LANDING_CONTINUITY.description).toContain("moves things forward across every room")
-    expect(LANDING_CONTINUITY.description).toContain("don’t have to keep every task on your mind")
+    expect(LANDING_CONTINUITY.description).toBe(
+      "Your agent holds context between sessions and moves tasks forward without you repeating instructions. An inbox catches what arrives while you’re away.",
+    )
   })
 
   it("keeps provider examples compact", () => {
@@ -98,7 +102,7 @@ describe("landing content contract", () => {
 
     expect(closing).toContain("Ready to share")
     expect(closing).toContain("BRAND_SLOGAN")
-    expect(closing).toContain("Bring the agents you rely on into a room with the people who matter.")
+    expect(closing).toContain("Bring AI agents you rely on into a shared workspace with the people who matter.")
     expect(closing).toContain('href={isLoggedIn ? "/c/me" : "/sign-in"}')
     expect(closing).toContain('data-testid="landing-closing-open"')
     expect(closing).toContain("LANDING_HERO.loggedInCta : LANDING_HERO.loggedOutCta")
@@ -135,6 +139,18 @@ describe("landing content contract", () => {
     expect(pairMachineSource).toContain('headingAs = "h3"')
   })
 
+  it("keeps the approved one-H1 and seven-H2 homepage outline", () => {
+    const root = webRoot()
+    const landingPageSource = readFileSync(path.join(root, "src/components/home/landing-page.tsx"), "utf8")
+    const heroSource = readFileSync(path.join(root, "src/components/home/hero-section.tsx"), "utf8")
+    const faqSource = readFileSync(path.join(root, "src/components/home/homepage-faq.tsx"), "utf8")
+
+    expect(heroSource.match(/<h1\b/g)).toHaveLength(1)
+    expect(landingPageSource.match(/<h2\b/g)).toHaveLength(6)
+    expect(faqSource.match(/<h2\b/g)).toHaveLength(1)
+    expect(faqSource).toContain("<summary>")
+  })
+
   it("requires every Lighthouse SEO audit to pass", () => {
     const root = webRoot()
     const config = JSON.parse(readFileSync(path.join(root, "lighthouserc.json"), "utf8"))
@@ -167,6 +183,7 @@ describe("landing content contract", () => {
     const swarmStyles = readFileSync(path.join(root, "src/components/home/hero-avatar-swarm.module.css"), "utf8")
     const navSource = readFileSync(path.join(root, "src/components/home/marketing-nav.tsx"), "utf8")
     const legacyHome = readFileSync(path.join(root, "src/components/home/home-page.tsx"), "utf8")
+    const normalizedLandingPageSource = landingPageSource.replace(/\s+/g, " ")
     const brandCopySource = readFileSync(path.join(root, "src/lib/brand-copy.ts"), "utf8")
     const manifest = JSON.parse(readFileSync(path.join(root, "public/manifest.json"), "utf8"))
     const tauriConfig = JSON.parse(
@@ -191,9 +208,13 @@ describe("landing content contract", () => {
     expect(BRAND_TITLE).toBe("Alook — Share your agents with people you trust")
     expect(BRAND_DESCRIPTION).toContain("agents you already use")
     expect(BRAND_DESCRIPTION).toContain("shared rooms")
+    expect(LANDING_META_TITLE).toBe("AI Agent Collaboration Rooms for Local Agents — Alook")
+    expect(LANDING_META_DESCRIPTION).toBe(
+      "Share your local AI agents with your team. Claude Code, Codex, Cursor, OpenCode, and Pi get persistent identities and memory — while running on your machine. Open source.",
+    )
     expect(brandCopySource).not.toContain("Personal Company")
-    expect(rootRoute).toContain("BRAND_TITLE")
-    expect(rootRoute).toContain("BRAND_DESCRIPTION")
+    expect(rootRoute).toContain("LANDING_META_TITLE")
+    expect(rootRoute).toContain("LANDING_META_DESCRIPTION")
     expect(rootLayout).toContain("BRAND_TITLE")
     expect(rootLayout).toContain("BRAND_DESCRIPTION")
     expect(rootLayout).toContain("BRAND_SLOGAN")
@@ -299,19 +320,19 @@ describe("landing content contract", () => {
     expect(landingPageSource).not.toContain("same memory")
     expect(landingPageSource).not.toContain("anyone")
     expect(landingPageSource).not.toContain("subscriptions")
-    expect(landingPageSource).toContain(
-      "Your agent stays on your machine while the people you trust talk with it in Alook.",
+    expect(normalizedLandingPageSource).toContain(
+      "The agent process stays on your computer, using the codebase and tools you configure for it. Alook connects it to people without moving the runtime to the cloud.",
     )
     expect(landingPageSource).not.toContain("NOT ANOTHER")
     expect(landingPageSource).not.toContain("leaves the terminal")
     expect(landingPageSource).not.toContain("Your agent gets a name")
     expect(landingPageSource).toContain("Share what already works")
-    expect(landingPageSource).toContain("Bring your agent into the room")
-    expect(landingPageSource).toContain(
-      "Invite people you trust into a room where they can talk with the agent you already use.",
+    expect(landingPageSource).toContain("Invite your team to talk with your AI agents")
+    expect(normalizedLandingPageSource).toContain(
+      "Your agents already handle real work — Claude Code, Codex, Cursor, OpenCode, or Pi. Alook lets your team collaborate with them directly in shared channels, without forwarding messages or sharing screens.",
     )
     expect(landingPageSource).toContain("Across every room")
-    expect(landingPageSource).toContain("One identity")
+    expect(landingPageSource).toContain("One persistent identity across rooms")
     expect(landingPageSource).toContain("I keep the same account, identity, and relationships across every room.")
     expect(landingPageSource).toContain("styles.sectionLead")
     expect(landingPageSource).toContain('<p className={styles.sectionMuted}>{LANDING_CONTINUITY.kicker}</p>')
@@ -339,6 +360,10 @@ describe("landing content contract", () => {
     expect(motionStyles).toContain("var(--motion-shell-border-width, 1px)")
     expect(landingStyles).toContain("@media (min-width: 640px) and (max-width: 1023px)")
     expect(landingStyles).toContain("@media (max-width: 639px)")
+    expect(landingStyles).toMatch(
+      /@media \(max-width: 639px\)[\s\S]*?\.landingHeroTypewriter\s*\{[\s\S]*?transform: translateY\(-12%\);/,
+    )
+    expect(landingStyles).not.toContain("translateY(-16%)")
     expect(landingStyles).toMatch(/\.identityProfileCard\s*\{[\s\S]*?width: 300px;/)
     expect(landingStyles).toMatch(/@media \(max-width: 639px\)[\s\S]*?\.identityProfileCard\s*\{[\s\S]*?width: min\(300px, 100%\);/)
     expect(landingPageSource).toContain("onPointerMove={tiltCard}")
@@ -376,8 +401,10 @@ describe("landing content contract", () => {
     expect(landingPageSource).not.toContain("ProductGallery")
     expect(landingPageSource).not.toContain("storyTabs")
     expect(landingPageSource).toContain("The same room")
-    expect(landingPageSource).toContain("Wherever you open it")
-    expect(landingPageSource).toContain("Open Alook on desktop or phone and keep talking in the same room, with the same people and agents.")
+    expect(landingPageSource).toContain("AI agents on desktop and phone")
+    expect(normalizedLandingPageSource).toContain(
+      "Desktop or phone — you stay in the same room with the same people and agents; nothing drops when you switch.",
+    )
     expect(reachSource).toContain("<p>Desktop</p>")
     expect(shellSource).toContain("<span>Phone</span>")
     expect(`${reachSource} ${shellSource}`).not.toContain("Alook Web")
@@ -398,7 +425,7 @@ describe("landing content contract", () => {
     expect(reachStyles).toMatch(/\.desktopShell\s*\{[\s\S]*?left: 9%;/)
     expect(landingPageSource).toContain("BRAND_SLOGAN")
     expect(landingPageSource).toContain("Alook holds the room")
-    expect(landingPageSource).toContain("Your machine runs the agent")
+    expect(landingPageSource).toContain("Run AI agents locally on your machine")
     expect(landingPageSource).toContain("styles.ownershipDescription")
     expect(landingPageSource).not.toContain("The runtime and workspace stay on your paired machine")
     expect(`${landingPageSource} ${landingContentSource}`).not.toMatch(/\bconversations?\b/i)

--- a/src/web/src/components/home/landing-content.ts
+++ b/src/web/src/components/home/landing-content.ts
@@ -1,6 +1,11 @@
 import type { LandingScene } from "./landing-shell-motion-timeline"
 import { BRAND_SLOGAN } from "@/lib/brand-copy"
 
+export const LANDING_META_TITLE = "AI Agent Collaboration Rooms for Local Agents — Alook"
+
+export const LANDING_META_DESCRIPTION =
+  "Share your local AI agents with your team. Claude Code, Codex, Cursor, OpenCode, and Pi get persistent identities and memory — while running on your machine. Open source."
+
 export const LANDING_SECTION_ORDER = [
   "hero",
   "product-proof",
@@ -17,7 +22,7 @@ export const LANDING_HERO = {
   headlineLead: "Share your agents",
   headlineTail: "with people you trust.",
   subline:
-    "Bring the agents you already use into a shared room where everyone can talk and work together.",
+    "Bring AI agents running on your machine into a shared room, give your team a way to collaborate with them directly — a Discord-style workspace.",
   loggedOutCta: "Start sharing",
   loggedInCta: "Open Alook",
   secondaryCta: "See how it works",
@@ -83,9 +88,9 @@ export const LANDING_AGENT = {
 
 export const LANDING_CONTINUITY = {
   kicker: "Memory with initiative",
-  headline: "Agents keep things moving",
+  headline: "AI agents with memory that keep work moving",
   description:
-    "Your agent moves things forward across every room, so you don’t have to keep every task on your mind.",
+    "Your agent holds context between sessions and moves tasks forward without you repeating instructions. An inbox catches what arrives while you’re away.",
 } as const
 
 export const LANDING_PROVIDERS = ["claude", "codex", "cursor", "opencode", "pi"] as const
@@ -119,7 +124,7 @@ export const HOME_FAQS = [
   {
     question: "How is Alook different from a managed AI workspace like Oasis?",
     answer:
-      "Managed workspaces like Oasis supply agents and route models inside their product. Alook does not supply models or route them. Instead it gives your existing local agents persistent account handles, an inbox with read waterlines, server/channel/DM memberships, and daemon wake semantics — the agent stays a participant even after a session ends.",
+      "Managed workspaces like Oasis can supply cloud-hosted agents and connect outside services. Alook does not supply models or route them. Instead, it gives your existing local agents persistent account handles, an inbox, server/channel/DM memberships, and daemon wake semantics — the agent stays a participant even after a session ends.",
   },
   {
     question: "Do agents act on their own?",
@@ -129,7 +134,7 @@ export const HOME_FAQS = [
   {
     question: "What runs locally and what is hosted?",
     answer:
-      "The agent process runs on your machine. Room and account data follow Alook's hosted model. 'Local' means where the runtime executes — not that all data stays on disk. You can also self-host the full room layer from the open-source repo.",
+      "The agent process runs on your machine. Room and account data follow Alook's hosted model. “Local” means where the runtime executes — not that all data stays on disk. You can also self-host the full room layer from the open-source repo.",
   },
 ] as const
 

--- a/src/web/src/components/home/landing-page.module.css
+++ b/src/web/src/components/home/landing-page.module.css
@@ -1349,7 +1349,7 @@
   }
 
   .landingHeroTypewriter {
-    transform: translateY(-16%);
+    transform: translateY(-12%);
   }
 
   .nav {

--- a/src/web/src/components/home/landing-page.tsx
+++ b/src/web/src/components/home/landing-page.tsx
@@ -290,9 +290,13 @@ export function LandingPage({ isLoggedIn }: { isLoggedIn: boolean }) {
           <div className={styles.sectionIntro}>
             <div className={styles.sectionLead}>
               <p className={styles.sectionMuted}>Share what already works</p>
-              <h2>Bring your agent into the room</h2>
+              <h2>Invite your team to talk with your AI agents</h2>
             </div>
-            <p>Invite people you trust into a room where they can talk with the agent you already use.</p>
+            <p>
+              Your agents already handle real work — Claude Code, Codex, Cursor, OpenCode, or Pi. Alook lets your
+              team collaborate with them directly in shared channels, without forwarding messages or sharing
+              screens.
+            </p>
           </div>
           <ProductScene scene="server" />
         </div>
@@ -303,7 +307,7 @@ export function LandingPage({ isLoggedIn }: { isLoggedIn: boolean }) {
           <div className={styles.sectionIntro}>
             <div className={styles.sectionLead}>
               <p className={styles.sectionMuted}>Across every room</p>
-              <h2>One identity</h2>
+              <h2>One persistent identity across rooms</h2>
             </div>
           </div>
           <IdentityProof />
@@ -328,10 +332,11 @@ export function LandingPage({ isLoggedIn }: { isLoggedIn: boolean }) {
           <div className={styles.sectionIntro}>
             <div className={styles.sectionLead}>
               <p className={styles.sectionMuted}>The same room</p>
-              <h2>Wherever you open it</h2>
+              <h2>AI agents on desktop and phone</h2>
             </div>
             <p>
-              Open Alook on desktop or phone and keep talking in the same room, with the same people and agents.
+              Desktop or phone — you stay in the same room with the same people and agents; nothing drops when you
+              switch.
             </p>
           </div>
           <LandingReachMotion />
@@ -342,9 +347,10 @@ export function LandingPage({ isLoggedIn }: { isLoggedIn: boolean }) {
         <div className={styles.ownershipInner}>
           <div className={styles.ownershipCopy}>
             <p className={styles.darkMuted}>Alook holds the room</p>
-            <h2>Your machine runs the agent</h2>
+            <h2>Run AI agents locally on your machine</h2>
             <p className={styles.ownershipDescription}>
-              Your agent stays on your machine while the people you trust talk with it in Alook.
+              The agent process stays on your computer, using the codebase and tools you configure for it. Alook
+              connects it to people without moving the runtime to the cloud.
             </p>
             <div className={styles.runtimeGroup}>
               <RuntimeBadges />
@@ -362,7 +368,7 @@ export function LandingPage({ isLoggedIn }: { isLoggedIn: boolean }) {
         <div className={styles.closingCta}>
           <p className={styles.kicker}>Ready to share</p>
           <h2>{BRAND_SLOGAN}</h2>
-          <p>Bring the agents you rely on into a room with the people who matter.</p>
+          <p>Bring AI agents you rely on into a shared workspace with the people who matter.</p>
           <div className={styles.closingGathering} data-testid="landing-closing-companions">
             {CLOSING_COMPANIONS.map((companion) => (
               <span


### PR DESCRIPTION
## Summary

- apply the approved homepage metadata, hero, five feature sections, closing CTA, and FAQ copy
- keep the existing one-H1/seven-H2 outline and native FAQ disclosure structure
- adjust the mobile hero typewriter offset from `-16%` to the approved `-12%`
- keep homepage SEO metadata separate from shared desktop/manifest brand copy

## Tests

- `pnpm --filter @alook/web exec vitest run src/components/home/landing-content.test.ts src/components/home/homepage-faq.test.ts` (14/14)
- `pnpm --filter @alook/web typecheck`
- `pnpm --filter @alook/web lint`
- `pnpm typecheck` (9/9 tasks)
- `pnpm test` (Web 569 files / 4899 tests; CI scripts 55 tests)
- commit hook: typecheck, lint, test, typegrep, knip all green

## Visual QA

- `/` at 1440×1000 and 390×844: HTTP 200, zero horizontal overflow
- exact title/description, one H1 + seven H2s, all canonical copy in order
- mobile hero subtitle remains legible after motion with no typewriter collision
- eight visible FAQ answers match FAQPage JSON-LD exactly
