### PR TITLE
[codex] clean up web search metadata

### DIFF
--- a/src/web/src/app/(auth)/layout.test.ts
+++ b/src/web/src/app/(auth)/layout.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "vitest";
 import { metadata } from "./layout";
 
 describe("(auth) layout metadata", () => {
-  it("noindexes sign-in and other auth pages", () => {
+  it("gives sign-in its own noindex metadata", () => {
     expect(metadata.robots).toEqual({ index: false, follow: true });
+    expect(metadata.alternates).toEqual({ canonical: "/sign-in" });
   });
 });

--- a/src/web/src/app/(auth)/layout.tsx
+++ b/src/web/src/app/(auth)/layout.tsx
@@ -7,6 +7,7 @@ export const metadata: Metadata = {
   title: "Sign In",
   description: BRAND_SLOGAN,
   robots: { index: false, follow: true },
+  alternates: { canonical: "/sign-in" },
   openGraph: {
     images: [{ url: "/og?title=Sign In", width: 1200, height: 630 }],
   },

--- a/src/web/src/app/layout.tsx
+++ b/src/web/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { MockNetworkBanner } from "@/components/mock-network-banner";
 import { TauriThemeSync } from "@/components/tauri-theme-sync";
 import { ThemeColorSync } from "@/components/theme-color-sync";
 import { BRAND_DESCRIPTION, BRAND_SLOGAN, BRAND_TITLE } from "@/lib/brand-copy";
+import { ALOOK_ORGANIZATION } from "@/lib/seo/entities";
 import { caveat, dmMono, dmSans, instrumentSerif, literata, vt323 } from "./fonts";
 import "./globals.css";
 
@@ -112,15 +113,7 @@ export default function RootLayout({
               },
               {
                 "@context": "https://schema.org",
-                "@type": "Organization",
-                name: "Alook",
-                url: SITE_URL,
-                logo: `${SITE_URL}/alook.svg`,
-                contactPoint: {
-                  "@type": "ContactPoint",
-                  email: "support@alook.ai",
-                  contactType: "customer support",
-                },
+                ...ALOOK_ORGANIZATION,
               },
             ]),
           }}

--- a/src/web/src/app/sitemap.test.ts
+++ b/src/web/src/app/sitemap.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/blog/posts", () => ({
+  getAllPosts: vi.fn(),
+}));
+
+import { getAllPosts } from "@/lib/blog/posts";
+import sitemap from "./sitemap";
+
+const posts = [
+  {
+    slug: "revised",
+    title: "Revised",
+    date: "2026-06-08",
+    dateModified: "2026-07-23",
+    author: "Alook Team",
+    excerpt: "Revised excerpt.",
+    readingTime: "5 min read",
+  },
+  {
+    slug: "published",
+    title: "Published",
+    date: "2026-07-01",
+    author: "Gus",
+    excerpt: "Published excerpt.",
+    readingTime: "4 min read",
+  },
+];
+
+describe("sitemap", () => {
+  beforeEach(() => {
+    vi.mocked(getAllPosts).mockReset();
+    vi.mocked(getAllPosts).mockResolvedValue(posts);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("lists only indexable public routes", async () => {
+    const entries = await sitemap();
+    const urls = entries.map((entry) => entry.url);
+
+    expect(urls).toContain("https://alook.ai");
+    expect(urls).toContain("https://alook.ai/templates");
+    expect(urls).toContain("https://alook.ai/blog");
+    expect(urls).toContain("https://alook.ai/privacy");
+    expect(urls).toContain("https://alook.ai/blog/revised");
+    expect(urls).not.toContain("https://alook.ai/sign-in");
+    expect(urls).not.toContain("https://alook.ai/llms.txt");
+  });
+
+  it("uses content metadata for stable blog modification dates", async () => {
+    vi.setSystemTime("2026-08-19T00:00:00Z");
+    const first = await sitemap();
+    vi.setSystemTime("2027-01-01T00:00:00Z");
+    const second = await sitemap();
+
+    expect(second).toEqual(first);
+    expect(first.find((entry) => entry.url.endsWith("/blog/revised")))
+      .toHaveProperty("lastModified", "2026-07-23");
+    expect(first.find((entry) => entry.url.endsWith("/blog/published")))
+      .toHaveProperty("lastModified", "2026-07-01");
+    expect(first.find((entry) => entry.url === "https://alook.ai/blog"))
+      .toHaveProperty("lastModified", "2026-07-23");
+  });
+
+  it("omits unverifiable modification dates from static and template routes", async () => {
+    const entries = await sitemap();
+    const datedUrls = new Set([
+      "https://alook.ai/blog",
+      "https://alook.ai/blog/revised",
+      "https://alook.ai/blog/published",
+    ]);
+
+    for (const entry of entries) {
+      if (!datedUrls.has(entry.url)) {
+        expect(entry).not.toHaveProperty("lastModified");
+      }
+    }
+  });
+});

--- a/src/web/src/app/sitemap.ts
+++ b/src/web/src/app/sitemap.ts
@@ -7,7 +7,6 @@ const SITE_URL = "https://alook.ai";
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const templateEntries: MetadataRoute.Sitemap = TEMPLATES.map((t) => ({
     url: `${SITE_URL}/templates/${t.id}`,
-    lastModified: new Date(),
     changeFrequency: "monthly",
     priority: 0.7,
   }));
@@ -15,49 +14,43 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const posts = await getAllPosts();
   const blogEntries: MetadataRoute.Sitemap = posts.map((post) => ({
     url: `${SITE_URL}/blog/${post.slug}`,
-    lastModified: new Date(post.date),
+    lastModified: post.dateModified ?? post.date,
     changeFrequency: "monthly",
     priority: 0.6,
   }));
+  const latestBlogModification = posts.reduce<string | undefined>(
+    (latest, post) => {
+      const modified = post.dateModified ?? post.date;
+      return !latest || modified > latest ? modified : latest;
+    },
+    undefined
+  );
 
   return [
     {
       url: SITE_URL,
-      lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 1,
     },
     {
       url: `${SITE_URL}/templates`,
-      lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 0.8,
     },
     ...templateEntries,
     {
       url: `${SITE_URL}/blog`,
-      lastModified: new Date(),
+      ...(latestBlogModification
+        ? { lastModified: latestBlogModification }
+        : {}),
       changeFrequency: "weekly",
       priority: 0.8,
-    },
-    {
-      url: `${SITE_URL}/llms.txt`,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 0.7,
     },
     ...blogEntries,
     {
       url: `${SITE_URL}/privacy`,
-      lastModified: new Date(),
       changeFrequency: "yearly",
       priority: 0.3,
-    },
-    {
-      url: `${SITE_URL}/sign-in`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
     },
   ];
 }

--- a/src/web/src/lib/blog/json-ld.test.ts
+++ b/src/web/src/lib/blog/json-ld.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { BlogPost } from "./types";
 import { buildBlogPostingJsonLd } from "./json-ld";
+import { ALOOK_ORGANIZATION_ID } from "@/lib/seo/entities";
 
 const base: BlogPost = {
   slug: "sample",
@@ -27,5 +28,32 @@ describe("buildBlogPostingJsonLd", () => {
     });
     expect(jsonLd.datePublished).toBe("2026-06-08");
     expect(jsonLd.dateModified).toBe("2026-07-23");
+  });
+
+  it("uses the Alook organization as author for Alook Team", () => {
+    const jsonLd = buildBlogPostingJsonLd(base);
+
+    expect(jsonLd.author).toMatchObject({
+      "@type": "Organization",
+      "@id": ALOOK_ORGANIZATION_ID,
+      name: "Alook AI",
+      url: "https://alook.ai",
+    });
+    expect(jsonLd.publisher).toMatchObject({
+      "@type": "Organization",
+      "@id": ALOOK_ORGANIZATION_ID,
+    });
+  });
+
+  it("uses a Person author for a named writer", () => {
+    const jsonLd = buildBlogPostingJsonLd({
+      ...base,
+      author: "Gus",
+    });
+
+    expect(jsonLd.author).toEqual({
+      "@type": "Person",
+      name: "Gus",
+    });
   });
 });

--- a/src/web/src/lib/blog/json-ld.ts
+++ b/src/web/src/lib/blog/json-ld.ts
@@ -1,4 +1,5 @@
 import type { BlogPost } from "./types";
+import { ALOOK_ORGANIZATION } from "@/lib/seo/entities";
 
 export function buildBlogPostingJsonLd(post: BlogPost) {
   return {
@@ -8,15 +9,14 @@ export function buildBlogPostingJsonLd(post: BlogPost) {
     description: post.excerpt,
     datePublished: post.date,
     ...(post.dateModified ? { dateModified: post.dateModified } : {}),
-    author: {
-      "@type": "Person",
-      name: post.author,
-    },
-    publisher: {
-      "@type": "Organization",
-      name: "Alook AI",
-      url: "https://alook.ai",
-    },
+    author:
+      post.author === "Alook Team"
+        ? { ...ALOOK_ORGANIZATION }
+        : {
+            "@type": "Person",
+            name: post.author,
+          },
+    publisher: { ...ALOOK_ORGANIZATION },
     url: `https://alook.ai/blog/${post.slug}`,
     ...(post.image ? { image: `https://alook.ai${post.image}` } : {}),
   };

--- a/src/web/src/lib/seo/entities.ts
+++ b/src/web/src/lib/seo/entities.ts
@@ -1,0 +1,14 @@
+export const ALOOK_ORGANIZATION_ID = "https://alook.ai/#organization";
+
+export const ALOOK_ORGANIZATION = {
+  "@type": "Organization",
+  "@id": ALOOK_ORGANIZATION_ID,
+  name: "Alook AI",
+  url: "https://alook.ai",
+  logo: "https://alook.ai/alook.svg",
+  contactPoint: {
+    "@type": "ContactPoint",
+    email: "support@alook.ai",
+    contactType: "customer support",
+  },
+} as const;


### PR DESCRIPTION
## What changed

- remove `/sign-in` and `/llms.txt` from the generated sitemap
- replace deploy-time sitemap timestamps with checked-in blog `dateModified ?? date` values, while omitting unverifiable dates for static/template pages
- give `/sign-in` its own canonical while preserving `noindex, follow`
- represent `Alook Team` as the shared Alook AI Organization entity and named writers as Person entities in BlogPosting JSON-LD
- add focused regression coverage for sitemap determinism, auth metadata, and author entity types

## Why

The sitemap advertised a noindex auth route and a machine-readable text resource as search landing pages. It also regenerated most `lastmod` values on every deploy, making them unreliable. Separately, the root homepage canonical leaked into sign-in metadata and every blog author was labeled as a Person, including `Alook Team`.

## Impact

Search crawlers receive a smaller, truthful sitemap with stable content-backed dates. Sign-in is explicitly self-canonical and noindex. Article structured data now distinguishes organizational from personal authorship without changing visible blog content or routes.

This PR does not include blog content rewrites, IA changes, redirects, crawler configuration, sitemap resubmission, or URL indexing requests.

## Validation

- focused Vitest: 8/8
- full web Vitest: 4,915/4,915
- CI-script Vitest: 55/55
- web typecheck, lint, knip
- production Next build and generated sitemap inspection
- runtime HTML inspection for `/sign-in`, an Alook Team article, and a Gus article
- root `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm typegrep:ws`, `pnpm knip`
