### PR TITLE
ci(config): optimize affected tasks and dependency setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,11 +369,11 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: src/desktop/src-tauri
+      - uses: taiki-e/install-action@d9585d8b553a3309cc2e7a695952297e311e4c10 # cargo-machete
       - run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxdo-dev
       - run: cargo test
-      - run: cargo install cargo-machete --locked
       - run: cargo machete
 
   lighthouse:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
+      full: ${{ steps.scope.outputs.full }}
+      base_sha: ${{ steps.scope.outputs.base_sha }}
+      head_sha: ${{ steps.scope.outputs.head_sha }}
       blog_only: ${{ steps.scope.outputs.blog_only }}
       run_code_checks: ${{ steps.scope.outputs.run_code_checks }}
       run_windows: ${{ steps.scope.outputs.run_windows }}
@@ -41,6 +44,7 @@ jobs:
           HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           FORCE_FULL: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         run: |
+          printf 'base_sha=%s\nhead_sha=%s\n' "$BASE_SHA" "$HEAD_SHA" >> "$GITHUB_OUTPUT"
           args=(--base "$BASE_SHA" --head "$HEAD_SHA" --output "$GITHUB_OUTPUT" --summary "$GITHUB_STEP_SUMMARY")
           if [[ "$FORCE_FULL" == "true" ]]; then args+=(--force-full); fi
           node scripts/ci/changed-scopes.mjs "${args[@]}"
@@ -58,6 +62,12 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @alook/web validate:blog
       - run: pnpm build --filter=@alook/web
@@ -70,14 +80,34 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
           cache: pnpm
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-
       - run: pnpm install --frozen-lockfile
-      - run: pnpm typecheck
-      - run: pnpm lint
+      - if: needs.scope.outputs.full == 'true'
+        run: pnpm typecheck
+      - if: needs.scope.outputs.full != 'true'
+        env:
+          TURBO_SCM_BASE: ${{ needs.scope.outputs.base_sha }}
+          TURBO_SCM_HEAD: ${{ needs.scope.outputs.head_sha }}
+        run: pnpm turbo run typecheck --affected
+      - if: needs.scope.outputs.full == 'true'
+        run: pnpm lint
+      - if: needs.scope.outputs.full != 'true'
+        env:
+          TURBO_SCM_BASE: ${{ needs.scope.outputs.base_sha }}
+          TURBO_SCM_HEAD: ${{ needs.scope.outputs.head_sha }}
+        run: pnpm turbo run lint --affected
       - run: pnpm typegrep:ws
 
   knip:
@@ -89,13 +119,27 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
           cache: pnpm
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-
       - run: pnpm install --frozen-lockfile
-      - run: pnpm knip
+      - if: needs.scope.outputs.full == 'true'
+        run: pnpm knip
+      - if: needs.scope.outputs.full != 'true'
+        env:
+          TURBO_SCM_BASE: ${{ needs.scope.outputs.base_sha }}
+          TURBO_SCM_HEAD: ${{ needs.scope.outputs.head_sha }}
+        run: pnpm turbo run knip --affected
 
   test-linux:
     name: Tests (ubuntu-latest)
@@ -105,6 +149,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
@@ -113,13 +159,34 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-
       - run: pnpm install --frozen-lockfile
       - name: Run daemon tests in isolation
+        if: needs.scope.outputs.full == 'true'
         env:
           VITEST_MAX_WORKERS: 1
-        run: pnpm --filter @alook/daemon test
+        run: pnpm turbo run test --filter=@alook/daemon
+      - name: Run affected daemon tests in isolation
+        if: needs.scope.outputs.full != 'true'
+        env:
+          VITEST_MAX_WORKERS: 1
+          TURBO_SCM_BASE: ${{ needs.scope.outputs.base_sha }}
+          TURBO_SCM_HEAD: ${{ needs.scope.outputs.head_sha }}
+        run: pnpm turbo run test --affected --filter=@alook/daemon
       - name: Run remaining workspace tests
+        if: needs.scope.outputs.full == 'true'
         run: pnpm turbo run test --filter='!@alook/daemon'
+      - name: Run affected workspace tests
+        if: needs.scope.outputs.full != 'true'
+        env:
+          TURBO_SCM_BASE: ${{ needs.scope.outputs.base_sha }}
+          TURBO_SCM_HEAD: ${{ needs.scope.outputs.head_sha }}
+        run: pnpm turbo run test --affected --filter='!@alook/daemon'
       - name: Run CI script tests
         run: pnpm vitest run --project ci-scripts
 
@@ -131,6 +198,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
@@ -139,13 +208,34 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-
       - run: pnpm install --frozen-lockfile
       - name: Run daemon tests in isolation
+        if: needs.scope.outputs.full == 'true'
         env:
           VITEST_MAX_WORKERS: 1
-        run: pnpm --filter @alook/daemon test
+        run: pnpm turbo run test --filter=@alook/daemon
+      - name: Run affected daemon tests in isolation
+        if: needs.scope.outputs.full != 'true'
+        env:
+          VITEST_MAX_WORKERS: 1
+          TURBO_SCM_BASE: ${{ needs.scope.outputs.base_sha }}
+          TURBO_SCM_HEAD: ${{ needs.scope.outputs.head_sha }}
+        run: pnpm turbo run test --affected --filter=@alook/daemon
       - name: Run remaining workspace tests
+        if: needs.scope.outputs.full == 'true'
         run: pnpm turbo run test --filter='!@alook/daemon'
+      - name: Run affected workspace tests
+        if: needs.scope.outputs.full != 'true'
+        env:
+          TURBO_SCM_BASE: ${{ needs.scope.outputs.base_sha }}
+          TURBO_SCM_HEAD: ${{ needs.scope.outputs.head_sha }}
+        run: pnpm turbo run test --affected --filter='!@alook/daemon'
       - name: Run CI script tests
         run: pnpm vitest run --project ci-scripts
 
@@ -213,6 +303,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
@@ -221,8 +313,20 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-
       - run: pnpm install --frozen-lockfile
-      - run: pnpm build --filter=@alook/shared --filter=@alook/web --filter=@alook/cli --filter=@alook/email-worker --filter=@alook/ws-do --filter=@alook/wake-worker
+      - if: needs.scope.outputs.full == 'true'
+        run: pnpm build --filter=@alook/shared --filter=@alook/web --filter=@alook/cli --filter=@alook/email-worker --filter=@alook/ws-do --filter=@alook/wake-worker
+      - if: needs.scope.outputs.full != 'true'
+        env:
+          TURBO_SCM_BASE: ${{ needs.scope.outputs.base_sha }}
+          TURBO_SCM_HEAD: ${{ needs.scope.outputs.head_sha }}
+        run: pnpm turbo run build --affected --filter=@alook/shared --filter=@alook/web --filter=@alook/cli --filter=@alook/email-worker --filter=@alook/ws-do --filter=@alook/wake-worker
 
   coverage:
     name: Coverage

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -28,18 +28,26 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          workspaces: src/desktop/src-tauri
+          key: ${{ matrix.target }}
 
       - name: Install dependencies (Linux)
         if: matrix.platform == 'ubuntu-22.04'

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -44,6 +44,9 @@ jobs:
     needs: scope
     if: needs.scope.outputs.run_ui_e2e == 'true'
     runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.image }}
+      options: --init --ipc=host --user 1001
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -60,20 +63,6 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: printf 'BETTER_AUTH_SECRET=ci-e2e-ui-secret\nBETTER_AUTH_URL=http://localhost:3000\nDEVICE_CLIENT_IDS=e2e-test-client\nENCRYPTION_KEY=ci-e2e-encryption-key-32chars!!\nDEV_WS_DO_URL=http://localhost:3000\nNODE_ENV=development\n' > src/web/.dev.vars
-      - id: playwright-version
-        working-directory: src/web
-        run: |
-          node -p '"version=" + require("./node_modules/@playwright/test/package.json").version' >> "$GITHUB_OUTPUT"
-      - id: playwright-browser-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ steps.playwright-version.outputs.version }}
-      - working-directory: src/web
-        run: pnpm exec playwright install-deps chromium
-      - if: steps.playwright-browser-cache.outputs.cache-hit != 'true'
-        working-directory: src/web
-        run: pnpm exec playwright install chromium
       - env:
           E2E_SPECS: ${{ toJSON(matrix.specs) }}
         run: |

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -47,6 +47,9 @@ jobs:
     container:
       image: ${{ matrix.image }}
       options: --init --ipc=host --user 1001
+    defaults:
+      run:
+        shell: bash
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/scripts/ci/changed-scopes.test.ts
+++ b/scripts/ci/changed-scopes.test.ts
@@ -34,7 +34,9 @@ describe("classifyPaths", () => {
   })
 
   it("keeps Windows for app, shared, and CLI changes", () => {
-    expect(classifyPaths(["src/app/src/lib/install.ts"]).run_windows).toBe(true)
+    const app = classifyPaths(["src/app/src/lib/install.ts"])
+    expect(app.full).toBe(false)
+    expect(app.run_windows).toBe(true)
     expect(classifyPaths(["src/shared/src/schema.ts"]).run_windows).toBe(true)
     expect(classifyPaths(["src/cli/src/index.ts"]).run_windows).toBe(true)
     expect(classifyPaths(["src/web/src/app/page.tsx"]).run_windows).toBe(false)

--- a/scripts/ci/e2e-shards.mjs
+++ b/scripts/ci/e2e-shards.mjs
@@ -1,10 +1,11 @@
-import { appendFileSync, readdirSync } from "node:fs"
+import { appendFileSync, readFileSync, readdirSync } from "node:fs"
 import { relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 export const E2E_SPEC_ROOT = "src/web/src/test/e2e-ui"
 export const E2E_SHARD_COUNT = 5
 export const DEFAULT_SPEC_SECONDS = 60
+export const PLAYWRIGHT_IMAGE_REPOSITORY = "mcr.microsoft.com/playwright"
 
 export const SPEC_SECONDS = {
   "01-auth.spec.ts": 5,
@@ -43,6 +44,29 @@ export function discoverE2eSpecs(root = resolve(E2E_SPEC_ROOT)) {
     .filter((path) => path.endsWith(".spec.ts"))
     .map((path) => relative(root, path).replaceAll("\\", "/"))
     .sort()
+}
+
+export function resolvePlaywrightVersion(lockfile = readFileSync(resolve("pnpm-lock.yaml"), "utf8")) {
+  const importerStart = lockfile.indexOf("\n  src/web:\n")
+  if (importerStart < 0) throw new Error("pnpm lockfile is missing the src/web importer")
+
+  const importerBody = lockfile.slice(importerStart + 1)
+  const nextImporter = importerBody.slice(1).search(/\n  \S[^\n]*:\n/)
+  const importer = nextImporter < 0
+    ? importerBody
+    : importerBody.slice(0, nextImporter + 1)
+  const dependency = importer.match(
+    /\n      '@playwright\/test':\n(?:        [^\n]*\n)*?        version: ([^\s(]+)/,
+  )
+  if (!dependency) throw new Error("src/web importer is missing an exact @playwright/test version")
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(dependency[1])) {
+    throw new Error(`invalid @playwright/test version: ${dependency[1]}`)
+  }
+  return dependency[1]
+}
+
+export function resolvePlaywrightImage(lockfile) {
+  return `${PLAYWRIGHT_IMAGE_REPOSITORY}:v${resolvePlaywrightVersion(lockfile)}-noble`
 }
 
 export function planE2eShards(
@@ -88,12 +112,13 @@ export function planE2eShards(
   }))
 }
 
-export function createE2eMatrix(specs = discoverE2eSpecs()) {
+export function createE2eMatrix(specs = discoverE2eSpecs(), image = resolvePlaywrightImage()) {
   const shards = planE2eShards(specs)
   return {
     include: shards.map((shard) => ({
       shard: shard.shard,
       total: shards.length,
+      image,
       predicted_seconds: shard.predicted_seconds,
       specs: shard.files.map((path) => `src/test/e2e-ui/${path}`),
     })),

--- a/scripts/ci/e2e-shards.mjs
+++ b/scripts/ci/e2e-shards.mjs
@@ -47,10 +47,11 @@ export function discoverE2eSpecs(root = resolve(E2E_SPEC_ROOT)) {
 }
 
 export function resolvePlaywrightVersion(lockfile = readFileSync(resolve("pnpm-lock.yaml"), "utf8")) {
-  const importerStart = lockfile.indexOf("\n  src/web:\n")
+  const normalizedLockfile = lockfile.replaceAll("\r\n", "\n")
+  const importerStart = normalizedLockfile.indexOf("\n  src/web:\n")
   if (importerStart < 0) throw new Error("pnpm lockfile is missing the src/web importer")
 
-  const importerBody = lockfile.slice(importerStart + 1)
+  const importerBody = normalizedLockfile.slice(importerStart + 1)
   const nextImporter = importerBody.slice(1).search(/\n  \S[^\n]*:\n/)
   const importer = nextImporter < 0
     ? importerBody

--- a/scripts/ci/e2e-shards.test.ts
+++ b/scripts/ci/e2e-shards.test.ts
@@ -7,7 +7,39 @@ import {
   discoverE2eSpecs,
   E2E_SHARD_COUNT,
   planE2eShards,
+  resolvePlaywrightImage,
+  resolvePlaywrightVersion,
 } from "./e2e-shards.mjs"
+
+describe("resolvePlaywrightVersion", () => {
+  const lockfile = `
+importers:
+
+  src/web:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
+
+  src/ws-do:
+    dependencies: {}
+`
+
+  it("resolves the exact web importer version and official image", () => {
+    expect(resolvePlaywrightVersion(lockfile)).toBe("1.62.1")
+    expect(resolvePlaywrightImage(lockfile)).toBe(
+      "mcr.microsoft.com/playwright:v1.62.1-noble",
+    )
+  })
+
+  it("rejects missing importers, missing dependencies, and malformed versions", () => {
+    expect(() => resolvePlaywrightVersion("importers:\n")).toThrow("src/web importer")
+    expect(() => resolvePlaywrightVersion(lockfile.replace("'@playwright/test'", "vitest")))
+      .toThrow("exact @playwright/test version")
+    expect(() => resolvePlaywrightVersion(lockfile.replace("version: 1.62.1", "version: latest")))
+      .toThrow("invalid @playwright/test version")
+  })
+})
 
 describe("discoverE2eSpecs", () => {
   it("discovers nested specs in deterministic order", () => {
@@ -79,5 +111,8 @@ describe("createE2eMatrix", () => {
       "src/test/e2e-ui/nested/b.spec.ts",
     ])
     expect(matrix.include.every((entry) => entry.total === E2E_SHARD_COUNT)).toBe(true)
+    expect(matrix.include.every(
+      (entry) => entry.image === "mcr.microsoft.com/playwright:v1.62.1-noble",
+    )).toBe(true)
   })
 })

--- a/scripts/ci/e2e-shards.test.ts
+++ b/scripts/ci/e2e-shards.test.ts
@@ -27,6 +27,7 @@ importers:
 
   it("resolves the exact web importer version and official image", () => {
     expect(resolvePlaywrightVersion(lockfile)).toBe("1.62.1")
+    expect(resolvePlaywrightVersion(lockfile.replaceAll("\n", "\r\n"))).toBe("1.62.1")
     expect(resolvePlaywrightImage(lockfile)).toBe(
       "mcr.microsoft.com/playwright:v1.62.1-noble",
     )

--- a/scripts/ci/workflow-contract.test.ts
+++ b/scripts/ci/workflow-contract.test.ts
@@ -64,6 +64,7 @@ describe("E2E UI workflow", () => {
   it("runs shards in the lockfile-selected Playwright image without host installs", () => {
     expect(workflow).toContain("image: ${{ matrix.image }}")
     expect(workflow).toContain("options: --init --ipc=host --user 1001")
+    expect(workflow).toMatch(/defaults:\n      run:\n        shell: bash/)
     expect(workflow).not.toContain("playwright-browser-cache")
     expect(workflow).not.toContain("~/.cache/ms-playwright")
     expect(workflow).not.toContain("playwright install-deps")

--- a/scripts/ci/workflow-contract.test.ts
+++ b/scripts/ci/workflow-contract.test.ts
@@ -60,6 +60,15 @@ describe("E2E UI workflow", () => {
   it("does not install Bun for Node-only browser tests", () => {
     expect(workflow).not.toContain("oven-sh/setup-bun")
   })
+
+  it("runs shards in the lockfile-selected Playwright image without host installs", () => {
+    expect(workflow).toContain("image: ${{ matrix.image }}")
+    expect(workflow).toContain("options: --init --ipc=host --user 1001")
+    expect(workflow).not.toContain("playwright-browser-cache")
+    expect(workflow).not.toContain("~/.cache/ms-playwright")
+    expect(workflow).not.toContain("playwright install-deps")
+    expect(workflow).not.toContain("playwright install chromium")
+  })
 })
 
 describe("Bun workflow setup", () => {
@@ -84,6 +93,30 @@ describe("Bun workflow setup", () => {
 describe("CI test budgets", () => {
   it("gives the slower Windows workspace suite enough job time", () => {
     expect(ciJob("test-windows")).toContain("timeout-minutes: 15")
+  })
+})
+
+describe("CI dependency setup", () => {
+  it("installs cargo-machete from the pinned release action", () => {
+    const desktopRust = ciJob("desktop-rust")
+    expect(desktopRust).toContain(
+      "taiki-e/install-action@d9585d8b553a3309cc2e7a695952297e311e4c10 # cargo-machete",
+    )
+    expect(desktopRust).not.toContain("cargo install cargo-machete")
+    expect(desktopRust).toContain("run: cargo machete")
+  })
+
+  it("caches pnpm and target-specific Rust artifacts for desktop releases", () => {
+    const pnpmSetup = desktopReleaseWorkflow.indexOf("pnpm/action-setup@")
+    const nodeSetup = desktopReleaseWorkflow.indexOf("actions/setup-node@")
+    expect(pnpmSetup).toBeGreaterThan(-1)
+    expect(nodeSetup).toBeGreaterThan(pnpmSetup)
+    expect(desktopReleaseWorkflow).toContain("cache: pnpm")
+    expect(desktopReleaseWorkflow).toContain("cache-dependency-path: pnpm-lock.yaml")
+    expect(desktopReleaseWorkflow).toContain(
+      "Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2",
+    )
+    expect(desktopReleaseWorkflow).toContain("key: ${{ matrix.target }}")
   })
 })
 

--- a/scripts/ci/workflow-contract.test.ts
+++ b/scripts/ci/workflow-contract.test.ts
@@ -87,6 +87,58 @@ describe("CI test budgets", () => {
   })
 })
 
+describe("Turbo CI execution", () => {
+  const cachedJobs = ["blog-content", "quality", "knip", "test-linux", "test-windows", "build"]
+  const affectedJobs = ["quality", "knip", "test-linux", "test-windows", "build"]
+
+  it("persists a task cache isolated by operating system, architecture, and job", () => {
+    expect(ciWorkflow.match(/actions\/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9/g))
+      .toHaveLength(cachedJobs.length)
+    for (const job of cachedJobs) {
+      const definition = ciJob(job)
+      expect(definition).toContain("path: .turbo/cache")
+      expect(definition).toContain(
+        "key: turbo-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ github.sha }}",
+      )
+      expect(definition).toContain(
+        "turbo-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-",
+      )
+    }
+  })
+
+  it("provides complete history and explicit comparison commits to affected jobs", () => {
+    const scope = ciJob("scope")
+    expect(scope).toContain("full: ${{ steps.scope.outputs.full }}")
+    expect(scope).toContain("base_sha: ${{ steps.scope.outputs.base_sha }}")
+    expect(scope).toContain("head_sha: ${{ steps.scope.outputs.head_sha }}")
+
+    for (const job of affectedJobs) {
+      const definition = ciJob(job)
+      expect(definition).toContain("fetch-depth: 0")
+      expect(definition).toContain("needs.scope.outputs.full == 'true'")
+      expect(definition).toContain("needs.scope.outputs.full != 'true'")
+      expect(definition).toContain("TURBO_SCM_BASE: ${{ needs.scope.outputs.base_sha }}")
+      expect(definition).toContain("TURBO_SCM_HEAD: ${{ needs.scope.outputs.head_sha }}")
+      expect(definition).toContain("--affected")
+    }
+  })
+
+  it("retains full commands when scope classification fails closed", () => {
+    expect(ciJob("quality")).toContain("run: pnpm typecheck")
+    expect(ciJob("quality")).toContain("run: pnpm lint")
+    expect(ciJob("knip")).toContain("run: pnpm knip")
+    for (const job of ["test-linux", "test-windows"]) {
+      const definition = ciJob(job)
+      expect(definition).toContain("run: pnpm turbo run test --filter=@alook/daemon")
+      expect(definition).toContain("run: pnpm turbo run test --filter='!@alook/daemon'")
+      expect(definition.match(/VITEST_MAX_WORKERS: 1/g)).toHaveLength(2)
+    }
+    expect(ciJob("build")).toContain(
+      "run: pnpm build --filter=@alook/shared --filter=@alook/web --filter=@alook/cli --filter=@alook/email-worker --filter=@alook/ws-do --filter=@alook/wake-worker",
+    )
+  })
+})
+
 describe("Desktop updater release", () => {
   it("uploads assets without replacing the auto-tag title or changelog", () => {
     expect(autoTagReleaseWorkflow).toContain('--title "$TAG"')


### PR DESCRIPTION
# Why we need this PR?
> No linked issue.

GitHub-hosted runners currently restore the pnpm store but do not persist Turborepo's task cache. The CI jobs also select every package in their static Turbo commands, so an app-only change can rerun unchanged web tests on both Linux and Windows. UI E2E shards additionally reinstall Chromium system packages on every runner, while Desktop Release misses the dependency caches already used by the main CI workflow.

## What changed
- Persist `.turbo/cache` in every Turbo-running CI job with keys isolated by OS, architecture, job, and commit.
- Expose the existing full-scope decision and comparison SHAs to downstream jobs.
- Use `turbo run --affected` for scoped pull request and merge-queue checks.
- Preserve full workspace commands for fail-closed changes, pushes to `main`, schedules, and manual runs.
- Keep daemon tests isolated with one Vitest worker.
- Derive the exact Playwright image from the `src/web` lockfile importer and run UI shards in that official browser/system-dependency image.
- Remove the redundant Playwright browser cache, browser install, and non-cacheable `install-deps` step.
- Add pnpm and target-scoped Rust caches to Desktop Release.
- Install `cargo-machete` from its pinned, checksum-verified release action instead of compiling it on each cold runner.
- Add workflow contract coverage for cache keys, affected task graphs, Playwright image selection, and dependency setup.

The first run seeds each GitHub Actions cache. Later runs can restore it; `Remote caching disabled` may still appear because this uses GitHub Actions cache rather than a shared Turbo remote-cache service. Tauri's required Linux system packages remain regular apt installs because those host dependencies are not safe cache targets.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [ ] Other: ...
