### PR TITLE
fix(app): normalize bundled paths on Windows

### DIFF
--- a/scripts/ci/changed-scopes.mjs
+++ b/scripts/ci/changed-scopes.mjs
@@ -100,7 +100,7 @@ export function classifyPaths(inputPaths, options = {}) {
     blog_only: effectiveBlogOnly,
     workflow_changed: workflowChanged,
     run_code_checks: runCodeChecks,
-    run_windows: runCodeChecks && (full || cli || daemon || shared),
+    run_windows: runCodeChecks && (full || app || cli || daemon || shared),
     run_e2e: runCodeChecks && (full || web || shared || cli || daemon || worker || integration),
     run_ui_e2e: !effectiveBlogOnly && runCodeChecks && (full || web || shared || wsDo),
     run_rust: runCodeChecks && (full || desktop),

--- a/scripts/ci/changed-scopes.test.ts
+++ b/scripts/ci/changed-scopes.test.ts
@@ -33,7 +33,8 @@ describe("classifyPaths", () => {
     expect(result.full).toBe(true)
   })
 
-  it("keeps Windows for shared and CLI changes", () => {
+  it("keeps Windows for app, shared, and CLI changes", () => {
+    expect(classifyPaths(["src/app/src/lib/install.ts"]).run_windows).toBe(true)
     expect(classifyPaths(["src/shared/src/schema.ts"]).run_windows).toBe(true)
     expect(classifyPaths(["src/cli/src/index.ts"]).run_windows).toBe(true)
     expect(classifyPaths(["src/web/src/app/page.tsx"]).run_windows).toBe(false)

--- a/src/app/src/lib/install.ts
+++ b/src/app/src/lib/install.ts
@@ -5,6 +5,10 @@ import { SELF_HOSTED_DIR } from "./constants.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+export function normalizeInstallFilePath(path: string): string {
+  return path.replaceAll("\\", "/");
+}
+
 function bundledDir(): string {
   const candidate = join(__dirname, "..", "..", "bundled");
   if (existsSync(candidate)) return candidate;
@@ -18,7 +22,7 @@ function bundledFiles(rootDir: string, currentDir = rootDir): string[] {
     const path = join(currentDir, entry.name);
     return entry.isDirectory()
       ? bundledFiles(rootDir, path)
-      : [relative(rootDir, path)];
+      : [normalizeInstallFilePath(relative(rootDir, path))];
   });
 }
 

--- a/src/app/test/install.test.ts
+++ b/src/app/test/install.test.ts
@@ -36,6 +36,15 @@ describe("install", () => {
     vi.resetModules();
   });
 
+  describe("normalizeInstallFilePath", () => {
+    it("uses forward slashes for logical install paths", async () => {
+      const { normalizeInstallFilePath } = await import("../src/lib/install.js");
+      expect(normalizeInstallFilePath("wake-worker\\wrangler.toml")).toBe(
+        "wake-worker/wrangler.toml",
+      );
+    });
+  });
+
   describe("isInstalled", () => {
     it("returns false when required files are absent", async () => {
       const { isInstalled } = await import("../src/lib/install.js");


### PR DESCRIPTION
# Why we need this PR?
> No linked issue.

The onboard integrity fix merged in #497 exposed a deterministic Windows test failure because Node's `path.relative()` returns backslash-separated paths on Windows. App-only pull requests also skipped the Windows job, so the regression was not caught before merge.

## What changed
- Normalize bundled install-manifest paths to forward slashes on every platform.
- Keep native filesystem resolution through `path.join()`.
- Run the Windows test job for app-only changes.
- Add regression coverage for Windows-style install paths and app CI scope classification.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [x] Other: Local app (`@alook/app`)
