### PR TITLE
fix(web): preserve native menu for selected message text

### DIFF
--- a/scripts/ci/e2e-shards.mjs
+++ b/scripts/ci/e2e-shards.mjs
@@ -29,6 +29,7 @@ export const SPEC_SECONDS = {
   "20-community-attachment-thumbnails.spec.ts": 60,
   "21-mobile-message-layout.spec.ts": 20,
   "22-committed-message-delivery.spec.ts": 85,
+  "23-message-selection-context-menu.spec.ts": 10,
 }
 
 function walk(directory) {

--- a/scripts/ci/e2e-shards.test.ts
+++ b/scripts/ci/e2e-shards.test.ts
@@ -37,7 +37,7 @@ describe("planE2eShards", () => {
     expect(first).toHaveLength(E2E_SHARD_COUNT)
     expect([...assigned].sort()).toEqual(specs)
     expect(new Set(assigned).size).toBe(specs.length)
-    expect(totals.sort((left, right) => left - right)).toEqual([155, 155, 155, 156, 157])
+    expect(totals.sort((left, right) => left - right)).toEqual([156, 157, 157, 157, 161])
     expect(Math.max(...totals) / Math.min(...totals)).toBeLessThanOrEqual(1.15)
   })
 

--- a/src/web/src/components/community/messages/message.render.test.ts
+++ b/src/web/src/components/community/messages/message.render.test.ts
@@ -330,17 +330,14 @@ describe("Message desktop text selection", () => {
 
     const stopPropagation = vi.fn()
     const preventDefault = vi.fn()
-    const preventBaseUIHandler = vi.fn()
-    act(() => row.props.onContextMenu({
+    act(() => row.props.onContextMenuCapture({
       currentTarget: rowElement,
       stopPropagation,
       preventDefault,
-      preventBaseUIHandler,
     }))
 
     expect(stopPropagation).toHaveBeenCalledOnce()
     expect(preventDefault).not.toHaveBeenCalled()
-    expect(preventBaseUIHandler).toHaveBeenCalledOnce()
     act(() => renderer!.unmount())
   })
 
@@ -362,17 +359,14 @@ describe("Message desktop text selection", () => {
 
     const stopPropagation = vi.fn()
     const preventDefault = vi.fn()
-    const preventBaseUIHandler = vi.fn()
-    act(() => row.props.onContextMenu({
+    act(() => row.props.onContextMenuCapture({
       currentTarget: rowElement,
       stopPropagation,
       preventDefault,
-      preventBaseUIHandler,
     }))
 
     expect(stopPropagation).not.toHaveBeenCalled()
     expect(preventDefault).not.toHaveBeenCalled()
-    expect(preventBaseUIHandler).not.toHaveBeenCalled()
     act(() => renderer!.unmount())
   })
 })

--- a/src/web/src/components/community/messages/message.tsx
+++ b/src/web/src/components/community/messages/message.tsx
@@ -220,19 +220,13 @@ function MessageImpl({
       onPointerEnter={activate}
       onFocusCapture={activate}
       onKeyDownCapture={activate}
-      onContextMenu={interactive && hoverCapable
+      onContextMenuCapture={interactive && hoverCapable
         ? (event) => {
             if (!selectionBelongsToRow(window.getSelection(), event.currentTarget)) return
 
-            // Base UI merges the rendered row's handler before its own context-
-            // menu handler. Cancel only that library handler, then keep the
-            // event away from Base UI's document listener (which otherwise
-            // prevents the native menu). Deliberately do not preventDefault:
-            // the browser must remain in charge of copying the selection.
-            const baseUIEvent = event as typeof event & {
-              preventBaseUIHandler?: () => void
-            }
-            baseUIEvent.preventBaseUIHandler?.()
+            // Stop before Base UI's trigger and document listeners see the
+            // event. Deliberately do not preventDefault: the browser must stay
+            // in charge of the native menu for copying the selected fragment.
             event.stopPropagation()
           }
         : undefined}

--- a/src/web/src/test/e2e-ui/23-message-selection-context-menu.spec.ts
+++ b/src/web/src/test/e2e-ui/23-message-selection-context-menu.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "./_fixtures/community-fixture"
+import { gotoAfterUserWsAuth } from "./_fixtures/actions"
+import { seedChannel, seedMessage, seedServer } from "./_fixtures/seed"
+import { tid } from "./_fixtures/testids"
+
+test("selected message text keeps the native context menu", async ({ asUser }) => {
+  const serverId = await seedServer("alice", `Selection Menu ${Date.now()}`)
+  const channelId = await seedChannel("alice", serverId, "selection-menu")
+  const body = `copy only this phrase ${Date.now()}`
+  const messageId = await seedMessage("alice", channelId, body)
+  const { page } = await asUser("alice")
+
+  await gotoAfterUserWsAuth(page, `/c/channels/${serverId}/${channelId}`)
+  const row = page.getByTestId(tid.message(messageId))
+  const messageBody = row.locator("[data-community-message-body]")
+  await expect(messageBody).toContainText(body)
+
+  // Message action overlays (including Base UI's context-menu trigger) mount
+  // lazily after hover. Reproduce the real pointer path before selecting text.
+  await row.hover()
+  await expect(row.locator('[data-slot="context-menu-trigger"]')).toHaveCount(1)
+
+  const selectionPoint = await messageBody.evaluate((element) => {
+    const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+    const textNode = walker.nextNode()
+    if (!textNode) throw new Error("message body has no text node")
+    const range = document.createRange()
+    range.setStart(textNode, 0)
+    range.setEnd(textNode, "copy only this phrase".length)
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    const rect = range.getBoundingClientRect()
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 }
+  })
+  await expect.poll(() => page.evaluate(() => window.getSelection()?.toString())).toBe("copy only this phrase")
+
+  await page.evaluate(() => {
+    const state = window as typeof window & { __contextMenuDefaultPrevented?: boolean }
+    delete state.__contextMenuDefaultPrevented
+    document.addEventListener("contextmenu", (event) => {
+      setTimeout(() => {
+        state.__contextMenuDefaultPrevented = event.defaultPrevented
+      })
+    }, { capture: true, once: true })
+  })
+  await page.mouse.click(selectionPoint.x, selectionPoint.y, { button: "right" })
+
+  await expect.poll(() => page.evaluate(() => (
+    window as typeof window & { __contextMenuDefaultPrevented?: boolean }
+  ).__contextMenuDefaultPrevented)).toBe(false)
+  await expect(page.locator('[data-slot="context-menu-content"]')).toHaveCount(0)
+
+  await page.evaluate(() => window.getSelection()?.removeAllRanges())
+  await messageBody.click({ button: "right" })
+  await expect(page.locator('[data-slot="context-menu-content"]')).toBeVisible()
+})


### PR DESCRIPTION
## Summary

- preserve the browser-native context menu when a user right-clicks a selected fragment inside a desktop message
- keep the existing Alook message action menu for right-clicks without an active selection
- add a real Chromium regression that verifies the final `contextmenu.defaultPrevented` state and both menu paths
- register the new spec in the deterministic E2E shard weights and update the balance contract

## Root cause

Base UI installs a document-level `contextmenu` listener that calls `preventDefault()` for targets inside its trigger. The previous row-level bubble handler ran too late to keep that listener away from the event. Moving the selection guard to the row's capture phase stops propagation before Base UI while deliberately leaving the browser default untouched.

## Verification

- focused message render unit: 21/21
- focused Chromium E2E: 1/1, including red on the previous implementation and green on this fix
- web full suite: 574 files / 4910 tests
- CI script suite: 9 files / 55 tests
- root pre-commit: typecheck, lint, test, typegrep, knip all green
- web typecheck, changed-file lint, diff-check, knip green
