### PR TITLE
fix(web): allocate composer accessory rail slots

### DIFF
--- a/scripts/ci/e2e-shards.mjs
+++ b/scripts/ci/e2e-shards.mjs
@@ -32,6 +32,7 @@ export const SPEC_SECONDS = {
   "22-committed-message-delivery.spec.ts": 85,
   "23-message-selection-context-menu.spec.ts": 10,
   "24-composer-overflow.spec.ts": 35,
+  "25-composer-accessory-rail-occupancy.spec.ts": 60,
 }
 
 function walk(directory) {

--- a/scripts/ci/e2e-shards.test.ts
+++ b/scripts/ci/e2e-shards.test.ts
@@ -70,7 +70,7 @@ describe("planE2eShards", () => {
     expect(first).toHaveLength(E2E_SHARD_COUNT)
     expect([...assigned].sort()).toEqual(specs)
     expect(new Set(assigned).size).toBe(specs.length)
-    expect(totals.sort((left, right) => left - right)).toEqual([163, 164, 165, 165, 166])
+    expect(totals.sort((left, right) => left - right)).toEqual([174, 176, 177, 177, 179])
     expect(Math.max(...totals) / Math.min(...totals)).toBeLessThanOrEqual(1.15)
   })
 

--- a/src/web/src/components/community/messages/composer-accessory-rail-layout.test.ts
+++ b/src/web/src/components/community/messages/composer-accessory-rail-layout.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+import {
+  allocateComposerAccessoryRail,
+  type ComposerAccessoryRailLayout,
+} from "./composer-accessory-rail-layout"
+
+describe("allocateComposerAccessoryRail", () => {
+  it.each([
+    [false, false, false, "empty"],
+    [true, false, false, "left-only"],
+    [false, true, false, "centered"],
+    [false, false, true, "right-only"],
+    [true, true, false, "centered"],
+    [true, false, true, "left-right"],
+    [false, true, true, "centered"],
+    [true, true, true, "centered"],
+  ] satisfies Array<[boolean, boolean, boolean, ComposerAccessoryRailLayout]>) (
+    "maps normal left=%s center=%s right=%s to %s",
+    (left, center, right, expected) => {
+      expect(allocateComposerAccessoryRail({ mode: "normal", left, center, right }))
+        .toBe(expected)
+    },
+  )
+
+  it.each([
+    [false, false],
+    [true, false],
+    [false, true],
+    [true, true],
+  ])("keeps selection centered for left=%s right=%s", (left, right) => {
+    expect(allocateComposerAccessoryRail({ mode: "selection", left, right }))
+      .toBe("centered")
+  })
+})

--- a/src/web/src/components/community/messages/composer-accessory-rail-layout.ts
+++ b/src/web/src/components/community/messages/composer-accessory-rail-layout.ts
@@ -1,0 +1,29 @@
+export type ComposerAccessoryRailOccupancy =
+  | {
+    mode: "normal"
+    left: boolean
+    center: boolean
+    right: boolean
+  }
+  | {
+    mode: "selection"
+    left: boolean
+    right: boolean
+  }
+
+export type ComposerAccessoryRailLayout =
+  | "empty"
+  | "centered"
+  | "left-right"
+  | "left-only"
+  | "right-only"
+
+export function allocateComposerAccessoryRail(
+  occupancy: ComposerAccessoryRailOccupancy,
+): ComposerAccessoryRailLayout {
+  if (occupancy.mode === "selection" || occupancy.center) return "centered"
+  if (occupancy.left && occupancy.right) return "left-right"
+  if (occupancy.left) return "left-only"
+  if (occupancy.right) return "right-only"
+  return "empty"
+}

--- a/src/web/src/components/community/messages/composer-accessory-rail.test.ts
+++ b/src/web/src/components/community/messages/composer-accessory-rail.test.ts
@@ -1,4 +1,5 @@
 import React from "react"
+import { readFileSync } from "node:fs"
 import TestRenderer, { act } from "react-test-renderer"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { tid } from "@/lib/community/testids"
@@ -53,14 +54,107 @@ describe("ComposerAccessoryRail", () => {
     return renderer!
   }
 
+  function slotClassName(renderer: TestRenderer.ReactTestRenderer, testId: string): string {
+    let node: TestRenderer.ReactTestInstance | null = renderer.root.findByProps({
+      "data-testid": testId,
+    })
+    while (node && !(node.type === "div" && node.props.className?.includes("col-start-"))) {
+      node = node.parent
+    }
+    expect(node, `${testId} must have a bounded grid slot`).not.toBeNull()
+    return node!.props.className
+  }
+
+  it.each([
+    [false, false, false, "empty", null, null, null],
+    [true, false, false, "left-only", "col-start-1", null, null],
+    [false, true, false, "centered", null, "col-start-2", null],
+    [false, false, true, "right-only", null, null, "col-start-1"],
+    [true, true, false, "centered", "col-start-1", "col-start-2", null],
+    [true, false, true, "left-right", "col-start-1", null, "col-start-2"],
+    [false, true, true, "centered", null, "col-start-2", "col-start-3"],
+    [true, true, true, "centered", "col-start-1", "col-start-2", "col-start-3"],
+  ] as const)(
+    "renders normal DOM matrix left=%s center=%s right=%s as %s",
+    (left, center, right, layout, leftColumn, centerColumn, rightColumn) => {
+      if (right) useCommunityWsStore.getState().setConnectionStatus("reconnecting")
+      const renderer = render({
+        typingNames: left ? ["Alice"] : [],
+        scrollCount: center ? 2 : 0,
+      })
+      const rails = renderer.root.findAllByProps({ "data-testid": tid.composerAccessoryRail })
+      expect(rails).toHaveLength(layout === "empty" ? 0 : 1)
+      expect(renderer.root.findAllByProps({ "data-testid": tid.typingIndicator }))
+        .toHaveLength(left ? 1 : 0)
+      expect(renderer.root.findAllByProps({ "data-testid": tid.scrollToPresent }))
+        .toHaveLength(center ? 1 : 0)
+      expect(renderer.root.findAllByProps({ "data-testid": tid.wsStatus }))
+        .toHaveLength(right ? 1 : 0)
+      expect(renderer.root.findAllByProps({ "data-testid": tid.wsRetry })).toHaveLength(0)
+      if (layout === "empty") return
+
+      expect(rails[0].props["data-layout"]).toBe(layout)
+      if (leftColumn) {
+        expect(slotClassName(renderer, tid.typingIndicator)).toContain(leftColumn)
+      }
+      if (centerColumn) {
+        expect(slotClassName(renderer, tid.scrollToPresent)).toContain(centerColumn)
+      }
+      if (rightColumn) {
+        const rightSlot = slotClassName(renderer, tid.wsStatus)
+        expect(rightSlot).toContain(rightColumn)
+        expect(rightSlot).toContain("justify-self-end")
+      }
+    },
+  )
+
+  it.each([
+    [false, false],
+    [true, false],
+    [false, true],
+    [true, true],
+  ])("renders selection DOM matrix left=%s right=%s", (left, right) => {
+    if (right) useCommunityWsStore.getState().setConnectionStatus("reconnecting")
+    const renderer = render({
+      selectMode: true,
+      selectedCount: 2,
+      typingNames: left ? ["Alice"] : [],
+      scrollCount: 0,
+    })
+    const rail = renderer.root.findByProps({ "data-testid": tid.composerAccessoryRail })
+    expect(rail.props["data-layout"]).toBe("centered")
+    expect(renderer.root.findAllByProps({ "data-testid": tid.messageSelectionToolbar }))
+      .toHaveLength(1)
+    expect(slotClassName(renderer, tid.messageSelectionToolbar)).toContain("col-start-2")
+    expect(renderer.root.findAllByProps({ "data-testid": tid.typingIndicator }))
+      .toHaveLength(left ? 1 : 0)
+    expect(renderer.root.findAllByProps({ "data-testid": tid.wsStatus }))
+      .toHaveLength(right ? 1 : 0)
+    expect(renderer.root.findAllByProps({ "data-testid": tid.scrollToPresent })).toHaveLength(0)
+    if (left) {
+      const leftSlot = slotClassName(renderer, tid.typingIndicator)
+      expect(leftSlot).toContain("hidden")
+      expect(leftSlot).toContain("sm:col-start-1")
+      expect(leftSlot).toContain("sm:block")
+    }
+    if (right) {
+      const rightSlot = slotClassName(renderer, tid.wsStatus)
+      expect(rightSlot).toContain("col-start-3")
+      expect(rightSlot).toContain("justify-self-end")
+    }
+  })
+
   it("owns the only floating position and lays out normal typing, scroll, and no healthy WS node", () => {
     const renderer = render()
     const rail = renderer.root.findByProps({ "data-testid": tid.composerAccessoryRail })
     expect(rail.props.className).toContain("absolute")
+    expect(rail.props["data-layout"]).toBe("centered")
     expect(rail.props.className).toContain("px-2")
     expect(rail.props.className).toContain("sm:px-4")
     expect(renderer.root.findByProps({ "data-testid": tid.typingIndicator }).props.className)
       .toContain("min-w-0")
+    expect(renderer.root.findByProps({ "data-testid": tid.typingIndicator }).props.className)
+      .toContain("max-w-full")
     expect(renderer.root.findByProps({ "data-testid": tid.scrollToPresent }).props["aria-label"])
       .toBe("Jump to present, 4 unread below")
     expect(renderer.root.findAllByProps({ "data-testid": tid.wsStatus })).toHaveLength(0)
@@ -69,6 +163,31 @@ describe("ComposerAccessoryRail", () => {
     const positioned = renderer.root.findAll((node) =>
       typeof node.props.className === "string" && node.props.className.includes("absolute"))
     expect(positioned).toEqual([rail])
+
+    const grid = rail.findAllByType("div").find((node) => node.props.className?.includes("grid w-full"))!
+    expect(grid.props.className)
+      .toContain("grid-cols-[minmax(0,1fr)_minmax(0,max-content)_minmax(0,1fr)]")
+    act(() => renderer.root.findByProps({ "data-testid": tid.scrollToPresent }).props.onClick())
+    expect(baseProps.onScroll).toHaveBeenCalledOnce()
+  })
+
+  it("does not render the normal rail when all three occupancies are empty", () => {
+    const renderer = render({ scrollCount: 0, typingNames: [] })
+    expect(renderer.root.findAllByProps({ "data-testid": tid.composerAccessoryRail })).toHaveLength(0)
+  })
+
+  it("reclaims the center track for typing before a right-aligned WS status", () => {
+    useCommunityWsStore.getState().setConnectionStatus("reconnecting")
+    const renderer = render({ scrollCount: 0 })
+    const rail = renderer.root.findByProps({ "data-testid": tid.composerAccessoryRail })
+    expect(rail.props["data-layout"]).toBe("left-right")
+    const grid = rail.findAllByType("div").find((node) => node.props.className?.includes("grid w-full"))!
+    expect(grid.props.className).toContain("grid-cols-[minmax(0,1fr)_auto]")
+    expect(grid.children).toHaveLength(2)
+    expect(grid.children[0].props.className).toContain("col-start-1")
+    expect(grid.children[0].props.className).toContain("min-w-0")
+    expect(grid.children[1].props.className).toContain("col-start-2")
+    expect(grid.children[1].props.className).toContain("justify-self-end")
   })
 
   it("shows an accessible muted warning reconnecting control without a spinner", () => {
@@ -85,8 +204,19 @@ describe("ComposerAccessoryRail", () => {
     expect(status.type).toBe("span")
     expect(status.props.className).toContain("text-warning")
     expect(status.props.className).toContain("focus-visible:ring-3")
+    const statusVisuals = status.findAllByType("span")
+      .filter((node) => node.props.className?.includes("size-8"))
+    expect(statusVisuals).toHaveLength(2)
+    expect(statusVisuals.every((node) => node.props.className.includes("self-end"))).toBe(true)
     expect(renderer.root.findByType("tooltip-content").children).toContain("Reconnecting…")
     expect(renderer.root.findAll((node) => node.props.className?.includes("animate-spin"))).toHaveLength(0)
+    const rail = renderer.root.findByProps({ "data-testid": tid.composerAccessoryRail })
+    expect(rail.props["data-layout"]).toBe("right-only")
+    const grid = rail.findAllByType("div").find((node) => node.props.className?.includes("grid w-full"))!
+    expect(grid.props.className).toContain("grid-cols-[minmax(0,1fr)]")
+    expect(grid.children).toHaveLength(1)
+    expect(grid.children[0].props.className).toContain("col-start-1")
+    expect(grid.children[0].props.className).toContain("justify-self-end")
   })
 
   it("shows a destructive failed retry button with a 40px desktop hit target", () => {
@@ -99,6 +229,9 @@ describe("ComposerAccessoryRail", () => {
     expect(retry.props["aria-label"]).toBe("WebSocket connection failed. Retry now")
     expect(retry.props.className).toContain("text-destructive")
     expect(retry.props.className).toContain("sm:size-10")
+    const retryVisual = retry.findAllByType("span")
+      .find((node) => node.props.className?.includes("size-8"))!
+    expect(retryVisual.props.className).toContain("self-end")
     act(() => retry.props.onClick())
     expect(reconnectNow).toHaveBeenCalledOnce()
   })
@@ -112,7 +245,8 @@ describe("ComposerAccessoryRail", () => {
     expect(renderer.root.findByProps({ "data-testid": tid.typingIndicator })).toBeTruthy()
 
     const grid = rail.findAllByType("div").find((node) => node.props.className?.includes("grid w-full"))!
-    expect(grid.props.className).toContain("grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]")
+    expect(grid.props.className)
+      .toContain("grid-cols-[minmax(0,1fr)_minmax(0,max-content)_minmax(0,1fr)]")
   })
 
   it("uses a symmetric mobile selection grid with a compact capped toolbar and hides typing below sm", () => {
@@ -120,18 +254,21 @@ describe("ComposerAccessoryRail", () => {
     const renderer = render({ selectMode: true, selectedCount: 12 })
     const rail = renderer.root.findByProps({ "data-testid": tid.composerAccessoryRail })
     const grid = rail.findAllByType("div").find((node) => node.props.className?.includes("grid w-full"))!
-    expect(grid.props.className).toContain("grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]")
+    expect(grid.props.className)
+      .toContain("grid-cols-[minmax(0,1fr)_minmax(0,max-content)_minmax(0,1fr)]")
     expect(grid.props.className).toContain("gap-1")
     expect(grid.props.className).toContain("sm:gap-2")
 
     const typingParent = renderer.root.findAllByType("div")
-      .find((node) => node.props.className?.includes("hidden w-full min-w-0"))!
+      .find((node) => node.props.className?.includes("hidden min-w-0 max-w-full"))!
     expect(typingParent.props.className).toContain("hidden")
-    expect(typingParent.props.className).toContain("w-full")
+    expect(typingParent.props.className).toContain("max-w-full")
     expect(typingParent.props.className).toContain("sm:block")
     const toolbar = renderer.root.findByProps({ "data-testid": tid.messageSelectionToolbar })
     expect(toolbar.props.className).toContain("h-10")
-    expect(toolbar.props.className).toContain("max-w-[calc(100vw-7rem)]")
+    expect(toolbar.props.className).toContain("w-fit")
+    expect(toolbar.props.className).toContain("max-w-full")
+    expect(toolbar.props.className).not.toContain("max-w-[calc(100vw-7rem)]")
     expect(toolbar.props.className).toContain("sm:h-auto")
     const toolbarSlot = rail.findAllByType("div")
       .find((node) => node.props.className?.includes("col-start-2"))!
@@ -159,7 +296,13 @@ describe("ComposerAccessoryRail", () => {
     expect(wsRetry.props.className).toContain("size-11")
     const wsSlot = rail.findAllByType("div")
       .find((node) => node.props.className?.includes("col-start-3"))!
-    expect(wsSlot.props.className).toContain("min-w-11")
+    expect(wsSlot.props.className).toContain("min-w-0")
+    expect(wsSlot.props.className).toContain("max-w-full")
     expect(wsSlot.props.className).toContain("justify-self-end")
+  })
+
+  it("does not reintroduce a viewport-derived rail or toolbar width cap", () => {
+    const source = readFileSync(new URL("./composer-accessory-rail.tsx", import.meta.url), "utf8")
+    expect(source).not.toMatch(/max-w-\[calc\([^\]]*vw/)
   })
 })

--- a/src/web/src/components/community/messages/composer-accessory-rail.tsx
+++ b/src/web/src/components/community/messages/composer-accessory-rail.tsx
@@ -7,6 +7,10 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { tid } from "@/lib/community/testids"
 import { cn } from "@/lib/utils"
 import { useCommunityWsStore } from "@/stores/community/ws"
+import {
+  allocateComposerAccessoryRail,
+  type ComposerAccessoryRailLayout,
+} from "./composer-accessory-rail-layout"
 import { TypingIndicator } from "./typing-indicator"
 
 export function ComposerAccessoryRail({
@@ -30,52 +34,87 @@ export function ComposerAccessoryRail({
 }) {
   const connectionStatus = useCommunityWsStore((state) => state.connectionStatus)
   const reconnectNow = useCommunityWsStore((state) => state.reconnectNow)
+  const hasTyping = typingNames.length > 0
+  const hasScroll = scrollCount > 0
+  const hasWsStatus = connectionStatus !== "connected"
+  const layout = allocateComposerAccessoryRail(selectMode
+    ? { mode: "selection", left: hasTyping, right: hasWsStatus }
+    : { mode: "normal", left: hasTyping, center: hasScroll, right: hasWsStatus })
+
+  if (layout === "empty") return null
 
   return (
     <div
       data-testid={tid.composerAccessoryRail}
       data-selection={selectMode ? "active" : "inactive"}
+      data-layout={layout}
       className="pointer-events-none absolute inset-x-0 bottom-3 z-20 px-2 sm:px-4"
     >
       <div
         className={cn(
           "grid w-full items-end gap-1 sm:gap-2",
-          selectMode
-            ? "grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]"
-            : "grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]",
+          layout === "centered" && "grid-cols-[minmax(0,1fr)_minmax(0,max-content)_minmax(0,1fr)]",
+          layout === "left-right" && "grid-cols-[minmax(0,1fr)_auto]",
+          (layout === "left-only" || layout === "right-only") && "grid-cols-[minmax(0,1fr)]",
         )}
       >
         {selectMode ? (
           <>
-            <div className="hidden w-full min-w-0 sm:col-start-1 sm:block">
-              <TypingIndicator names={typingNames} className="w-fit" />
-            </div>
-            <div className="col-start-2 min-w-0 justify-self-center">
+            {hasTyping && (
+              <div key="left" className="hidden min-w-0 max-w-full sm:col-start-1 sm:block">
+                <TypingIndicator names={typingNames} className="w-fit max-w-full" />
+              </div>
+            )}
+            <div key="center" className="col-start-2 min-w-0 max-w-full justify-self-center">
               <SelectionToolbar
                 selectedCount={selectedCount}
                 onCancel={onCancelSelection}
                 onShare={onShareSelection}
               />
             </div>
-            <div className="col-start-3 min-w-11 justify-self-end">
-              <WsStatusControl status={connectionStatus} onRetry={reconnectNow} />
-            </div>
+            {hasWsStatus && (
+              <div key="right" className="col-start-3 min-w-0 max-w-full justify-self-end">
+                <WsStatusControl status={connectionStatus} onRetry={reconnectNow} />
+              </div>
+            )}
           </>
         ) : (
           <>
-            <div className="col-start-1 w-full min-w-0">
-              <TypingIndicator names={typingNames} className="w-fit" />
-            </div>
-            <div className="col-start-2 justify-self-center">
-              <ScrollControl count={scrollCount} mode={scrollMode} onClick={onScroll} />
-            </div>
-            <div className="col-start-3 justify-self-end">
-              <WsStatusControl status={connectionStatus} onRetry={reconnectNow} />
-            </div>
+            {hasTyping && (
+              <div key="left" className={normalSlotClassName(layout, "left")}>
+                <TypingIndicator names={typingNames} className="w-fit max-w-full" />
+              </div>
+            )}
+            {hasScroll && (
+              <div key="center" className="col-start-2 min-w-0 max-w-full justify-self-center">
+                <ScrollControl count={scrollCount} mode={scrollMode} onClick={onScroll} />
+              </div>
+            )}
+            {hasWsStatus && (
+              <div key="right" className={normalSlotClassName(layout, "right")}>
+                <WsStatusControl status={connectionStatus} onRetry={reconnectNow} />
+              </div>
+            )}
           </>
         )}
       </div>
     </div>
+  )
+}
+
+function normalSlotClassName(
+  layout: ComposerAccessoryRailLayout,
+  side: "left" | "right",
+): string {
+  const column = layout === "centered"
+    ? side === "left" ? "col-start-1" : "col-start-3"
+    : layout === "left-right"
+      ? side === "left" ? "col-start-1" : "col-start-2"
+      : "col-start-1"
+  return cn(
+    column,
+    "min-w-0 max-w-full",
+    side === "right" && "justify-self-end",
   )
 }
 
@@ -91,7 +130,7 @@ function SelectionToolbar({
   return (
     <div
       data-testid={tid.messageSelectionToolbar}
-      className="pointer-events-auto flex h-10 w-max min-w-0 max-w-[calc(100vw-7rem)] items-center gap-1 rounded-full border border-border/60 bg-card p-1 shadow-(--e2) sm:h-auto sm:max-w-full"
+      className="pointer-events-auto flex h-10 w-fit min-w-0 max-w-full items-center gap-1 rounded-full border border-border/60 bg-card p-1 shadow-(--e2) sm:h-auto"
     >
       <span className="min-w-0 flex-1 truncate px-1 text-xs text-muted-foreground sm:px-2 sm:text-sm">
         {selectedCount} selected
@@ -197,11 +236,11 @@ function WsStatusControl({
         )}
       >
         {!failed && (
-          <span className="absolute size-8 rounded-full bg-warning/10 motion-safe:animate-pulse" />
+          <span className="absolute size-8 self-end rounded-full bg-warning/10 motion-safe:animate-pulse" />
         )}
         <span
           className={cn(
-            "relative grid size-8 place-items-center rounded-full border bg-background/90 shadow-(--e1) backdrop-blur-sm",
+            "relative grid size-8 self-end place-items-center rounded-full border bg-background/90 shadow-(--e1) backdrop-blur-sm",
             failed ? "border-destructive/30" : "border-warning/30",
           )}
         >

--- a/src/web/src/test/e2e-ui/25-composer-accessory-rail-occupancy.spec.ts
+++ b/src/web/src/test/e2e-ui/25-composer-accessory-rail-occupancy.spec.ts
@@ -1,0 +1,489 @@
+import type { Page, TestInfo, WebSocketRoute } from "@playwright/test"
+import { test, expect } from "./_fixtures/community-fixture"
+import { composerEditable, gotoAfterUserWsAuth, sendMessage } from "./_fixtures/actions"
+import { renameUser, seedChannel, seedJoinServer, seedMessage, seedServer } from "./_fixtures/seed"
+import { tid } from "./_fixtures/testids"
+
+const MOBILE_WIDTHS = [390, 320] as const
+const LONG_TYPING_NAME = `Typing ${"occupancy ".repeat(8)}edge`
+
+type Rect = {
+  left: number
+  right: number
+  bottom: number
+  width: number
+  center: number
+}
+
+type RailMetrics = {
+  layout: string | null
+  rail: Rect
+  composer: Rect
+  typing: Rect | null
+  center: Rect | null
+  right: Rect | null
+  rightVisual: Rect | null
+  documentClientWidth: number
+  documentScrollWidth: number
+  typingText: {
+    clientWidth: number
+    scrollWidth: number
+    overflowX: string
+    textOverflow: string
+    whiteSpace: string
+  } | null
+}
+
+async function railMetrics(page: Page): Promise<RailMetrics> {
+  const rail = page.getByTestId(tid.composerAccessoryRail)
+  const composer = page.locator("[data-onboarding-target='channel-composer']")
+  return rail.evaluate((element, ids) => {
+    const target = element as HTMLElement
+    const find = (id: string) => target.querySelector<HTMLElement>(`[data-testid='${id}']`)
+    const typing = find(ids.typing)
+    const center = find(ids.scroll) ?? find(ids.selection)
+    const right = find(ids.wsStatus) ?? find(ids.wsRetry)
+    const rightVisual = right?.querySelector<HTMLElement>(":scope > span.relative") ?? null
+    const typingText = typing?.querySelector<HTMLElement>("span.min-w-0.truncate") ?? null
+    const style = typingText ? getComputedStyle(typingText) : null
+    const toRect = (value: DOMRect) => ({
+      left: value.left,
+      right: value.right,
+      bottom: value.bottom,
+      width: value.width,
+      center: value.left + value.width / 2,
+    })
+    return {
+      layout: target.dataset.layout ?? null,
+      rail: toRect(target.getBoundingClientRect()),
+      composer: toRect(document.querySelector<HTMLElement>("[data-onboarding-target='channel-composer']")!.getBoundingClientRect()),
+      typing: typing ? toRect(typing.getBoundingClientRect()) : null,
+      center: center ? toRect(center.getBoundingClientRect()) : null,
+      right: right ? toRect(right.getBoundingClientRect()) : null,
+      rightVisual: rightVisual ? toRect(rightVisual.getBoundingClientRect()) : null,
+      documentClientWidth: document.documentElement.clientWidth,
+      documentScrollWidth: document.documentElement.scrollWidth,
+      typingText: typingText && style
+        ? {
+          clientWidth: typingText.clientWidth,
+          scrollWidth: typingText.scrollWidth,
+          overflowX: style.overflowX,
+          textOverflow: style.textOverflow,
+          whiteSpace: style.whiteSpace,
+        }
+        : null,
+    }
+  }, {
+    typing: tid.typingIndicator,
+    scroll: tid.scrollToPresent,
+    selection: tid.messageSelectionToolbar,
+    wsStatus: tid.wsStatus,
+    wsRetry: tid.wsRetry,
+  }).then(async (metrics) => {
+    await expect(composer).toBeVisible()
+    return metrics
+  })
+}
+
+function expectContained(metrics: RailMetrics, state: string, width: number): void {
+  const evidence = `${state}@${width}: ${JSON.stringify(metrics)}`
+  expect(metrics.documentScrollWidth, evidence).toBe(metrics.documentClientWidth)
+  for (const control of [metrics.typing, metrics.center, metrics.right]) {
+    if (!control || control.width === 0) continue
+    expect(control.left, evidence).toBeGreaterThanOrEqual(metrics.rail.left - 0.5)
+    expect(control.right, evidence).toBeLessThanOrEqual(metrics.rail.right + 0.5)
+  }
+}
+
+async function captureState(args: {
+  page: Page
+  testInfo: TestInfo
+  state: string
+  layout: RailMetrics["layout"]
+  center: boolean
+  typing: boolean
+  right: boolean
+  selection?: boolean
+  widths?: readonly number[]
+}): Promise<Record<number, RailMetrics>> {
+  const {
+    page,
+    testInfo,
+    state,
+    layout,
+    center,
+    typing,
+    right,
+    selection = false,
+    widths = MOBILE_WIDTHS,
+  } = args
+  const evidence: Record<number, RailMetrics> = {}
+  for (const width of widths) {
+    await page.setViewportSize({ width, height: width >= 768 ? 900 : 844 })
+    const composer = page.locator("[data-onboarding-target='channel-composer']")
+    await expect.poll(() => composer.evaluate((element, viewportWidth) => {
+      const rect = element.getBoundingClientRect()
+      return viewportWidth < 640
+        ? Math.abs(rect.left) <= 1 && Math.abs(rect.right - viewportWidth) <= 1
+        : rect.left > 1 && Math.abs(rect.right - viewportWidth) <= 1
+    }, width)).toBe(true)
+    const rail = page.getByTestId(tid.composerAccessoryRail)
+    await expect(rail).toHaveAttribute("data-layout", layout!)
+    await expect(page.getByTestId(tid.typingIndicator)).toHaveCount(typing ? 1 : 0)
+    await expect(page.getByTestId(tid.scrollToPresent)).toHaveCount(center && !selection ? 1 : 0)
+    await expect(page.getByTestId(tid.messageSelectionToolbar)).toHaveCount(selection ? 1 : 0)
+    const rightControl = page.locator(
+      `[data-testid='${tid.wsStatus}'], [data-testid='${tid.wsRetry}']`,
+    )
+    await expect(rightControl).toHaveCount(right ? 1 : 0)
+    const metrics = await railMetrics(page)
+    expectContained(metrics, state, width)
+    if (center) {
+      expect(metrics.center, `${state}@${width}`).not.toBeNull()
+      expect(Math.abs(metrics.center!.center - metrics.composer.center), `${state}@${width}`)
+        .toBeLessThanOrEqual(1)
+    }
+    if (typing && right) {
+      expect(metrics.typing!.right, `${state}@${width}`).toBeLessThan(metrics.right!.left)
+    }
+    if (right) {
+      expect(metrics.rightVisual, `${state}@${width}`).not.toBeNull()
+      const visibleBaseline = metrics.center?.bottom ?? metrics.typing?.bottom ?? metrics.rail.bottom
+      expect(
+        Math.abs(metrics.rightVisual!.bottom - visibleBaseline),
+        `${state}@${width}: visible WS bottom must align with its rail peers`,
+      ).toBeLessThanOrEqual(1)
+    }
+    evidence[width] = metrics
+    await testInfo.attach(`${width}-${state}.png`, {
+      body: await page.screenshot(),
+      contentType: "image/png",
+    })
+  }
+  return evidence
+}
+
+async function captureEmptyState(page: Page, testInfo: TestInfo): Promise<void> {
+  for (const width of MOBILE_WIDTHS) {
+    await page.setViewportSize({ width, height: 844 })
+    await expect(page.getByTestId(tid.composerAccessoryRail)).toHaveCount(0)
+    await expect(page.locator("[data-onboarding-target='channel-composer']")).toBeVisible()
+    const documentWidths = await page.evaluate(() => ({
+      client: document.documentElement.clientWidth,
+      scroll: document.documentElement.scrollWidth,
+    }))
+    expect(documentWidths.scroll, `empty@${width}`).toBe(documentWidths.client)
+    await testInfo.attach(`${width}-empty.png`, {
+      body: await page.screenshot(),
+      contentType: "image/png",
+    })
+  }
+}
+
+test("composer accessory rail reallocates every occupied slot without overflow", async ({ asUser }, testInfo) => {
+  test.setTimeout(180_000)
+  const serverId = await seedServer("alice", `Rail occupancy ${Date.now()}`)
+  const channelId = await seedChannel("alice", serverId, "rail-occupancy")
+  await seedJoinServer("alice", "bob", serverId)
+  await renameUser("bob", LONG_TYPING_NAME)
+  let selectableMessageId = ""
+  for (let index = 0; index < 28; index++) {
+    selectableMessageId = await seedMessage(
+      "alice",
+      channelId,
+      `occupancy row ${index + 1} ${"content ".repeat(8)}`,
+    )
+  }
+
+  const alice = await asUser("alice")
+  const bob = await asUser("bob")
+  let aliceWs: WebSocketRoute | null = null
+  await alice.page.routeWebSocket((url) => url.pathname.endsWith("/user"), (ws) => {
+    aliceWs = ws
+    ws.connectToServer()
+  })
+  await alice.page.setViewportSize({ width: 390, height: 844 })
+  await bob.page.setViewportSize({ width: 390, height: 844 })
+  const route = `/c/channels/${serverId}/${channelId}`
+  await gotoAfterUserWsAuth(alice.page, route)
+  await gotoAfterUserWsAuth(bob.page, route)
+  await expect(composerEditable(alice.page)).toBeVisible()
+  await expect(composerEditable(bob.page)).toBeVisible()
+
+  const ping = `rail ws ready ${Date.now()}`
+  await sendMessage(bob.page, ping)
+  await expect(alice.page.getByText(ping)).toBeVisible()
+
+  const scrollRoot = alice.page
+    .locator("[data-onboarding-target='channel-composer']")
+    .locator("xpath=ancestor::main[1]")
+    .locator(".thin-scrollbar")
+    .first()
+  await expect.poll(() => scrollRoot.evaluate((element) => element.scrollHeight > element.clientHeight))
+    .toBe(true)
+  await scrollRoot.evaluate((element) => {
+    element.scrollTop = element.scrollHeight
+    element.dispatchEvent(new Event("scroll"))
+  })
+  await expect(alice.page.getByTestId(tid.scrollToPresent)).toHaveCount(0)
+  await captureEmptyState(alice.page, testInfo)
+
+  let row = alice.page.getByTestId(tid.message(selectableMessageId))
+  await row.hover()
+  await alice.page.getByTestId(tid.messageShare(selectableMessageId)).click()
+  await expect(alice.page.getByTestId(tid.messageSelectionToolbar)).toBeVisible()
+  await captureState({
+    page: alice.page,
+    testInfo,
+    state: "selection-none",
+    layout: "centered",
+    center: true,
+    typing: false,
+    right: false,
+    selection: true,
+  })
+  await alice.page.getByRole("button", { name: "Cancel message selection" }).click()
+
+  await scrollRoot.evaluate((element) => {
+    element.scrollTop = 0
+    element.dispatchEvent(new Event("scroll"))
+  })
+  await expect(alice.page.getByTestId(tid.scrollToPresent)).toBeVisible()
+
+  await captureState({
+    page: alice.page,
+    testInfo,
+    state: "c-only",
+    layout: "centered",
+    center: true,
+    typing: false,
+    right: false,
+  })
+
+  const bobEditor = composerEditable(bob.page)
+  await expect(async () => {
+    await bobEditor.click()
+    await bob.page.keyboard.press("ControlOrMeta+A")
+    await bob.page.keyboard.press("Backspace")
+    await bob.page.keyboard.type("typing occupancy")
+    await expect(alice.page.getByTestId(tid.typingIndicator)).toBeVisible({ timeout: 4_000 })
+  }).toPass({ timeout: 20_000 })
+
+  await captureState({
+    page: alice.page,
+    testInfo,
+    state: "l-c",
+    layout: "centered",
+    center: true,
+    typing: true,
+    right: false,
+  })
+
+  await alice.page.getByTestId(tid.typingIndicator).evaluate((element) => {
+    element.setAttribute("data-e2e-node-identity", "typing-survived")
+    element.querySelector("span > span")?.setAttribute("data-e2e-dot-identity", "dot-survived")
+  })
+
+  await alice.page.getByTestId(tid.scrollToPresent).click()
+  await expect(alice.page.getByTestId(tid.scrollToPresent)).toHaveCount(0)
+  await expect(alice.page.locator("[data-e2e-node-identity='typing-survived']")).toHaveCount(1)
+  await expect(alice.page.locator("[data-e2e-dot-identity='dot-survived']")).toHaveCount(1)
+  const leftOnly = await captureState({
+    page: alice.page,
+    testInfo,
+    state: "l-only",
+    layout: "left-only",
+    center: false,
+    typing: true,
+    right: false,
+  })
+  expect(leftOnly[320].typingText?.overflowX).toBe("hidden")
+  expect(leftOnly[320].typingText?.textOverflow).toBe("ellipsis")
+  expect(leftOnly[320].typingText?.whiteSpace).toBe("nowrap")
+  expect(leftOnly[320].typingText!.scrollWidth).toBeGreaterThan(leftOnly[320].typingText!.clientWidth)
+
+  row = alice.page.getByTestId(tid.message(selectableMessageId))
+  await row.hover()
+  await alice.page.getByTestId(tid.messageShare(selectableMessageId)).click()
+  await expect(alice.page.getByTestId(tid.messageSelectionToolbar)).toBeVisible()
+  await captureState({
+    page: alice.page,
+    testInfo,
+    state: "selection-l",
+    layout: "centered",
+    center: true,
+    typing: true,
+    right: false,
+    selection: true,
+    widths: [390, 1280],
+  })
+  await alice.page.getByRole("button", { name: "Cancel message selection" }).click()
+
+  await expect(async () => {
+    await bobEditor.click()
+    await bob.page.keyboard.press("ControlOrMeta+A")
+    await bob.page.keyboard.press("Backspace")
+    await bob.page.keyboard.type("typing occupancy outage")
+    await expect(alice.page.getByTestId(tid.typingIndicator)).toBeVisible({ timeout: 4_000 })
+  }).toPass({ timeout: 20_000 })
+
+  try {
+    await alice.context.setOffline(true)
+    expect(aliceWs).not.toBeNull()
+    await aliceWs!.close({ code: 1012, reason: "occupancy e2e outage" })
+    const unhealthyWs = alice.page.locator(
+      `[data-testid='${tid.wsStatus}'], [data-testid='${tid.wsRetry}']`,
+    )
+    await expect(unhealthyWs).toBeVisible({ timeout: 10_000 })
+    await expect(alice.page.locator("[data-e2e-node-identity='typing-survived']")).toHaveCount(1)
+    await expect(alice.page.locator("[data-e2e-dot-identity='dot-survived']")).toHaveCount(1)
+
+    await scrollRoot.evaluate((element) => {
+      element.scrollTop = 0
+      element.dispatchEvent(new Event("scroll"))
+    })
+    await expect(alice.page.getByTestId(tid.scrollToPresent)).toBeVisible()
+    await captureState({
+      page: alice.page,
+      testInfo,
+      state: "l-c-r",
+      layout: "centered",
+      center: true,
+      typing: true,
+      right: true,
+      widths: [390, 320, 1280],
+    })
+
+    await scrollRoot.evaluate((element) => {
+      element.scrollTop = element.scrollHeight
+      element.dispatchEvent(new Event("scroll"))
+    })
+    await expect(alice.page.getByTestId(tid.scrollToPresent)).toHaveCount(0)
+    row = alice.page.getByTestId(tid.message(selectableMessageId))
+    await row.hover()
+    await alice.page.getByTestId(tid.messageShare(selectableMessageId)).click()
+    await expect(alice.page.getByTestId(tid.messageSelectionToolbar)).toBeVisible()
+    await captureState({
+      page: alice.page,
+      testInfo,
+      state: "selection-l-r",
+      layout: "centered",
+      center: true,
+      typing: true,
+      right: true,
+      selection: true,
+      widths: [390, 320, 1280],
+    })
+    await alice.page.getByRole("button", { name: "Cancel message selection" }).click()
+    await scrollRoot.evaluate((element) => {
+      element.scrollTop = element.scrollHeight
+      element.dispatchEvent(new Event("scroll"))
+    })
+    await expect(alice.page.getByTestId(tid.scrollToPresent)).toHaveCount(0)
+
+    const leftRight = await captureState({
+      page: alice.page,
+      testInfo,
+      state: "l-r",
+      layout: "left-right",
+      center: false,
+      typing: true,
+      right: true,
+      widths: [390, 320, 1280],
+    })
+    expect(leftRight[320].typingText!.scrollWidth).toBeGreaterThan(leftRight[320].typingText!.clientWidth)
+
+    await expect(alice.page.getByTestId(tid.typingIndicator)).toHaveCount(0, { timeout: 15_000 })
+    await scrollRoot.evaluate((element) => {
+      element.scrollTop = 0
+      element.dispatchEvent(new Event("scroll"))
+    })
+    await expect(alice.page.getByTestId(tid.scrollToPresent)).toBeVisible()
+    await captureState({
+      page: alice.page,
+      testInfo,
+      state: "c-r",
+      layout: "centered",
+      center: true,
+      typing: false,
+      right: true,
+      widths: [390, 320, 1280],
+    })
+
+    await scrollRoot.evaluate((element) => {
+      element.scrollTop = element.scrollHeight
+      element.dispatchEvent(new Event("scroll"))
+    })
+    await expect(alice.page.getByTestId(tid.scrollToPresent)).toHaveCount(0)
+    await captureState({
+      page: alice.page,
+      testInfo,
+      state: "r-only",
+      layout: "right-only",
+      center: false,
+      typing: false,
+      right: true,
+      widths: [390, 320, 1280],
+    })
+
+    const retry = alice.page.getByTestId(tid.wsRetry)
+    await expect(retry).toBeVisible({ timeout: 40_000 })
+    await retry.focus()
+    await retry.evaluate((element) => {
+      element.setAttribute("data-e2e-node-identity", "retry-survived")
+    })
+    await expect(retry).toBeFocused()
+    await scrollRoot.evaluate((element) => {
+      element.scrollTop = 0
+      element.dispatchEvent(new Event("scroll"))
+    })
+    await expect(alice.page.getByTestId(tid.scrollToPresent)).toBeVisible()
+    await expect(alice.page.locator("[data-e2e-node-identity='retry-survived']")).toBeFocused()
+    await scrollRoot.evaluate((element) => {
+      element.scrollTop = element.scrollHeight
+      element.dispatchEvent(new Event("scroll"))
+    })
+    await expect(alice.page.getByTestId(tid.scrollToPresent)).toHaveCount(0)
+    await expect(alice.page.locator("[data-e2e-node-identity='retry-survived']")).toBeFocused()
+
+    await alice.page.setViewportSize({ width: 390, height: 844 })
+    row = alice.page.getByTestId(tid.message(selectableMessageId))
+    await row.hover()
+    await alice.page.getByTestId(tid.messageShare(selectableMessageId)).click()
+    await expect(alice.page.getByTestId(tid.messageSelectionToolbar)).toBeVisible()
+    await captureState({
+      page: alice.page,
+      testInfo,
+      state: "selection-r",
+      layout: "centered",
+      center: true,
+      typing: false,
+      right: true,
+      selection: true,
+      widths: [390, 320, 1280],
+    })
+    await alice.page.getByRole("button", { name: "Cancel message selection" }).click()
+  } finally {
+    await alice.context.setOffline(false)
+  }
+
+  await alice.page.evaluate((retryTestId) => {
+    document.querySelector<HTMLElement>(`[data-testid='${retryTestId}']`)?.click()
+  }, tid.wsRetry)
+  await expect(alice.page.locator(
+    `[data-testid='${tid.wsStatus}'], [data-testid='${tid.wsRetry}']`,
+  )).toHaveCount(0, { timeout: 20_000 })
+  await expect(alice.page.getByTestId(tid.composerAccessoryRail)).toHaveCount(0)
+
+  await scrollRoot.evaluate((element) => {
+    element.scrollTop = 0
+    element.dispatchEvent(new Event("scroll"))
+  })
+  await expect(alice.page.getByTestId(tid.scrollToPresent)).toBeVisible()
+  await alice.page.setViewportSize({ width: 430, height: 844 })
+  let metrics = await railMetrics(alice.page)
+  expect(Math.abs(metrics.center!.center - metrics.composer.center)).toBeLessThanOrEqual(1)
+  await alice.page.setViewportSize({ width: 1280, height: 900 })
+  metrics = await railMetrics(alice.page)
+  expect(Math.abs(metrics.center!.center - metrics.composer.center)).toBeLessThanOrEqual(1)
+})


### PR DESCRIPTION
# Why we need this PR?

The composer accessory rail reserved left, center, and right tracks even when their controls were absent. That wasted mobile width, let side content compete with the centered scroll/share control, and required a viewport-derived toolbar width cap.

## What changed

- Add a pure occupancy allocator for the normal typing / scroll / unhealthy-WS matrix and selection mode.
- Use symmetric tracks whenever a center control exists; reclaim empty center space for left/right-only layouts and omit the rail when all normal slots are empty.
- Bound every occupied slot with `min-w-0` / `max-w-full`, remove the toolbar `vw` cap, and preserve surviving control DOM identity across layout changes.
- Bottom-align the internal 32px WS visual layers while preserving the 44px mobile / 40px desktop hit targets and rail geometry.
- Add exhaustive allocator/component coverage plus a real Chromium journey at 320, 390, 430, and desktop widths, including geometry, overflow, truncation, selection, reconnect/failure, focus, node identity, and R-control visual-baseline assertions.
- Register the new E2E spec in the deterministic five-shard duration plan.

## Checklist

- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [ ] Other: ...

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (11 package tasks + 9 CI-script files / 78 tests)
- focused rail unit tests: 2 files / 32 tests
- focused Chromium stability: 3/3 sequential runs, zero retries
- independent exact-head Chromium QA: 1/1, zero retries
- mandatory `/c` QA: 1/1, zero retries, 31 screenshots, D1/WS/HTTP correlation PASS
- current-head CI, five UI shards, merged Playwright report, UI gate, and `codecov/patch`: PASS
