### PR TITLE
feat(web): organize blog by topic

### DIFF
--- a/src/web/src/app/blog/[slug]/page.tsx
+++ b/src/web/src/app/blog/[slug]/page.tsx
@@ -4,6 +4,12 @@ import Link from "next/link";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import { getAllPosts, getPostBySlug } from "@/lib/blog/posts";
 import { buildBlogPostingJsonLd } from "@/lib/blog/json-ld";
+import {
+  getBlogTopicBySlug,
+  getBlogTopicEntryBySlug,
+  getNextTopicBridge,
+  getRelatedPosts,
+} from "@/lib/blog/topics";
 
 export const dynamicParams = false;
 
@@ -62,9 +68,9 @@ export default async function BlogPostPage({
   if (!post) notFound();
 
   const posts = await getAllPosts();
-  const currentIndex = posts.findIndex((p) => p.slug === slug);
-  const prevPost = currentIndex < posts.length - 1 ? posts[currentIndex + 1] : null;
-  const nextPost = currentIndex > 0 ? posts[currentIndex - 1] : null;
+  const topic = getBlogTopicBySlug(slug);
+  const relatedPosts = getRelatedPosts(slug, posts);
+  const nextTopicBridge = getNextTopicBridge(slug, posts);
 
   const { default: PostContent, jsonLd } = await import(
     `@/content/${slug}.mdx`
@@ -96,6 +102,14 @@ export default async function BlogPostPage({
         </Link>
 
         <header className="mb-10 sm:mb-16">
+          {topic && (
+            <Link
+              href={`/blog#${topic.id}`}
+              className="mb-4 inline-block font-mono text-[11px] uppercase tracking-[0.16em] text-muted-foreground transition-colors hover:text-foreground"
+            >
+              {topic.label}
+            </Link>
+          )}
           <h1 className="font-news text-4xl sm:text-5xl font-semibold tracking-tight leading-[1.12]">
             {post.title}
           </h1>
@@ -131,40 +145,71 @@ export default async function BlogPostPage({
           <PostContent />
         </div>
 
-        <nav className="mt-20 border-t border-border pt-10 flex items-stretch justify-between gap-6">
-          {prevPost ? (
-            <Link
-              href={`/blog/${prevPost.slug}`}
-              className="group flex flex-col gap-2 text-left max-w-[45%]"
-            >
-              <span className="text-[11px] uppercase tracking-[0.15em] font-mono text-muted-foreground flex items-center gap-2">
-                <ArrowLeft className="size-3" />
-                Previous
-              </span>
-              <span className="text-[15px] font-sans group-hover:-translate-x-0.5 transition-transform duration-200 leading-snug">
-                {prevPost.title}
-              </span>
-            </Link>
-          ) : (
-            <div />
-          )}
-          {nextPost ? (
-            <Link
-              href={`/blog/${nextPost.slug}`}
-              className="group flex flex-col gap-2 text-right ml-auto max-w-[45%]"
-            >
-              <span className="text-[11px] uppercase tracking-[0.15em] font-mono text-muted-foreground flex items-center justify-end gap-2">
-                Next
-                <ArrowRight className="size-3" />
-              </span>
-              <span className="text-[15px] font-sans group-hover:translate-x-0.5 transition-transform duration-200 leading-snug">
-                {nextPost.title}
-              </span>
-            </Link>
-          ) : (
-            <div />
-          )}
-        </nav>
+        {topic && (relatedPosts.length > 0 || nextTopicBridge) && (
+          <aside className="mt-20 border-t border-border pt-10">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-muted-foreground/60">
+                  Keep exploring
+                </p>
+                <h2 className="mt-2 font-news text-2xl sm:text-3xl font-semibold tracking-tight">
+                  {topic.label}
+                </h2>
+              </div>
+              <Link
+                href={`/blog#${topic.id}`}
+                className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+              >
+                All in this topic
+              </Link>
+            </div>
+
+            {relatedPosts.length > 0 && (
+              <nav
+                aria-label={`More in ${topic.label}`}
+                className="mt-7 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-3"
+              >
+                {relatedPosts.map((relatedPost) => (
+                  <Link
+                    key={relatedPost.slug}
+                    href={`/blog/${relatedPost.slug}`}
+                    className="group flex min-h-44 flex-col bg-background p-5 transition-colors hover:bg-muted/50"
+                  >
+                    <span className="font-mono text-[10px] uppercase tracking-[0.13em] text-muted-foreground/60">
+                      {getBlogTopicEntryBySlug(relatedPost.slug)?.userJob}
+                    </span>
+                    <span className="mt-3 font-news text-lg font-semibold leading-snug tracking-tight group-hover:translate-x-0.5 transition-transform duration-200">
+                      {relatedPost.title}
+                    </span>
+                    <span className="mt-auto pt-4 text-xs text-muted-foreground">
+                      {relatedPost.readingTime}
+                    </span>
+                  </Link>
+                ))}
+              </nav>
+            )}
+
+            {nextTopicBridge && (
+              <Link
+                href={`/blog/${nextTopicBridge.post.slug}`}
+                className="group mt-5 grid gap-3 rounded-xl border border-border p-5 transition-colors hover:bg-muted/40 sm:grid-cols-[9rem_1fr_auto] sm:items-center sm:gap-6"
+              >
+                <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground/60">
+                  Next topic
+                </span>
+                <span>
+                  <span className="block text-xs text-muted-foreground">
+                    {nextTopicBridge.topic.label}
+                  </span>
+                  <span className="mt-1 block font-news text-lg font-semibold leading-snug tracking-tight">
+                    {nextTopicBridge.post.title}
+                  </span>
+                </span>
+                <ArrowRight className="hidden size-4 text-muted-foreground transition-transform duration-200 group-hover:translate-x-1 sm:block" />
+              </Link>
+            )}
+          </aside>
+        )}
       </article>
     </>
   );

--- a/src/web/src/app/blog/page.tsx
+++ b/src/web/src/app/blog/page.tsx
@@ -1,6 +1,11 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { getAllPosts } from "@/lib/blog/posts";
+import {
+  blogTopics,
+  getBlogTopicEntryBySlug,
+  getPostsForTopic,
+} from "@/lib/blog/topics";
 
 const pageTitle = "Multi-Agent Collaboration & AI Team";
 
@@ -47,7 +52,6 @@ const collectionJsonLd = {
 
 export default async function BlogPage() {
   const posts = await getAllPosts();
-  const [featured, ...rest] = posts;
 
   return (
     <>
@@ -55,8 +59,8 @@ export default async function BlogPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(collectionJsonLd) }}
       />
-      <div className="mx-auto max-w-3xl px-6 pt-10 sm:pt-20 pb-24">
-        <header className="mb-16">
+      <div className="mx-auto max-w-5xl px-6 pt-10 sm:pt-20 pb-24">
+        <header className="max-w-3xl">
           <h1 className="font-news text-5xl sm:text-6xl font-semibold tracking-tight leading-none">
             {pageTitle}
           </h1>
@@ -77,64 +81,129 @@ export default async function BlogPage() {
           </p>
         </header>
 
-        {featured && (
-          <Link
-            href={`/blog/${featured.slug}`}
-            className="group block pb-14 mb-14 border-b border-border"
-          >
-            <span className="text-xs font-mono uppercase tracking-[0.2em] text-muted-foreground/60">
-              Latest
-            </span>
-            <h2 className="mt-3 font-news text-3xl sm:text-4xl font-semibold tracking-tight leading-tight group-hover:translate-x-1 transition-transform duration-200">
-              {featured.title}
-            </h2>
-            <p className="mt-3 text-sm text-muted-foreground">
-              {new Date(featured.date).toLocaleDateString("en-US", {
-                year: "numeric",
-                month: "long",
-                day: "numeric",
-              })}{" "}
-              &middot; {featured.readingTime}
-            </p>
-            <p className="mt-4 font-sans text-lg text-foreground/80 leading-relaxed max-w-2xl">
-              {featured.excerpt}
-            </p>
-          </Link>
-        )}
-
-        <div className="space-y-0">
-          {rest.map((post, i) => (
-            <article
-              key={post.slug}
-              className={`py-10 ${i < rest.length - 1 ? "border-b border-border" : ""}`}
+        <nav
+          aria-label="Blog topics"
+          className="mt-12 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2 lg:grid-cols-4"
+        >
+          {blogTopics.map((topic, index) => (
+            <a
+              key={topic.id}
+              href={`#${topic.id}`}
+              className="group bg-background px-5 py-5 transition-colors hover:bg-muted/60"
             >
-              <Link href={`/blog/${post.slug}`} className="group block">
-                <div className="flex items-baseline gap-4">
-                  <span className="text-xs font-mono text-muted-foreground/40 tabular-nums w-6 shrink-0">
-                    {String(i + 2).padStart(2, "0")}
-                  </span>
+              <span className="font-mono text-[11px] tabular-nums text-muted-foreground/50">
+                {String(index + 1).padStart(2, "0")}
+              </span>
+              <span className="mt-3 block font-sans text-sm font-medium leading-snug group-hover:translate-x-0.5 transition-transform duration-200">
+                {topic.label}
+              </span>
+            </a>
+          ))}
+        </nav>
+
+        <div className="mt-24 space-y-24">
+          {blogTopics.map((topic, topicIndex) => {
+            const topicPosts = getPostsForTopic(topic, posts);
+            const pillar = topicPosts.find(
+              (post) => post.slug === topic.pillarSlug
+            );
+            const supportPosts = topicPosts.filter(
+              (post) => post.slug !== topic.pillarSlug
+            );
+
+            return (
+              <section
+                key={topic.id}
+                id={topic.id}
+                className="scroll-mt-24"
+                aria-labelledby={`${topic.id}-heading`}
+              >
+                <div className="grid gap-5 border-t border-border pt-7 md:grid-cols-[11rem_1fr] md:gap-10">
+                  <p className="font-mono text-xs uppercase tracking-[0.16em] text-muted-foreground/60">
+                    Topic {String(topicIndex + 1).padStart(2, "0")}
+                  </p>
                   <div>
-                    <h2 className="font-news text-xl sm:text-2xl font-semibold tracking-tight group-hover:translate-x-0.5 transition-transform duration-200">
-                      {post.title}
+                    <h2
+                      id={`${topic.id}-heading`}
+                      className="font-news text-3xl sm:text-4xl font-semibold tracking-tight leading-tight"
+                    >
+                      {topic.label}
                     </h2>
-                    <p className="mt-2 text-sm text-muted-foreground">
-                      {new Date(post.date).toLocaleDateString("en-US", {
-                        year: "numeric",
-                        month: "long",
-                        day: "numeric",
-                      })}{" "}
-                      &middot; {post.readingTime}
-                    </p>
-                    <p className="mt-3 font-sans text-foreground/75 leading-relaxed">
-                      {post.excerpt}
+                    <p className="mt-3 max-w-2xl font-sans text-foreground/70 leading-relaxed">
+                      {topic.description}
                     </p>
                   </div>
                 </div>
-              </Link>
-            </article>
-          ))}
+
+                {pillar && (
+                  <Link
+                    href={`/blog/${pillar.slug}`}
+                    className="group mt-10 block rounded-xl border border-border bg-muted/25 p-6 sm:p-8 transition-colors hover:bg-muted/50"
+                  >
+                    <span className="font-mono text-[11px] uppercase tracking-[0.16em] text-muted-foreground/60">
+                      Start here
+                    </span>
+                    <div className="mt-4 grid gap-4 md:grid-cols-[1fr_14rem] md:gap-10">
+                      <div>
+                        <h3 className="font-news text-2xl sm:text-3xl font-semibold tracking-tight leading-tight group-hover:translate-x-0.5 transition-transform duration-200">
+                          {pillar.title}
+                        </h3>
+                        <p className="mt-3 font-sans text-foreground/75 leading-relaxed">
+                          {pillar.excerpt}
+                        </p>
+                      </div>
+                      <div className="md:border-l md:border-border md:pl-6">
+                        <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground/60">
+                          Use this to
+                        </p>
+                        <p className="mt-2 text-sm leading-relaxed text-foreground/80">
+                          {getBlogTopicEntryBySlug(pillar.slug)?.userJob}
+                        </p>
+                        <p className="mt-4 text-xs text-muted-foreground">
+                          {formatPostDate(pillar.date)} &middot;{" "}
+                          {pillar.readingTime}
+                        </p>
+                      </div>
+                    </div>
+                  </Link>
+                )}
+
+                <div className="mt-4 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2">
+                  {supportPosts.map((post) => (
+                    <article key={post.slug} className="bg-background">
+                      <Link
+                        href={`/blog/${post.slug}`}
+                        className="group flex h-full flex-col p-6 transition-colors hover:bg-muted/40"
+                      >
+                        <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground/60">
+                          {getBlogTopicEntryBySlug(post.slug)?.userJob}
+                        </p>
+                        <h3 className="mt-3 font-news text-xl sm:text-2xl font-semibold tracking-tight leading-snug group-hover:translate-x-0.5 transition-transform duration-200">
+                          {post.title}
+                        </h3>
+                        <p className="mt-3 font-sans text-sm text-foreground/70 leading-relaxed">
+                          {post.excerpt}
+                        </p>
+                        <p className="mt-auto pt-5 text-xs text-muted-foreground">
+                          {formatPostDate(post.date)} &middot; {post.readingTime}
+                        </p>
+                      </Link>
+                    </article>
+                  ))}
+                </div>
+              </section>
+            );
+          })}
         </div>
       </div>
     </>
   );
+}
+
+function formatPostDate(date: string): string {
+  return new Date(date).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
 }

--- a/src/web/src/lib/blog/topics.test.ts
+++ b/src/web/src/lib/blog/topics.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { readFileSync, readdirSync } from "fs";
 import { join } from "path";
+import { fileURLToPath } from "url";
 import type { BlogPost } from "./types";
 import { isDraftBlogPost, readBlogMetadata } from "./validate-assets";
 import {
@@ -29,7 +30,7 @@ describe("blogTopics", () => {
     const registrySlugs = blogTopics
       .flatMap((topic) => topic.entries.map((entry) => entry.slug))
       .sort();
-    const contentDir = join(process.cwd(), "src", "content");
+    const contentDir = fileURLToPath(new URL("../../content", import.meta.url));
     const publishedSlugs = readdirSync(contentDir)
       .filter((file) => file.endsWith(".mdx"))
       .flatMap((file) => {

--- a/src/web/src/lib/blog/topics.test.ts
+++ b/src/web/src/lib/blog/topics.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync } from "fs";
+import { join } from "path";
 import type { BlogPost } from "./types";
+import { isDraftBlogPost, readBlogMetadata } from "./validate-assets";
 import {
   blogTopics,
   getBlogTopicBySlug,
@@ -22,6 +25,27 @@ const allPosts = blogTopics.flatMap((topic) =>
 );
 
 describe("blogTopics", () => {
+  it("matches the real published post set in both directions", () => {
+    const registrySlugs = blogTopics
+      .flatMap((topic) => topic.entries.map((entry) => entry.slug))
+      .sort();
+    const contentDir = join(process.cwd(), "src", "content");
+    const publishedSlugs = readdirSync(contentDir)
+      .filter((file) => file.endsWith(".mdx"))
+      .flatMap((file) => {
+        const fileSlug = file.replace(/\.mdx$/, "");
+        const content = readFileSync(join(contentDir, file), "utf-8");
+        if (isDraftBlogPost(content)) return [];
+
+        const { metadata, errors } = readBlogMetadata(content, fileSlug);
+        expect(errors).toEqual([]);
+        return metadata.slug ? [metadata.slug] : [];
+      })
+      .sort();
+
+    expect(registrySlugs).toEqual(publishedSlugs);
+  });
+
   it("covers all 22 locked slugs exactly once", () => {
     const orderedSlugs = blogTopics.map((topic) =>
       topic.entries.map((entry) => entry.slug)
@@ -70,6 +94,57 @@ describe("blogTopics", () => {
         topic.pillarSlug
       );
     }
+  });
+
+  it("preserves the exact locked user job for every slug", () => {
+    expect(
+      Object.fromEntries(
+        blogTopics.flatMap((topic) =>
+          topic.entries.map((entry) => [entry.slug, entry.userJob])
+        )
+      )
+    ).toEqual({
+      "ai-agent-vs-chatbot": "Decide whether I need an agent or a chatbot",
+      "how-to-delegate-tasks-to-ai-agents":
+        "Package a task so an agent can run it reliably",
+      "ai-agent-team": "Design a multi-agent team with roles and handoffs",
+      "ai-agent-orchestration":
+        "Understand the coordination layer between agents",
+      "multi-agent-workflow-patterns":
+        "Pick a workflow pattern for my multi-agent setup",
+      "run-ai-agent-team-that-stays-on-track":
+        "Keep a running agent team from drifting",
+      "ai-team-vs-ai-tools":
+        "Stop being the copy-paste layer between coding agents",
+      "claude-code-subagents-vs-independent-agents":
+        "Choose nested vs independent agents for my Claude Code work",
+      "claude-code-and-codex-same-team":
+        "Use Claude Code and Codex together as one coordinated team",
+      "claude-code-dynamic-workflow-alternative":
+        "Choose between session workflows and persistent coordination",
+      "keep-context-across-coding-agent-sessions":
+        "Carry decisions across coding agent sessions",
+      "multiple-ai-agents-edit-same-repository":
+        "Run parallel agents on one repo without conflicts",
+      "prevent-coding-agents-duplicating-work":
+        "Stop agents from redoing each other's work",
+      "shared-context-between-agents":
+        "Understand why agents drift without shared context",
+      "what-makes-a-shared-ai-workspace-usable":
+        "Judge whether a shared workspace actually works",
+      "human-ai-collaboration-small-teams":
+        "Move from one chat to a coordinated human+agent team",
+      "humans-and-ai-agents-in-one-room":
+        "Bring multiple people's agents into one shared room",
+      "why-we-built-alook": "Understand why Alook exists (founder narrative)",
+      "ai-agent-identity":
+        "Evaluate whether an agent stays addressable across rooms and servers",
+      "personal-ai-company": "Run a one-person company with AI agents",
+      "multi-agent-collaboration-without-code":
+        "Coordinate multiple agents without writing orchestration code",
+      "no-code-automation-ai-agents":
+        "Choose between trigger-action automation and agent teams",
+    });
   });
 
   it("resolves a topic from any mapped slug", () => {

--- a/src/web/src/lib/blog/topics.test.ts
+++ b/src/web/src/lib/blog/topics.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import type { BlogPost } from "./types";
+import {
+  blogTopics,
+  getBlogTopicBySlug,
+  getNextTopicBridge,
+  getPostsForTopic,
+  getRelatedPosts,
+} from "./topics";
+
+const post = (slug: string): BlogPost => ({
+  slug,
+  title: slug,
+  date: "2026-08-01",
+  author: "Alook Team",
+  excerpt: `${slug} excerpt`,
+  readingTime: "5 min read",
+});
+
+const allPosts = blogTopics.flatMap((topic) =>
+  topic.entries.map((entry) => post(entry.slug))
+);
+
+describe("blogTopics", () => {
+  it("covers all 22 locked slugs exactly once", () => {
+    const orderedSlugs = blogTopics.map((topic) =>
+      topic.entries.map((entry) => entry.slug)
+    );
+    const slugs = orderedSlugs.flat();
+
+    expect(slugs).toHaveLength(22);
+    expect(new Set(slugs).size).toBe(22);
+    expect(orderedSlugs).toEqual([
+      [
+        "ai-agent-vs-chatbot",
+        "how-to-delegate-tasks-to-ai-agents",
+        "ai-agent-team",
+        "ai-agent-orchestration",
+        "multi-agent-workflow-patterns",
+        "run-ai-agent-team-that-stays-on-track",
+      ],
+      [
+        "ai-team-vs-ai-tools",
+        "claude-code-subagents-vs-independent-agents",
+        "claude-code-and-codex-same-team",
+        "claude-code-dynamic-workflow-alternative",
+        "keep-context-across-coding-agent-sessions",
+        "multiple-ai-agents-edit-same-repository",
+        "prevent-coding-agents-duplicating-work",
+      ],
+      [
+        "shared-context-between-agents",
+        "what-makes-a-shared-ai-workspace-usable",
+        "human-ai-collaboration-small-teams",
+        "humans-and-ai-agents-in-one-room",
+        "why-we-built-alook",
+        "ai-agent-identity",
+      ],
+      [
+        "personal-ai-company",
+        "multi-agent-collaboration-without-code",
+        "no-code-automation-ai-agents",
+      ],
+    ]);
+  });
+
+  it("keeps every pillar inside its own topic", () => {
+    for (const topic of blogTopics) {
+      expect(topic.entries.map((entry) => entry.slug)).toContain(
+        topic.pillarSlug
+      );
+    }
+  });
+
+  it("resolves a topic from any mapped slug", () => {
+    expect(getBlogTopicBySlug("ai-agent-identity")?.id).toBe(
+      "shared-human-agent-workspace"
+    );
+    expect(getBlogTopicBySlug("not-a-post")).toBeUndefined();
+  });
+});
+
+describe("topic discovery", () => {
+  it("returns posts in the locked topic order and filters missing posts", () => {
+    const topic = blogTopics[3];
+    const available = allPosts.filter(
+      (candidate) => candidate.slug !== "multi-agent-collaboration-without-code"
+    );
+
+    expect(getPostsForTopic(topic, available).map((candidate) => candidate.slug)).toEqual([
+      "personal-ai-company",
+      "no-code-automation-ai-agents",
+    ]);
+  });
+
+  it("recommends support articles in order from a pillar", () => {
+    expect(
+      getRelatedPosts("ai-agent-team", allPosts).map(
+        (candidate) => candidate.slug
+      )
+    ).toEqual([
+      "ai-agent-vs-chatbot",
+      "how-to-delegate-tasks-to-ai-agents",
+      "ai-agent-orchestration",
+    ]);
+  });
+
+  it("prioritizes the pillar, then nearby support articles", () => {
+    expect(
+      getRelatedPosts("ai-agent-orchestration", allPosts).map(
+        (candidate) => candidate.slug
+      )
+    ).toEqual([
+      "ai-agent-team",
+      "multi-agent-workflow-patterns",
+      "how-to-delegate-tasks-to-ai-agents",
+    ]);
+  });
+
+  it("never returns the current article or missing metadata", () => {
+    const available = allPosts.filter(
+      (candidate) => candidate.slug !== "ai-agent-team"
+    );
+    const related = getRelatedPosts("ai-agent-vs-chatbot", available);
+
+    expect(related.map((candidate) => candidate.slug)).not.toContain(
+      "ai-agent-vs-chatbot"
+    );
+    expect(related.map((candidate) => candidate.slug)).not.toContain(
+      "ai-agent-team"
+    );
+  });
+
+  it("bridges to the next topic pillar and wraps to the first topic", () => {
+    expect(getNextTopicBridge("ai-agent-team", allPosts)?.post.slug).toBe(
+      "claude-code-and-codex-same-team"
+    );
+    expect(getNextTopicBridge("personal-ai-company", allPosts)?.post.slug).toBe(
+      "ai-agent-team"
+    );
+  });
+});

--- a/src/web/src/lib/blog/topics.ts
+++ b/src/web/src/lib/blog/topics.ts
@@ -21,12 +21,12 @@ export const blogTopics = [
       "Understand what agents are, then design the roles, handoffs, and operating patterns that keep a team on track.",
     pillarSlug: "ai-agent-team",
     entries: [
-      { slug: "ai-agent-vs-chatbot", userJob: "Decide between an agent and a chatbot" },
-      { slug: "how-to-delegate-tasks-to-ai-agents", userJob: "Package a task reliably" },
-      { slug: "ai-agent-team", userJob: "Design multi-agent team roles and handoffs" },
-      { slug: "ai-agent-orchestration", userJob: "Understand the coordination layer" },
-      { slug: "multi-agent-workflow-patterns", userJob: "Pick a workflow pattern" },
-      { slug: "run-ai-agent-team-that-stays-on-track", userJob: "Keep a team from drifting" },
+      { slug: "ai-agent-vs-chatbot", userJob: "Decide whether I need an agent or a chatbot" },
+      { slug: "how-to-delegate-tasks-to-ai-agents", userJob: "Package a task so an agent can run it reliably" },
+      { slug: "ai-agent-team", userJob: "Design a multi-agent team with roles and handoffs" },
+      { slug: "ai-agent-orchestration", userJob: "Understand the coordination layer between agents" },
+      { slug: "multi-agent-workflow-patterns", userJob: "Pick a workflow pattern for my multi-agent setup" },
+      { slug: "run-ai-agent-team-that-stays-on-track", userJob: "Keep a running agent team from drifting" },
     ],
   },
   {
@@ -36,30 +36,30 @@ export const blogTopics = [
       "Coordinate coding agents across tools and repositories without duplicated work, lost decisions, or merge conflicts.",
     pillarSlug: "claude-code-and-codex-same-team",
     entries: [
-      { slug: "ai-team-vs-ai-tools", userJob: "Stop being the copy-paste layer" },
+      { slug: "ai-team-vs-ai-tools", userJob: "Stop being the copy-paste layer between coding agents" },
       {
         slug: "claude-code-subagents-vs-independent-agents",
-        userJob: "Choose nested or independent agents",
+        userJob: "Choose nested vs independent agents for my Claude Code work",
       },
       {
         slug: "claude-code-and-codex-same-team",
-        userJob: "Coordinate Claude Code and Codex",
+        userJob: "Use Claude Code and Codex together as one coordinated team",
       },
       {
         slug: "claude-code-dynamic-workflow-alternative",
-        userJob: "Compare session workflows with persistent coordination",
+        userJob: "Choose between session workflows and persistent coordination",
       },
       {
         slug: "keep-context-across-coding-agent-sessions",
-        userJob: "Carry decisions across sessions",
+        userJob: "Carry decisions across coding agent sessions",
       },
       {
         slug: "multiple-ai-agents-edit-same-repository",
-        userJob: "Run agents in parallel without conflicts",
+        userJob: "Run parallel agents on one repo without conflicts",
       },
       {
         slug: "prevent-coding-agents-duplicating-work",
-        userJob: "Stop agents from duplicating work",
+        userJob: "Stop agents from redoing each other's work",
       },
     ],
   },
@@ -70,23 +70,23 @@ export const blogTopics = [
       "Build a workspace where people and agents share context, remain addressable, and coordinate in the same rooms.",
     pillarSlug: "humans-and-ai-agents-in-one-room",
     entries: [
-      { slug: "shared-context-between-agents", userJob: "Understand why agents drift" },
+      { slug: "shared-context-between-agents", userJob: "Understand why agents drift without shared context" },
       {
         slug: "what-makes-a-shared-ai-workspace-usable",
-        userJob: "Judge whether a shared workspace works",
+        userJob: "Judge whether a shared workspace actually works",
       },
       {
         slug: "human-ai-collaboration-small-teams",
-        userJob: "Move from one chat to a coordinated team",
+        userJob: "Move from one chat to a coordinated human+agent team",
       },
       {
         slug: "humans-and-ai-agents-in-one-room",
-        userJob: "Put multiple people's agents in one room",
+        userJob: "Bring multiple people's agents into one shared room",
       },
-      { slug: "why-we-built-alook", userJob: "Understand why Alook exists" },
+      { slug: "why-we-built-alook", userJob: "Understand why Alook exists (founder narrative)" },
       {
         slug: "ai-agent-identity",
-        userJob: "Keep an agent addressable across rooms and servers",
+        userJob: "Evaluate whether an agent stays addressable across rooms and servers",
       },
     ],
   },
@@ -97,14 +97,14 @@ export const blogTopics = [
       "Turn repeatable work into a coordinated agent operation without building a custom orchestration system.",
     pillarSlug: "personal-ai-company",
     entries: [
-      { slug: "personal-ai-company", userJob: "Build a one-person company" },
+      { slug: "personal-ai-company", userJob: "Run a one-person company with AI agents" },
       {
         slug: "multi-agent-collaboration-without-code",
-        userJob: "Coordinate agents without orchestration code",
+        userJob: "Coordinate multiple agents without writing orchestration code",
       },
       {
         slug: "no-code-automation-ai-agents",
-        userJob: "Choose trigger-action automation or an agent team",
+        userJob: "Choose between trigger-action automation and agent teams",
       },
     ],
   },

--- a/src/web/src/lib/blog/topics.ts
+++ b/src/web/src/lib/blog/topics.ts
@@ -1,0 +1,182 @@
+import type { BlogPost } from "./types";
+
+export type BlogTopicEntry = {
+  slug: string;
+  userJob: string;
+};
+
+export type BlogTopic = {
+  id: string;
+  label: string;
+  description: string;
+  pillarSlug: string;
+  entries: readonly BlogTopicEntry[];
+};
+
+export const blogTopics = [
+  {
+    id: "foundations-team-design",
+    label: "Foundations & team design",
+    description:
+      "Understand what agents are, then design the roles, handoffs, and operating patterns that keep a team on track.",
+    pillarSlug: "ai-agent-team",
+    entries: [
+      { slug: "ai-agent-vs-chatbot", userJob: "Decide between an agent and a chatbot" },
+      { slug: "how-to-delegate-tasks-to-ai-agents", userJob: "Package a task reliably" },
+      { slug: "ai-agent-team", userJob: "Design multi-agent team roles and handoffs" },
+      { slug: "ai-agent-orchestration", userJob: "Understand the coordination layer" },
+      { slug: "multi-agent-workflow-patterns", userJob: "Pick a workflow pattern" },
+      { slug: "run-ai-agent-team-that-stays-on-track", userJob: "Keep a team from drifting" },
+    ],
+  },
+  {
+    id: "coding-agents",
+    label: "Coding agents across runtimes & repos",
+    description:
+      "Coordinate coding agents across tools and repositories without duplicated work, lost decisions, or merge conflicts.",
+    pillarSlug: "claude-code-and-codex-same-team",
+    entries: [
+      { slug: "ai-team-vs-ai-tools", userJob: "Stop being the copy-paste layer" },
+      {
+        slug: "claude-code-subagents-vs-independent-agents",
+        userJob: "Choose nested or independent agents",
+      },
+      {
+        slug: "claude-code-and-codex-same-team",
+        userJob: "Coordinate Claude Code and Codex",
+      },
+      {
+        slug: "claude-code-dynamic-workflow-alternative",
+        userJob: "Compare session workflows with persistent coordination",
+      },
+      {
+        slug: "keep-context-across-coding-agent-sessions",
+        userJob: "Carry decisions across sessions",
+      },
+      {
+        slug: "multiple-ai-agents-edit-same-repository",
+        userJob: "Run agents in parallel without conflicts",
+      },
+      {
+        slug: "prevent-coding-agents-duplicating-work",
+        userJob: "Stop agents from duplicating work",
+      },
+    ],
+  },
+  {
+    id: "shared-human-agent-workspace",
+    label: "Shared context & human-agent workspace",
+    description:
+      "Build a workspace where people and agents share context, remain addressable, and coordinate in the same rooms.",
+    pillarSlug: "humans-and-ai-agents-in-one-room",
+    entries: [
+      { slug: "shared-context-between-agents", userJob: "Understand why agents drift" },
+      {
+        slug: "what-makes-a-shared-ai-workspace-usable",
+        userJob: "Judge whether a shared workspace works",
+      },
+      {
+        slug: "human-ai-collaboration-small-teams",
+        userJob: "Move from one chat to a coordinated team",
+      },
+      {
+        slug: "humans-and-ai-agents-in-one-room",
+        userJob: "Put multiple people's agents in one room",
+      },
+      { slug: "why-we-built-alook", userJob: "Understand why Alook exists" },
+      {
+        slug: "ai-agent-identity",
+        userJob: "Keep an agent addressable across rooms and servers",
+      },
+    ],
+  },
+  {
+    id: "solo-business-no-code",
+    label: "Solo business & no-code operations",
+    description:
+      "Turn repeatable work into a coordinated agent operation without building a custom orchestration system.",
+    pillarSlug: "personal-ai-company",
+    entries: [
+      { slug: "personal-ai-company", userJob: "Build a one-person company" },
+      {
+        slug: "multi-agent-collaboration-without-code",
+        userJob: "Coordinate agents without orchestration code",
+      },
+      {
+        slug: "no-code-automation-ai-agents",
+        userJob: "Choose trigger-action automation or an agent team",
+      },
+    ],
+  },
+] as const satisfies readonly BlogTopic[];
+
+export function getBlogTopicBySlug(slug: string): BlogTopic | undefined {
+  return blogTopics.find((topic) =>
+    topic.entries.some((entry) => entry.slug === slug)
+  );
+}
+
+export function getBlogTopicEntryBySlug(
+  slug: string
+): BlogTopicEntry | undefined {
+  return getBlogTopicBySlug(slug)?.entries.find((entry) => entry.slug === slug);
+}
+
+export function getPostsForTopic(
+  topic: BlogTopic,
+  posts: readonly BlogPost[]
+): BlogPost[] {
+  const postsBySlug = new Map(posts.map((post) => [post.slug, post]));
+  return topic.entries.flatMap((entry) => {
+    const post = postsBySlug.get(entry.slug);
+    return post ? [post] : [];
+  });
+}
+
+export function getRelatedPosts(
+  slug: string,
+  posts: readonly BlogPost[],
+  limit = 3
+): BlogPost[] {
+  const topic = getBlogTopicBySlug(slug);
+  if (!topic || limit <= 0) return [];
+
+  const currentIndex = topic.entries.findIndex((entry) => entry.slug === slug);
+  const pillar = topic.entries.find((entry) => entry.slug === topic.pillarSlug);
+  const candidates = topic.entries
+    .filter((entry) => entry.slug !== slug && entry.slug !== topic.pillarSlug)
+    .sort((a, b) => {
+      if (slug === topic.pillarSlug) return 0;
+      const aIndex = topic.entries.indexOf(a);
+      const bIndex = topic.entries.indexOf(b);
+      return (
+        Math.abs(aIndex - currentIndex) - Math.abs(bIndex - currentIndex) ||
+        aIndex - bIndex
+      );
+    });
+
+  const orderedEntries =
+    slug === topic.pillarSlug || !pillar ? candidates : [pillar, ...candidates];
+  const postsBySlug = new Map(posts.map((post) => [post.slug, post]));
+
+  return orderedEntries
+    .flatMap((entry) => {
+      const post = postsBySlug.get(entry.slug);
+      return post ? [post] : [];
+    })
+    .slice(0, limit);
+}
+
+export function getNextTopicBridge(
+  slug: string,
+  posts: readonly BlogPost[]
+): { topic: BlogTopic; post: BlogPost } | undefined {
+  const topicIndex = blogTopics.findIndex((topic) =>
+    topic.entries.some((entry) => entry.slug === slug)
+  );
+  if (topicIndex === -1) return undefined;
+
+  const nextTopic = blogTopics[(topicIndex + 1) % blogTopics.length];
+  const pillar = posts.find((post) => post.slug === nextTopic.pillarSlug);
+  return pillar ? { topic: nextTopic, post: pillar } : undefined;
+}

--- a/src/web/src/lib/blog/validate-assets.test.ts
+++ b/src/web/src/lib/blog/validate-assets.test.ts
@@ -4,6 +4,7 @@ import {
   collectBlogAssetErrors,
   findBlogImageErrors,
   findDuplicateMdxH1Errors,
+  isDraftBlogPost,
   readBlogMetadata,
   runValidateBlogAssetsCli,
   validateBlogAssets,
@@ -80,6 +81,18 @@ describe("readBlogMetadata", () => {
     expect(
       readBlogMetadata('export const metadata = { slug: "demo"', "demo").errors[0]
     ).toContain("Missing or unterminated");
+  });
+});
+
+describe("isDraftBlogPost", () => {
+  it("reads the draft flag only from the metadata object", () => {
+    expect(
+      isDraftBlogPost(post().replace('title: "Demo",', 'title: "Demo",\n  draft: true,'))
+    ).toBe(true);
+    expect(isDraftBlogPost(`${post()}\nDraft example: draft: true`)).toBe(false);
+    expect(
+      isDraftBlogPost(post().replace('title: "Demo",', 'title: "Demo",\n  draft: false,'))
+    ).toBe(false);
   });
 });
 

--- a/src/web/src/lib/blog/validate-assets.ts
+++ b/src/web/src/lib/blog/validate-assets.ts
@@ -88,6 +88,14 @@ function readStringProperty(object: string, property: string): string | null {
   return null;
 }
 
+export function isDraftBlogPost(content: string): boolean {
+  const object = extractMetadataObject(content);
+  if (!object) return false;
+  return new RegExp(`(?:^|[,\\n])\\s*draft\\s*:\\s*true(?:\\s*[,\\n]|\\s*$)`).test(
+    object
+  );
+}
+
 function isIsoDate(value: string): boolean {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
   const date = new Date(`${value}T00:00:00.000Z`);


### PR DESCRIPTION
## Summary

- encode the locked 22-post / four-topic IA as a typed registry with one user job per article
- replace the flat chronological `/blog` list with topic jump navigation, pillar-first sections, and goal-oriented support cards
- replace chronological article footers with deterministic same-topic recommendations plus a next-topic pillar bridge
- preserve all current routes, metadata, feed behavior, and MDX content

## Verification

- focused topic IA tests: 8 passed
- full web suite: 575 files / 4918 tests passed
- full pre-commit gates passed: typecheck, lint, tests, websocket event check, knip
- blog asset validation passed
- `git diff --check` passed
- visual QA passed at 1440×1000 and 390×844 for `/blog`, a pillar article, and a support article

## Coordination

- based on the cluster lock in `/Alook#5620/board/#3#91`
- isolated from the P0 MDX copy patch and PR #498 metadata/sitemap work
