### PR TITLE
fix(app): repair incomplete installs during onboard

### DIFF
--- a/src/app/src/commands/onboard.ts
+++ b/src/app/src/commands/onboard.ts
@@ -2,7 +2,12 @@ import { Command } from "commander";
 import { execSync, spawn as spawnAsync } from "child_process";
 import { createInterface } from "readline";
 import { checkNodeVersion, checkPorts } from "../lib/checks.js";
-import { isInstalled, installBundled } from "../lib/install.js";
+import {
+  assertInstallationComplete,
+  getMissingInstallFiles,
+  installBundled,
+  isInstalled,
+} from "../lib/install.js";
 import { ensureSecrets } from "../lib/secrets.js";
 import { runMigrations } from "../lib/migrate.js";
 import { startServices, isRunning } from "../lib/services.js";
@@ -59,12 +64,14 @@ export function onboardCommand(): Command {
       } else {
         // Production: install bundled assets
         if (!isInstalled()) {
-          console.log("Installing Alook...");
+          const missingFiles = getMissingInstallFiles();
+          console.log(`Installing missing Alook files (${missingFiles.length} required files missing)...`);
           installBundled();
         } else {
           console.log(`Installation found at ${SELF_HOSTED_DIR}`);
         }
 
+        assertInstallationComplete();
         ensureSecrets(ports.web);
         patchWranglerConfigs(ports);
         runMigrations();

--- a/src/app/src/lib/install.ts
+++ b/src/app/src/lib/install.ts
@@ -1,5 +1,5 @@
-import { cpSync, existsSync, mkdirSync } from "fs";
-import { join, dirname } from "path";
+import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync } from "fs";
+import { dirname, join, relative } from "path";
 import { fileURLToPath } from "url";
 import { SELF_HOSTED_DIR } from "./constants.js";
 
@@ -13,8 +13,50 @@ function bundledDir(): string {
   throw new Error("Cannot find bundled directory. Package may be corrupted.");
 }
 
-export function isInstalled(): boolean {
-  return existsSync(join(SELF_HOSTED_DIR, "web", "wrangler.toml"));
+function bundledFiles(rootDir: string, currentDir = rootDir): string[] {
+  return readdirSync(currentDir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(currentDir, entry.name);
+    return entry.isDirectory()
+      ? bundledFiles(rootDir, path)
+      : [relative(rootDir, path)];
+  });
+}
+
+function isInstalledFile(path: string): boolean {
+  try {
+    return !lstatSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export function isInstalled(sourceDir = bundledDir(), installDir = SELF_HOSTED_DIR): boolean {
+  return getMissingInstallFiles(sourceDir, installDir).length === 0;
+}
+
+export function getMissingInstallFiles(
+  sourceDir = bundledDir(),
+  installDir = SELF_HOSTED_DIR,
+): string[] {
+  return bundledFiles(sourceDir)
+    .filter((file) => !isInstalledFile(join(installDir, file)))
+    .sort();
+}
+
+export function assertInstallationComplete(
+  sourceDir = bundledDir(),
+  installDir = SELF_HOSTED_DIR,
+): void {
+  const missingFiles = getMissingInstallFiles(sourceDir, installDir);
+  if (missingFiles.length === 0) return;
+
+  const preview = missingFiles.slice(0, 10).join(", ");
+  const remainder = missingFiles.length > 10
+    ? `, and ${missingFiles.length - 10} more`
+    : "";
+  throw new Error(
+    `Alook installation is incomplete after installing bundled assets. Missing required files: ${preview}${remainder}. Reinstall @alook/app and try again.`,
+  );
 }
 
 export function installBundled(): void {

--- a/src/app/test/install.test.ts
+++ b/src/app/test/install.test.ts
@@ -1,30 +1,112 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdirSync, existsSync, rmSync, writeFileSync } from "fs";
-import { join } from "path";
+import { dirname, join } from "path";
 import { tmpdir } from "os";
 
 const testDir = join(tmpdir(), `alook-test-install-${process.pid}`);
+const bundleDir = join(tmpdir(), `alook-test-bundle-${process.pid}`);
+
+const bundledFixtureFiles = [
+  "web/wrangler.toml",
+  "email-worker/index.js",
+  "ws-do/index.js",
+  "wake-worker/wrangler.toml",
+  "wake-worker/index.js",
+];
+
+function createFiles(rootDir: string, files: string[]): void {
+  for (const file of files) {
+    const path = join(rootDir, file);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, "fixture");
+  }
+}
 
 vi.mock("../src/lib/constants.js", () => ({ SELF_HOSTED_DIR: testDir }));
 
 describe("install", () => {
-  beforeEach(() => mkdirSync(testDir, { recursive: true }));
+  beforeEach(() => {
+    mkdirSync(testDir, { recursive: true });
+    mkdirSync(bundleDir, { recursive: true });
+    createFiles(bundleDir, bundledFixtureFiles);
+  });
   afterEach(() => {
     if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+    if (existsSync(bundleDir)) rmSync(bundleDir, { recursive: true, force: true });
     vi.resetModules();
   });
 
   describe("isInstalled", () => {
-    it("returns false when web/wrangler.toml is absent", async () => {
+    it("returns false when required files are absent", async () => {
       const { isInstalled } = await import("../src/lib/install.js");
-      expect(isInstalled()).toBe(false);
+      expect(isInstalled(bundleDir, testDir)).toBe(false);
     });
 
-    it("returns true once web/wrangler.toml exists", async () => {
-      mkdirSync(join(testDir, "web"), { recursive: true });
-      writeFileSync(join(testDir, "web", "wrangler.toml"), "name = 'x'");
+    it("returns true once every required file exists", async () => {
+      createFiles(testDir, bundledFixtureFiles);
       const { isInstalled } = await import("../src/lib/install.js");
-      expect(isInstalled()).toBe(true);
+      expect(isInstalled(bundleDir, testDir)).toBe(true);
+    });
+
+    it("returns false for a legacy installation without wake-worker", async () => {
+      createFiles(testDir, bundledFixtureFiles.filter((file) => !file.startsWith("wake-worker/")));
+      const { isInstalled } = await import("../src/lib/install.js");
+      expect(isInstalled(bundleDir, testDir)).toBe(false);
+    });
+  });
+
+  describe("getMissingInstallFiles", () => {
+    it("returns all missing required files", async () => {
+      createFiles(testDir, ["web/wrangler.toml"]);
+      const { getMissingInstallFiles } = await import("../src/lib/install.js");
+      expect(getMissingInstallFiles(bundleDir, testDir)).toEqual(
+        bundledFixtureFiles.filter((file) => file !== "web/wrangler.toml").sort(),
+      );
+    });
+
+    it("automatically requires newly bundled files", async () => {
+      createFiles(testDir, bundledFixtureFiles);
+      createFiles(bundleDir, ["future-worker/nested/entry.js"]);
+      const { getMissingInstallFiles } = await import("../src/lib/install.js");
+      expect(getMissingInstallFiles(bundleDir, testDir)).toEqual([
+        "future-worker/nested/entry.js",
+      ]);
+    });
+
+    it("treats a directory at a bundled file path as missing", async () => {
+      createFiles(testDir, bundledFixtureFiles.filter((file) => file !== "wake-worker/index.js"));
+      mkdirSync(join(testDir, "wake-worker/index.js"), { recursive: true });
+      const { getMissingInstallFiles } = await import("../src/lib/install.js");
+      expect(getMissingInstallFiles(bundleDir, testDir)).toEqual([
+        "wake-worker/index.js",
+      ]);
+    });
+  });
+
+  describe("assertInstallationComplete", () => {
+    it("names missing files in the error", async () => {
+      createFiles(testDir, bundledFixtureFiles.filter((file) => file !== "wake-worker/wrangler.toml"));
+      const { assertInstallationComplete } = await import("../src/lib/install.js");
+      expect(() => assertInstallationComplete(bundleDir, testDir)).toThrow(
+        "Alook installation is incomplete after installing bundled assets. Missing required files: wake-worker/wrangler.toml. Reinstall @alook/app and try again.",
+      );
+    });
+
+    it("does not throw for a complete installation", async () => {
+      createFiles(testDir, bundledFixtureFiles);
+      const { assertInstallationComplete } = await import("../src/lib/install.js");
+      expect(() => assertInstallationComplete(bundleDir, testDir)).not.toThrow();
+    });
+
+    it("limits the missing-file preview for corrupted installations", async () => {
+      createFiles(bundleDir, Array.from(
+        { length: 12 },
+        (_, index) => `future-worker/chunk-${index}.js`,
+      ));
+      const { assertInstallationComplete } = await import("../src/lib/install.js");
+      expect(() => assertInstallationComplete(bundleDir, testDir)).toThrow(
+        /, and 7 more\. Reinstall @alook\/app and try again\.$/,
+      );
     });
   });
 });

--- a/src/app/test/onboard.test.ts
+++ b/src/app/test/onboard.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  assertInstallationComplete: vi.fn(),
+  checkNodeVersion: vi.fn(),
+  checkPorts: vi.fn(),
+  createInterface: vi.fn(),
+  ensureSecrets: vi.fn(),
+  getMissingInstallFiles: vi.fn(() => ["wake-worker/wrangler.toml"]),
+  installBundled: vi.fn(),
+  isInstalled: vi.fn(() => false),
+  isRunning: vi.fn(() => false),
+  patchWranglerConfigs: vi.fn(),
+  runMigrations: vi.fn(),
+  spawn: vi.fn(() => ({ unref: vi.fn() })),
+  startServices: vi.fn(),
+  waitForServer: vi.fn(),
+}));
+
+vi.mock("child_process", () => ({ execSync: vi.fn(), spawn: mocks.spawn }));
+vi.mock("readline", () => ({ createInterface: mocks.createInterface }));
+vi.mock("../src/lib/checks.js", () => ({
+  checkNodeVersion: mocks.checkNodeVersion,
+  checkPorts: mocks.checkPorts,
+}));
+vi.mock("../src/lib/install.js", () => ({
+  assertInstallationComplete: mocks.assertInstallationComplete,
+  getMissingInstallFiles: mocks.getMissingInstallFiles,
+  installBundled: mocks.installBundled,
+  isInstalled: mocks.isInstalled,
+}));
+vi.mock("../src/lib/secrets.js", () => ({ ensureSecrets: mocks.ensureSecrets }));
+vi.mock("../src/lib/migrate.js", () => ({ runMigrations: mocks.runMigrations }));
+vi.mock("../src/lib/services.js", () => ({
+  isRunning: mocks.isRunning,
+  startServices: mocks.startServices,
+}));
+vi.mock("../src/lib/register.js", () => ({ waitForServer: mocks.waitForServer }));
+vi.mock("../src/lib/wrangler-config.js", () => ({ patchWranglerConfigs: mocks.patchWranglerConfigs }));
+vi.mock("../src/lib/daemon.js", () => ({ pairAndStartDaemon: vi.fn() }));
+
+import { onboardCommand } from "../src/commands/onboard.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.ALOOK_PROJECT_ROOT;
+  mocks.getMissingInstallFiles.mockReturnValue(["wake-worker/wrangler.toml"]);
+  mocks.isInstalled.mockReturnValue(false);
+  mocks.isRunning.mockReturnValue(false);
+  mocks.createInterface.mockReturnValue({
+    close: vi.fn(),
+    question: vi.fn((_prompt: string, callback: () => void) => callback()),
+  });
+  vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("onboard command installation repair", () => {
+  it("repairs and verifies an incomplete installation before patching configs", async () => {
+    await onboardCommand().parseAsync(["--skip-register"], { from: "user" });
+
+    expect(mocks.installBundled).toHaveBeenCalledOnce();
+    expect(mocks.assertInstallationComplete).toHaveBeenCalledOnce();
+    expect(mocks.installBundled.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.assertInstallationComplete.mock.invocationCallOrder[0],
+    );
+    expect(mocks.assertInstallationComplete.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.patchWranglerConfigs.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not copy the bundle when the installation is complete", async () => {
+    mocks.isInstalled.mockReturnValue(true);
+    mocks.getMissingInstallFiles.mockReturnValue([]);
+
+    await onboardCommand().parseAsync(["--skip-register"], { from: "user" });
+
+    expect(mocks.installBundled).not.toHaveBeenCalled();
+    expect(mocks.assertInstallationComplete).toHaveBeenCalledOnce();
+    expect(mocks.patchWranglerConfigs).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
# Why we need this PR?
> No linked issue.

Older self-hosted installations can predate the wake worker. `onboard` previously treated an installation as complete when only `web/wrangler.toml` existed, then crashed with `ENOENT` while patching the missing `wake-worker/wrangler.toml`.

## What changed
- Derive the required installation file set recursively from the current npm package's `bundled/` tree instead of maintaining a duplicate hard-coded list.
- Restore missing assets from the packaged bundle before patching Wrangler configs.
- Verify the repaired installation and report a readable package-integrity error if required files are still absent.
- Add installation-level and command-level regression tests for legacy, complete, and corrupted installations.
- Preserve D1 state, secrets, daemon credentials, and workspaces through the existing non-destructive recursive bundle copy.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [x] Other: Local app (`@alook/app`)
