### PR TITLE
fix(web): show forum post actions on mobile

### DIFF
--- a/scripts/ci/e2e-shards.mjs
+++ b/scripts/ci/e2e-shards.mjs
@@ -33,6 +33,7 @@ export const SPEC_SECONDS = {
   "23-message-selection-context-menu.spec.ts": 10,
   "24-composer-overflow.spec.ts": 35,
   "25-composer-accessory-rail-occupancy.spec.ts": 60,
+  "26-mobile-forum-post-actions.spec.ts": 45,
 }
 
 function walk(directory) {

--- a/scripts/ci/e2e-shards.test.ts
+++ b/scripts/ci/e2e-shards.test.ts
@@ -70,7 +70,7 @@ describe("planE2eShards", () => {
     expect(first).toHaveLength(E2E_SHARD_COUNT)
     expect([...assigned].sort()).toEqual(specs)
     expect(new Set(assigned).size).toBe(specs.length)
-    expect(totals.sort((left, right) => left - right)).toEqual([174, 176, 177, 177, 179])
+    expect(totals.sort((left, right) => left - right)).toEqual([183, 184, 186, 187, 188])
     expect(Math.max(...totals) / Math.min(...totals)).toBeLessThanOrEqual(1.15)
   })
 

--- a/src/web/src/components/community/channels/forum-view.test.ts
+++ b/src/web/src/components/community/channels/forum-view.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest"
 import { createElement } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
-import { ForumView, shouldActivateForumRow } from "./forum-view"
+import { ForumView, forumTagScrollFades, shouldActivateForumRow } from "./forum-view"
 import { tid } from "@/lib/community/testids"
 import type { ForumThread } from "@/lib/community/models/message"
 
@@ -56,6 +56,26 @@ function renderWithDelete(
       canDeletePost: opts.canDeletePost ?? (() => true),
       deletingPost: opts.deletingPost ?? null,
     })
+  )
+}
+
+function renderWithActions(
+  post: ForumThread,
+  opts: { canEdit?: boolean; canDelete?: boolean } = {},
+): string {
+  return renderToStaticMarkup(
+    createElement(ForumView, {
+      forumChannelId: "cha_forum",
+      members: [],
+      posts: [post],
+      tag: "All",
+      onTagChange: () => {},
+      onOpenPost: () => {},
+      onEditPostTags: () => {},
+      canEditPostTags: () => opts.canEdit ?? true,
+      onDeletePost: () => {},
+      canDeletePost: () => opts.canDelete ?? true,
+    }),
   )
 }
 
@@ -184,7 +204,53 @@ describe("ForumView post delete button", () => {
   })
 })
 
+describe("ForumView responsive post actions", () => {
+  it("keeps authorized actions visible and touch-safe on mobile, then progressive on desktop", () => {
+    const html = renderWithActions(makePost({ parentSeq: 3 }))
+    const tagIndex = html.indexOf(tid.forumThreadTagBtn("p1"))
+    const deleteIndex = html.indexOf(tid.forumThreadDeleteBtn("p1"))
+    const tagButton = html.slice(Math.max(0, tagIndex - 500), tagIndex + 500)
+    const deleteButton = html.slice(Math.max(0, deleteIndex - 500), deleteIndex + 500)
+
+    for (const button of [tagButton, deleteButton]) {
+      expect(button).toContain("size-8")
+      expect(button).toContain("opacity-100")
+      expect(button).toContain("sm:size-6")
+      expect(button).toContain("sm:opacity-0")
+      expect(button).toContain("sm:focus-visible:opacity-100")
+      expect(button).toContain("sm:group-hover/card:opacity-100")
+    }
+    expect(tagButton).toContain("sm:data-popup-open:opacity-100")
+    expect(deleteButton).toContain("disabled:opacity-50")
+    expect(html).toContain("min-h-8 pr-16 sm:min-h-0")
+    expect(html).toContain("relative line-clamp-2 w-full min-w-0 max-w-full wrap-break-word")
+    expect(html).toContain(tid.forumThreadTitle("p1"))
+    expect(html).toContain(tid.forumThreadTitleText("p1"))
+    expect(html).toContain(tid.forumThreadSeq("p1"))
+  })
+
+  it("does not render actions or reserve mobile header space without permission", () => {
+    const html = renderWithActions(makePost(), { canEdit: false, canDelete: false })
+
+    expect(html).not.toContain(tid.forumThreadTagBtn("p1"))
+    expect(html).not.toContain(tid.forumThreadDeleteBtn("p1"))
+    expect(html).not.toContain("min-h-8 pr-16 sm:min-h-0")
+    expect(html).toContain("sm:pr-14 pr-0")
+  })
+})
+
 describe("ForumView filter bar / composer swap", () => {
+  it("derives conditional edge fades from rail scroll geometry", () => {
+    expect(forumTagScrollFades({ scrollLeft: 0, clientWidth: 200, scrollWidth: 200 }))
+      .toEqual({ left: false, right: false })
+    expect(forumTagScrollFades({ scrollLeft: 0, clientWidth: 200, scrollWidth: 420 }))
+      .toEqual({ left: false, right: true })
+    expect(forumTagScrollFades({ scrollLeft: 110, clientWidth: 200, scrollWidth: 420 }))
+      .toEqual({ left: true, right: true })
+    expect(forumTagScrollFades({ scrollLeft: 220, clientWidth: 200, scrollWidth: 420 }))
+      .toEqual({ left: true, right: false })
+  })
+
   it("shows the New Post trigger by default (not the composer)", () => {
     const html = render([makePost()])
     // The trigger button renders on first paint, in the filter bar slot.
@@ -197,6 +263,29 @@ describe("ForumView filter bar / composer swap", () => {
     const html = render([makePost({ tags: ["bug", "help"] })])
     expect(html).toContain("#bug")
     expect(html).toContain("#help")
+  })
+
+  it("keeps mobile filter tags in their own single-line scroller beside the fixed action", () => {
+    const html = render([makePost({ tags: ["alpha", "beta", "gamma", "delta"] })])
+    const railIndex = html.indexOf(tid.forumTagScroller)
+    const listIndex = html.indexOf(tid.forumPostList)
+    const railMarkup = html.slice(Math.max(0, railIndex - 400), railIndex + 900)
+    const listMarkup = html.slice(Math.max(0, listIndex - 300), listIndex + 300)
+
+    expect(html).toContain(tid.forumFilterBar)
+    expect(html).toContain(tid.forumTagAll)
+    expect(html).toContain(tid.forumNewPost)
+    expect(railMarkup).toContain("min-w-0")
+    expect(railMarkup).toContain("flex-nowrap")
+    expect(railMarkup).toContain("overflow-x-auto")
+    expect(railMarkup).toContain("thin-scrollbar")
+    expect(railMarkup).toContain("sm:flex-wrap")
+    expect(railMarkup).toContain("sm:overflow-x-visible")
+    expect(railMarkup).toContain('tabindex="0"')
+    expect(html).not.toContain(tid.forumTagFadeLeft)
+    expect(html).not.toContain(tid.forumTagFadeRight)
+    expect(listMarkup).toContain("px-0")
+    expect(listMarkup).toContain("sm:px-4")
   })
 })
 

--- a/src/web/src/components/community/channels/forum-view.tsx
+++ b/src/web/src/components/community/channels/forum-view.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useLayoutEffect, useRef, useState } from "react"
+import { useCallback, useLayoutEffect, useRef, useState } from "react"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import { COMMUNITY_VIRTUALIZER_REACT_OPTIONS } from "@/hooks/community/virtualizer-react-options"
 import { MessagesSquare, ListChevronsUpDown, Plus, Tag, Trash2 } from "lucide-react"
@@ -31,6 +31,23 @@ export function shouldActivateForumRow(event: {
   currentTarget: EventTarget | null
 }) {
   return event.target === event.currentTarget && (event.key === "Enter" || event.key === " ")
+}
+
+export function forumTagScrollFades({
+  scrollLeft,
+  scrollWidth,
+  clientWidth,
+}: {
+  scrollLeft: number
+  scrollWidth: number
+  clientWidth: number
+}) {
+  const maxScrollLeft = Math.max(0, scrollWidth - clientWidth)
+  if (maxScrollLeft <= 1) return { left: false, right: false }
+  return {
+    left: scrollLeft > 1,
+    right: scrollLeft < maxScrollLeft - 1,
+  }
 }
 
 function ForumTagSummary({ tags }: { tags: string[] }) {
@@ -72,6 +89,89 @@ function ForumTagSummary({ tags }: { tags: string[] }) {
         </Popover>
       )}
     </div>
+  )
+}
+
+function ForumPostTitle({ name, postId, seq }: { name: string; postId: string; seq?: number }) {
+  const hostRef = useRef<HTMLHeadingElement>(null)
+  const measureRef = useRef<HTMLSpanElement>(null)
+  const measureNameRef = useRef<HTMLSpanElement>(null)
+  const [rendered, setRendered] = useState({ name, truncated: false })
+
+  useLayoutEffect(() => {
+    const host = hostRef.current
+    const measure = measureRef.current
+    const measureName = measureNameRef.current
+    if (!host || !measure || !measureName) return
+
+    const characters = Array.from(name)
+    const commit = (nextName: string, truncated: boolean) => {
+      setRendered((current) => current.name === nextName && current.truncated === truncated
+        ? current
+        : { name: nextName, truncated })
+    }
+    const recompute = () => {
+      if (host.clientWidth === 0) return
+      const view = measure.ownerDocument?.defaultView
+      if (!view) return
+      const lineHeight = Number.parseFloat(view.getComputedStyle(measure).lineHeight)
+      if (!Number.isFinite(lineHeight)) return
+      const fits = (count: number, truncated: boolean) => {
+        measureName.textContent = `${characters.slice(0, count).join("")}${truncated ? "…" : ""}`
+        return measure.getBoundingClientRect().height <= lineHeight * 2 + 0.5
+      }
+
+      if (fits(characters.length, false)) {
+        commit(name, false)
+        return
+      }
+
+      let low = 0
+      let high = characters.length
+      while (low < high) {
+        const midpoint = Math.ceil((low + high) / 2)
+        if (fits(midpoint, true)) low = midpoint
+        else high = midpoint - 1
+      }
+      commit(characters.slice(0, low).join(""), true)
+    }
+
+    recompute()
+    if (typeof ResizeObserver === "undefined") return
+    const observer = new ResizeObserver(recompute)
+    observer.observe(host)
+    return () => observer.disconnect()
+  }, [name, seq])
+
+  const renderSequence = (measurement = false) => seq === undefined ? null : (
+    <span
+      data-testid={measurement ? undefined : tid.forumThreadSeq(postId)}
+      className="ml-1.5 whitespace-nowrap font-mono text-[13px] font-medium text-muted-foreground"
+    >
+      <span className="opacity-60">#</span>{seq}
+    </span>
+  )
+
+  return (
+    <h3
+      ref={hostRef}
+      data-testid={tid.forumThreadTitle(postId)}
+      data-truncated={rendered.truncated ? "true" : "false"}
+      aria-label={rendered.truncated ? `${name}${seq === undefined ? "" : ` #${seq}`}` : undefined}
+      title={rendered.truncated ? name : undefined}
+      className="relative line-clamp-2 w-full min-w-0 max-w-full wrap-break-word text-[15px] font-semibold leading-tight"
+    >
+      <span data-testid={tid.forumThreadTitleText(postId)}>{rendered.name}{rendered.truncated ? "…" : ""}</span>
+      {renderSequence()}
+      <span
+        ref={measureRef}
+        aria-hidden
+        className="invisible absolute left-0 top-0 block w-full whitespace-normal wrap-break-word text-[15px] font-semibold leading-tight"
+      >
+        <span ref={measureNameRef}>{name}</span>
+        {renderSequence(true)}
+      </span>
+    </h3>
   )
 }
 
@@ -119,7 +219,10 @@ export function ForumView({
 }) {
   const [composing, setComposing] = useState(false)
   const [deletingFor, setDeletingFor] = useState<ForumThread | null>(null)
+  const [tagFades, setTagFades] = useState({ left: false, right: false })
   const newPostTriggerRef = useRef<HTMLButtonElement>(null)
+  const activeFilterRef = useRef<HTMLButtonElement>(null)
+  const tagScrollerRef = useRef<HTMLDivElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const alignedTagRef = useRef<string | null>(null)
   // eslint-disable-next-line react-hooks/incompatible-library -- library limitation, same as member-list.tsx
@@ -135,11 +238,40 @@ export function ForumView({
   const filterTags = availableTags.length > 0
     ? availableTags
     : [...new Set(posts.flatMap((post) => post.tags))]
+  const filterTagKey = filterTags.join("\0")
+  const syncTagFades = useCallback(() => {
+    const scroller = tagScrollerRef.current
+    if (!scroller) return
+    const next = forumTagScrollFades(scroller)
+    setTagFades((current) => current.left === next.left && current.right === next.right ? current : next)
+  }, [])
   useLayoutEffect(() => {
     if (posts.length === 0 || alignedTagRef.current === tag) return
     alignedTagRef.current = tag
     virtualizer.scrollToIndex(0, { align: "start" })
   }, [posts.length, tag, virtualizer])
+  useLayoutEffect(() => {
+    const scroller = tagScrollerRef.current
+    const active = activeFilterRef.current
+    if (!scroller || !active) return
+    const scrollerRect = scroller.getBoundingClientRect()
+    const activeRect = active.getBoundingClientRect()
+    if (activeRect.left < scrollerRect.left) {
+      scroller.scrollLeft -= scrollerRect.left - activeRect.left
+    } else if (activeRect.right > scrollerRect.right) {
+      scroller.scrollLeft += activeRect.right - scrollerRect.right
+    }
+    syncTagFades()
+  }, [filterTagKey, syncTagFades, tag])
+  useLayoutEffect(() => {
+    const scroller = tagScrollerRef.current
+    if (!scroller) return
+    syncTagFades()
+    if (typeof ResizeObserver === "undefined") return
+    const observer = new ResizeObserver(syncTagFades)
+    observer.observe(scroller)
+    return () => observer.disconnect()
+  }, [filterTagKey, syncTagFades])
   const olderSentinelRef = useVirtualCursorSentinel({
     scrollRef,
     hasMore,
@@ -173,46 +305,94 @@ export function ForumView({
           }}
         />
       ) : (
-        <div className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-2">
-          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
-            {filterTags.length > 0 && (
-              <>
-                <button
-                  type="button"
-                  className={cn(
-                    "shrink-0 rounded-lg px-2.75 py-1 text-[13px] leading-5 transition-colors",
-                    tag === "All" ? "bg-accent text-foreground" : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
-                  )}
-                  onClick={() => onTagChange("All")}
-                >
-                  All
-                </button>
-                {filterTags.map((t) => (
+        <div
+          data-testid={tid.forumFilterBar}
+          className="flex min-w-0 shrink-0 items-center gap-2 overflow-hidden border-b border-border px-4 py-2"
+        >
+          <div className="relative min-w-0 flex-1">
+            <div
+              ref={tagScrollerRef}
+              data-testid={tid.forumTagScroller}
+              role="region"
+              aria-label="Forum tag filters"
+              tabIndex={0}
+              onScroll={syncTagFades}
+              onKeyDown={(event) => {
+                if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
+                  event.preventDefault()
+                  event.currentTarget.scrollLeft += event.key === "ArrowLeft" ? -48 : 48
+                  syncTagFades()
+                } else if (event.key === "Home" || event.key === "End") {
+                  event.preventDefault()
+                  event.currentTarget.scrollLeft = event.key === "Home"
+                    ? 0
+                    : event.currentTarget.scrollWidth - event.currentTarget.clientWidth
+                  syncTagFades()
+                }
+              }}
+              className="flex w-full min-w-0 flex-nowrap items-center gap-2 overflow-x-auto overscroll-x-contain thin-scrollbar sm:flex-wrap sm:overflow-x-visible"
+            >
+              {filterTags.length > 0 && (
+                <>
                   <button
-                    key={t}
+                    ref={tag === "All" ? activeFilterRef : undefined}
                     type="button"
-                    style={tagColorStyle(t)}
+                    data-testid={tid.forumTagAll}
                     className={cn(
-                      "shrink-0 rounded-lg px-2.75 py-1 text-[13px] leading-5 transition-opacity",
-                      tagColorClassName,
-                      tag === t ? "opacity-100 ring-1 ring-current/20" : "opacity-70 hover:opacity-100",
+                      "shrink-0 rounded-lg px-2.75 py-1 text-[13px] leading-5 transition-colors",
+                      tag === "All" ? "bg-accent text-foreground" : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
                     )}
-                    data-testid={tid.forumTagChip(t)}
-                    onClick={() => onTagChange(t)}
+                    onClick={() => onTagChange("All")}
                   >
-                    {`#${t}`}
+                    All
                   </button>
-                ))}
-              </>
+                  {filterTags.map((t) => (
+                    <button
+                      key={t}
+                      ref={tag === t ? activeFilterRef : undefined}
+                      type="button"
+                      style={tagColorStyle(t)}
+                      className={cn(
+                        "shrink-0 rounded-lg px-2.75 py-1 text-[13px] leading-5 transition-opacity",
+                        tagColorClassName,
+                        tag === t ? "opacity-100 ring-1 ring-current/20" : "opacity-70 hover:opacity-100",
+                      )}
+                      data-testid={tid.forumTagChip(t)}
+                      onClick={() => onTagChange(t)}
+                    >
+                      {`#${t}`}
+                    </button>
+                  ))}
+                </>
+              )}
+            </div>
+            {tagFades.left && (
+              <span
+                aria-hidden
+                data-testid={tid.forumTagFadeLeft}
+                className="pointer-events-none absolute inset-y-0 left-0 z-10 w-3.5 bg-linear-to-r from-background to-transparent sm:hidden"
+              />
+            )}
+            {tagFades.right && (
+              <span
+                aria-hidden
+                data-testid={tid.forumTagFadeRight}
+                className="pointer-events-none absolute inset-y-0 right-0 z-10 w-3.5 bg-linear-to-l from-background to-transparent sm:hidden"
+              />
             )}
           </div>
           <div className="flex shrink-0 items-center gap-1">
-            <Button size="sm" ref={newPostTriggerRef} onClick={() => setComposing(true)}><Plus className="size-4" /> New Post</Button>
+            <Button data-testid={tid.forumNewPost} size="sm" ref={newPostTriggerRef} onClick={() => setComposing(true)}><Plus className="size-4" /> New Post</Button>
           </div>
         </div>
       )}
 
-      <div ref={scrollRef} role="main" className="flex-1 overflow-y-auto thin-scrollbar px-4 py-2">
+      <div
+        ref={scrollRef}
+        role="main"
+        data-testid={tid.forumPostList}
+        className="flex-1 overflow-y-auto thin-scrollbar px-0 py-2 sm:px-4"
+      >
         {loading && posts.length === 0 ? (
           <ForumListSkeleton />
         ) : posts.length === 0 ? (
@@ -260,7 +440,7 @@ export function ForumView({
                               type="button"
                               data-testid={tid.forumThreadTagBtn(p.id)}
                               onClick={(event) => event.stopPropagation()}
-                              className="grid size-6 shrink-0 place-items-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground focus-visible:opacity-100 data-popup-open:opacity-100 group-hover/card:opacity-100"
+                              className="grid size-8 shrink-0 place-items-center rounded-md text-muted-foreground opacity-100 transition-opacity hover:bg-accent hover:text-foreground sm:size-6 sm:opacity-0 sm:focus-visible:opacity-100 sm:data-popup-open:opacity-100 sm:group-hover/card:opacity-100"
                               aria-label="Edit tags"
                             >
                               <Tag className="size-4" />
@@ -279,7 +459,7 @@ export function ForumView({
                         data-testid={tid.forumThreadDeleteBtn(p.id)}
                         disabled={deletingPost === p.id}
                         onClick={(e) => { e.stopPropagation(); setDeletingFor(p) }}
-                        className="grid size-6 shrink-0 place-items-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-destructive focus-visible:opacity-100 group-hover/card:opacity-100 disabled:cursor-not-allowed disabled:opacity-50"
+                        className="grid size-8 shrink-0 place-items-center rounded-md text-muted-foreground opacity-100 transition-opacity hover:bg-accent hover:text-destructive sm:size-6 sm:opacity-0 sm:focus-visible:opacity-100 sm:group-hover/card:opacity-100 disabled:cursor-not-allowed disabled:opacity-50"
                         aria-label="Delete post"
                       >
                         <Trash2 className="size-4" />
@@ -288,13 +468,11 @@ export function ForumView({
                     </div>
                   )}
 
-                  <div className="flex flex-wrap items-baseline gap-1.75 pr-14">
-                    <h3 className="max-w-full text-[15px] font-semibold leading-tight">{p.name}</h3>
-                    {p.parentSeq !== undefined && (
-                      <span className="shrink-0 font-mono text-[13px] font-medium text-muted-foreground">
-                        <span className="opacity-60">#</span>{p.parentSeq}
-                      </span>
-                    )}
+                  <div className={cn(
+                    "sm:pr-14",
+                    canEdit || canDelete ? "min-h-8 pr-16 sm:min-h-0" : "pr-0",
+                  )}>
+                    <ForumPostTitle name={p.name} postId={p.id} seq={p.parentSeq} />
                   </div>
                   <p className="mb-2.25 mt-0.75 line-clamp-2 text-[13.5px] text-muted-foreground">{p.preview}</p>
                   <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1.5 text-xs text-muted-foreground">

--- a/src/web/src/lib/community/testids.ts
+++ b/src/web/src/lib/community/testids.ts
@@ -91,15 +91,26 @@ export const tid = {
   threadIndicator: (msgId: string) => `community-thread-indicator-${msgId}`,
   railUnreadBadge: (serverId: string) => `community-rail-unread-badge-${serverId}`,
   // Forum post feed (ForumView). `forumThreadCard` is the whole clickable card;
-  // `forumThreadTagBtn` is the hover-revealed tag-edit icon; `forumThreadDeleteBtn`
-  // is the hover-revealed delete icon; `forumThreadAvatars` wraps the participant
-  // AvatarGroup; `forumTagChip` is a filter-bar tag chip.
+  // `forumThreadTitle` / `forumThreadTitleText` expose the clamped title cluster
+  // and its visible text; `forumThreadTagBtn` is the responsive tag-edit icon;
+  // `forumThreadDeleteBtn` is the responsive delete icon; `forumThreadAvatars`
+  // wraps the participant AvatarGroup; `forumTagChip` is a filter-bar tag chip.
   forumThreadCard: (id: string) => `community-forum-post-${id}`,
   forumSidebarThread: (id: string) => `community-forum-sidebar-thread-${id}`,
+  forumThreadTitle: (id: string) => `community-forum-post-title-${id}`,
+  forumThreadTitleText: (id: string) => `community-forum-post-title-text-${id}`,
+  forumThreadSeq: (id: string) => `community-forum-post-seq-${id}`,
   forumThreadTagBtn: (id: string) => `community-forum-post-tag-btn-${id}`,
   forumThreadDeleteBtn: (id: string) => `community-forum-post-delete-btn-${id}`,
   forumThreadAvatars: (id: string) => `community-forum-post-avatars-${id}`,
+  forumFilterBar: "community-forum-filter-bar",
+  forumTagScroller: "community-forum-tag-scroller",
+  forumTagFadeLeft: "community-forum-tag-fade-left",
+  forumTagFadeRight: "community-forum-tag-fade-right",
+  forumTagAll: "community-forum-tag-all",
   forumTagChip: (tag: string) => `community-forum-tag-chip-${tag}`,
+  forumNewPost: "community-forum-new-post",
+  forumPostList: "community-forum-post-list",
   inboxUnreadChild: (id: string) => `community-inbox-unread-child-${id}`,
   channelRefPill: (id: string) => `community-channel-ref-pill-${id}`,
 } as const

--- a/src/web/src/test/e2e-ui/26-mobile-forum-post-actions.spec.ts
+++ b/src/web/src/test/e2e-ui/26-mobile-forum-post-actions.spec.ts
@@ -1,0 +1,641 @@
+import type { Locator, Page, TestInfo } from "@playwright/test"
+import { test, expect, sessionCookie } from "./_fixtures/community-fixture"
+import { gotoAfterUserWsAuth } from "./_fixtures/actions"
+import { seedChannel, seedForumThread, seedJoinServer, seedMessage, seedServer } from "./_fixtures/seed"
+import { tid } from "./_fixtures/testids"
+import { WEB_URL } from "./_setup/paths"
+
+const MOBILE_WIDTHS = [320, 390] as const
+const TAGS = ["alpha-long-tag", "beta-long-tag", "gamma", "delta", "epsilon"]
+
+type Rect = { left: number; right: number; top: number; bottom: number; width: number; height: number }
+
+function intersects(left: Rect, right: Rect): boolean {
+  return left.left < right.right
+    && left.right > right.left
+    && left.top < right.bottom
+    && left.bottom > right.top
+}
+
+async function rect(locator: Locator): Promise<Rect | null> {
+  const box = await locator.boundingBox()
+  return box === null ? null : {
+    left: box.x,
+    right: box.x + box.width,
+    top: box.y,
+    bottom: box.y + box.height,
+    width: box.width,
+    height: box.height,
+  }
+}
+
+async function expectNewPostGeometry(
+  page: Page,
+  width: (typeof MOBILE_WIDTHS)[number],
+  state: string,
+  expected?: Rect,
+): Promise<Rect> {
+  const geometry = await page.evaluate(([barId, railId, newPostId, fadeLeftId, fadeRightId]) => {
+    const bar = document.querySelector(`[data-testid="${barId}"]`) as HTMLElement
+    const rail = document.querySelector(`[data-testid="${railId}"]`) as HTMLElement
+    const newPost = document.querySelector(`[data-testid="${newPostId}"]`) as HTMLElement
+    const toRect = (element: Element) => {
+      const box = element.getBoundingClientRect()
+      return { left: box.left, right: box.right, top: box.top, bottom: box.bottom, width: box.width, height: box.height }
+    }
+    const button = toRect(newPost)
+    const centerTarget = document.elementFromPoint(
+      button.left + button.width / 2,
+      button.top + button.height / 2,
+    )?.closest("button")?.getAttribute("data-testid") ?? null
+    return {
+      viewport: { left: 0, right: document.documentElement.clientWidth, top: 0, bottom: window.innerHeight },
+      documentScrollWidth: document.documentElement.scrollWidth,
+      barClientWidth: bar.clientWidth,
+      barScrollWidth: bar.scrollWidth,
+      bar: toRect(bar),
+      rail: toRect(rail),
+      button,
+      centerTarget,
+      chips: Array.from(rail.querySelectorAll("button")).map(toRect),
+      fades: [fadeLeftId, fadeRightId]
+        .map((id) => document.querySelector(`[data-testid="${id}"]`))
+        .filter((element): element is Element => element !== null)
+        .map(toRect),
+    }
+  }, [
+    tid.forumFilterBar,
+    tid.forumTagScroller,
+    tid.forumNewPost,
+    tid.forumTagFadeLeft,
+    tid.forumTagFadeRight,
+  ] as const)
+  const label = `filter rail@${width}/${state}`
+  expect(geometry.documentScrollWidth, `${label}: document containment`).toBe(geometry.viewport.right)
+  expect(geometry.barScrollWidth, `${label}: bar containment`).toBe(geometry.barClientWidth)
+  expect(geometry.button.left, `${label}: New Post left`).toBeGreaterThanOrEqual(geometry.bar.left - 0.5)
+  expect(geometry.button.right, `${label}: New Post bar right`).toBeLessThanOrEqual(geometry.bar.right + 0.5)
+  expect(geometry.button.top, `${label}: New Post top`).toBeGreaterThanOrEqual(geometry.bar.top - 0.5)
+  expect(geometry.button.bottom, `${label}: New Post bottom`).toBeLessThanOrEqual(geometry.bar.bottom + 0.5)
+  expect(geometry.button.left, `${label}: New Post viewport left`).toBeGreaterThanOrEqual(geometry.viewport.left - 0.5)
+  expect(geometry.button.right, `${label}: New Post viewport right`).toBeLessThanOrEqual(geometry.viewport.right + 0.5)
+  expect(geometry.button.top, `${label}: New Post viewport top`).toBeGreaterThanOrEqual(geometry.viewport.top - 0.5)
+  expect(geometry.button.bottom, `${label}: New Post viewport bottom`).toBeLessThanOrEqual(geometry.viewport.bottom + 0.5)
+  expect(geometry.centerTarget, `${label}: New Post center hit`).toBe(tid.forumNewPost)
+  for (const chip of geometry.chips) {
+    const visibleChip = {
+      left: Math.max(chip.left, geometry.rail.left),
+      right: Math.min(chip.right, geometry.rail.right),
+      top: Math.max(chip.top, geometry.rail.top),
+      bottom: Math.min(chip.bottom, geometry.rail.bottom),
+      width: 0,
+      height: 0,
+    }
+    visibleChip.width = Math.max(0, visibleChip.right - visibleChip.left)
+    visibleChip.height = Math.max(0, visibleChip.bottom - visibleChip.top)
+    if (visibleChip.width > 0 && visibleChip.height > 0) {
+      expect(intersects(geometry.button, visibleChip), `${label}: New Post/visible chip overlap`).toBe(false)
+    }
+  }
+  for (const fade of geometry.fades) {
+    expect(intersects(geometry.button, fade), `${label}: New Post/fade overlap`).toBe(false)
+  }
+  if (expected) {
+    for (const edge of ["left", "right", "top", "bottom", "width", "height"] as const) {
+      expect(Math.abs(geometry.button[edge] - expected[edge]), `${label}: stable ${edge}`).toBeLessThanOrEqual(0.5)
+    }
+  }
+  return geometry.button
+}
+
+function observeClientWrites(page: Page) {
+  const state = { active: false, http: [] as string[], ws: [] as string[] }
+  page.on("request", (request) => {
+    if (!state.active || ["GET", "HEAD", "OPTIONS"].includes(request.method())) return
+    const path = new URL(request.url()).pathname
+    if (!path.startsWith("/api/community/")) return
+    if (path.endsWith("/read")) return
+    state.http.push(`${request.method()} ${path}`)
+  })
+  page.on("websocket", (socket) => {
+    socket.on("framesent", (payload) => {
+      if (!state.active) return
+      const raw = String(payload)
+      try {
+        const frame = JSON.parse(raw) as { type?: unknown }
+        if (typeof frame.type === "string" && frame.type.startsWith("community:")) {
+          state.ws.push(frame.type)
+        }
+      } catch {
+        return
+      }
+    })
+  })
+  return state
+}
+
+async function expectMobileGeometry(
+  page: Page,
+  card: Locator,
+  postId: string,
+  visibleTags: string[],
+  titleState: "single" | "double" | "truncated",
+  role: "author" | "manager",
+  width: (typeof MOBILE_WIDTHS)[number],
+): Promise<void> {
+  await page.setViewportSize({ width, height: 844 })
+  const tagButton = page.getByTestId(tid.forumThreadTagBtn(postId))
+  const deleteButton = page.getByTestId(tid.forumThreadDeleteBtn(postId))
+  await expect(tagButton).toHaveCSS("opacity", "1")
+  await expect(deleteButton).toHaveCSS("opacity", "1")
+
+  const title = page.getByTestId(tid.forumThreadTitle(postId))
+  const titleText = page.getByTestId(tid.forumThreadTitleText(postId))
+  const sequence = page.getByTestId(tid.forumThreadSeq(postId))
+  await expect(title).toHaveAttribute("data-truncated", titleState === "truncated" ? "true" : "false")
+  await expect(sequence).toBeVisible()
+  const [listRect, cardRect, titleRect, tagRect, deleteRect, sequenceRect] = await Promise.all([
+    rect(page.getByTestId(tid.forumPostList)),
+    rect(card),
+    rect(title),
+    rect(tagButton),
+    rect(deleteButton),
+    rect(sequence),
+  ])
+  for (const renderedRect of [listRect, cardRect, titleRect, tagRect, deleteRect, sequenceRect]) {
+    expect(renderedRect, `${role}/${postId}@${width}: expected rendered geometry`).not.toBeNull()
+  }
+  expect(Math.abs(cardRect!.left - listRect!.left), `${role}/${postId}@${width}: edge-to-edge left`).toBeLessThanOrEqual(0.5)
+  expect(Math.abs(cardRect!.right - listRect!.right), `${role}/${postId}@${width}: edge-to-edge right`).toBeLessThanOrEqual(0.5)
+  expect(titleRect!.left - cardRect!.left, `${role}/${postId}@${width}: internal title inset`).toBeGreaterThanOrEqual(16)
+  const titleMetrics = await title.evaluate((element) => {
+    const lineHeight = Number.parseFloat(getComputedStyle(element).lineHeight)
+    return { height: element.getBoundingClientRect().height, lineHeight }
+  })
+  const textFragments = await titleText.evaluate((element) => Array.from(element.getClientRects())
+    .filter((fragment) => fragment.width > 0 && fragment.height > 0)
+    .map((fragment) => ({ left: fragment.left, right: fragment.right, top: fragment.top, bottom: fragment.bottom })))
+  const textLines = textFragments.reduce<typeof textFragments>((lines, fragment) => {
+    const line = lines.find((candidate) => Math.abs(candidate.top - fragment.top) <= 1)
+    if (line) {
+      line.left = Math.min(line.left, fragment.left)
+      line.right = Math.max(line.right, fragment.right)
+      line.bottom = Math.max(line.bottom, fragment.bottom)
+    } else {
+      lines.push({ ...fragment })
+    }
+    return lines
+  }, [])
+  const expectedLines = titleState === "single" ? 1 : 2
+  expect(textLines, `${role}/${postId}@${width}: visible title lines`).toHaveLength(expectedLines)
+  expect(titleMetrics.height, `${role}/${postId}@${width}: two-line clamp`).toBeLessThanOrEqual(titleMetrics.lineHeight * 2 + 0.5)
+  const lastTextLine = textLines.at(-1)!
+  expect(Math.abs(sequenceRect!.top - lastTextLine.top), `${role}/${postId}@${width}: seq line`).toBeLessThanOrEqual(3)
+  expect(Math.abs(sequenceRect!.bottom - lastTextLine.bottom), `${role}/${postId}@${width}: seq baseline`).toBeLessThanOrEqual(3)
+  expect(sequenceRect!.left - lastTextLine.right, `${role}/${postId}@${width}: seq gap`).toBeGreaterThanOrEqual(4)
+  expect(sequenceRect!.left - lastTextLine.right, `${role}/${postId}@${width}: seq gap`).toBeLessThanOrEqual(8)
+  const controls = [tagRect!, deleteRect!]
+  for (const controlRect of controls) {
+    expect(controlRect.width, `${role}/${postId}@${width}: touch width`).toBe(32)
+    expect(controlRect.height, `${role}/${postId}@${width}: touch height`).toBe(32)
+    expect(controlRect.left, `${role}/${postId}@${width}: control left`).toBeGreaterThanOrEqual(cardRect!.left)
+    expect(controlRect.right, `${role}/${postId}@${width}: control right`).toBeLessThanOrEqual(cardRect!.right)
+    expect(controlRect.top, `${role}/${postId}@${width}: control top`).toBeGreaterThanOrEqual(cardRect!.top)
+    expect(controlRect.bottom, `${role}/${postId}@${width}: control bottom`).toBeLessThanOrEqual(cardRect!.bottom)
+    expect(intersects(titleRect!, controlRect), `${role}/${postId}@${width}: title/action overlap`).toBe(false)
+    const centerTarget = await page.evaluate(({ x, y }) => {
+      const target = document.elementFromPoint(x, y)
+      return target?.closest("button")?.getAttribute("data-testid") ?? null
+    }, { x: controlRect.left + controlRect.width / 2, y: controlRect.top + controlRect.height / 2 })
+    expect(centerTarget, `${role}/${postId}@${width}: pointer target`).not.toBeNull()
+  }
+  expect(intersects(tagRect!, deleteRect!), `${role}/${postId}@${width}: action overlap`).toBe(false)
+  for (const tag of visibleTags) {
+    const tagRect = await rect(card.getByText(`#${tag}`, { exact: true }))
+    expect(tagRect, `${role}/${postId}@${width}: tag geometry`).not.toBeNull()
+    expect(controls.some((controlRect) => intersects(tagRect!, controlRect)), `${role}/${postId}@${width}: tag/action overlap`).toBe(false)
+  }
+
+  const documentWidth = await page.evaluate(() => ({
+    client: document.documentElement.clientWidth,
+    scroll: document.documentElement.scrollWidth,
+  }))
+  expect(documentWidth.scroll, `${role}@${width}: horizontal overflow`).toBe(documentWidth.client)
+}
+
+async function expectMobileFilterRail(
+  page: Page,
+  width: (typeof MOBILE_WIDTHS)[number],
+  testInfo: TestInfo,
+): Promise<Rect> {
+  await page.setViewportSize({ width, height: 844 })
+  const bar = page.getByTestId(tid.forumFilterBar)
+  const rail = page.getByTestId(tid.forumTagScroller)
+  const all = page.getByTestId(tid.forumTagAll)
+  const last = page.getByTestId(tid.forumTagChip(TAGS.at(-1)!))
+  const fadeLeft = page.getByTestId(tid.forumTagFadeLeft)
+  const fadeRight = page.getByTestId(tid.forumTagFadeRight)
+  const originalColorScheme = await page.evaluate(() => matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light")
+  await page.emulateMedia({ colorScheme: "light" })
+  await expect(page.locator("html")).not.toHaveClass(/dark/)
+  await expect(bar).toBeVisible()
+  await expect(rail).toBeVisible()
+  const initial = await rail.evaluate((element) => {
+    const style = getComputedStyle(element)
+    element.scrollLeft = 0
+    return {
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+      flexWrap: style.flexWrap,
+      overflowX: style.overflowX,
+    }
+  })
+  expect(initial.flexWrap, `filter rail@${width}: single line`).toBe("nowrap")
+  expect(initial.overflowX, `filter rail@${width}: horizontal scroll`).toBe("auto")
+  expect(initial.scrollWidth, `filter rail@${width}: owns overflow`).toBeGreaterThan(initial.clientWidth)
+  await expect(fadeLeft).toHaveCount(0)
+  await expect(fadeRight).toBeVisible()
+  const startFadeStyle = await fadeRight.evaluate((element) => {
+    const style = getComputedStyle(element)
+    return {
+      width: element.getBoundingClientRect().width,
+      backgroundImage: style.backgroundImage,
+      pointerEvents: style.pointerEvents,
+    }
+  })
+  expect(startFadeStyle.width, `filter rail@${width}: fade width`).toBeGreaterThanOrEqual(12)
+  expect(startFadeStyle.width, `filter rail@${width}: fade width`).toBeLessThanOrEqual(16)
+  expect(startFadeStyle.backgroundImage, `filter rail@${width}: fade gradient`).toContain("linear-gradient")
+  expect(startFadeStyle.pointerEvents, `filter rail@${width}: pointer transparency`).toBe("none")
+  const initialNewPostRect = await expectNewPostGeometry(page, width, "start-light")
+  await testInfo.attach(`author-${width}-filter-rail-start-light.png`, {
+    body: await page.screenshot(),
+    contentType: "image/png",
+  })
+  await page.emulateMedia({ colorScheme: "dark" })
+  await expect(page.locator("html")).toHaveClass(/dark/)
+  await expectNewPostGeometry(page, width, "start-dark", initialNewPostRect)
+  await page.emulateMedia({ colorScheme: "light" })
+  await expect(page.locator("html")).not.toHaveClass(/dark/)
+
+  await rail.focus()
+  await page.keyboard.press("ArrowRight")
+  await expect.poll(() => rail.evaluate((element) => element.scrollLeft)).toBeGreaterThan(0)
+  await rail.evaluate((element) => {
+    element.scrollLeft = (element.scrollWidth - element.clientWidth) / 2
+  })
+  await expect(fadeLeft).toBeVisible()
+  await expect(fadeRight).toBeVisible()
+  await expectNewPostGeometry(page, width, "middle-light", initialNewPostRect)
+  const pointerHit = await page.evaluate(([railId, fadeId]) => {
+    const railElement = document.querySelector(`[data-testid="${railId}"]`) as HTMLElement
+    const fadeElement = document.querySelector(`[data-testid="${fadeId}"]`) as HTMLElement
+    const fadeRect = fadeElement.getBoundingClientRect()
+    const candidates = Array.from(railElement.querySelectorAll<HTMLButtonElement>("button"))
+      .map((button) => {
+        const buttonRect = button.getBoundingClientRect()
+        const left = Math.max(buttonRect.left, fadeRect.left)
+        const right = Math.min(buttonRect.right, fadeRect.right)
+        return { button, buttonRect, left, right, overlap: right - left }
+      })
+      .filter((candidate) => candidate.overlap > 0)
+      .sort((a, b) => b.overlap - a.overlap)
+    const candidate = candidates[0]
+    if (!candidate) return null
+    const x = (candidate.left + candidate.right) / 2
+    const y = candidate.buttonRect.top + candidate.buttonRect.height / 2
+    return {
+      expected: candidate.button.dataset.testid ?? null,
+      actual: document.elementFromPoint(x, y)?.closest("button")?.getAttribute("data-testid") ?? null,
+    }
+  }, [tid.forumTagScroller, tid.forumTagFadeRight] as const)
+  expect(pointerHit, `filter rail@${width}: chip beneath fade`).not.toBeNull()
+  expect(pointerHit!.actual, `filter rail@${width}: fade pointer pass-through`).toBe(pointerHit!.expected)
+  const lightGradient = await fadeRight.evaluate((element) => getComputedStyle(element).backgroundImage)
+  await testInfo.attach(`author-${width}-filter-rail-middle-light.png`, {
+    body: await page.screenshot(),
+    contentType: "image/png",
+  })
+  await page.emulateMedia({ colorScheme: "dark" })
+  await expect(page.locator("html")).toHaveClass(/dark/)
+  const darkGradient = await fadeRight.evaluate((element) => getComputedStyle(element).backgroundImage)
+  expect(darkGradient, `filter rail@${width}: dark fade gradient`).toContain("linear-gradient")
+  expect(darkGradient, `filter rail@${width}: theme-aware fade`).not.toBe(lightGradient)
+  await expectNewPostGeometry(page, width, "middle-dark", initialNewPostRect)
+  await testInfo.attach(`author-${width}-filter-rail-middle-dark.png`, {
+    body: await page.screenshot(),
+    contentType: "image/png",
+  })
+  await page.emulateMedia({ colorScheme: originalColorScheme })
+  if (originalColorScheme === "dark") {
+    await expect(page.locator("html")).toHaveClass(/dark/)
+  } else {
+    await expect(page.locator("html")).not.toHaveClass(/dark/)
+  }
+
+  await page.keyboard.press("End")
+  await expect.poll(() => rail.evaluate((element) => element.scrollLeft)).toBeGreaterThan(0)
+  await expect(fadeLeft).toBeVisible()
+  await expect(fadeRight).toHaveCount(0)
+  const [railAtEnd, lastAtEnd] = await Promise.all([rect(rail), rect(last)])
+  expect(lastAtEnd!.left, `filter rail@${width}: last chip left`).toBeGreaterThanOrEqual(railAtEnd!.left - 0.5)
+  expect(lastAtEnd!.right, `filter rail@${width}: last chip right`).toBeLessThanOrEqual(railAtEnd!.right + 0.5)
+  await page.emulateMedia({ colorScheme: "light" })
+  await expect(page.locator("html")).not.toHaveClass(/dark/)
+  await expectNewPostGeometry(page, width, "end-light", initialNewPostRect)
+  await testInfo.attach(`author-${width}-filter-rail-end.png`, {
+    body: await page.screenshot(),
+    contentType: "image/png",
+  })
+  await page.emulateMedia({ colorScheme: "dark" })
+  await expect(page.locator("html")).toHaveClass(/dark/)
+  await expectNewPostGeometry(page, width, "end-dark", initialNewPostRect)
+  await page.emulateMedia({ colorScheme: originalColorScheme })
+  if (originalColorScheme === "dark") {
+    await expect(page.locator("html")).toHaveClass(/dark/)
+  } else {
+    await expect(page.locator("html")).not.toHaveClass(/dark/)
+  }
+
+  await last.click()
+  await expect(last).toHaveClass(/ring-current/)
+  const [railWithLastActive, activeLast] = await Promise.all([rect(rail), rect(last)])
+  expect(activeLast!.left).toBeGreaterThanOrEqual(railWithLastActive!.left - 0.5)
+  expect(activeLast!.right).toBeLessThanOrEqual(railWithLastActive!.right + 0.5)
+  await rail.focus()
+  await page.keyboard.press("Home")
+  await expect.poll(() => rail.evaluate((element) => element.scrollLeft)).toBe(0)
+  await expect(fadeLeft).toHaveCount(0)
+  await expect(fadeRight).toBeVisible()
+  await all.click()
+  await expect(all).toHaveClass(/bg-accent/)
+  const [railAtStart, allAtStart] = await Promise.all([rect(rail), rect(all)])
+  expect(allAtStart!.left).toBeGreaterThanOrEqual(railAtStart!.left - 0.5)
+  expect(allAtStart!.right).toBeLessThanOrEqual(railAtStart!.right + 0.5)
+
+  const containment = await page.evaluate(([barId, railId]) => {
+    const barElement = document.querySelector(`[data-testid="${barId}"]`) as HTMLElement
+    const railElement = document.querySelector(`[data-testid="${railId}"]`) as HTMLElement
+    return {
+      documentClient: document.documentElement.clientWidth,
+      documentScroll: document.documentElement.scrollWidth,
+      barClient: barElement.clientWidth,
+      barScroll: barElement.scrollWidth,
+      railClient: railElement.clientWidth,
+      railScroll: railElement.scrollWidth,
+    }
+  }, [tid.forumFilterBar, tid.forumTagScroller] as const)
+  expect(containment.documentScroll, `filter rail@${width}: document containment`).toBe(containment.documentClient)
+  expect(containment.barScroll, `filter rail@${width}: bar containment`).toBe(containment.barClient)
+  expect(containment.railScroll, `filter rail@${width}: local overflow`).toBeGreaterThan(containment.railClient)
+  return initialNewPostRect
+}
+
+async function expectNoOverflowFilterRail(
+  page: Page,
+  width: (typeof MOBILE_WIDTHS)[number],
+  route: string,
+  postId: string,
+  expectedNewPost: Rect,
+  testInfo: TestInfo,
+): Promise<void> {
+  await page.setViewportSize({ width, height: 844 })
+  await page.goto(`${WEB_URL}${route}`)
+  await expect(page.getByTestId(tid.forumThreadCard(postId))).toBeVisible({ timeout: 20_000 })
+  const originalColorScheme = await page.evaluate(() => matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light")
+  await page.emulateMedia({ colorScheme: "light" })
+  await expect(page.locator("html")).not.toHaveClass(/dark/)
+  const rail = page.getByTestId(tid.forumTagScroller)
+  const geometry = await rail.evaluate((element) => ({ clientWidth: element.clientWidth, scrollWidth: element.scrollWidth }))
+  expect(geometry.scrollWidth, `no-overflow rail@${width}`).toBe(geometry.clientWidth)
+  await expect(page.getByTestId(tid.forumTagFadeLeft)).toHaveCount(0)
+  await expect(page.getByTestId(tid.forumTagFadeRight)).toHaveCount(0)
+  await expectNewPostGeometry(page, width, "no-overflow-light", expectedNewPost)
+  await testInfo.attach(`author-${width}-filter-rail-no-overflow.png`, {
+    body: await page.screenshot(),
+    contentType: "image/png",
+  })
+  await page.emulateMedia({ colorScheme: "dark" })
+  await expect(page.locator("html")).toHaveClass(/dark/)
+  await expect(page.getByTestId(tid.forumTagFadeLeft)).toHaveCount(0)
+  await expect(page.getByTestId(tid.forumTagFadeRight)).toHaveCount(0)
+  await expectNewPostGeometry(page, width, "no-overflow-dark", expectedNewPost)
+  await page.emulateMedia({ colorScheme: originalColorScheme })
+  if (originalColorScheme === "dark") {
+    await expect(page.locator("html")).toHaveClass(/dark/)
+  } else {
+    await expect(page.locator("html")).not.toHaveClass(/dark/)
+  }
+}
+
+async function seedTags(forumId: string, threadId: string, tags: string[]): Promise<void> {
+  const listResponse = await fetch(
+    `${WEB_URL}/api/community/channels/${forumId}/threads?order=createdAt&limit=50`,
+    { headers: { Cookie: sessionCookie("bob"), Origin: WEB_URL } },
+  )
+  expect(listResponse.ok).toBe(true)
+  const page = await listResponse.json() as {
+    threads: Array<{ id: string; parentMessageId: string | null }>
+  }
+  const openerMessageId = page.threads.find((thread) => thread.id === threadId)?.parentMessageId
+  expect(openerMessageId).toBeTruthy()
+  const tagResponse = await fetch(`${WEB_URL}/api/community/messages/${openerMessageId}/tags`, {
+    method: "PUT",
+    headers: {
+      Cookie: sessionCookie("bob"),
+      "Content-Type": "application/json",
+      Origin: WEB_URL,
+    },
+    body: JSON.stringify({ tags }),
+  })
+  expect(tagResponse.status).toBe(200)
+}
+
+test("forum post actions stay discoverable on mobile without changing permissions", async ({ asUser }, testInfo) => {
+  test.setTimeout(120_000)
+  const stamp = Date.now().toString().slice(-6)
+  const serverId = await seedServer("alice", `Mobile forum actions ${Date.now()}`)
+  const forumId = await seedChannel("alice", serverId, "mobile-actions", "forum")
+  const compactForumId = await seedChannel("alice", serverId, "compact-tags", "forum")
+  await seedJoinServer("alice", "bob", serverId)
+  await seedJoinServer("alice", "carol", serverId)
+  const primaryPostId = await seedForumThread(
+    "bob",
+    forumId,
+    `UnbrokenForumTitle${Date.now()}${"abcdefghij".repeat(12)}`,
+    "mobile action geometry",
+  )
+  const cjkPostId = await seedForumThread(
+    "bob",
+    forumId,
+    `移动端论坛标题必须换到第二行展示${stamp}`,
+    "two tag geometry",
+  )
+  const noTagPostId = await seedForumThread(
+    "bob",
+    forumId,
+    `One line ${stamp}`,
+    "zero tag geometry",
+  )
+  const compactPostId = await seedForumThread(
+    "bob",
+    compactForumId,
+    `Compact tags ${stamp}`,
+    "no overflow rail geometry",
+  )
+  await seedMessage("carol", primaryPostId, "participant and reply-count coverage")
+  await seedTags(forumId, primaryPostId, TAGS)
+  await seedTags(forumId, cjkPostId, TAGS.slice(0, 2))
+  await seedTags(compactForumId, compactPostId, ["solo"])
+  const postCases = [
+    { id: primaryPostId, tags: TAGS.slice(0, 2), titleState: "truncated" as const },
+    { id: cjkPostId, tags: TAGS.slice(0, 2), titleState: "double" as const },
+    { id: noTagPostId, tags: [], titleState: "single" as const },
+  ]
+  const route = `/c/channels/${serverId}/${forumId}`
+  const compactRoute = `/c/channels/${serverId}/${compactForumId}`
+
+  const author = await asUser("bob")
+  await author.page.setViewportSize({ width: 1280, height: 900 })
+  await gotoAfterUserWsAuth(author.page, route)
+  const authorCard = author.page.getByTestId(tid.forumThreadCard(primaryPostId))
+  await expect(authorCard).toBeVisible({ timeout: 20_000 })
+  await expect(authorCard.getByText(`#${TAGS[0]}`, { exact: true })).toBeVisible()
+
+  const authorWrites = observeClientWrites(author.page)
+  authorWrites.active = true
+  const newPostGeometry = new Map<(typeof MOBILE_WIDTHS)[number], Rect>()
+  for (const width of MOBILE_WIDTHS) {
+    newPostGeometry.set(width, await expectMobileFilterRail(author.page, width, testInfo))
+    for (const post of postCases) {
+      await expectMobileGeometry(
+        author.page,
+        author.page.getByTestId(tid.forumThreadCard(post.id)),
+        post.id,
+        post.tags,
+        post.titleState,
+        "author",
+        width,
+      )
+    }
+    await testInfo.attach(`author-${width}.png`, {
+      body: await author.page.screenshot(),
+      contentType: "image/png",
+    })
+  }
+  authorWrites.active = false
+  for (const width of MOBILE_WIDTHS) {
+    const expectedNewPost = newPostGeometry.get(width)
+    expect(expectedNewPost, `filter rail@${width}: expected baseline New Post geometry`).toBeDefined()
+    await expectNoOverflowFilterRail(author.page, width, compactRoute, compactPostId, expectedNewPost!, testInfo)
+  }
+  await author.page.goto(`${WEB_URL}${route}`)
+  await expect(authorCard).toBeVisible({ timeout: 20_000 })
+  authorWrites.active = true
+  const authorUrl = author.page.url()
+  await author.page.setViewportSize({ width: 320, height: 844 })
+  await author.page.getByTestId(tid.forumThreadTagBtn(primaryPostId)).click()
+  await expect(author.page.getByTestId(tid.forumTagDialog)).toBeVisible()
+  await expect(author.page).toHaveURL(authorUrl)
+  await author.page.keyboard.press("Escape")
+  await author.page.getByTestId(tid.forumThreadDeleteBtn(primaryPostId)).click()
+  await expect(author.page.getByRole("heading", { name: "Delete post?" })).toBeVisible()
+  await expect(author.page).toHaveURL(authorUrl)
+  await author.page.getByRole("button", { name: "Cancel" }).click()
+  authorWrites.active = false
+  expect(authorWrites.http).toEqual([])
+  expect(authorWrites.ws).toEqual([])
+
+  const manager = await asUser("alice")
+  const managerWrites = observeClientWrites(manager.page)
+  await gotoAfterUserWsAuth(manager.page, route)
+  const managerCard = manager.page.getByTestId(tid.forumThreadCard(primaryPostId))
+  await expect(managerCard).toBeVisible({ timeout: 20_000 })
+  managerWrites.active = true
+  for (const width of MOBILE_WIDTHS) {
+    for (const post of postCases) {
+      await expectMobileGeometry(
+        manager.page,
+        manager.page.getByTestId(tid.forumThreadCard(post.id)),
+        post.id,
+        post.tags,
+        post.titleState,
+        "manager",
+        width,
+      )
+    }
+    await testInfo.attach(`manager-${width}.png`, {
+      body: await manager.page.screenshot(),
+      contentType: "image/png",
+    })
+  }
+  await manager.page.setViewportSize({ width: 1280, height: 900 })
+  const [desktopListRect, desktopCardRect] = await Promise.all([
+    rect(manager.page.getByTestId(tid.forumPostList)),
+    rect(managerCard),
+  ])
+  expect(desktopCardRect!.left - desktopListRect!.left).toBeGreaterThanOrEqual(15)
+  expect(desktopListRect!.right - desktopCardRect!.right).toBeGreaterThanOrEqual(15)
+  await manager.page.mouse.move(0, 0)
+  const managerTagButton = manager.page.getByTestId(tid.forumThreadTagBtn(primaryPostId))
+  const managerDeleteButton = manager.page.getByTestId(tid.forumThreadDeleteBtn(primaryPostId))
+  await expect(managerTagButton).toHaveCSS("opacity", "0")
+  await expect(managerDeleteButton).toHaveCSS("opacity", "0")
+  for (const button of [managerTagButton, managerDeleteButton]) {
+    const buttonRect = await rect(button)
+    expect(buttonRect?.width).toBe(24)
+    expect(buttonRect?.height).toBe(24)
+  }
+  await managerCard.hover()
+  await expect(managerTagButton).toHaveCSS("opacity", "1")
+  await expect(managerDeleteButton).toHaveCSS("opacity", "1")
+  await manager.page.mouse.move(0, 0)
+  await managerTagButton.focus()
+  await expect(managerTagButton).toHaveCSS("opacity", "1")
+  await managerTagButton.click()
+  const managerTagDialog = manager.page.getByTestId(tid.forumTagDialog)
+  await expect(managerTagDialog).toBeVisible()
+  await manager.page.mouse.move(0, 0)
+  await expect(managerTagButton).toHaveCSS("opacity", "1")
+  await expect(managerTagDialog).toHaveCSS("opacity", "1")
+  await testInfo.attach("manager-desktop-popup.png", {
+    body: await manager.page.screenshot(),
+    contentType: "image/png",
+  })
+  await manager.page.keyboard.press("Escape")
+  await expect(managerTagDialog).toHaveCount(0)
+  await managerDeleteButton.focus()
+  await expect(managerDeleteButton).toHaveCSS("opacity", "1")
+  managerWrites.active = false
+  expect(managerWrites.http).toEqual([])
+  expect(managerWrites.ws).toEqual([])
+  await testInfo.attach("manager-desktop-focus.png", {
+    body: await manager.page.screenshot(),
+    contentType: "image/png",
+  })
+
+  const unauthorized = await asUser("carol")
+  await unauthorized.page.setViewportSize({ width: 390, height: 844 })
+  await gotoAfterUserWsAuth(unauthorized.page, route)
+  const unauthorizedCard = unauthorized.page.getByTestId(tid.forumThreadCard(primaryPostId))
+  await expect(unauthorizedCard).toBeVisible({ timeout: 20_000 })
+  for (const post of postCases) {
+    await expect(unauthorized.page.getByTestId(tid.forumThreadTagBtn(post.id))).toHaveCount(0)
+    await expect(unauthorized.page.getByTestId(tid.forumThreadDeleteBtn(post.id))).toHaveCount(0)
+  }
+  await unauthorized.page.setViewportSize({ width: 320, height: 844 })
+  for (const post of postCases) {
+    await expect(unauthorized.page.getByTestId(tid.forumThreadTagBtn(post.id))).toHaveCount(0)
+    await expect(unauthorized.page.getByTestId(tid.forumThreadDeleteBtn(post.id))).toHaveCount(0)
+  }
+  await testInfo.attach("unauthorized-320.png", {
+    body: await unauthorized.page.screenshot(),
+    contentType: "image/png",
+  })
+
+  await authorCard.click()
+  await expect(author.page).toHaveURL(new RegExp(`/channels/${serverId}/${primaryPostId}$`))
+  await managerCard.focus()
+  await managerCard.press("Enter")
+  await expect(manager.page).toHaveURL(new RegExp(`/channels/${serverId}/${primaryPostId}$`))
+})


### PR DESCRIPTION
# Why we need this PR?

Forum post authors and server managers could only discover Edit tags and Delete through hover, leaving those authorized actions inaccessible on touch-only mobile layouts. Long titles could also separate the opener sequence from the title or grow the card without a clear bound. The mobile forum filter wrapped into multiple rows, lacked overflow affordance, and the post list retained unnecessary outer gutters.

## What changed

- Keep Edit tags and Delete visible below the `sm` breakpoint with compact 32×32 targets.
- Preserve the existing 24×24 desktop hover/focus/popup-open reveal behavior at `sm` and above.
- Preserve the existing permission boundary: only the post author or a server manager renders these controls.
- Keep title and `#seq` in one inline flow: single-line titles remain natural, two-line titles retain the sequence on the second line, and overlong unbroken/CJK/mixed titles ellipsize at two lines while the sequence remains visible.
- Keep the top mobile `All + filter tags` strip on one horizontally scrollable line, keep `New Post` fixed outside it, provide keyboard scrolling, and align the selected chip inside the rail.
- Add short conditional edge fades to the mobile filter rail: right-only at the start, both in the middle, left-only at the end, and neither without overflow. The surface-aware overlays are non-interactive and never cover `New Post`.
- Remove only the mobile post-list outer horizontal gutter while retaining safe internal row padding and the existing desktop gutter.
- Prevent any horizontal overflow outside the filter rail at 320px and 390px.
- Add component coverage plus a real Chromium journey for author, manager, and unauthorized states, exact action/title/rail/fade/list geometry, desktop disclosure, navigation behavior, and Community-mutation isolation.
- Directly verify `New Post` containment, center hit, visible-chip/fade separation, and stable x/y/size in every start/middle/end/no-overflow state under light and dark themes.
- Add the focused journey to deterministic E2E shard weights.

## Verification

- Candidate: `27b7c50cc17932ff76c0a1dd38154aa98c4cda37`; base / parent / merge-base: `965aa00b4398405f554f1599d63211f5fa743ec9`.
- Focused component and scroll-helper regression: 2 files / 23 tests passed.
- E2E shard contract: 1 file / 7 tests passed.
- Focused exact-head Chromium: 1/1 passed, zero retries; 26.931-second test / 37.631-second run.
- `pnpm typecheck`: 11/11 tasks passed.
- `pnpm test`: 11/11 tasks passed; Web 592 files / 5,085 tests and CI scripts 9 files / 78 tests.
- Commit hooks: typecheck, lint, tests, WebSocket typegrep, agent-driver boundary, and knip passed.
- Required 320/390 start/middle/end/no-overflow, light/dark, pointer pass-through, fixed `New Post`, mobile rows, desktop popup/focus, and unauthorized evidence inspected.

## Checklist

- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [ ] Other