### PR TITLE
fix(web): use English image preview copy

### DIFF
--- a/src/web/src/components/community/messages/image-lightbox.test.ts
+++ b/src/web/src/components/community/messages/image-lightbox.test.ts
@@ -86,7 +86,9 @@ describe("ImageLightbox", () => {
 
     expect(renderer.root.findAllByProps({ "data-testid": tid.imageLightboxOriginal })).toHaveLength(0)
     expect(renderer.root.findByProps({ "data-testid": tid.imageLightboxThumbnail }).props.src).toBe("/thumbnail")
-    expect(renderer.root.findByProps({ "data-testid": tid.imageLightboxError })).toBeDefined()
+    expect(renderer.root.findByProps({ "data-testid": tid.imageLightboxError }).findByType("span").children)
+      .toEqual(["Failed to load original image"])
+    expect(renderer.root.findByProps({ "data-testid": tid.imageLightboxRetry }).children).toEqual(["Retry"])
 
     act(() => renderer.root.findByProps({ "data-testid": tid.imageLightboxRetry }).props.onClick())
     const retriedOriginal = renderer.root.findByProps({ "data-testid": tid.imageLightboxOriginal })
@@ -184,7 +186,7 @@ describe("ImageLightbox", () => {
 
   it("shows an explicit original-loading fallback when no thumbnail exists", () => {
     const { renderer } = renderLightbox({ originalUrl: "/original", name: "legacy" })
-    expect(renderer.root.findByProps({ "data-testid": tid.imageLightboxLoading }).children).toEqual(["正在加载原图"])
+    expect(renderer.root.findByProps({ "data-testid": tid.imageLightboxLoading }).children).toEqual(["Loading original image"])
     expect(renderer.root.findByProps({ "data-testid": tid.imageLightbox }).props.style).toEqual({
       width: "min(200px, 90vw, 85vh)",
       aspectRatio: "1 / 1",

--- a/src/web/src/components/community/messages/image-lightbox.tsx
+++ b/src/web/src/components/community/messages/image-lightbox.tsx
@@ -128,7 +128,7 @@ function PreviewFrame({ image }: { image: ImagePreview }) {
             role="status"
             className="absolute inset-0 flex items-center justify-center px-4 text-sm text-muted-foreground"
           >
-            正在加载原图
+            Loading original image
           </div>
         )}
         {state.originalStatus !== "failed" && (
@@ -149,14 +149,14 @@ function PreviewFrame({ image }: { image: ImagePreview }) {
           role="status"
           className="absolute bottom-3 left-1/2 z-10 flex min-h-11 w-max max-w-[min(90vw,24rem)] -translate-x-1/2 items-center justify-between gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm shadow-sm"
         >
-          <span>原图加载失败</span>
+          <span>Failed to load original image</span>
           <button
             type="button"
             data-testid={tid.imageLightboxRetry}
             onClick={retryOriginal}
             className="h-12 min-w-12 rounded-md px-3 font-medium text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:h-9 sm:min-w-0"
           >
-            重试
+            Retry
           </button>
         </div>
       )}

--- a/src/web/src/test/e2e-ui/20-community-attachment-thumbnails.spec.ts
+++ b/src/web/src/test/e2e-ui/20-community-attachment-thumbnails.spec.ts
@@ -280,7 +280,7 @@ test("image previews keep one frame through loading, decode, failure, retry, and
   const desktopPortraitLoading = await previewRects(page)
   await attachScreenshot(testInfo, "desktop-portrait-loading", page)
   releasePortraitFailure()
-  await expect(page.getByTestId(tid.imageLightboxError)).toContainText("原图加载失败")
+  await expect(page.getByTestId(tid.imageLightboxError)).toContainText("Failed to load original image")
   await expect(page.getByTestId(tid.imageLightboxThumbnail)).toBeVisible()
   await waitForDialogEntrance(page)
   const desktopPortraitFailed = {


### PR DESCRIPTION
Replaces the image lightbox loading, failure, and retry strings with the approved exact English product copy: Loading original image / Failed to load original image / Retry. Pins the copy in component tests. No request, storage, auth, cache, layout, or retry behavior changes.

Validation: focused 4 files / 43 tests; root typecheck, lint, tests, typegrep, and knip pass.