### PR TITLE
fix(cli): surface meeting callback HTTP errors

### DIFF
--- a/src/cli/daemon/meeting-callback.test.ts
+++ b/src/cli/daemon/meeting-callback.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { sendMeetingCallback } from "./meeting-callback.js"
+
+const input = {
+  meetingId: "meeting-1",
+  workspaceId: "workspace-1",
+  callbackUrl: "https://alook.example",
+  authToken: "token-1",
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("sendMeetingCallback", () => {
+  it("returns successful callback responses", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const response = await sendMeetingCallback(input, "completed", "Speaker: hello")
+
+    expect(response.status).toBe(204)
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://alook.example/api/meeting/callback",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer token-1",
+        },
+        body: JSON.stringify({
+          meetingId: "meeting-1",
+          workspaceId: "workspace-1",
+          status: "completed",
+          transcript: "Speaker: hello",
+        }),
+      },
+    )
+  })
+
+  it("rejects non-success responses with their status and body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("callback unavailable", { status: 503 })),
+    )
+
+    await expect(sendMeetingCallback(input, "failed", undefined, "meeting failed"))
+      .rejects.toThrow("HTTP 503: callback unavailable")
+  })
+
+  it("preserves the status when an error response body cannot be read", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: vi.fn().mockRejectedValue(new Error("body stream failed")),
+      }),
+    )
+
+    await expect(sendMeetingCallback(input, "completed"))
+      .rejects.toThrow("HTTP 500")
+  })
+})

--- a/src/cli/daemon/meeting-callback.ts
+++ b/src/cli/daemon/meeting-callback.ts
@@ -1,0 +1,35 @@
+export interface MeetingCallbackInput {
+  meetingId: string
+  workspaceId: string
+  callbackUrl: string
+  authToken: string
+}
+
+export async function sendMeetingCallback(
+  input: MeetingCallbackInput,
+  status: "completed" | "failed",
+  transcript?: string,
+  error?: string,
+): Promise<Response> {
+  const response = await fetch(`${input.callbackUrl}/api/meeting/callback`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${input.authToken}`,
+    },
+    body: JSON.stringify({
+      meetingId: input.meetingId,
+      workspaceId: input.workspaceId,
+      status,
+      transcript: transcript || undefined,
+      error: error || undefined,
+    }),
+  })
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "")
+    throw new Error(`HTTP ${response.status}${body ? `: ${body}` : ""}`)
+  }
+
+  return response
+}

--- a/src/cli/daemon/meeting-runner.ts
+++ b/src/cli/daemon/meeting-runner.ts
@@ -19,6 +19,7 @@ import { mkdirSync } from "fs"
 import { tempDir } from "../lib/platform.js"
 import { createLogger } from "../lib/logger.js"
 import { createTimelineEntry, initEntry, updateEntry } from "./execenv/timeline.js"
+import { sendMeetingCallback } from "./meeting-callback.js"
 
 const log = createLogger({ module: "meeting-runner" })
 
@@ -46,23 +47,8 @@ async function callbackWeb(
   transcript?: string,
   error?: string,
 ): Promise<void> {
-  const payload = JSON.stringify({
-    meetingId: input.meetingId,
-    workspaceId: input.workspaceId,
-    status,
-    transcript: transcript || undefined,
-    error: error || undefined,
-  })
-
   try {
-    const res = await fetch(`${input.callbackUrl}/api/meeting/callback`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${input.authToken}`,
-      },
-      body: payload,
-    })
+    const res = await sendMeetingCallback(input, status, transcript, error)
     log.info(`callback ${status} → HTTP ${res.status}`, { meeting: input.meetingId })
   } catch (err) {
     log.error(`callback failed: ${err instanceof Error ? err.message : err}`, { meeting: input.meetingId })


### PR DESCRIPTION
# Why we need this PR?

> Closes #155

Meeting callbacks logged the HTTP status but treated 4xx/5xx responses as successful delivery, which could hide callback failures and lost meeting transcripts.

## What changed

- extract the meeting callback request into a focused, testable helper
- reject non-2xx responses with the HTTP status and readable response body
- preserve the HTTP status if reading an error response body fails
- add focused tests for successful and unsuccessful callback responses

## Validation

- `pnpm --filter @alook/cli exec vitest run daemon/meeting-callback.test.ts` — passed (3 tests)
- CLI Vitest suite — passed (1,024 tests total; 1,020 in the restricted run, plus 4 loopback health tests in an audited rerun)
- `pnpm --filter @alook/cli typecheck` — passed
- targeted ESLint for the three changed files — passed
- `git diff --check` — passed

## Checklist

- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [x] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other

No dependency or public API changes.