### PR TITLE
fix(web): preserve partial message selection copy

### DIFF
--- a/src/web/src/components/community/messages/message.render.test.ts
+++ b/src/web/src/components/community/messages/message.render.test.ts
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import {
   createMessageMenuPointAnchor,
   Message,
+  selectionBelongsToRow,
   shouldActivateMessageOverlays,
   shouldSuppressTouchMenuOpen,
 } from "./message"
@@ -266,6 +267,112 @@ describe("Message touch action menu", () => {
     expect(globalCss).toMatch(
       /\[data-community-message-body\]\s*\{[^}]*-webkit-touch-callout:\s*default;[^}]*user-select:\s*text;/s,
     )
+    act(() => renderer!.unmount())
+  })
+})
+
+describe("Message desktop text selection", () => {
+  const insideAnchor = {} as Node
+  const insideFocus = {} as Node
+  const outside = {} as Node
+  const rowElement = {
+    contains: (node: Node | null) => node === insideAnchor || node === insideFocus,
+  }
+
+  it("recognizes a non-collapsed selection with either endpoint inside the row", () => {
+    expect(selectionBelongsToRow({
+      isCollapsed: false,
+      anchorNode: insideAnchor,
+      focusNode: outside,
+    }, rowElement)).toBe(true)
+    expect(selectionBelongsToRow({
+      isCollapsed: false,
+      anchorNode: outside,
+      focusNode: insideFocus,
+    }, rowElement)).toBe(true)
+  })
+
+  it("rejects collapsed and outside-row selections", () => {
+    expect(selectionBelongsToRow({
+      isCollapsed: true,
+      anchorNode: insideAnchor,
+      focusNode: insideFocus,
+    }, rowElement)).toBe(false)
+    expect(selectionBelongsToRow({
+      isCollapsed: false,
+      anchorNode: outside,
+      focusNode: outside,
+    }, rowElement)).toBe(false)
+    expect(selectionBelongsToRow(null, rowElement)).toBe(false)
+  })
+
+  it("preserves the native context menu for a selection inside the row", () => {
+    vi.stubGlobal("window", {
+      getSelection: () => ({
+        isCollapsed: false,
+        anchorNode: insideAnchor,
+        focusNode: insideFocus,
+      }),
+    })
+    let renderer: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(makeTree({
+        m: baseMsg(),
+        onOpenThread: vi.fn(),
+        onCopy: vi.fn(),
+      }), { createNodeMock: () => genericMock })
+    })
+
+    const row = renderer!.root.find(
+      (node) => typeof node.props.className === "string"
+        && node.props.className.includes("group relative -mx-2"),
+    )
+
+    const stopPropagation = vi.fn()
+    const preventDefault = vi.fn()
+    const preventBaseUIHandler = vi.fn()
+    act(() => row.props.onContextMenu({
+      currentTarget: rowElement,
+      stopPropagation,
+      preventDefault,
+      preventBaseUIHandler,
+    }))
+
+    expect(stopPropagation).toHaveBeenCalledOnce()
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(preventBaseUIHandler).toHaveBeenCalledOnce()
+    act(() => renderer!.unmount())
+  })
+
+  it("keeps Alook's context menu for a row with no active selection", () => {
+    vi.stubGlobal("window", { getSelection: () => null })
+    let renderer: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(makeTree({
+        m: baseMsg(),
+        onOpenThread: vi.fn(),
+        onCopy: vi.fn(),
+      }), { createNodeMock: () => genericMock })
+    })
+
+    const row = renderer!.root.find(
+      (node) => typeof node.props.className === "string"
+        && node.props.className.includes("group relative -mx-2"),
+    )
+
+    const stopPropagation = vi.fn()
+    const preventDefault = vi.fn()
+    const preventBaseUIHandler = vi.fn()
+    act(() => row.props.onContextMenu({
+      currentTarget: rowElement,
+      stopPropagation,
+      preventDefault,
+      preventBaseUIHandler,
+    }))
+
+    expect(stopPropagation).not.toHaveBeenCalled()
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(preventBaseUIHandler).not.toHaveBeenCalled()
     act(() => renderer!.unmount())
   })
 })

--- a/src/web/src/components/community/messages/message.tsx
+++ b/src/web/src/components/community/messages/message.tsx
@@ -58,6 +58,17 @@ export function shouldSuppressTouchMenuOpen({
   return nestedControl || selectionInsideRow || longPress
 }
 
+type RowSelection = Pick<Selection, "isCollapsed" | "anchorNode" | "focusNode">
+
+export function selectionBelongsToRow(
+  selection: RowSelection | null,
+  row: Pick<HTMLElement, "contains">,
+): boolean {
+  if (!selection || selection.isCollapsed) return false
+  return (!!selection.anchorNode && row.contains(selection.anchorNode))
+    || (!!selection.focusNode && row.contains(selection.focusNode))
+}
+
 export function createMessageMenuPointAnchor(clientX: number, clientY: number) {
   const rect = {
     x: clientX,
@@ -209,6 +220,22 @@ function MessageImpl({
       onPointerEnter={activate}
       onFocusCapture={activate}
       onKeyDownCapture={activate}
+      onContextMenu={interactive && hoverCapable
+        ? (event) => {
+            if (!selectionBelongsToRow(window.getSelection(), event.currentTarget)) return
+
+            // Base UI merges the rendered row's handler before its own context-
+            // menu handler. Cancel only that library handler, then keep the
+            // event away from Base UI's document listener (which otherwise
+            // prevents the native menu). Deliberately do not preventDefault:
+            // the browser must remain in charge of copying the selection.
+            const baseUIEvent = event as typeof event & {
+              preventBaseUIHandler?: () => void
+            }
+            baseUIEvent.preventBaseUIHandler?.()
+            event.stopPropagation()
+          }
+        : undefined}
       onTouchStart={interactive && !hoverCapable
           ? () => {
             touchStartedAt.current = performance.now()
@@ -234,10 +261,7 @@ function MessageImpl({
         : interactive && !hoverCapable
           ? (event) => {
             const selection = window.getSelection()
-            const selectionInsideRow = !!selection
-              && !selection.isCollapsed
-              && !!selection.anchorNode
-              && event.currentTarget.contains(selection.anchorNode)
+            const selectionInsideRow = selectionBelongsToRow(selection, event.currentTarget)
             const nearestControl = (event.target as Element).closest(
               "button, a, input, textarea, select, [role=button]",
             )


### PR DESCRIPTION
## What changed

- detects a non-collapsed selection whose anchor or focus belongs to a community message row
- lets the browser keep its native context menu for that selection instead of opening Alook's whole-message menu
- retains the existing Alook context menu when no text is selected
- reuses the same selection predicate for the existing touch guard
- adds focused renderer regression coverage

## Why

Right-clicking a partial text selection was intercepted by Base UI's message context-menu trigger. Its Copy Text action then copied the entire message, even though the browser selection contained only a substring.

The row now cancels only Base UI's merged handler and stops the library's document listener without calling `preventDefault`, leaving native selection/copy behavior authoritative.

## User impact

People can select and copy only the portion of a community message they need. Whole-message Copy Text and touch message actions continue to work as before.

## Validation

- focused message renderer: 21/21
- web typecheck
- targeted ESLint
- full repo `pnpm typecheck`
- full repo `pnpm test`: 4,907 web tests, 1,300 daemon tests, 55 CI-script tests
- pre-commit full lint, knip, typegrep, and diff-check
- `alook-c-qa` PASS on desktop partial-copy, desktop whole-message menu, and 390px coarse-pointer touch paths
- backend baseline unchanged: zero mutation requests, zero relevant WS frames, and the original D1 message row unchanged
