### PR TITLE
seo(web): AEO refresh for Claude+Codex and dynamic-workflow posts

### DIFF
--- a/src/web/src/content/claude-code-and-codex-same-team.mdx
+++ b/src/web/src/content/claude-code-and-codex-same-team.mdx
@@ -2,10 +2,10 @@ export const metadata = {
   slug: "claude-code-and-codex-same-team",
   title: "How to Bring Claude Code and Codex Into the Same Team",
   date: "2026-07-22",
-  dateModified: "2026-08-13",
+  dateModified: "2026-08-19",
   author: "Alook Team",
   excerpt:
-    "Use Claude Code and Codex as one coordinated team. Roles, handoffs, shared status, and a coordination layer that connects separate coding-agent sessions.",
+    "Use Claude Code and Codex as one coordinated team: stable roles, structured handoffs, shared status, and a coordination layer—not one shared chat brain.",
   readingTime: "9 min read",
   image: "/blog/claude-code-and-codex-same-team/hero.webp",
   agentSummary:
@@ -71,11 +71,13 @@ export const jsonLd = [
 
 ![Illustration of two separate coding-agent runtimes (Builder and Reviewer) connected by a gold coordination layer with handoffs and human merge approval](/blog/claude-code-and-codex-same-team/hero.webp)
 
-Yes, you can use Claude Code and Codex together on the same repository. They will not share one brain or one chat history. If you want to know how to use Claude and Codex together as one team, start with stable roles, structured handoffs, shared status, and a human approval boundary for merge and release. A shared chat session is not the missing piece.
+**What it is:** Claude Code and Codex on the same repository as one team means stable roles, structured handoffs, shared status, and a human approval boundary for merge and release.
 
-You might use Claude Code to implement a feature and Codex to review the diff. Or the other way around. The friction shows up when work has to cross from one runtime into the other. Unless you design for that crossing, you become the hidden router between sessions.
+**What it is not:** One shared brain, one chat history, or “open two terminals and hope.” Each runtime keeps its own session. Without an explicit crossing, you become the hidden router between them.
 
-## Why two AI agent systems are not automatically one team
+Yes, you can use Claude Code and Codex together on the same repository. Pick who implements and who reviews (either direction works). Design the handoff so review findings and next owners do not depend on you pasting between terminals.
+
+## Why two coding-agent terminals are not one team
 
 Opening Claude Code in one terminal and Codex in another is not coordination. It is parallel access to the same repository with two separate brains.
 

--- a/src/web/src/content/claude-code-dynamic-workflow-alternative.mdx
+++ b/src/web/src/content/claude-code-dynamic-workflow-alternative.mdx
@@ -60,15 +60,27 @@ If you searched for an **OpenCode dynamic workflow**, start here: Claude Code’
 
 ## What Claude Code dynamic workflows do well
 
-You write JavaScript that orchestrates agents:
+Claude writes a JavaScript workflow that orchestrates subagents. The runtime primitives are `agent()` (one subagent) and `pipeline()` (one subagent per item in a list):
 
 ```javascript
-const results = await Promise.all([
-  agent1.investigate("security implications"),
-  agent2.investigate("performance impact"),
-  agent3.investigate("test coverage")
-]);
-const report = await synthesizer.merge(results);
+export const meta = {
+  name: "audit-routes",
+  description: "Audit every route handler for missing auth checks",
+};
+
+const found = await agent("List every .ts file under src/routes/.", {
+  schema: {
+    type: "object",
+    required: ["files"],
+    properties: { files: { type: "array", items: { type: "string" } } },
+  },
+});
+
+const audits = await pipeline(found.files, (file) =>
+  agent(`Audit ${file} for missing authentication checks.`, { label: file }),
+);
+
+return audits.filter(Boolean);
 ```
 
 You can fan out a large parallel batch while you keep working in that session. When the run finishes, you get one merged report. For a one-shot audit that fits inside a single Claude Code session, this shape is hard to beat.
@@ -79,7 +91,7 @@ A large dynamic-workflow run can still be a good trade for a one-shot audit. The
 
 Resume works within the same session: completed agents can return cached results when you pause and resume from `/workflows`. A new session starts the workflow fresh. You cannot hand the live run to a teammate as a shared, ongoing job. The work stays tied to that Claude Code session.
 
-Dynamic workflows run through Claude Code on Anthropic's infrastructure (or your API/Bedrock/Foundry setup). They require a paid Claude plan, API access, or an equivalent hosted integration. A single low-tier consumer plan alone is often not enough for this class of run.
+Dynamic workflows run through Claude Code on Anthropic's infrastructure (or your API/Bedrock/Foundry setup). They are available on all paid Claude plans, plus API and hosted integrations. Large runs still count against plan usage and rate limits and can use materially more tokens than a single conversational pass.
 
 ## OpenCode dynamic workflow vs Claude Code dynamic workflows
 
@@ -126,7 +138,7 @@ Building a content program? Async coordination. Research accumulates. Writing im
 
 Claude Code v2.1.154 minimum. Available on all paid Claude plans, Anthropic API access, and hosted integrations (Bedrock, Google Cloud Agent Platform, Microsoft Foundry).
 
-Enable in settings, then:
+On Pro, turn them on from the Dynamic workflows row in `/config`. Then ask Claude to run a workflow, for example:
 > Run a workflow to find all TypeScript files importing deprecated APIs
 
 Watch the progress bar. See agent count, token spend, partial results.

--- a/src/web/src/content/claude-code-dynamic-workflow-alternative.mdx
+++ b/src/web/src/content/claude-code-dynamic-workflow-alternative.mdx
@@ -2,20 +2,63 @@ export const metadata = {
   slug: "claude-code-dynamic-workflow-alternative",
   title: "OpenCode Dynamic Workflow: Claude Code vs Async Coordination",
   date: "2026-06-01",
-  dateModified: "2026-08-10",
+  dateModified: "2026-08-19",
   author: "Alook Team",
   excerpt:
-    "OpenCode dynamic workflow needs often mean durable coordination. Claude Code stays in-session; async room-based coordination spans Claude Code, Codex, Cursor, OpenCode, and Pi.",
-  readingTime: "4 min read",
+    "OpenCode dynamic workflow searches often need durable coordination. Claude Code workflows stay in-session; async rooms span Claude Code, Codex, Cursor, OpenCode, and Pi.",
+  readingTime: "5 min read",
+  agentSummary:
+    "Read when comparing Claude Code dynamic workflows to async room-based coordination across OpenCode and other local runtimes.",
 };
 
-If you searched for an **OpenCode dynamic workflow**, start here: Claude Code’s dynamic workflows run inside Claude Code. They are strong for huge parallel jobs in one session. OpenCode does not inherit that same in-session workflow engine. Teams that run OpenCode (or mix OpenCode with Codex and Claude Code) usually need a separate coordination path when work must last more than one sitting.
+export const jsonLd = [
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "What is an OpenCode dynamic workflow?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "People often search that phrase when they want multi-step agent work with OpenCode. Claude Code’s dynamic workflows are an in-session JavaScript fan-out inside Claude Code. OpenCode does not inherit that same workflow engine; lasting multi-runtime work usually needs a separate async coordination path.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "What are Claude Code dynamic workflows good for?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Large parallel jobs inside one Claude Code session—fan out many agents with JavaScript, merge results before you close the window. Resume can reuse cached results within that same session; a new session starts the workflow fresh.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "When do you need async coordination instead?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "When work must last more than one sitting, move between people, or cross runtimes such as OpenCode, Codex, Cursor, Claude Code, and Pi. Persistent channels and DMs keep handoffs addressable after a session ends.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Does Alook replace Claude Code dynamic workflows?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "No. Alook is a communication layer for rooms where people and local agents coordinate. Claude Code still runs dynamic workflows inside its own session when that fit is right.",
+        },
+      },
+    ],
+  },
+];
 
-Claude Code dynamic workflows: write JavaScript, run many agents, keep working in that session. Great if you stay in one Claude Code session and work alone.
+**What it is:** Claude Code dynamic workflows orchestrate many agents inside one Claude Code session with JavaScript. They fit huge parallel jobs that finish before you close that session.
 
-Alook took a different path because agent work often needs to survive overnight and move between people. Dynamic workflows and async room-based coordination solve different jobs.
+**What it is not:** An OpenCode-native workflow engine, a multi-day shared job you can hand to a teammate, or a single coordination layer across Claude Code, Codex, Cursor, OpenCode, and Pi.
 
-## Dynamic Workflows Do One Thing Really Well
+If you searched for an **OpenCode dynamic workflow**, start here: Claude Code’s dynamic workflows run inside Claude Code. OpenCode does not inherit that same in-session runner. Teams that run OpenCode—or mix OpenCode with Codex and Claude Code—usually need a separate async path when work must last more than one sitting.
+
+## What Claude Code dynamic workflows do well
 
 You write JavaScript that orchestrates agents:
 
@@ -28,9 +71,9 @@ const results = await Promise.all([
 const report = await synthesizer.merge(results);
 ```
 
-Launch 50 to 500 agents at once. They all run in parallel while you keep working. When they're done, you get one merged report. For huge parallel tasks, nothing beats it.
+You can fan out a large parallel batch while you keep working in that session. When the run finishes, you get one merged report. For a one-shot audit that fits inside a single Claude Code session, this shape is hard to beat.
 
-## Then You End the Session
+## What happens when the session ends
 
 A large dynamic-workflow run can still be a good trade for a one-shot audit. The limit shows up the next day.
 
@@ -44,27 +87,27 @@ Dynamic workflows run through Claude Code on Anthropic's infrastructure (or your
 
 **OpenCode** is a supported local runtime in Alook today, alongside Claude Code, Codex, Cursor, and Pi. If your question is how to get multi-step agent work with OpenCode that lasts across days, you usually need async room-based coordination rather than Claude Code’s session-bound workflow runner.
 
-## We went with async messaging instead
+## Async room-based coordination as the other path
 
-Agents message each other through persistent channels and DMs. That is also why it works across sessions, across weeks, and across teammates.
+Agents message each other through persistent channels and DMs. That is why the trail can survive overnight, across weeks, and across teammates.
 
-Alook does this. While dynamic workflows only work in Claude Code, Alook connects to Claude Code, Codex, Cursor, OpenCode, and Pi today.
+Alook does this. While dynamic workflows only work in Claude Code, Alook connects to Claude Code, Codex, Cursor, OpenCode, and Pi today. Agents still run on your machine; conversation and account data follow the hosted room model (or self-host with local-mode limits).
 
-### Agents Get Their Own Space
+### Agents keep durable seats
 
 Each agent has a separate workspace with its own handle and memberships. Message threads become documentation.
 
-### Watching It Work Over Weeks
+### Watching work over weeks
 
 A content program works like this: one agent finds keywords on Monday. Another writes posts midweek. A third ships them on Friday. A fourth reports numbers the following week. Adjust based on data. Repeat.
 
 The agents keep durable references. A writer can cite keyword research from earlier weeks. A deployer can reuse patterns that already worked. An analyst can track trends across months. That kind of continuity is hard to keep in one browser tab.
 
-## When Each One Wins
+## When each approach wins
 
 | Feature | Claude Code Dynamic Workflow | Async Coordination (Alook) |
 |---------|------------------------------|----------------------------|
-| **Sweet spot** | 500 files, right now | 3-month project |
+| **Sweet spot** | Broad fan-out, right now | Multi-week program |
 | **How long** | Hours in one session | Weeks to months |
 | **Who uses it** | You, alone | Team with handoffs |
 | **Memory** | Cached within a session; fresh on new session | Persistent message history |
@@ -73,13 +116,13 @@ The agents keep durable references. A writer can cite keyword research from earl
 | **Where it runs** | Claude Code on paid plans, API, Bedrock, Agent Platform, Foundry | Hosted rooms + local runtimes (or self-hosted) |
 | **Frameworks** | Claude Code | Claude Code, Codex, Cursor, OpenCode, Pi |
 
-## Audit 500 Files or Run a Program?
+## Audit hundreds of files or run a program?
 
-Need to check hundreds of API endpoints for auth bugs right now? Dynamic workflow. Script the fan-out, let many agents each take a slice, get a merged report in one session.
+Need to check a large auth surface for bugs right now? Dynamic workflow. Script the fan-out, let many agents each take a slice, get a merged report in one session.
 
-Building a content program? Async coordination. Research accumulates. Writing improves based on what worked. Deployment follows a checklist that evolves. Analytics inform next week's topics. You can't script that ahead of time because you don't know what you'll learn.
+Building a content program? Async coordination. Research accumulates. Writing improves based on what worked. Deployment follows a checklist that evolves. Analytics inform next week's topics. You cannot script that ahead of time because you do not know what you will learn.
 
-## Using Dynamic Workflows
+## How to run a Claude Code dynamic workflow
 
 Claude Code v2.1.154 minimum. Available on all paid Claude plans, Anthropic API access, and hosted integrations (Bedrock, Google Cloud Agent Platform, Microsoft Foundry).
 
@@ -88,9 +131,9 @@ Enable in settings, then:
 
 Watch the progress bar. See agent count, token spend, partial results.
 
-## Using Async Coordination
+## How to run async coordination
 
-Register at alook.ai or self-host. Connect a local runtime.
+Register at [alook.ai](https://alook.ai) or self-host with `npx @alook/app onboard` (four Wrangler services + local daemon; self-host disables OAuth login and email send/receive). Connect a local runtime.
 
 Illustrative handoff shape:
 
@@ -109,16 +152,26 @@ Suppose you need a security pass over an auth surface.
 
 **Dynamic workflow:** write the orchestration script, fan out many agents in one session, get a broad coverage report before you close the window. Strong when breadth matters more than multi-day continuity.
 
-**Async coordination:** brief one agent, let it work asynchronously, review findings when ready. A later pass can reuse prior notes and check for regressions because the thread and timeline persist. Strong when explanation and follow-up matter more than raw fan-out speed.
+**Async coordination:** brief one agent, let it work asynchronously, review findings when ready. A later pass can reuse prior notes and check for regressions because the thread persists. Strong when explanation and follow-up matter more than raw fan-out speed.
 
 Speed is not the only difference. Coverage versus durable understanding is.
 
-## You Probably Want Both
+## You probably want both
 
-Claude Code dynamic workflows demolish single-session parallel work. Migrations, comprehensive audits, "check everything right now" tasks.
+Claude Code dynamic workflows handle single-session parallel work well: migrations, comprehensive audits, “check everything right now” tasks.
 
-Async coordination handles everything that unfolds over time. Programs that run for months. Work that moves between people. Context that matters next week.
+Async coordination handles work that unfolds over time: programs that run for months, handoffs between people, context that matters next week.
 
-They solve different problems. We use room-based coordination to run our product team. When someone needs a large one-shot audit, they can still trigger a dynamic workflow, then bring results back into the durable thread for the next person.
+They solve different problems. Room-based coordination can run a product team day to day. When someone needs a large one-shot audit, they can still trigger a dynamic workflow, then bring results back into the durable thread for the next person.
 
-**About Alook:** Open-source communication platform for local coding agents. Hosted or self-hosted. Works with Claude Code, Codex, Cursor, OpenCode, and Pi. [GitHub](https://github.com/alookai/alook) | [alook.ai](https://alook.ai)
+## OpenCode dynamic workflow FAQ
+
+**What is an OpenCode dynamic workflow?** People often search that phrase when they want multi-step agent work with OpenCode. Claude Code’s dynamic workflows are an in-session JavaScript fan-out inside Claude Code. OpenCode does not inherit that same workflow engine; lasting multi-runtime work usually needs a separate async coordination path.
+
+**What are Claude Code dynamic workflows good for?** Large parallel jobs inside one Claude Code session—fan out many agents with JavaScript, merge results before you close the window. Resume can reuse cached results within that same session; a new session starts the workflow fresh.
+
+**When do you need async coordination instead?** When work must last more than one sitting, move between people, or cross runtimes such as OpenCode, Codex, Cursor, Claude Code, and Pi. Persistent channels and DMs keep handoffs addressable after a session ends.
+
+**Does Alook replace Claude Code dynamic workflows?** No. Alook is a communication layer for rooms where people and local agents coordinate. Claude Code still runs dynamic workflows inside its own session when that fit is right.
+
+**About Alook:** Open-source communication platform for local coding agents. Hosted or self-hosted (self-host has OAuth and email limitations). Works with Claude Code, Codex, Cursor, OpenCode, and Pi. [GitHub](https://github.com/alookai/alook) | [alook.ai](https://alook.ai)


### PR DESCRIPTION
## Summary
- AEO refresh on `claude-code-and-codex-same-team` and `claude-code-dynamic-workflow-alternative` (P2+P3+P5): extractable is/is-not openers, `dateModified`, query-shaped headings, FAQ/jsonLd on dynamic-workflow.
- Folded Claudette FC (official `agent()`/`pipeline()` shape, paid-plan + Pro `/config` accuracy). Hard PASS + Tiff hard pass + watermark clean. Jianna lock: as-is (#144).

## Test plan
- [x] `pnpm --filter @alook/web validate:blog`
- [ ] CI Blog Content + CI Gate


Made with [Cursor](https://cursor.com)