### PR TITLE
fix(web): contain composer text overflow

### DIFF
--- a/scripts/ci/e2e-shards.mjs
+++ b/scripts/ci/e2e-shards.mjs
@@ -31,6 +31,7 @@ export const SPEC_SECONDS = {
   "21-mobile-message-layout.spec.ts": 20,
   "22-committed-message-delivery.spec.ts": 85,
   "23-message-selection-context-menu.spec.ts": 10,
+  "24-composer-overflow.spec.ts": 35,
 }
 
 function walk(directory) {

--- a/scripts/ci/e2e-shards.test.ts
+++ b/scripts/ci/e2e-shards.test.ts
@@ -70,7 +70,7 @@ describe("planE2eShards", () => {
     expect(first).toHaveLength(E2E_SHARD_COUNT)
     expect([...assigned].sort()).toEqual(specs)
     expect(new Set(assigned).size).toBe(specs.length)
-    expect(totals.sort((left, right) => left - right)).toEqual([156, 157, 157, 157, 161])
+    expect(totals.sort((left, right) => left - right)).toEqual([163, 164, 165, 165, 166])
     expect(Math.max(...totals) / Math.min(...totals)).toBeLessThanOrEqual(1.15)
   })
 

--- a/src/web/src/app/globals.css
+++ b/src/web/src/app/globals.css
@@ -1886,6 +1886,24 @@ body.community-onboarding-active.driver-active :is(
   line-height: 24px;
 }
 
+.chat-composer .tiptap p.is-editor-empty:first-child {
+  position: relative;
+  min-width: 0;
+}
+
+.chat-composer .tiptap p.is-editor-empty:first-child::before {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  display: block;
+  float: none;
+  height: auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .chat-composer .tiptap>p:first-child {
   margin-top: 0;
 }

--- a/src/web/src/components/community/messages/composer-suggestion-popups.test.ts
+++ b/src/web/src/components/community/messages/composer-suggestion-popups.test.ts
@@ -166,6 +166,52 @@ describe("Composer suggestion popups", () => {
     const selected = renderer.root.find(
       (node) => node.type === "button" && node.props["aria-selected"] === true,
     )
+    expect(selected.props.className).toContain("min-w-0")
+    expect(selected.props.title).toBe("Ada#0001")
+    expect(
+      selected.findAll(
+        (node) =>
+          node.type === "span" &&
+          node.props["data-suggestion-icon"] === true,
+      ),
+    ).toHaveLength(1)
+    expect(
+      selected.find(
+        (node) =>
+          node.type === "span" &&
+          node.props.className?.includes("flex-1"),
+      ).props.className,
+    ).toContain("min-w-0")
+    expect(
+      selected.find(
+        (node) =>
+          node.type === "span" &&
+          node.props["data-suggestion-label"] === true,
+      ).props.className,
+    ).toContain("truncate")
+    expect(
+      selected.find(
+        (node) =>
+          node.type === "span" &&
+          node.props["data-suggestion-discriminator"] === true,
+      ).props.className,
+    ).toContain("shrink-0")
+    const virtual = renderer.root.findAllByType("button")[0]
+    expect(virtual.props.title).toBe("@everyone")
+    expect(
+      virtual.find(
+        (node) =>
+          node.type === "span" &&
+          node.props.className?.includes("bg-primary/15"),
+      ).props.className,
+    ).toContain("shrink-0")
+    expect(
+      virtual.find(
+        (node) =>
+          node.type === "span" &&
+          node.children.includes("Notify everyone"),
+      ).props.className,
+    ).toContain("shrink-0")
     const preventDefault = vi.fn()
     await act(async () => selected.props.onMouseDown({ preventDefault }))
     expect(preventDefault).toHaveBeenCalledOnce()
@@ -216,6 +262,29 @@ describe("Composer suggestion popups", () => {
 
     const first = renderer.root.findAllByType("button")[0]
     expect(first.props["data-testid"]).toBe("community-channel-ref-option-channel-1")
+    expect(first.props.className).toContain("min-w-0")
+    expect(first.props.title).toBe("One / general")
+    expect(
+      first.find(
+        (node) =>
+          node.type === "span" &&
+          node.props["data-suggestion-icon"] === true,
+      ).props.className,
+    ).toContain("shrink-0")
+    expect(
+      first.find(
+        (node) =>
+          node.type === "span" &&
+          node.props["data-suggestion-label"] === true,
+      ).props.className,
+    ).toContain("min-w-0")
+    expect(
+      first.find(
+        (node) =>
+          node.type === "span" &&
+          node.props["data-suggestion-label"] === true,
+      ).props.className,
+    ).toContain("truncate")
     const preventDefault = vi.fn()
     await act(async () => first.props.onMouseDown({ preventDefault }))
     expect(preventDefault).toHaveBeenCalledOnce()

--- a/src/web/src/components/community/messages/composer-suggestion-popups.tsx
+++ b/src/web/src/components/community/messages/composer-suggestion-popups.tsx
@@ -147,8 +147,9 @@ function ChannelRefRow({
       role="option"
       data-testid={tid.channelRefOption(item.id)}
       aria-selected={selected}
+      title={showServerPrefix ? `${item.serverName} / ${item.name}` : item.name}
       className={[
-        "flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm transition-colors",
+        "flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-2 text-left text-sm transition-colors",
         selected ? "bg-accent" : "hover:bg-accent/50",
       ].join(" ")}
       onMouseDown={(event) => {
@@ -156,8 +157,13 @@ function ChannelRefRow({
         onSelect()
       }}
     >
-      <ChannelIcon className="size-3.5 text-muted-foreground" />
-      <span className="font-medium">
+      <span data-suggestion-icon className="inline-flex shrink-0">
+        <ChannelIcon className="size-3.5 text-muted-foreground" />
+      </span>
+      <span
+        data-suggestion-label
+        className="min-w-0 flex-1 truncate font-medium"
+      >
         {showServerPrefix && (
           <span className="text-muted-foreground">{item.serverName} / </span>
         )}
@@ -190,8 +196,9 @@ function MentionRow({
         role="option"
         data-testid={tid.mentionOption(item.id)}
         aria-selected={selected}
+        title={item.kind === "member" ? `${item.name}#${item.discriminator}` : `@${item.label}`}
         className={[
-          "flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm transition-colors",
+          "flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-2 text-left text-sm transition-colors",
           selected ? "bg-accent" : "hover:bg-accent/50",
         ].join(" ")}
         onMouseDown={(event) => {
@@ -200,32 +207,45 @@ function MentionRow({
         }}
       >
         {item.kind === "member" ? (
-          <Avatar
-            label={item.avatar}
-            seed={item.userId}
-            size={24}
-            presence={item.status}
-            ringColor="var(--popover)"
-          />
+          <span data-suggestion-icon className="shrink-0">
+            <Avatar
+              label={item.avatar}
+              seed={item.userId}
+              size={24}
+              presence={item.status}
+              ringColor="var(--popover)"
+            />
+          </span>
         ) : (
-          <span className="grid size-6 place-items-center rounded-full bg-primary/15 text-primary">
+          <span
+            data-suggestion-icon
+            className="grid size-6 shrink-0 place-items-center rounded-full bg-primary/15 text-primary"
+          >
             <Users className="size-3.5" />
           </span>
         )}
-        <span className="font-medium">
-          {item.kind === "member" ? (
-            <>
+        {item.kind === "member" ? (
+          <span className="flex min-w-0 flex-1 items-baseline font-medium">
+            <span data-suggestion-label className="min-w-0 truncate">
               {item.name}
-              <span className="ml-1 text-xs font-normal tracking-wide text-muted-foreground">
-                #{item.discriminator}
-              </span>
-            </>
-          ) : (
-            `@${item.label}`
-          )}
-        </span>
+            </span>
+            <span
+              data-suggestion-discriminator
+              className="ml-1 shrink-0 text-xs font-normal tracking-wide text-muted-foreground"
+            >
+              #{item.discriminator}
+            </span>
+          </span>
+        ) : (
+          <span
+            data-suggestion-label
+            className="min-w-0 flex-1 truncate font-medium"
+          >
+            @{item.label}
+          </span>
+        )}
         {item.kind !== "member" && (
-          <span className="ml-auto text-xs text-muted-foreground">
+          <span className="ml-auto shrink-0 text-xs text-muted-foreground">
             Notify everyone
           </span>
         )}

--- a/src/web/src/components/community/messages/composer-view.test.ts
+++ b/src/web/src/components/community/messages/composer-view.test.ts
@@ -1,4 +1,5 @@
 import { createElement } from "react"
+import { readFileSync } from "node:fs"
 import TestRenderer, { act } from "react-test-renderer"
 import { describe, expect, it, vi } from "vitest"
 
@@ -85,6 +86,26 @@ function baseProps(
 }
 
 describe("ComposerView", () => {
+  it("scopes single-line placeholder containment to chat composers", () => {
+    const css = readFileSync(
+      new URL("../../../app/globals.css", import.meta.url),
+      "utf8",
+    )
+    const globalRule = css.match(
+      /\.tiptap p\.is-editor-empty:first-child::before\s*\{([^}]*)\}/,
+    )?.[1]
+    const chatRule = css.match(
+      /\.chat-composer \.tiptap p\.is-editor-empty:first-child::before\s*\{([^}]*)\}/,
+    )?.[1]
+    expect(globalRule).toBeDefined()
+    expect(globalRule).not.toContain("text-overflow")
+    expect(globalRule).not.toContain("white-space")
+    expect(chatRule).toContain("position: absolute")
+    expect(chatRule).toContain("overflow: hidden")
+    expect(chatRule).toContain("text-overflow: ellipsis")
+    expect(chatRule).toContain("white-space: nowrap")
+  })
+
   it("keeps popup, reply, icon-only pending, drag, editor, and control order", async () => {
     const removePendingFile = vi.fn()
     const onCancelReply = vi.fn()

--- a/src/web/src/test/e2e-ui/24-composer-overflow.spec.ts
+++ b/src/web/src/test/e2e-ui/24-composer-overflow.spec.ts
@@ -1,0 +1,361 @@
+import { type Locator, type Page } from "@playwright/test"
+import { test, expect, userId } from "./_fixtures/community-fixture"
+import { composerEditable } from "./_fixtures/actions"
+import { tid } from "./_fixtures/testids"
+import {
+  memberInfo,
+  renameUser,
+  seedChannel,
+  seedDm,
+  seedJoinServer,
+  seedMessage,
+  seedServer,
+  seedThread,
+} from "./_fixtures/seed"
+
+const VIEWPORT_WIDTHS = [375, 639, 640] as const
+const LONG_ENGLISH = "overflow".repeat(12) + "edge"
+const LONG_CJK = "界".repeat(100)
+
+type Rect = {
+  left: number
+  right: number
+  width: number
+  height: number
+}
+
+type PlaceholderMetrics = {
+  content: string
+  composer: Rect
+  paragraph: Rect
+  naturalTextWidth: number
+  pseudoWidth: number | null
+  visualTextRight: number
+  pseudo: {
+    position: string
+    whiteSpace: string
+    overflowX: string
+    textOverflow: string
+  }
+  attach: Rect | null
+  emoji: Rect | null
+}
+
+async function placeholderMetrics(composer: Locator): Promise<PlaceholderMetrics> {
+  const paragraph = composer.locator(".tiptap p.is-editor-empty").first()
+  await expect(paragraph).toBeVisible()
+  return paragraph.evaluate((node) => {
+    const element = node as HTMLElement
+    const composerElement = element.closest("[data-testid='community-composer-input']") as HTMLElement
+    const pseudo = getComputedStyle(element, "::before")
+    const text = element.dataset.placeholder ?? ""
+    const canvas = document.createElement("canvas")
+    const context = canvas.getContext("2d")!
+    const elementStyle = getComputedStyle(element)
+    context.font = elementStyle.font || `${elementStyle.fontSize} ${elementStyle.fontFamily}`
+    const naturalTextWidth = context.measureText(text).width
+    const paragraphRect = element.getBoundingClientRect()
+    const composerRect = composerElement.getBoundingClientRect()
+    const clipsHorizontally = pseudo.overflowX === "hidden" || pseudo.overflowX === "clip"
+    const attachElement = composerElement.parentElement?.querySelector<HTMLElement>(
+      "[data-testid='community-composer-attach']",
+    )
+    const emojiElement = composerElement.parentElement?.querySelector<HTMLElement>(
+      "button[aria-label='Emoji picker']",
+    )
+    const toRect = (value: DOMRect) => ({
+      left: value.left,
+      right: value.right,
+      width: value.width,
+      height: value.height,
+    })
+    const parsedPseudoWidth = Number.parseFloat(pseudo.width)
+    return {
+      content: text,
+      composer: toRect(composerRect),
+      paragraph: toRect(paragraphRect),
+      naturalTextWidth,
+      pseudoWidth: Number.isFinite(parsedPseudoWidth) ? parsedPseudoWidth : null,
+      visualTextRight: element.getBoundingClientRect().left
+        + (clipsHorizontally ? Math.min(naturalTextWidth, paragraphRect.width) : naturalTextWidth),
+      pseudo: {
+        position: pseudo.position,
+        whiteSpace: pseudo.whiteSpace,
+        overflowX: pseudo.overflowX,
+        textOverflow: pseudo.textOverflow,
+      },
+      attach: attachElement ? toRect(attachElement.getBoundingClientRect()) : null,
+      emoji: emojiElement ? toRect(emojiElement.getBoundingClientRect()) : null,
+    }
+  })
+}
+
+function expectContainedPlaceholder(metrics: PlaceholderMetrics, expected: string, width: number): void {
+  const evidence = `viewport=${width} metrics=${JSON.stringify(metrics)}`
+  expect(metrics.content, evidence).toBe(expected)
+  expect(metrics.composer.height, evidence).toBeCloseTo(48, 0)
+  expect(metrics.pseudo.position, evidence).toBe("absolute")
+  expect(metrics.pseudo.whiteSpace, evidence).toBe("nowrap")
+  expect(metrics.pseudo.overflowX, evidence).toBe("hidden")
+  expect(metrics.pseudo.textOverflow, evidence).toBe("ellipsis")
+  expect(metrics.pseudoWidth, evidence).not.toBeNull()
+  expect(metrics.pseudoWidth!, evidence).toBeLessThanOrEqual(metrics.paragraph.width + 0.5)
+  expect(metrics.visualTextRight, evidence).toBeLessThanOrEqual(metrics.paragraph.right + 0.5)
+  if (metrics.attach) {
+    expect(metrics.attach.right, evidence).toBeLessThanOrEqual(metrics.paragraph.left + 0.5)
+  }
+  if (metrics.emoji) {
+    expect(metrics.paragraph.right, evidence).toBeLessThanOrEqual(metrics.emoji.left + 0.5)
+  }
+}
+
+async function expectChatPlaceholderAtWidths(
+  page: Page,
+  composer: Locator,
+  expected: string,
+): Promise<void> {
+  let sawOverflowingSource = false
+  for (const width of VIEWPORT_WIDTHS) {
+    await page.setViewportSize({ width, height: 800 })
+    const metrics = await placeholderMetrics(composer)
+    sawOverflowingSource ||= metrics.naturalTextWidth > metrics.paragraph.width
+    expectContainedPlaceholder(metrics, expected, width)
+  }
+  expect(sawOverflowingSource).toBe(true)
+}
+
+async function ignoreNextDevToolsPointerCapture(page: Page): Promise<void> {
+  await page.addStyleTag({
+    content: [
+      "nextjs-portal { pointer-events: none !important; }",
+      ".tsqd-parent-container { pointer-events: none !important; }",
+    ].join("\n"),
+  })
+}
+
+async function suggestionMetrics(option: Locator): Promise<{
+  option: Rect
+  listClientWidth: number
+  listScrollWidth: number
+  optionClientWidth: number
+  optionScrollWidth: number
+  icon: Rect
+  label: Rect
+  labelStyle: {
+    whiteSpace: string
+    overflowX: string
+    textOverflow: string
+  }
+  discriminator: Rect | null
+}> {
+  return option.evaluate((node) => {
+    const element = node as HTMLElement
+    const list = element.parentElement as HTMLElement
+    const icon = element.querySelector<HTMLElement>("[data-suggestion-icon]")!
+    const label = element.querySelector<HTMLElement>("[data-suggestion-label]")!
+    const labelStyle = getComputedStyle(label)
+    const discriminator = element.querySelector<HTMLElement>("[data-suggestion-discriminator]")
+    const toRect = (value: DOMRect) => ({
+      left: value.left,
+      right: value.right,
+      width: value.width,
+      height: value.height,
+    })
+    return {
+      option: toRect(element.getBoundingClientRect()),
+      listClientWidth: list.clientWidth,
+      listScrollWidth: list.scrollWidth,
+      optionClientWidth: element.clientWidth,
+      optionScrollWidth: element.scrollWidth,
+      icon: toRect(icon.getBoundingClientRect()),
+      label: toRect(label.getBoundingClientRect()),
+      labelStyle: {
+        whiteSpace: labelStyle.whiteSpace,
+        overflowX: labelStyle.overflowX,
+        textOverflow: labelStyle.textOverflow,
+      },
+      discriminator: discriminator
+        ? toRect(discriminator.getBoundingClientRect())
+        : null,
+    }
+  })
+}
+
+function expectContainedSuggestion(
+  metrics: Awaited<ReturnType<typeof suggestionMetrics>>,
+  evidence: string,
+): void {
+  expect(metrics.listScrollWidth, evidence).toBeLessThanOrEqual(metrics.listClientWidth)
+  expect(metrics.optionScrollWidth, evidence).toBeLessThanOrEqual(metrics.optionClientWidth)
+  expect(metrics.icon.width, evidence).toBeGreaterThan(0)
+  expect(metrics.icon.left, evidence).toBeGreaterThanOrEqual(metrics.option.left)
+  expect(metrics.icon.right, evidence).toBeLessThanOrEqual(metrics.label.left)
+  expect(metrics.labelStyle.whiteSpace, evidence).toBe("nowrap")
+  expect(metrics.labelStyle.overflowX, evidence).toBe("hidden")
+  expect(metrics.labelStyle.textOverflow, evidence).toBe("ellipsis")
+  expect(metrics.label.right, evidence).toBeLessThanOrEqual(metrics.option.right + 0.5)
+  if (metrics.discriminator) {
+    expect(metrics.discriminator.width, evidence).toBeGreaterThan(0)
+    expect(metrics.label.right, evidence).toBeLessThanOrEqual(metrics.discriminator.left)
+    expect(metrics.discriminator.right, evidence).toBeLessThanOrEqual(metrics.option.right + 0.5)
+  }
+}
+
+test.describe.serial("community composer text containment", () => {
+  let serverId: string
+  let longChannelId: string
+  let threadId: string
+  let forumChannelId: string
+  let dmId: string
+  let longMemberId: string
+  let longMemberDiscriminator: string
+  let secondaryServerName: string
+  let secondaryChannelName: string
+  let secondaryChannelId: string
+
+  test.beforeAll(async () => {
+    serverId = await seedServer("alice", `overflow-${Date.now()}`)
+    longChannelId = await seedChannel("alice", serverId, LONG_ENGLISH)
+    forumChannelId = await seedChannel("alice", serverId, `forum-${Date.now()}`, "forum")
+    const parentMessageId = await seedMessage("alice", longChannelId, "thread opener")
+    threadId = await seedThread("alice", parentMessageId, LONG_CJK)
+    await renameUser("bob", LONG_CJK)
+    await seedJoinServer("alice", "bob", serverId)
+    const longMember = await memberInfo("alice", serverId, userId("bob"))
+    longMemberId = longMember.id
+    longMemberDiscriminator = longMember.discriminator
+
+    secondaryServerName = `secondary-${"s".repeat(90)}`
+    secondaryChannelName = `channel-${"c".repeat(92)}`
+    const secondaryServerId = await seedServer("alice", secondaryServerName)
+    secondaryChannelId = await seedChannel(
+      "alice",
+      secondaryServerId,
+      secondaryChannelName,
+    )
+    dmId = await seedDm("alice", userId("carol"))
+  })
+
+  test("default channel placeholder stays in the editable width and leaves controls clickable", async ({ asUser }) => {
+    const { page } = await asUser("alice")
+    await page.goto(`/c/channels/${serverId}/${longChannelId}`)
+    await page.waitForURL(new RegExp(longChannelId), { timeout: 20_000, waitUntil: "commit" })
+    await ignoreNextDevToolsPointerCapture(page)
+    const composer = page.getByTestId(tid.composerInput)
+    await expectChatPlaceholderAtWidths(page, composer, `Message /${LONG_ENGLISH}`)
+
+    await page.setViewportSize({ width: 375, height: 800 })
+    const attach = page.getByTestId(tid.composerAttach)
+    await attach.click()
+    await expect(page.getByRole("menuitem", { name: "Upload a File" })).toBeVisible()
+    await page.keyboard.press("Escape")
+    const emoji = page.getByRole("button", { name: "Emoji picker" })
+    await emoji.click()
+    await expect(emoji).toHaveAttribute("aria-expanded", "true")
+    await page.keyboard.press("Escape")
+  })
+
+  test("default CJK thread placeholder stays in the editable width", async ({ asUser }) => {
+    const { page } = await asUser("alice")
+    await page.goto(`/c/channels/${serverId}/${threadId}`)
+    await page.waitForURL(new RegExp(threadId), { timeout: 20_000, waitUntil: "commit" })
+    await expectChatPlaceholderAtWidths(
+      page,
+      page.getByTestId(tid.composerInput),
+      `Message ${LONG_CJK}`,
+    )
+  })
+
+  test("forum custom placeholder uses the same bounded chat-only rule", async ({ asUser }) => {
+    const { page } = await asUser("alice")
+    await page.goto(`/c/channels/${serverId}/${forumChannelId}`)
+    await page.waitForURL(new RegExp(forumChannelId), { timeout: 20_000, waitUntil: "commit" })
+    await ignoreNextDevToolsPointerCapture(page)
+    await page.getByRole("button", { name: "New Post" }).click()
+    const region = page.getByRole("region", { name: "Create post" })
+    const composer = region.getByTestId(tid.composerInput)
+    for (const width of VIEWPORT_WIDTHS) {
+      await page.setViewportSize({ width, height: 800 })
+      const metrics = await placeholderMetrics(composer)
+      expectContainedPlaceholder(metrics, "What do you want to discuss?", width)
+      expect(metrics.attach).toBeNull()
+      expect(metrics.emoji).toBeNull()
+    }
+  })
+
+  test("non-chat TipTap control retains the global placeholder behavior", async ({ asUser }) => {
+    const { page } = await asUser("alice")
+    await page.goto(`/c/channels/${serverId}/${longChannelId}`)
+    await page.waitForURL(new RegExp(longChannelId), { timeout: 20_000, waitUntil: "commit" })
+    await page.locator("body").evaluate((body, placeholder) => {
+      const host = document.createElement("div")
+      host.id = "non-chat-tiptap-control"
+      host.innerHTML = `<div class="tiptap"><p class="is-editor-empty" data-placeholder="${placeholder}"></p></div>`
+      body.appendChild(host)
+    }, LONG_ENGLISH)
+    const style = await page.locator("#non-chat-tiptap-control p").evaluate((node) => {
+      const pseudo = getComputedStyle(node, "::before")
+      return {
+        position: pseudo.position,
+        whiteSpace: pseudo.whiteSpace,
+        overflowX: pseudo.overflowX,
+        textOverflow: pseudo.textOverflow,
+        height: pseudo.height,
+      }
+    })
+    expect(style).toEqual({
+      position: "static",
+      whiteSpace: "normal",
+      overflowX: "visible",
+      textOverflow: "clip",
+      height: "0px",
+    })
+  })
+
+  test("long mention keeps avatar and discriminator visible without horizontal crop", async ({ asUser }) => {
+    const { page } = await asUser("alice")
+    await page.setViewportSize({ width: 375, height: 800 })
+    await page.goto(`/c/channels/${serverId}/${longChannelId}`)
+    await page.waitForURL(new RegExp(longChannelId), { timeout: 20_000, waitUntil: "commit" })
+    await ignoreNextDevToolsPointerCapture(page)
+    const editable = composerEditable(page)
+    await editable.click()
+    await editable.pressSequentially("@界")
+    const option = page.getByTestId(tid.mentionOption(longMemberId))
+    await expect(option).toHaveAttribute("title", `${LONG_CJK}#${longMemberDiscriminator}`)
+    for (const width of VIEWPORT_WIDTHS) {
+      await page.setViewportSize({ width, height: 800 })
+      await expect(option).toBeVisible({ timeout: 15_000 })
+      const metrics = await suggestionMetrics(option)
+      expectContainedSuggestion(
+        metrics,
+        `viewport=${width} mention metrics=${JSON.stringify(metrics)}`,
+      )
+    }
+  })
+
+  test("long cross-server channel row truncates within the popup without hard crop", async ({ asUser }) => {
+    const { page } = await asUser("alice")
+    await page.setViewportSize({ width: 375, height: 800 })
+    await page.goto(`/c/me/${dmId}`)
+    await page.waitForURL(new RegExp(dmId), { timeout: 20_000, waitUntil: "commit" })
+    await ignoreNextDevToolsPointerCapture(page)
+    const editable = composerEditable(page)
+    await editable.click()
+    await editable.pressSequentially("/")
+    const option = page.getByTestId(tid.channelRefOption(secondaryChannelId))
+    await expect(option).toHaveAttribute(
+      "title",
+      `${secondaryServerName} / ${secondaryChannelName}`,
+    )
+    for (const width of VIEWPORT_WIDTHS) {
+      await page.setViewportSize({ width, height: 800 })
+      await expect(option).toBeVisible({ timeout: 15_000 })
+      const metrics = await suggestionMetrics(option)
+      expectContainedSuggestion(
+        metrics,
+        `viewport=${width} channel-ref metrics=${JSON.stringify(metrics)}`,
+      )
+    }
+  })
+})


### PR DESCRIPTION
# Why we need this PR?

Long community composer placeholders could paint hundreds of pixels beyond the editable region and overlap the emoji control. Long `/` channel-reference and `@` mention candidates could also shrink or crop their icon, label, or discriminator instead of truncating within the popup.

## What changed

- Scope a single-line ellipsis rule to empty TipTap paragraphs inside `.chat-composer`, leaving the global TipTap placeholder rule unchanged and preserving the 48px composer height.
- Make channel-reference and mention rows flex-shrink safely: icons/actions/discriminators remain visible, labels truncate, and each option exposes its full text through `title`.
- Add focused component contracts and Playwright journey 24, plus register the journey in the deterministic CI shard weights.
- Exercise real channel, thread, and forum composers plus real mention/channel-reference popups at 375/639/640px with 100-character English/CJK inputs. The non-chat TipTap test is a synthetic CSS-scope control only; it proves the chat override does not leak into the global rule and is not a real email or Markdown UI journey.

## Verification

- `pnpm typecheck` — PASS (9/9 tasks)
- `pnpm lint` — PASS (4/4 tasks)
- `pnpm test` — PASS (9/9 package tasks; web 583 files / 4969 tests; CI scripts 10 files / 85 tests)
- `pnpm exec vitest run src/components/community/messages/composer-suggestion-popups.test.ts src/components/community/messages/composer-view.test.ts` from `src/web` — PASS (2 files / 7 tests)
- `pnpm exec playwright test src/test/e2e-ui/24-composer-overflow.spec.ts` from `src/web` — PASS (6/6)
- `pnpm vitest run --coverage --coverage.reporter=json --coverage.reporter=text` — PASS (899 files / 9857 tests; 63.14% statements, 60.46% branches, 63.25% functions, 75.45% lines)

## Checklist

- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [ ] Other: ...
