### PR TITLE
fix(web): align loading skeletons with final UI

### DIFF
--- a/src/web/src/app/c/channels/[serverId]/page.test.ts
+++ b/src/web/src/app/c/channels/[serverId]/page.test.ts
@@ -36,8 +36,11 @@ vi.mock("@/lib/community/last-channel", async () => {
 vi.mock("@/components/community/messages/message-list", () => ({
   MessageList: (props: Record<string, unknown>) => createElement("message-list", props),
 }))
-vi.mock("@/components/ui/skeleton", () => ({
-  Skeleton: (props: Record<string, unknown>) => createElement("skeleton-row", props),
+vi.mock("@/components/community/channels/channel-header", () => ({
+  ChannelHeaderSkeleton: (props: Record<string, unknown>) => createElement("channel-header-skeleton", props),
+}))
+vi.mock("@/components/community/messages/composer", () => ({
+  ComposerSkeleton: (props: Record<string, unknown>) => createElement("composer-skeleton", props),
 }))
 
 beforeEach(() => {
@@ -74,6 +77,8 @@ describe("ServerDefaultPage checkpoint route contract", () => {
       "/c/channels/server_1/channel_2?settings=1",
     )
     expect(renderer.root.findAllByType("message-list")).toHaveLength(1)
+    expect(renderer.root.findAllByType("channel-header-skeleton")).toHaveLength(1)
+    expect(renderer.root.findAllByType("composer-skeleton")).toHaveLength(1)
   })
 
   it("falls back to the first top-level channel on desktop", async () => {

--- a/src/web/src/app/c/channels/[serverId]/page.tsx
+++ b/src/web/src/app/c/channels/[serverId]/page.tsx
@@ -3,7 +3,8 @@
 import { useEffect } from "react"
 import { useParams, useRouter, useSearchParams } from "next/navigation"
 import { MessageList } from "@/components/community/messages/message-list"
-import { Skeleton } from "@/components/ui/skeleton"
+import { ComposerSkeleton } from "@/components/community/messages/composer"
+import { ChannelHeaderSkeleton } from "@/components/community/channels/channel-header"
 import { useServer } from "@/hooks/community/use-servers"
 import { useBreakpoint } from "@/hooks/use-mobile"
 import { getLastChannel, pickServerLandingChannel } from "@/lib/community/last-channel"
@@ -53,20 +54,10 @@ export default function ServerDefaultPage() {
 
   return (
     <>
-      <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border/40 px-3">
-        <Skeleton className="size-4 rounded" />
-        <Skeleton className="h-4 w-40 rounded" />
-        <div className="ml-auto flex items-center gap-2">
-          <Skeleton className="size-7 rounded-md" />
-          <Skeleton className="size-7 rounded-md" />
-          <Skeleton className="size-7 rounded-md" />
-        </div>
-      </header>
+      <ChannelHeaderSkeleton />
       <main className="flex min-h-0 min-w-0 flex-1 flex-col">
         <MessageList channel="" messages={[]} loading onOpenThread={() => {}} />
-        <div className="px-3 pb-3 pt-0">
-          <Skeleton className="h-12 w-full rounded-xl" />
-        </div>
+        <ComposerSkeleton />
       </main>
     </>
   )

--- a/src/web/src/app/c/invite/[token]/invite-accept-client.test.ts
+++ b/src/web/src/app/c/invite/[token]/invite-accept-client.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+describe("InviteAcceptClient loading geometry", () => {
+  it("reserves the ready landing title, metadata, CTA, members, and footer stack", () => {
+    const source = readFileSync(new URL("./invite-accept-client.tsx", import.meta.url), "utf8")
+    expect(source).toContain('className="mt-1 h-10 w-56 rounded"')
+    expect(source).toContain('className="mt-4 flex h-5 items-center gap-1.5"')
+    expect(source).toContain('className="mt-6 h-11 w-full rounded-xl"')
+    expect(source).toContain('className="mt-4 flex h-5 items-center gap-2"')
+    expect(source).toContain('className="mt-3 h-3 w-32 rounded"')
+  })
+})

--- a/src/web/src/app/c/invite/[token]/invite-accept-client.tsx
+++ b/src/web/src/app/c/invite/[token]/invite-accept-client.tsx
@@ -119,10 +119,27 @@ export function InviteAcceptClient({ token }: { token: string }) {
     return (
       <Shell>
         <Skeleton className="size-21 rounded-2xl" />
-        <Skeleton className="mt-5 h-3 w-32 rounded" />
-        <Skeleton className="mt-3 h-7 w-48 rounded" />
-        <Skeleton className="mt-4 h-4 w-64 rounded" />
+        <Skeleton className="mt-5 h-3 w-28 rounded" />
+        <Skeleton className="mt-1 h-10 w-56 rounded" />
+        <div className="mt-3 flex w-full max-w-xs flex-col items-center gap-1.5">
+          <Skeleton className="h-3.5 w-64 max-w-full rounded" />
+          <Skeleton className="h-3.5 w-48 max-w-full rounded" />
+        </div>
+        <div className="mt-4 flex h-5 items-center gap-1.5">
+          <Skeleton className="h-3.5 w-16 rounded" />
+          <Skeleton className="size-5 rounded-full" />
+          <Skeleton className="h-3.5 w-20 rounded" />
+        </div>
         <Skeleton className="mt-6 h-11 w-full rounded-xl" />
+        <div className="mt-4 flex h-5 items-center gap-2">
+          <div className="flex -space-x-1.5">
+            <Skeleton className="size-5 rounded-full ring-2 ring-background" />
+            <Skeleton className="size-5 rounded-full ring-2 ring-background" />
+            <Skeleton className="size-5 rounded-full ring-2 ring-background" />
+          </div>
+          <Skeleton className="h-3 w-20 rounded" />
+        </div>
+        <Skeleton className="mt-3 h-3 w-32 rounded" />
       </Shell>
     )
   }

--- a/src/web/src/components/community/bots/bot-list-view.test.ts
+++ b/src/web/src/components/community/bots/bot-list-view.test.ts
@@ -40,7 +40,7 @@ vi.mock("@/components/community/onboarding-tiles/create-tile", () => ({
   CreateTile: () => React.createElement("create-tile"),
 }))
 
-import { renderBotListView } from "./bot-list-view"
+import { BotListSkeleton, renderBotListView } from "./bot-list-view"
 
 function controller(overrides: Partial<BotListController> = {}): BotListController {
   const noop = vi.fn()
@@ -96,7 +96,7 @@ function controller(overrides: Partial<BotListController> = {}): BotListControll
 describe("renderBotListView", () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it("keeps the exact three-card skeleton branch for either loading source", () => {
+  it("keeps the loaded header, group, and scroll geometry for either loading source", () => {
     for (const loading of [{ isLoading: true }, { machinesLoading: true }]) {
       let renderer!: TestRenderer.ReactTestRenderer
       act(() => {
@@ -110,8 +110,22 @@ describe("renderBotListView", () => {
         skeletonFibers[0]!.parent,
         skeletonFibers[0]!.parent,
       ])
-      expect(renderer.root.findAllByProps({ className: "flex flex-col gap-3 p-6" }))
+      expect(renderer.root.findAllByProps({
+        className: "flex flex-1 flex-col gap-6 overflow-y-auto p-6 thin-scrollbar",
+      }))
         .toHaveLength(1)
+      expect(renderer.root.findAllByProps({
+        className: "flex items-center justify-between gap-4",
+      })).toHaveLength(1)
+      expect(renderer.root.findAllByProps({
+        className: "flex min-w-0 flex-1 flex-col gap-1",
+      })).toHaveLength(1)
+      expect(renderer.root.findAllByProps({
+        className: "flex flex-col gap-3 rounded-lg p-1",
+      })).toHaveLength(1)
+      expect(renderer.root.findAllByProps({
+        className: "flex h-7 items-center gap-2 px-1",
+      })).toHaveLength(1)
       expect(renderer.root.findAllByProps({ className: "flex flex-col gap-3 p-4" }))
         .toHaveLength(3)
       expect(renderer.root.findAllByProps({ className: "size-10 shrink-0 rounded-full" }))
@@ -262,8 +276,17 @@ describe("renderBotListView", () => {
 
   it("keeps the same outer/back-bar contract in loading, empty, and populated branches", () => {
     const onBack = vi.fn()
+    let loadingRenderer!: TestRenderer.ReactTestRenderer
+    act(() => {
+      loadingRenderer = TestRenderer.create(React.createElement(BotListSkeleton, { onBack }))
+    })
+    expect(loadingRenderer.root.findAll((node) =>
+      typeof node.type === "string" && node.props["data-slot"] === "loading-back-placeholder"))
+      .toHaveLength(1)
+    expect(loadingRenderer.root.findAllByProps({ "aria-label": "Back" })).toHaveLength(0)
+    act(() => loadingRenderer.unmount())
+
     const states = [
-      controller({ isLoading: true }),
       controller(),
       controller({ bots: [{ id: "b1" }] as BotListController["bots"] }),
     ]
@@ -279,6 +302,6 @@ describe("renderBotListView", () => {
       act(() => back.props.onClick())
       act(() => renderer.unmount())
     }
-    expect(onBack).toHaveBeenCalledTimes(3)
+    expect(onBack).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/web/src/components/community/bots/bot-list-view.tsx
+++ b/src/web/src/components/community/bots/bot-list-view.tsx
@@ -23,36 +23,77 @@ function BotCardSkeleton() {
   )
 }
 
+function botBackBar(onBack?: () => void, reserveBackSlot = false) {
+  return onBack || reserveBackSlot ? (
+    <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border/40 px-6">
+      {onBack ? (
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={onBack}
+          className="text-muted-foreground hover:text-foreground"
+          aria-label="Back"
+        >
+          <ChevronLeft className="size-5" />
+        </Button>
+      ) : (
+        <Skeleton data-slot="loading-back-placeholder" aria-hidden className="size-8 shrink-0 rounded-md" />
+      )}
+      <span className="ml-1 truncate text-base font-semibold">My Bots</span>
+    </header>
+  ) : null
+}
+
+export function BotListSkeleton({
+  onBack,
+  reserveBackSlot = false,
+}: {
+  onBack?: () => void
+  reserveBackSlot?: boolean
+} = {}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {botBackBar(undefined, reserveBackSlot || Boolean(onBack))}
+      <div className="flex flex-1 flex-col gap-6 overflow-y-auto p-6 thin-scrollbar">
+        <header className="flex items-center justify-between gap-4">
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <Skeleton className="h-6 w-24 rounded" />
+            <Skeleton className="h-4 w-full max-w-80 rounded" />
+          </div>
+          <div className="flex items-center gap-1">
+            <Skeleton className="size-9 rounded-md" />
+            <Skeleton className="h-9 w-28 rounded-md" />
+          </div>
+        </header>
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-col gap-3 rounded-lg p-1">
+            <div className="flex h-7 items-center gap-2 px-1">
+              <Skeleton className="size-3 rounded" />
+              <Skeleton className="size-3.5 rounded" />
+              <Skeleton className="h-3 w-28 rounded" />
+              <Skeleton className="size-1.5 rounded-full" />
+              <Skeleton className="ml-auto h-7 w-20 rounded-md" />
+            </div>
+            <div className="flex flex-col gap-3">
+              <BotCardSkeleton />
+              <BotCardSkeleton />
+              <BotCardSkeleton />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export function renderBotListView(
   { onBack }: BotListProps,
   controller: BotListController,
 ) {
-  const backBar = onBack ? (
-    <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border/40 px-6">
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        onClick={onBack}
-        className="text-muted-foreground hover:text-foreground"
-        aria-label="Back"
-      >
-        <ChevronLeft className="size-5" />
-      </Button>
-      <span className="ml-1 truncate text-base font-semibold">My Bots</span>
-    </header>
-  ) : null
+  const backBar = botBackBar(onBack)
 
   if ((controller.isLoading || controller.machinesLoading) && controller.bots.length === 0) {
-    return (
-      <div className="flex min-h-0 flex-1 flex-col">
-        {backBar}
-        <div className="flex flex-col gap-3 p-6">
-          <BotCardSkeleton />
-          <BotCardSkeleton />
-          <BotCardSkeleton />
-        </div>
-      </div>
-    )
+    return <BotListSkeleton onBack={onBack} />
   }
 
   if (controller.bots.length === 0) {

--- a/src/web/src/components/community/channels/channel-header.skeleton.test.ts
+++ b/src/web/src/components/community/channels/channel-header.skeleton.test.ts
@@ -1,0 +1,16 @@
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+import { ChannelHeaderSkeleton } from "./channel-header"
+
+describe("ChannelHeaderSkeleton", () => {
+  it("renders Back geometry without exposing loading interaction", () => {
+    const html = renderToStaticMarkup(
+      createElement(ChannelHeaderSkeleton, { onBack: vi.fn() }),
+    )
+
+    expect(html).toContain('data-slot="loading-back-placeholder"')
+    expect(html).not.toContain("<button")
+    expect(html).not.toContain('aria-label="Back"')
+  })
+})

--- a/src/web/src/components/community/channels/channel-header.tsx
+++ b/src/web/src/components/community/channels/channel-header.tsx
@@ -22,11 +22,18 @@ import { CreateDialogShell } from "../settings/create-dialog-shell"
 // Skeleton header for the loading frame between route change and channel
 // metadata arriving. Same h-12 footprint as <ChannelHeader> so the body below
 // doesn't shift when the real header lands.
-export function ChannelHeaderSkeleton({ onBack }: { onBack?: () => void }) {
+export function ChannelHeaderSkeleton({
+  onBack,
+  reserveBackSlot = false,
+}: {
+  onBack?: () => void
+  reserveBackSlot?: boolean
+}) {
+  const showBackSlot = reserveBackSlot || Boolean(onBack)
   return (
     <header role="banner" className="flex h-12 shrink-0 items-center gap-1 border-b border-border/40 px-3">
-      {onBack && (
-        <Button variant="ghost" size="icon-sm" onClick={onBack} className="text-muted-foreground hover:text-foreground" aria-label="Back"><ChevronLeft className="size-5" /></Button>
+      {showBackSlot && (
+        <Skeleton data-slot="loading-back-placeholder" aria-hidden className="size-8 shrink-0 rounded-md" />
       )}
       <Skeleton className="ml-1 size-6 rounded-md" />
       <Skeleton className="h-4 w-32 rounded" />

--- a/src/web/src/components/community/channels/channel-loading-frame.test.ts
+++ b/src/web/src/components/community/channels/channel-loading-frame.test.ts
@@ -1,0 +1,54 @@
+import { createElement } from "react"
+import TestRenderer, { act } from "react-test-renderer"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("./channel-header", () => ({
+  ChannelHeaderSkeleton: (props: Record<string, unknown>) =>
+    createElement("channel-header-skeleton", props),
+}))
+vi.mock("@/components/community/messages/message-list", () => ({
+  MessageList: (props: Record<string, unknown>) => createElement("message-list", props),
+}))
+vi.mock("@/components/community/messages/composer", () => ({
+  ComposerSkeleton: () => createElement("composer-skeleton"),
+}))
+
+import { ChannelLoadingFrame } from "./channel-loading-frame"
+
+describe("ChannelLoadingFrame", () => {
+  it("composes canonical detail zones and converts a legacy Back handler to inert geometry", () => {
+    const onBack = vi.fn()
+    let renderer!: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(createElement(ChannelLoadingFrame, { onBack }))
+    })
+
+    expect(renderer.root.findByType("channel-header-skeleton").props).toMatchObject({
+      reserveBackSlot: true,
+    })
+    expect(renderer.root.findByType("channel-header-skeleton").props.onBack).toBeUndefined()
+    expect(renderer.root.findByType("message-list").props).toMatchObject({
+      channel: "",
+      messages: [],
+      loading: true,
+    })
+    expect(renderer.root.findAllByType("composer-skeleton")).toHaveLength(1)
+    const tree = renderer.toJSON() as TestRenderer.ReactTestRendererJSON
+    expect(tree.props).toMatchObject({
+      "aria-busy": "true",
+      "aria-label": "Loading conversation",
+    })
+  })
+
+  it("reserves loading Back geometry without exposing an interactive handler", () => {
+    let renderer!: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(createElement(ChannelLoadingFrame, { reserveBackSlot: true }))
+    })
+
+    expect(renderer.root.findByType("channel-header-skeleton").props).toMatchObject({
+      reserveBackSlot: true,
+    })
+    expect(renderer.root.findByType("channel-header-skeleton").props.onBack).toBeUndefined()
+  })
+})

--- a/src/web/src/components/community/channels/channel-loading-frame.tsx
+++ b/src/web/src/components/community/channels/channel-loading-frame.tsx
@@ -1,42 +1,28 @@
-import { Skeleton } from "@/components/ui/skeleton"
+"use client"
 
-export function ChannelLoadingFrame() {
+import { MessageList } from "@/components/community/messages/message-list"
+import { ComposerSkeleton } from "@/components/community/messages/composer"
+import { ChannelHeaderSkeleton } from "./channel-header"
+
+export function ChannelLoadingFrame({
+  onBack,
+  reserveBackSlot = false,
+}: {
+  onBack?: () => void
+  reserveBackSlot?: boolean
+}) {
   return (
     <div
       aria-busy="true"
       aria-label="Loading conversation"
       className="flex min-h-0 min-w-0 flex-1 flex-col"
     >
-      <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border/40 px-3">
-        <Skeleton className="size-4 rounded" />
-        <Skeleton className="h-4 w-40 rounded" />
-        <div className="ml-auto flex items-center gap-2">
-          <Skeleton className="size-7 rounded-md" />
-          <Skeleton className="size-7 rounded-md" />
-          <Skeleton className="size-7 rounded-md" />
-        </div>
-      </header>
-      <main className="flex min-h-0 min-w-0 flex-1 flex-col px-3 py-4">
-        <div className="flex flex-1 flex-col justify-end gap-4">
-          <MessageRowSkeleton width="w-2/3" />
-          <MessageRowSkeleton width="w-4/5" />
-          <MessageRowSkeleton width="w-1/2" />
-        </div>
-        <Skeleton className="mt-4 h-12 w-full shrink-0 rounded-xl" />
+      <ChannelHeaderSkeleton reserveBackSlot={reserveBackSlot || Boolean(onBack)} />
+      <main className="flex min-h-0 min-w-0 flex-1 flex-col">
+        <MessageList channel="" messages={[]} loading onOpenThread={() => {}} />
+        <ComposerSkeleton />
       </main>
       <span className="sr-only">Loading conversation</span>
-    </div>
-  )
-}
-
-function MessageRowSkeleton({ width }: { width: string }) {
-  return (
-    <div className="flex items-start gap-3">
-      <Skeleton className="size-9 shrink-0 rounded-full" />
-      <div className="flex min-w-0 flex-1 flex-col gap-2">
-        <Skeleton className="h-3.5 w-28 rounded" />
-        <Skeleton className={`h-3.5 rounded ${width}`} />
-      </div>
     </div>
   )
 }

--- a/src/web/src/components/community/channels/channel-sidebar.crumb.test.ts
+++ b/src/web/src/components/community/channels/channel-sidebar.crumb.test.ts
@@ -36,6 +36,20 @@ const render = () =>
     }),
   )
 
+const renderLoading = () =>
+  renderToStaticMarkup(
+    createElement(ChannelSidebar, {
+      tree: emptyTree,
+      serverName: "Alpha",
+      serverIcon: null,
+      serverId: "srv_1",
+      activeChannel: "",
+      setActiveChannel: vi.fn(),
+      loading: true,
+      onInvitePopoverOpenChange: vi.fn(),
+    }),
+  )
+
 const forumTree = {
   ...emptyTree,
   catOrder: ["cat_1"],
@@ -98,6 +112,16 @@ describe("ChannelSidebar header", () => {
     const css = readFileSync(new URL("../../../app/globals.css", import.meta.url), "utf8")
     expect(css).toContain(".thin-scrollbar.scrollbar-none")
     expect(css).toContain("scrollbar-width: none")
+  })
+
+  it("keeps the same header action slot and scroll owner while loading", () => {
+    const html = renderLoading()
+    expect(html).toContain("flex min-h-0 min-w-0 flex-1 flex-col")
+    expect(html).toContain(
+      "min-h-0 flex-1 overflow-y-auto px-2 py-4 thin-scrollbar scrollbar-none",
+    )
+    expect(html).toContain("ml-auto size-7 shrink-0 rounded-md")
+    expect(html).not.toContain("overflow-hidden")
   })
 
   it("renders the server name as the sole header identity marker (no duplicate ServerCrumb icon)", () => {

--- a/src/web/src/components/community/channels/channel-sidebar.tsx
+++ b/src/web/src/components/community/channels/channel-sidebar.tsx
@@ -199,7 +199,14 @@ export const ChannelSidebar = memo(function ChannelSidebar({
   // PREVIOUS server's categories for one commit while `loading` has already
   // flipped true. Gating on catOrder would flash the old server's channel list
   // for a frame before collapsing to skeleton.
-  if (loading) return <ChannelSidebarSkeleton noHeader={noHeader} />
+  if (loading) {
+    return (
+      <ChannelSidebarSkeleton
+        noHeader={noHeader}
+        showInviteAction={Boolean(serverId && onInvitePopoverOpenChange)}
+      />
+    )
+  }
 
 
   // Who may create a channel where:
@@ -454,15 +461,22 @@ function ForumSidebarThreadRow({
 
 // Loading placeholder for the channel sidebar. Kept colocated so changes to
 // row density or header height stay in sync with the live sidebar above.
-function ChannelSidebarSkeleton({ noHeader }: { noHeader?: boolean }) {
+function ChannelSidebarSkeleton({
+  noHeader,
+  showInviteAction,
+}: {
+  noHeader?: boolean
+  showInviteAction: boolean
+}) {
   return (
-    <aside className="flex min-w-0 flex-1 flex-col">
+    <aside className="flex min-h-0 min-w-0 flex-1 flex-col">
       {!noHeader && (
-        <header className="flex h-12 items-center border-b border-border/40 px-2">
-          <Skeleton className="h-5 w-32 rounded" />
+        <header className="flex h-12 items-center gap-1 border-b border-border/40 px-2">
+          <Skeleton className="ml-2 h-7 w-32 rounded" />
+          {showInviteAction && <Skeleton className="ml-auto size-7 shrink-0 rounded-md" />}
         </header>
       )}
-      <div className="flex-1 overflow-hidden px-2 py-4">
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 py-4 thin-scrollbar scrollbar-none">
         <div className="mb-4 space-y-1">
           <Skeleton className="h-7 w-full rounded-md" />
           <Skeleton className="h-7 w-11/12 rounded-md" />

--- a/src/web/src/components/community/channels/dm-header.test.ts
+++ b/src/web/src/components/community/channels/dm-header.test.ts
@@ -1,0 +1,21 @@
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+import { DmHeaderSkeleton } from "./dm-header"
+
+describe("DmHeaderSkeleton", () => {
+  it("reserves avatar, title, notification, and optional Back footprints", () => {
+    const desktop = renderToStaticMarkup(createElement(DmHeaderSkeleton))
+    expect(desktop).toContain("size-6 rounded-full")
+    expect(desktop).toContain("h-4 w-32 rounded")
+    expect(desktop).toContain("ml-auto size-7 rounded-md")
+    expect(desktop).not.toContain('aria-label="Back"')
+
+    const mobile = renderToStaticMarkup(
+      createElement(DmHeaderSkeleton, { onBack: vi.fn() }),
+    )
+    expect(mobile).toContain('data-slot="loading-back-placeholder"')
+    expect(mobile).not.toContain("<button")
+    expect(mobile).not.toContain('aria-label="Back"')
+  })
+})

--- a/src/web/src/components/community/channels/dm-header.tsx
+++ b/src/web/src/components/community/channels/dm-header.tsx
@@ -60,10 +60,11 @@ export function DmHeaderSkeleton({ onBack }: { onBack?: () => void }) {
   return (
     <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border/40 px-3">
       {onBack && (
-        <Button variant="ghost" size="icon-sm" onClick={onBack} className="text-muted-foreground hover:text-foreground" aria-label="Back"><ChevronLeft className="size-5" /></Button>
+        <Skeleton data-slot="loading-back-placeholder" aria-hidden className="size-8 shrink-0 rounded-md" />
       )}
       <Skeleton className="size-6 rounded-full" />
       <Skeleton className="h-4 w-32 rounded" />
+      <Skeleton className="ml-auto size-7 rounded-md" />
     </header>
   )
 }

--- a/src/web/src/components/community/channels/forum-view.test.ts
+++ b/src/web/src/components/community/channels/forum-view.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from "vitest"
 import { createElement } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
-import { ForumView, forumTagScrollFades, shouldActivateForumRow } from "./forum-view"
+import {
+  ForumView,
+  ForumViewSkeleton,
+  forumTagScrollFades,
+  shouldActivateForumRow,
+} from "./forum-view"
 import { tid } from "@/lib/community/testids"
 import type { ForumThread } from "@/lib/community/models/message"
 
@@ -286,6 +291,18 @@ describe("ForumView filter bar / composer swap", () => {
     expect(html).not.toContain(tid.forumTagFadeRight)
     expect(listMarkup).toContain("px-0")
     expect(listMarkup).toContain("sm:px-4")
+  })
+
+  it("matches the real responsive filter rail and 28px chip footprints while loading", () => {
+    const html = renderToStaticMarkup(createElement(ForumViewSkeleton))
+    expect(html.match(/h-7/g)).toHaveLength(4)
+    expect(html).not.toContain("h-5 w-10 rounded-full")
+    expect(html).toContain("flex-nowrap")
+    expect(html).toContain("overflow-x-auto")
+    expect(html).toContain("sm:flex-wrap")
+    expect(html).toContain("sm:overflow-x-visible")
+    expect(html).toContain("pointer-events-none")
+    expect(html).toContain("px-0 py-2 sm:px-4")
   })
 })
 

--- a/src/web/src/components/community/channels/forum-view.tsx
+++ b/src/web/src/components/community/channels/forum-view.tsx
@@ -549,18 +549,23 @@ function ForumListSkeleton() {
 export function ForumViewSkeleton() {
   return (
     <>
-      <div className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-2">
-        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
-          <Skeleton className="h-5 w-10 rounded-full" />
-          <Skeleton className="h-5 w-16 rounded-full" />
-          <Skeleton className="h-5 w-14 rounded-full" />
-          <Skeleton className="h-5 w-20 rounded-full" />
+      <div className="flex min-w-0 shrink-0 items-center gap-2 overflow-hidden border-b border-border px-4 py-2">
+        <div className="relative min-w-0 flex-1">
+          <div
+            aria-hidden
+            className="pointer-events-none flex w-full min-w-0 flex-nowrap items-center gap-2 overflow-x-auto overscroll-x-contain thin-scrollbar sm:flex-wrap sm:overflow-x-visible"
+          >
+            <Skeleton className="h-7 w-10 shrink-0 rounded-full" />
+            <Skeleton className="h-7 w-16 shrink-0 rounded-full" />
+            <Skeleton className="h-7 w-14 shrink-0 rounded-full" />
+            <Skeleton className="h-7 w-20 shrink-0 rounded-full" />
+          </div>
         </div>
         <div className="flex shrink-0 items-center gap-1">
           <Skeleton className="h-8 w-25 rounded-md" />
         </div>
       </div>
-      <main className="flex-1 overflow-y-auto thin-scrollbar px-4 py-2">
+      <main className="flex-1 overflow-y-auto thin-scrollbar px-0 py-2 sm:px-4">
         <ForumListSkeleton />
       </main>
     </>

--- a/src/web/src/components/community/machines/machine-list.test.ts
+++ b/src/web/src/components/community/machines/machine-list.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   toastSuccess: vi.fn(),
   toastError: vi.fn(),
   fetchLatestDaemonVersion: vi.fn(),
+  machinesLoading: { current: false },
 }))
 
 vi.mock("sonner", () => ({
@@ -52,12 +53,16 @@ vi.mock("@tanstack/react-query", () => ({
 
 vi.mock("@/components/ui/button", () => ({ Button: () => null }))
 vi.mock("@/components/ui/card", () => ({ Card: () => null }))
-vi.mock("@/components/ui/skeleton", () => ({ Skeleton: () => null }))
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: (props: Record<string, unknown>) => React.createElement("skeleton-row", props),
+}))
 vi.mock("@/components/avatar", () => ({ GeneratedAvatar: () => null }))
 vi.mock("./machine-card", () => ({ MachineCard: () => null }))
 vi.mock("./pair-machine-sheet", () => ({ PairMachineSheet: () => null }))
 vi.mock("@/components/community/onboarding-tiles/connect-tile", () => ({ ConnectTile: () => null }))
-vi.mock("@/hooks/community/use-machines", () => ({ useMachines: () => ({ machines: [], isLoading: false }) }))
+vi.mock("@/hooks/community/use-machines", () => ({
+  useMachines: () => ({ machines: [], isLoading: mocks.machinesLoading.current }),
+}))
 vi.mock("@/hooks/community/use-bots", () => ({ useBots: () => ({ bots: [] }) }))
 vi.mock("@/stores/community", () => ({
   usePendingMachineTokenId: () => null,
@@ -79,6 +84,7 @@ import type { CommunityMachineSummary } from "@alook/shared"
 import {
   canUpdateMachine,
   MachineList,
+  MachineListSkeleton,
   MachineUpdateDialog,
   requestMachineUpdate,
 } from "./machine-list"
@@ -104,6 +110,7 @@ describe("machine daemon update UI", () => {
       version: "0.1.8",
       package: "@alook/daemon",
     })
+    mocks.machinesLoading.current = false
   })
 
   it("loads Community update eligibility from the daemon package endpoint", async () => {
@@ -114,6 +121,42 @@ describe("machine daemon update UI", () => {
 
     expect(mocks.fetchLatestDaemonVersion).toHaveBeenCalledOnce()
     act(() => renderer.unmount())
+  })
+
+  it("keeps the loaded page header, action, card group, and scroll owner while loading", async () => {
+    mocks.machinesLoading.current = true
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(React.createElement(MachineList))
+    })
+
+    expect(renderer.root.findAllByProps({
+      className: "flex flex-1 flex-col gap-6 overflow-y-auto p-6 thin-scrollbar",
+    })).toHaveLength(1)
+    expect(renderer.root.findAllByProps({
+      className: "flex items-center justify-between",
+    })).toHaveLength(1)
+    expect(renderer.root.findAllByProps({
+      className: "flex min-w-0 flex-1 flex-col gap-1",
+    })).toHaveLength(1)
+    expect(renderer.root.findAllByProps({ className: "flex flex-col gap-3" }))
+      .toHaveLength(1)
+    expect(renderer.root.findAllByProps({ className: "h-9 w-36 rounded-md" }))
+      .toHaveLength(2)
+  })
+
+  it("turns a loading Back request into an inert skeleton slot", () => {
+    let renderer!: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(
+        React.createElement(MachineListSkeleton, { onBack: vi.fn() }),
+      )
+    })
+
+    expect(renderer.root.findAll((node) =>
+      typeof node.type === "string" && node.props["data-slot"] === "loading-back-placeholder"))
+      .toHaveLength(1)
+    expect(renderer.root.findAllByProps({ "aria-label": "Back" })).toHaveLength(0)
   })
 
   it("allows every remote controller mode and hides Update only in dev", () => {

--- a/src/web/src/components/community/machines/machine-list.tsx
+++ b/src/web/src/components/community/machines/machine-list.tsx
@@ -67,6 +67,49 @@ function MachineCardSkeleton() {
   )
 }
 
+function machineBackBar(onBack?: () => void, reserveBackSlot = false) {
+  return onBack || reserveBackSlot ? (
+    <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border/40 px-6">
+      {onBack ? (
+        <Button variant="ghost" size="icon-sm" onClick={onBack} className="text-muted-foreground hover:text-foreground" aria-label="Back">
+          <ChevronLeft className="size-5" />
+        </Button>
+      ) : (
+        <Skeleton data-slot="loading-back-placeholder" aria-hidden className="size-8 shrink-0 rounded-md" />
+      )}
+      <span className="ml-1 truncate text-base font-semibold">Machines</span>
+    </header>
+  ) : null
+}
+
+export function MachineListSkeleton({
+  onBack,
+  reserveBackSlot = false,
+}: {
+  onBack?: () => void
+  reserveBackSlot?: boolean
+} = {}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {machineBackBar(undefined, reserveBackSlot || Boolean(onBack))}
+      <div className="flex flex-1 flex-col gap-6 overflow-y-auto p-6 thin-scrollbar">
+        <header className="flex items-center justify-between">
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <Skeleton className="h-6 w-24 rounded" />
+            <Skeleton className="h-4 w-full max-w-56 rounded" />
+          </div>
+          <Skeleton className="h-9 w-36 rounded-md" />
+        </header>
+        <div className="flex flex-col gap-3">
+          <MachineCardSkeleton />
+          <MachineCardSkeleton />
+          <MachineCardSkeleton />
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export function canUpdateMachine(
   machine: Pick<CommunityMachineSummary, "status" | "daemonVersion">,
   latestVersion: string | null,
@@ -290,26 +333,10 @@ export function MachineList({ onBack }: { onBack?: () => void } = {}) {
     ? bots.filter((b) => b.machineId === confirmDelete.id)
     : []
 
-  const backBar = onBack ? (
-    <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border/40 px-6">
-      <Button variant="ghost" size="icon-sm" onClick={onBack} className="text-muted-foreground hover:text-foreground" aria-label="Back">
-        <ChevronLeft className="size-5" />
-      </Button>
-      <span className="ml-1 truncate text-base font-semibold">Machines</span>
-    </header>
-  ) : null
+  const backBar = machineBackBar(onBack)
 
   if (machinesLoading) {
-    return (
-      <div className="flex min-h-0 flex-1 flex-col">
-        {backBar}
-        <div className="flex flex-col gap-3 p-6">
-          <MachineCardSkeleton />
-          <MachineCardSkeleton />
-          <MachineCardSkeleton />
-        </div>
-      </div>
-    )
+    return <MachineListSkeleton onBack={onBack} />
   }
 
   if (machines.length === 0) {
@@ -373,7 +400,7 @@ export function MachineList({ onBack }: { onBack?: () => void } = {}) {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {backBar}
-      <div className="flex flex-1 flex-col gap-6 p-6 overflow-y-auto thin-scrollbar">
+      <div className="flex flex-1 flex-col gap-6 overflow-y-auto p-6 thin-scrollbar">
         <header className="flex items-center justify-between">
           <div>
             <h1 className="text-xl font-medium text-foreground">Machines</h1>

--- a/src/web/src/components/community/members/member-list.test.ts
+++ b/src/web/src/components/community/members/member-list.test.ts
@@ -77,4 +77,20 @@ describe("member action identity contract", () => {
     expect(source).toContain("onSetRole?.(mem.id, r)")
     expect(source).not.toContain("onSetRole?.(mem.name, r)")
   })
+
+  it("keeps loading inside the real toolbar and scroll ownership", () => {
+    const source = fs.readFileSync(
+      path.join(path.dirname(fileURLToPath(import.meta.url)), "member-list.tsx"),
+      "utf8",
+    )
+    expect(source).toContain(
+      "<MemberListSkeleton showSearch={Boolean(onSearch)} showAddMember={Boolean(onAddMember)} />",
+    )
+    expect(source).toContain(
+      'className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-3"',
+    )
+    expect(source).toContain(
+      'className="min-h-0 flex-1 overflow-y-auto thin-scrollbar"',
+    )
+  })
 })

--- a/src/web/src/components/community/members/member-list.tsx
+++ b/src/web/src/components/community/members/member-list.tsx
@@ -186,7 +186,9 @@ export function MemberList({
     return () => observer.disconnect()
   }, [onLoadMore, hasMore, loadingMore])
 
-  if (loading && members.length === 0 && !query) return <MemberListSkeleton />
+  if (loading && members.length === 0 && !query) {
+    return <MemberListSkeleton showSearch={Boolean(onSearch)} showAddMember={Boolean(onAddMember)} />
+  }
 
   return (
     <>
@@ -447,28 +449,42 @@ function MemberRow({
 
 // Loading placeholder for the right-panel Members list — reserves space for
 // two role groups + a body of online members, matching <MemberList>'s grouping.
-function MemberListSkeleton() {
+function MemberListSkeleton({
+  showSearch,
+  showAddMember,
+}: {
+  showSearch: boolean
+  showAddMember: boolean
+}) {
   const groups: { width: number; rows: number }[] = [
     { width: 60, rows: 1 },
     { width: 60, rows: 2 },
     { width: 60, rows: 6 },
   ]
   return (
-    <aside className="flex h-full flex-col overflow-hidden bg-background">
-      <div className="px-4 py-4">
-        {groups.map((g, i) => (
-          <div key={i} className="mb-4">
-            <Skeleton className="mb-2 ml-1 h-3 rounded" style={{ width: g.width }} />
-            <div className="space-y-1">
-              {Array.from({ length: g.rows }).map((_, j) => (
-                <div key={j} className="flex items-center gap-3 rounded-md px-2 py-2">
-                  <Skeleton className="size-8 shrink-0 rounded-full" />
-                  <Skeleton className="h-3.5 w-3/5 rounded" />
-                </div>
-              ))}
+    <aside className="flex h-full flex-col bg-background">
+      {(showSearch || showAddMember) && (
+        <div className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-3">
+          {showSearch && <Skeleton className="h-9 flex-1 rounded-md" />}
+          {showAddMember && <Skeleton className="size-9 shrink-0 rounded-md" />}
+        </div>
+      )}
+      <div className="min-h-0 flex-1 overflow-y-auto thin-scrollbar">
+        <div className="px-4 py-4">
+          {groups.map((g, i) => (
+            <div key={i} className="mb-4">
+              <Skeleton className="mb-2 ml-1 h-3 rounded" style={{ width: g.width }} />
+              <div className="space-y-1">
+                {Array.from({ length: g.rows }).map((_, j) => (
+                  <div key={j} className="flex items-center gap-3 rounded-md px-2 py-2">
+                    <Skeleton className="size-8 shrink-0 rounded-full" />
+                    <Skeleton className="h-3.5 w-3/5 rounded" />
+                  </div>
+                ))}
+              </div>
             </div>
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
     </aside>
   )

--- a/src/web/src/components/community/messages/message-list-view.test.ts
+++ b/src/web/src/components/community/messages/message-list-view.test.ts
@@ -86,7 +86,7 @@ describe("renderMessageListView", () => {
     expect(renderer!.root.findAll((node) => node.props.className === "mb-6")).toHaveLength(1)
   })
 
-  it("keeps the same wrappers while true empty loading hides pill content and typing names", () => {
+  it("keeps the same wrappers while true empty loading omits the interactive accessory rail", () => {
     const listProps = props({ messages: [] })
     const state = controller({ isLoading: true, pillCount: 8 })
     const renderRows = vi.fn(() => React.createElement("virtual-rows"))
@@ -95,10 +95,7 @@ describe("renderMessageListView", () => {
       renderer = TestRenderer.create(renderMessageListView(listProps, state, renderRows))
     })
     expect(renderer!.root.findByType("div").props.className).toBe("relative flex min-h-0 flex-1 flex-col")
-    expect(mockedRail).toHaveBeenCalledWith(expect.objectContaining({
-      typingNames: [],
-      scrollCount: 0,
-    }), undefined)
+    expect(mockedRail).not.toHaveBeenCalled()
     expect(renderRows).not.toHaveBeenCalled()
     expect(renderer!.root.findAll((node) => node.props.className === "mb-6")).toHaveLength(1)
   })

--- a/src/web/src/components/community/messages/message-list-view.tsx
+++ b/src/web/src/components/community/messages/message-list-view.tsx
@@ -13,16 +13,18 @@ export function renderMessageListView(
 ) {
   return (
     <div className="relative flex min-h-0 flex-1 flex-col">
-      <ComposerAccessoryRail
-        typingNames={controller.isLoading ? [] : props.typingUsers ?? []}
-        scrollCount={controller.isLoading ? 0 : controller.pillCount}
-        scrollMode={controller.pillMode}
-        onScroll={controller.pillOnClick}
-        selectMode={controller.selectMode}
-        selectedCount={controller.selectedIds.size}
-        onCancelSelection={controller.exitSelect}
-        onShareSelection={() => controller.setShareOpen(true)}
-      />
+      {!controller.isLoading && (
+        <ComposerAccessoryRail
+          typingNames={props.typingUsers ?? []}
+          scrollCount={controller.pillCount}
+          scrollMode={controller.pillMode}
+          onScroll={controller.pillOnClick}
+          selectMode={controller.selectMode}
+          selectedCount={controller.selectedIds.size}
+          onCancelSelection={controller.exitSelect}
+          onShareSelection={() => controller.setShareOpen(true)}
+        />
+      )}
       {controller.shareOpen && controller.selectedMessages.length > 0 && (
         <MessageShareDialog
           m={controller.selectedMessages}

--- a/src/web/src/components/community/settings/server-settings.skeleton.test.ts
+++ b/src/web/src/components/community/settings/server-settings.skeleton.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+describe("SettingsMembers loading geometry", () => {
+  it("keeps search, count, and the loaded scroll owner", () => {
+    const source = readFileSync(new URL("./server-settings.tsx", import.meta.url), "utf8")
+    expect(source).toContain(
+      "<SettingsMembersSkeleton showSearch={Boolean(onSearch)} />",
+    )
+    expect(source).toContain(
+      'className="mx-auto flex h-full min-h-0 max-w-xl flex-col"',
+    )
+    expect(source).toContain('className="mb-3 h-9 shrink-0 rounded-md"')
+    expect(source).toContain(
+      'className="min-h-0 flex-1 overflow-y-auto thin-scrollbar"',
+    )
+  })
+})

--- a/src/web/src/components/community/settings/server-settings.tsx
+++ b/src/web/src/components/community/settings/server-settings.tsx
@@ -253,7 +253,9 @@ function SettingsMembers({ members, loading, loadingMore, hasMore, total, onLoad
     return () => observer.disconnect()
   }, [onLoadMore, hasMore, loadingMore])
 
-  if (loading && members.length === 0 && !query) return <SettingsMembersSkeleton />
+  if (loading && members.length === 0 && !query) {
+    return <SettingsMembersSkeleton showSearch={Boolean(onSearch)} />
+  }
 
   // Prefer the paginated envelope's total when present — otherwise fall back
   // to the loaded slice size. When searching, `total` still reflects the
@@ -430,21 +432,26 @@ export function SettingsNotifications({ serverId, level, onSetLevel }: { serverI
 
 // Loading placeholders for the settings panels — match the real row heights
 // so the body doesn't shift when data lands.
-function SettingsMembersSkeleton() {
+function SettingsMembersSkeleton({ showSearch }: { showSearch: boolean }) {
   return (
-    <div className="mx-auto max-w-xl space-y-2">
-      <Skeleton className="mb-3 h-4 w-24 rounded" />
-      {Array.from({ length: 5 }).map((_, i) => (
-        <div key={i} className="flex items-center gap-3 rounded-md px-2 py-2">
-          <Skeleton className="size-8 shrink-0 rounded-full" />
-          <div className="flex min-w-0 flex-1 flex-col gap-2">
-            <Skeleton className="h-4 w-2/5 rounded" />
-            <Skeleton className="h-3 w-16 rounded" />
-          </div>
-          <Skeleton className="h-6 w-16 rounded-full" />
-          <Skeleton className="size-7 shrink-0 rounded-md" />
+    <div className="mx-auto flex h-full min-h-0 max-w-xl flex-col">
+      {showSearch && <Skeleton className="mb-3 h-9 shrink-0 rounded-md" />}
+      <Skeleton className="mb-3 h-4 w-24 shrink-0 rounded" />
+      <div className="min-h-0 flex-1 overflow-y-auto thin-scrollbar">
+        <div className="space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-3 rounded-md px-2 py-2">
+              <Skeleton className="size-8 shrink-0 rounded-full" />
+              <div className="flex min-w-0 flex-1 flex-col gap-2">
+                <Skeleton className="h-4 w-2/5 rounded" />
+                <Skeleton className="h-3 w-16 rounded" />
+              </div>
+              <Skeleton className="h-6 w-16 rounded-full" />
+              <Skeleton className="size-7 shrink-0 rounded-md" />
+            </div>
+          ))}
         </div>
-      ))}
+      </div>
     </div>
   )
 }

--- a/src/web/src/components/community/shell/community-pending-frame.test.ts
+++ b/src/web/src/components/community/shell/community-pending-frame.test.ts
@@ -1,0 +1,58 @@
+import { createElement } from "react"
+import TestRenderer, { act } from "react-test-renderer"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/components/community/machines/machine-list", () => ({
+  MachineListSkeleton: (props: Record<string, unknown>) => createElement("machine-skeleton", props),
+}))
+vi.mock("@/components/community/bots/bot-list-view", () => ({
+  BotListSkeleton: (props: Record<string, unknown>) => createElement("bot-skeleton", props),
+}))
+vi.mock("@/components/community/social/friends-page", () => ({
+  FriendsPage: (props: Record<string, unknown>) => createElement("friends-skeleton", props),
+}))
+vi.mock("@/components/community/channels/channel-loading-frame", () => ({
+  ChannelLoadingFrame: (props: Record<string, unknown>) => createElement("channel-skeleton", props),
+}))
+
+import { CommunityPendingFrame } from "./community-pending-frame"
+
+function render(href: string, reserveBackSlot = true) {
+  let renderer!: TestRenderer.ReactTestRenderer
+  act(() => {
+    renderer = TestRenderer.create(createElement(CommunityPendingFrame, { href, reserveBackSlot }))
+  })
+  return renderer
+}
+
+describe("CommunityPendingFrame", () => {
+  it("selects destination-specific @me skeletons and reserves a non-interactive Back slot", () => {
+    const machines = render("/c/me/machines?from=shortcut")
+    expect(machines.root.findByType("machine-skeleton").props).toMatchObject({
+      reserveBackSlot: true,
+    })
+    expect(machines.root.findByType("machine-skeleton").props.onBack).toBeUndefined()
+
+    const bots = render("/c/me/bots")
+    expect(bots.root.findByType("bot-skeleton").props.reserveBackSlot).toBe(true)
+    expect(bots.root.findByType("bot-skeleton").props.onBack).toBeUndefined()
+
+    const friends = render("/c/me/friends#new")
+    expect(friends.root.findByType("friends-skeleton").props).toMatchObject({
+      friends: [],
+      pending: [],
+      blocked: [],
+      loading: true,
+      reserveBackSlot: true,
+    })
+    expect(friends.root.findByType("friends-skeleton").props.onBack).toBeUndefined()
+  })
+
+  it("uses the canonical conversation skeleton for DM and channel details", () => {
+    for (const href of ["/c/me/dm_1", "/c/channels/s1/c1"] ) {
+      const result = render(href)
+      expect(result.root.findByType("channel-skeleton").props.reserveBackSlot).toBe(true)
+      expect(result.root.findByType("channel-skeleton").props.onBack).toBeUndefined()
+    }
+  })
+})

--- a/src/web/src/components/community/shell/community-pending-frame.tsx
+++ b/src/web/src/components/community/shell/community-pending-frame.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { BotListSkeleton } from "@/components/community/bots/bot-list-view"
+import { ChannelLoadingFrame } from "@/components/community/channels/channel-loading-frame"
+import { MachineListSkeleton } from "@/components/community/machines/machine-list"
+import { FriendsPage } from "@/components/community/social/friends-page"
+
+export function CommunityPendingFrame({
+  href,
+  reserveBackSlot = false,
+}: {
+  href: string
+  reserveBackSlot?: boolean
+}) {
+  const pathname = href.split(/[?#]/, 1)[0]
+  if (pathname === "/c/me/machines") return <MachineListSkeleton reserveBackSlot={reserveBackSlot} />
+  if (pathname === "/c/me/bots") return <BotListSkeleton reserveBackSlot={reserveBackSlot} />
+  if (pathname === "/c/me/friends") {
+    return (
+      <FriendsPage
+        friends={[]}
+        pending={[]}
+        blocked={[]}
+        loading
+        reserveBackSlot={reserveBackSlot}
+      />
+    )
+  }
+  return <ChannelLoadingFrame reserveBackSlot={reserveBackSlot} />
+}

--- a/src/web/src/components/community/shell/shell-frame-view.test.ts
+++ b/src/web/src/components/community/shell/shell-frame-view.test.ts
@@ -36,8 +36,8 @@ vi.mock("./community-inbox-popover", () => ({
 vi.mock("./shell-frame-overlays", () => ({
   ShellFrameOverlays: (props: Record<string, unknown>) => createElement("shell-overlays", props),
 }))
-vi.mock("@/components/community/channels/channel-loading-frame", () => ({
-  ChannelLoadingFrame: () => createElement("channel-loading-frame"),
+vi.mock("./community-pending-frame", () => ({
+  CommunityPendingFrame: (props: Record<string, unknown>) => createElement("channel-loading-frame", props),
 }))
 
 const rail = { railProps: { activeServerId: "s1" } } as never
@@ -72,12 +72,13 @@ describe("ShellFrameView", () => {
     vi.stubGlobal("ResizeObserver", ResizeObserverMock)
   })
 
-  it("shows one stable loading frame while the breakpoint is unknown", async () => {
+  it("keeps responsive detail shell zones while the breakpoint is unknown", async () => {
     let renderer!: TestRenderer.ReactTestRenderer
     await act(async () => {
       renderer = TestRenderer.create(createElement(ShellFrameView, {
         breakpoint: "unknown",
         surface: "detail",
+        loadingHref: "/c/me/dm_1",
         navigationPending: false,
         sidebar: () => createElement("sidebar-content"),
         cancelPendingNavigation: vi.fn(),
@@ -86,8 +87,36 @@ describe("ShellFrameView", () => {
         inbox,
       }, createElement("main-content")))
     })
+    expect(renderer.root.findAllByType("channel-loading-frame")).toHaveLength(2)
+    expect(renderer.root.findAllByType("server-rail")).toHaveLength(1)
+    expect(renderer.root.findAllByProps({ className: "hidden sm:contents" })).toHaveLength(1)
+    expect(renderer.root.findAllByType("sidebar-content")).toHaveLength(1)
+    expect(renderer.root.findAllByType("user-bar")).toHaveLength(1)
+    expect(renderer.root.findByProps({ "data-slot": "community-user-bar-overlay" }).props.className)
+      .toContain("max-sm:hidden")
+    expect(renderer.root.findAllByType("main-content")).toHaveLength(0)
+    expect(renderer.root.findAllByType("shell-overlays")).toHaveLength(0)
+  })
+
+  it("keeps rail, sidebar, and UserBar in the unknown list shell", async () => {
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(ShellFrameView, {
+        breakpoint: "unknown",
+        surface: "list",
+        loadingHref: "/c/me",
+        navigationPending: false,
+        sidebar: () => createElement("sidebar-content"),
+        cancelPendingNavigation: vi.fn(),
+        rail,
+        profile,
+        inbox,
+      }, createElement("main-content")))
+    })
+    expect(renderer.root.findAllByType("server-rail")).toHaveLength(1)
+    expect(renderer.root.findAllByType("sidebar-content")).toHaveLength(1)
+    expect(renderer.root.findAllByType("user-bar")).toHaveLength(1)
     expect(renderer.root.findAllByType("channel-loading-frame")).toHaveLength(1)
-    expect(renderer.root.findAllByType("server-rail")).toHaveLength(0)
     expect(renderer.root.findAllByType("main-content")).toHaveLength(0)
   })
 
@@ -98,6 +127,7 @@ describe("ShellFrameView", () => {
       renderer = TestRenderer.create(createElement(ShellFrameView, {
         breakpoint: "desktop",
         surface: "detail",
+        loadingHref: "/c/channels/s1/c1",
         navigationPending: false,
         sidebar,
         cancelPendingNavigation: vi.fn(),
@@ -149,6 +179,7 @@ describe("ShellFrameView", () => {
       renderer = TestRenderer.create(createElement(ShellFrameView, {
         breakpoint: "desktop",
         surface: "list",
+        loadingHref: "/c/channels/s1",
         navigationPending: false,
         sidebar,
         cancelPendingNavigation: vi.fn(),
@@ -173,6 +204,7 @@ describe("ShellFrameView", () => {
       renderer = TestRenderer.create(createElement(ShellFrameView, {
         breakpoint: "mobile",
         surface: "list",
+        loadingHref: "/c/me",
         navigationPending: false,
         sidebar,
         cancelPendingNavigation: vi.fn(),
@@ -211,6 +243,7 @@ describe("ShellFrameView", () => {
       renderer.update(createElement(ShellFrameView, {
         breakpoint: "mobile",
         surface: "detail",
+        loadingHref: "/c/me/dm_1",
         navigationPending: false,
         sidebar,
         cancelPendingNavigation: vi.fn(),
@@ -240,6 +273,7 @@ describe("ShellFrameView", () => {
     }
     const common = {
       surface: "detail" as const,
+      loadingHref: "/c/me/dm_1",
       navigationPending: false,
       sidebar: () => createElement("sidebar-content"),
       cancelPendingNavigation: vi.fn(),
@@ -275,6 +309,7 @@ describe("ShellFrameView", () => {
     const sidebar = vi.fn(() => createElement("sidebar-content"))
     const common = {
       surface: "list" as const,
+      loadingHref: "/c/me",
       navigationPending: false,
       sidebar,
       cancelPendingNavigation: vi.fn(),
@@ -318,6 +353,7 @@ describe("ShellFrameView", () => {
     const sidebar = vi.fn(() => createElement("sidebar-content"))
     const common = {
       sidebar,
+      loadingHref: "/c/me/friends",
       cancelPendingNavigation: vi.fn(),
       navigationPending: true,
       rail,
@@ -334,6 +370,8 @@ describe("ShellFrameView", () => {
     })
     expect(renderer.root.findAllByType("channel-loading-frame")).toHaveLength(1)
     expect(renderer.root.findAllByType("main-content")).toHaveLength(0)
+    expect(renderer.root.findAllByType("server-rail")).toHaveLength(1)
+    expect(renderer.root.findAllByType("user-bar")).toHaveLength(1)
 
     await act(async () => {
       renderer.update(createElement(
@@ -343,6 +381,15 @@ describe("ShellFrameView", () => {
       ))
     })
     expect(renderer.root.findAllByType("channel-loading-frame")).toHaveLength(1)
+    expect(renderer.root.findAllByType("server-rail")).toHaveLength(1)
+    expect(renderer.root.findAllByType("sidebar-content")).toHaveLength(1)
+    expect(renderer.root.findAllByType("user-bar")).toHaveLength(1)
+    expect(renderer.root.findAll((node) =>
+      typeof node.props.className === "string" &&
+      node.props.className.includes("absolute inset-0 z-20")))
+      .toHaveLength(0)
+    expect(renderer.root.findAllByType("panel")[1]!.findAllByType("channel-loading-frame"))
+      .toHaveLength(1)
 
     await act(async () => {
       renderer.update(createElement(
@@ -353,5 +400,9 @@ describe("ShellFrameView", () => {
     })
     expect(renderer.root.findAllByType("channel-loading-frame")).toHaveLength(1)
     expect(renderer.root.findAllByType("main-content")).toHaveLength(0)
+    expect(renderer.root.findAllByType("server-rail")).toHaveLength(0)
+    expect(renderer.root.findAllByType("user-bar")).toHaveLength(0)
+    expect(renderer.root.findByType("channel-loading-frame").props.reserveBackSlot).toBe(true)
+    expect(renderer.root.findByType("channel-loading-frame").props.onBack).toBeUndefined()
   })
 })

--- a/src/web/src/components/community/shell/shell-frame-view.tsx
+++ b/src/web/src/components/community/shell/shell-frame-view.tsx
@@ -1,10 +1,10 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useRef, useState, type CSSProperties } from "react"
 import { useDefaultLayout } from "react-resizable-panels"
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable"
 import { AppSurface } from "@/components/ui/app-surface"
-import { ChannelLoadingFrame } from "@/components/community/channels/channel-loading-frame"
+import { CommunityPendingFrame } from "./community-pending-frame"
 import { Shell } from "./shell"
 import { ServerRail } from "./server-rail"
 import { UserBar } from "./user-bar"
@@ -25,6 +25,7 @@ import type { useShellInboxController } from "./use-shell-inbox-controller"
 type Props = Pick<ShellFrameProps, "sidebar" | "children" | "extraDialogs"> & {
   breakpoint: Breakpoint
   surface: CommunitySurface
+  loadingHref: string
   cancelPendingNavigation: () => void
   navigationPending: boolean
   rail: ReturnType<typeof useShellRailController>
@@ -37,6 +38,7 @@ const SHELL_SURFACE_CLASS = "rounded-tl-xl rounded-tr-none rounded-br-none round
 export function ShellFrameView({
   breakpoint,
   surface,
+  loadingHref,
   sidebar,
   children,
   extraDialogs,
@@ -72,29 +74,33 @@ export function ShellFrameView({
   const isDesktop = breakpoint === "desktop"
   const isMobileList = breakpoint === "mobile" && surface === "list"
   const isMobileDetail = breakpoint === "mobile" && surface === "detail"
-  if (breakpoint === "unknown") {
-    return (
-      <Shell onNavigationIntent={cancelPendingNavigation}>
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background">
-          <ChannelLoadingFrame />
-        </div>
-      </Shell>
-    )
-  }
+  const isInitial = breakpoint === "unknown"
+  const isInitialDetail = isInitial && surface === "detail"
+  const showUserBar = isDesktop || isMobileList || isInitial
+  const initialUserBarStyle = {
+    "--community-desktop-user-bar-width": `${desktopUserBarOverlayWidth(sidebarWidth)}px`,
+    marginLeft: -COMMUNITY_RAIL_WIDTH,
+  } as CSSProperties
 
   return (
     <Shell onNavigationIntent={cancelPendingNavigation}>
-      {!isMobileDetail && <ServerRail {...rail.railProps} bottomInset={60} />}
+      {!isMobileDetail && (
+        <div className={cn(isInitialDetail && "hidden sm:contents")}>
+          <ServerRail {...rail.railProps} bottomInset={60} />
+        </div>
+      )}
       <div
         className={cn(
           "relative flex min-h-0 min-w-0 flex-1 flex-col",
-          !isMobileDetail && "pt-2",
+          !isMobileDetail && !isInitialDetail && "pt-2",
+          isInitialDetail && "pt-0 sm:pt-2",
         )}
       >
         <AppSurface
           className={cn(
             SHELL_SURFACE_CLASS,
             isMobileDetail && "rounded-none border-0 bg-background shadow-none ring-0",
+            isInitialDetail && "max-sm:rounded-none max-sm:border-0 max-sm:bg-background max-sm:shadow-none max-sm:ring-0",
           )}
         >
           <ResizablePanelGroup
@@ -117,7 +123,9 @@ export function ShellFrameView({
               data-mobile-active={isMobileList || undefined}
               className={cn(
                 "flex flex-col bg-sidebar",
-                (isDesktop || isMobileList) && "pb-15",
+                (isDesktop || isMobileList || isInitial) && "pb-15",
+                isInitial && surface === "list" && "max-sm:flex-1!",
+                isInitialDetail && "max-sm:hidden",
               )}
             >
               <div ref={sidebarPanelRef} className="flex min-h-0 min-w-0 flex-1 flex-col">
@@ -132,26 +140,49 @@ export function ShellFrameView({
               data-mobile-active={isMobileDetail || undefined}
               className={cn(
                 "flex min-w-0 flex-col bg-background",
+                isInitial && surface === "list" && "max-sm:hidden",
+                isInitialDetail && "max-sm:flex-1!",
               )}
             >
-              {navigationPending && !isMobileList ? <ChannelLoadingFrame /> : children}
+              {navigationPending || isInitial ? (
+                isInitialDetail ? (
+                  <>
+                    <div className="flex min-h-0 flex-1 sm:hidden">
+                      <CommunityPendingFrame href={loadingHref} reserveBackSlot />
+                    </div>
+                    <div className="hidden min-h-0 flex-1 sm:flex">
+                      <CommunityPendingFrame href={loadingHref} />
+                    </div>
+                  </>
+                ) : (
+                  <CommunityPendingFrame
+                    href={loadingHref}
+                    reserveBackSlot={isMobileDetail}
+                  />
+                )
+              ) : children}
             </ResizablePanel>
           </ResizablePanelGroup>
         </AppSurface>
 
-        {(isDesktop || isMobileList) && (
+        {showUserBar && (
           <div
             data-slot="community-user-bar-overlay"
-            className="absolute bottom-0 left-0 z-10"
+            className={cn(
+              "absolute bottom-0 left-0 z-10",
+              isInitial && "w-[calc(100%+3.5rem)] sm:w-(--community-desktop-user-bar-width)",
+              isInitialDetail && "max-sm:hidden",
+            )}
             style={isDesktop
               ? {
                   width: desktopUserBarOverlayWidth(sidebarWidth),
                   marginLeft: -COMMUNITY_RAIL_WIDTH,
                 }
-              : {
+              : isMobileList ? {
                   width: `calc(100% + ${COMMUNITY_RAIL_WIDTH}px)`,
                   marginLeft: -COMMUNITY_RAIL_WIDTH,
-                }}
+                }
+              : initialUserBarStyle}
           >
             <UserBar
               user={user}
@@ -165,23 +196,20 @@ export function ShellFrameView({
           </div>
         )}
 
-        {isMobileList && navigationPending && (
-          <div className="absolute inset-0 z-20 flex bg-background">
-            <ChannelLoadingFrame />
-          </div>
-        )}
       </div>
-      <ShellFrameOverlays
-        controller={profile}
-        breakpoint={breakpoint}
-        {...(isDesktop && profile.profile ? {
-          profileStatusSeeds: {
-            initialStatusEmoji: profile.profile.initialStatusEmoji,
-            initialStatusText: profile.profile.initialStatusText,
-          },
-        } : {})}
-        extraDialogs={extraDialogs}
-      />
+      {!isInitial && (
+        <ShellFrameOverlays
+          controller={profile}
+          breakpoint={breakpoint}
+          {...(isDesktop && profile.profile ? {
+            profileStatusSeeds: {
+              initialStatusEmoji: profile.profile.initialStatusEmoji,
+              initialStatusText: profile.profile.initialStatusText,
+            },
+          } : {})}
+          extraDialogs={extraDialogs}
+        />
+      )}
     </Shell>
   )
 }

--- a/src/web/src/components/community/shell/shell-frame.test.ts
+++ b/src/web/src/components/community/shell/shell-frame.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => {
   }
   return {
     currentHref: { current: "/c/channels/s1" },
+    pendingHref: { current: null as string | null },
     breakpoint: { current: "desktop" },
     onboardingState: { current: null as Record<string, unknown> | null },
     replace: vi.fn(),
@@ -42,6 +43,7 @@ vi.mock("./use-community-navigation-controller", () => ({
   useCommunityNavigationController: () => ({
     currentHref: mocks.currentHref.current,
     navigationPending: false,
+    pendingHref: mocks.pendingHref.current,
     push: mocks.push,
     replace: mocks.replace,
     prefetch: vi.fn(),
@@ -76,6 +78,7 @@ const baseProps = {
 describe("ShellFrame orchestration", () => {
   beforeEach(() => {
     mocks.currentHref.current = "/c/channels/s1"
+    mocks.pendingHref.current = null
     mocks.breakpoint.current = "desktop"
     mocks.onboardingState.current = null
     mocks.registerUiHandlers.mockClear()
@@ -91,12 +94,32 @@ describe("ShellFrame orchestration", () => {
       renderer = TestRenderer.create(createElement(ShellFrame, baseProps))
     })
     expect(renderer.root.findByType("shell-frame-view").props.surface).toBe("list")
+    expect(renderer.root.findByType("shell-frame-view").props.loadingHref).toBe("/c/channels/s1")
 
     mocks.currentHref.current = "/c/channels/s1/c1?keep=1"
     await act(async () => {
       renderer.update(createElement(ShellFrame, baseProps, "next"))
     })
     expect(renderer.root.findByType("shell-frame-view").props.surface).toBe("detail")
+  })
+
+  it("uses the pending destination surface before the committed href changes", async () => {
+    mocks.currentHref.current = "/c/channels/s1/c1"
+    mocks.pendingHref.current = "/c/channels/s1"
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(ShellFrame, baseProps))
+    })
+    expect(renderer.root.findByType("shell-frame-view").props.surface).toBe("list")
+    expect(renderer.root.findByType("shell-frame-view").props.loadingHref).toBe("/c/channels/s1")
+
+    mocks.pendingHref.current = "/c/me/dm_1?from=inbox"
+    await act(async () => {
+      renderer.update(createElement(ShellFrame, baseProps, "next"))
+    })
+    expect(renderer.root.findByType("shell-frame-view").props.surface).toBe("detail")
+    expect(renderer.root.findByType("shell-frame-view").props.loadingHref)
+      .toBe("/c/me/dm_1?from=inbox")
   })
 
   it("replaces a mobile detail with its semantic parent", async () => {

--- a/src/web/src/components/community/shell/shell-frame.tsx
+++ b/src/web/src/components/community/shell/shell-frame.tsx
@@ -31,6 +31,8 @@ export function ShellFrame(props: ShellFrameProps) {
   const replacePath = navigation.replace
   const pathname = navigation.currentHref.split("?")[0]!
   const route = resolveCommunityRoute(pathname)
+  const pendingPathname = navigation.pendingHref?.split("?")[0]
+  const pendingRoute = pendingPathname ? resolveCommunityRoute(pendingPathname) : null
 
   const rail = useShellRailController({
     navigation,
@@ -92,7 +94,8 @@ export function ShellFrame(props: ShellFrameProps) {
   return (
     <ShellFrameView
       breakpoint={breakpoint}
-      surface={route.surface}
+      surface={pendingRoute?.surface ?? route.surface}
+      loadingHref={navigation.pendingHref ?? navigation.currentHref}
       sidebar={sidebar}
       extraDialogs={extraDialogs}
       cancelPendingNavigation={navigation.cancelPendingNavigation}

--- a/src/web/src/components/community/shell/use-community-navigation-controller.test.ts
+++ b/src/web/src/components/community/shell/use-community-navigation-controller.test.ts
@@ -55,14 +55,17 @@ describe("useCommunityNavigationController", () => {
   it("sets pending immediately and clears it after the committed href changes", async () => {
     const hook = await renderController()
     expect(hook.current.navigationPending).toBe(false)
+    expect(hook.current.pendingHref).toBeNull()
 
     await act(async () => hook.current.push("/c/me/friends"))
     expect(mocks.push).toHaveBeenCalledWith("/c/me/friends")
     expect(hook.current.navigationPending).toBe(true)
+    expect(hook.current.pendingHref).toBe("/c/me/friends")
 
     mocks.pathname.current = "/c/me/friends"
     await hook.rerender()
     expect(hook.current.navigationPending).toBe(false)
+    expect(hook.current.pendingHref).toBeNull()
   })
 
   it("uses replace for semantic parent navigation", async () => {
@@ -70,6 +73,7 @@ describe("useCommunityNavigationController", () => {
     await act(async () => hook.current.replace("/c/channels/s1"))
     expect(mocks.replace).toHaveBeenCalledWith("/c/channels/s1")
     expect(mocks.push).not.toHaveBeenCalled()
+    expect(hook.current.pendingHref).toBe("/c/channels/s1")
   })
 
   it("commits only the latest async destination", async () => {
@@ -85,12 +89,40 @@ describe("useCommunityNavigationController", () => {
       firstResult = hook.current.resolveAndPush(() => first)
       secondResult = hook.current.resolveAndPush(() => second)
     })
-    resolveFirst("/c/channels/s1/c1")
-    resolveSecond("/c/channels/s2/c2")
-
-    await expect(firstResult).resolves.toBe(false)
-    await expect(secondResult).resolves.toBe(true)
+    await act(async () => {
+      resolveFirst("/c/channels/s1/c1")
+      resolveSecond("/c/channels/s2/c2")
+      await expect(firstResult).resolves.toBe(false)
+      await expect(secondResult).resolves.toBe(true)
+    })
     expect(mocks.push).toHaveBeenCalledTimes(1)
     expect(mocks.push).toHaveBeenCalledWith("/c/channels/s2/c2")
+    expect(hook.current.pendingHref).toBe("/c/channels/s2/c2")
+  })
+
+  it("clears pending destination state on cancellation and async failure", async () => {
+    const hook = await renderController()
+    await act(async () => hook.current.push("/c/me/friends"))
+    expect(hook.current.pendingHref).toBe("/c/me/friends")
+
+    await act(async () => hook.current.cancelPendingNavigation())
+    expect(hook.current.navigationPending).toBe(false)
+    expect(hook.current.pendingHref).toBeNull()
+
+    await expect(act(async () => {
+      await hook.current.resolveAndPush(async () => {
+        throw new Error("lookup failed")
+      })
+    })).rejects.toThrow("lookup failed")
+    expect(hook.current.navigationPending).toBe(false)
+    expect(hook.current.pendingHref).toBeNull()
+  })
+
+  it("does not enter pending state for the committed href", async () => {
+    const hook = await renderController()
+    await act(async () => hook.current.push("/c/me"))
+    expect(mocks.push).not.toHaveBeenCalled()
+    expect(hook.current.navigationPending).toBe(false)
+    expect(hook.current.pendingHref).toBeNull()
   })
 })

--- a/src/web/src/components/community/shell/use-community-navigation-controller.ts
+++ b/src/web/src/components/community/shell/use-community-navigation-controller.ts
@@ -12,6 +12,7 @@ import type { ShellRouter } from "./shell-frame-types"
 export type CommunityNavigationController = {
   currentHref: string
   navigationPending: boolean
+  pendingHref: string | null
   push: (href: string) => void
   replace: (href: string) => void
   prefetch: (href: string) => void
@@ -27,21 +28,25 @@ export function useCommunityNavigationController(): CommunityNavigationControlle
   const currentHref = search ? `${pathname}?${search}` : pathname
   const gateRef = useRef(createNavigationIntentGate())
   const [navigationPending, setNavigationPending] = useState(false)
+  const [pendingHref, setPendingHref] = useState<string | null>(null)
 
   const cancelPendingNavigation = useCallback(() => {
     supersedeNavigationIntent(gateRef.current)
     setNavigationPending(false)
+    setPendingHref(null)
   }, [])
 
   useEffect(() => {
     supersedeNavigationIntent(gateRef.current)
     setNavigationPending(false)
+    setPendingHref(null)
   }, [currentHref])
 
   const push = useCallback((href: string) => {
     if (href === currentHref) return
     supersedeNavigationIntent(gateRef.current)
     setNavigationPending(true)
+    setPendingHref(href)
     router.push(href)
   }, [currentHref, router])
 
@@ -49,21 +54,26 @@ export function useCommunityNavigationController(): CommunityNavigationControlle
     if (href === currentHref) return
     supersedeNavigationIntent(gateRef.current)
     setNavigationPending(true)
+    setPendingHref(href)
     router.replace(href)
   }, [currentHref, router])
 
   const resolveAndPush = useCallback(async (resolve: () => Promise<string>) => {
     setNavigationPending(true)
+    setPendingHref(null)
     try {
       return await commitLatestNavigationIntent(gateRef.current, resolve, (href) => {
         if (href === currentHref) {
           setNavigationPending(false)
+          setPendingHref(null)
           return
         }
+        setPendingHref(href)
         router.push(href)
       })
     } catch (error) {
       setNavigationPending(false)
+      setPendingHref(null)
       throw error
     }
   }, [currentHref, router])
@@ -71,6 +81,7 @@ export function useCommunityNavigationController(): CommunityNavigationControlle
   return {
     currentHref,
     navigationPending,
+    pendingHref,
     push,
     replace,
     prefetch: router.prefetch,

--- a/src/web/src/components/community/social/community-invite-card.test.ts
+++ b/src/web/src/components/community/social/community-invite-card.test.ts
@@ -40,6 +40,14 @@ describe("resolveInviteCardPresentation", () => {
 })
 
 describe("invite-card perspective wiring", () => {
+  it("keeps loading on the real three-line text footprint", () => {
+    const card = readComponent("community-invite-card.tsx")
+    expect(card).toContain('className="min-w-0 flex-1 space-y-1"')
+    expect(card).toContain('className="h-3 w-32 rounded"')
+    expect(card).toContain('className="h-4 w-24 rounded"')
+    expect(card).toContain('className="h-3 w-16 rounded"')
+  })
+
   it("derives sender perspective from the message author and viewer", () => {
     const message = readComponent("../messages/message.tsx")
 

--- a/src/web/src/components/community/social/community-invite-card.tsx
+++ b/src/web/src/components/community/social/community-invite-card.tsx
@@ -92,8 +92,9 @@ export function CommunityInviteCard({
         data-perspective={perspective}
       >
         <Skeleton className="size-12 shrink-0 rounded-lg" />
-        <div className="min-w-0 flex-1 space-y-2">
-          <Skeleton className="h-3 w-24 rounded" />
+        <div className="min-w-0 flex-1 space-y-1">
+          <Skeleton className="h-3 w-32 rounded" />
+          <Skeleton className="h-4 w-24 rounded" />
           <Skeleton className="h-3 w-16 rounded" />
         </div>
         {perspective === "recipient" && <Skeleton className="h-8 w-16 rounded-md" />}

--- a/src/web/src/components/community/social/friends-page.skeleton.test.ts
+++ b/src/web/src/components/community/social/friends-page.skeleton.test.ts
@@ -1,0 +1,40 @@
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+import { FriendsPage } from "./friends-page"
+
+describe("FriendsPage loading header", () => {
+  it("keeps Back geometry inert until the real page is loaded", () => {
+    const html = renderToStaticMarkup(createElement(FriendsPage, {
+      friends: [],
+      pending: [],
+      blocked: [],
+      loading: true,
+      onBack: vi.fn(),
+    }))
+
+    expect(html).toContain('data-slot="loading-back-placeholder"')
+    expect(html).not.toContain("<button")
+    expect(html).not.toContain("<input")
+    expect(html).not.toContain('aria-label="Back"')
+  })
+
+  it("keeps the real Back control during a warm-data refresh", () => {
+    const html = renderToStaticMarkup(createElement(FriendsPage, {
+      friends: [{
+        id: "friend_1",
+        userId: "user_1",
+        name: "Alice",
+        discriminator: "0001",
+        avatar: "A",
+        status: "online",
+      }],
+      pending: [],
+      blocked: [],
+      loading: true,
+      onBack: vi.fn(),
+    }))
+
+    expect(html).toContain('aria-label="Back"')
+  })
+})

--- a/src/web/src/components/community/social/friends-page.tsx
+++ b/src/web/src/components/community/social/friends-page.tsx
@@ -33,7 +33,7 @@ function FriendSection({ title, count, emptyLabel, children }: {
 
 // Friends page (@me, no DM selected) — All (friends + blocked) / New (add friend + pending).
 export function FriendsPage({
-  friends, pending, blocked, loading, onBack,
+  friends, pending, blocked, loading, onBack, reserveBackSlot = false,
   onAccept, onReject, onCancelRequest, onUnblock, onSendRequest, onRemoveFriend, onBlock, onDm,
 }: {
   friends: Friend[]
@@ -41,6 +41,7 @@ export function FriendsPage({
   blocked: BlockedUser[]
   loading?: boolean
   onBack?: () => void
+  reserveBackSlot?: boolean
   onOpenProfile?: OpenProfile
   onAccept?: (id: string) => void
   onReject?: (id: string) => void
@@ -98,6 +99,38 @@ export function FriendsPage({
     }, 300)
     return () => { if (debounceRef.current) clearTimeout(debounceRef.current) }
   }, [addValue])
+
+  if (loading && friends.length === 0 && pending.length === 0 && blocked.length === 0) {
+    return (
+      <div
+        aria-busy="true"
+        aria-label="Loading friends"
+        className="flex min-h-0 min-w-0 flex-1 flex-col gap-2"
+      >
+        <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border/40 px-4">
+          {(reserveBackSlot || Boolean(onBack)) && (
+            <Skeleton data-slot="loading-back-placeholder" aria-hidden className="size-8 shrink-0 rounded-md" />
+          )}
+          <div aria-hidden className="inline-flex h-8 items-center gap-1 p-0.75 text-muted-foreground">
+            <span className="inline-flex h-[calc(100%-1px)] items-center px-2 py-1 text-sm font-medium">All</span>
+            <span className="inline-flex h-[calc(100%-1px)] items-center px-2 py-1 text-sm font-medium">New</span>
+          </div>
+        </header>
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto thin-scrollbar p-4">
+          <Skeleton className="mb-4 h-11 w-full rounded-md" />
+          <div className="flex min-h-0 flex-col">
+            <div className="mb-2 text-xs font-semibold text-muted-foreground">All friends — …</div>
+            <FriendRowsSkeleton />
+          </div>
+          <div className="mt-8 flex min-h-0 flex-col">
+            <div className="mb-2 text-xs font-semibold text-muted-foreground">Blocked — …</div>
+            <FriendRowsSkeleton withActions />
+          </div>
+        </div>
+        <span className="sr-only">Loading friends</span>
+      </div>
+    )
+  }
 
   const sendRequest = (u: { id: string; name: string; discriminator: string }) => {
     onSendRequest?.({ userId: u.id, username: `${u.name}#${u.discriminator}` })

--- a/src/web/src/components/community/social/invite-dialog.test.ts
+++ b/src/web/src/components/community/social/invite-dialog.test.ts
@@ -1,6 +1,7 @@
 import { createElement } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { readFileSync } from "node:fs"
 import type { Friend } from "@/lib/community/models/people"
 
 const { toastSpy } = vi.hoisted(() => ({ toastSpy: vi.fn() }))
@@ -85,6 +86,15 @@ describe("InviteFriendRow", () => {
     const html = renderRow({ invited: true })
     expect(html).toContain(">Invited<")
     expect(hasDisabledButton(html)).toBe(true)
+  })
+
+  it("keeps loading rows on the real row padding and trailing action footprint", () => {
+    const source = readFileSync(new URL("./invite-dialog.tsx", import.meta.url), "utf8")
+    expect(source).toContain('<div data-slot="invite-friends-loading">')
+    expect(source).toContain(
+      'className="flex items-center gap-3 rounded-md px-2 py-2"',
+    )
+    expect(source).toContain('className="h-8 w-16 shrink-0 rounded-md"')
   })
 })
 

--- a/src/web/src/components/community/social/invite-dialog.tsx
+++ b/src/web/src/components/community/social/invite-dialog.tsx
@@ -251,11 +251,15 @@ export function InviteDialog({
 
         <div className="min-h-0 flex-1 overflow-y-auto thin-scrollbar px-2 py-2">
           {friendsLoading && friends.length === 0 ? (
-            <div className="space-y-2 px-2">
+            <div data-slot="invite-friends-loading">
               {Array.from({ length: 4 }).map((_, i) => (
-                <div key={i} className="flex items-center gap-3">
-                  <Skeleton className="size-8 rounded-full" />
-                  <Skeleton className="h-3 w-32 rounded" />
+                <div key={i} className="flex items-center gap-3 rounded-md px-2 py-2">
+                  <Skeleton className="size-8 shrink-0 rounded-full" />
+                  <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+                    <Skeleton className="h-3.5 w-32 rounded" />
+                    <Skeleton className="h-3 w-24 rounded" />
+                  </div>
+                  <Skeleton className="h-8 w-16 shrink-0 rounded-md" />
                 </div>
               ))}
             </div>


### PR DESCRIPTION
# Why we need this PR?

Loading states across `/c` had drifted from the UI they reveal. Mobile route pending could also cover the persistent shell, while several page skeletons were missing final headers, actions, scroll owners, or responsive spacing.

## What changed

- Preserve ServerRail, sidebar, and the shell-level UserBar for list destinations while switching pending content by destination route.
- Keep mobile detail loading to the detail surface with a same-size inert Back footprint; skeletons add no navigation/history behavior or focusable fake controls.
- Align Machines, My Bots, Friends, members/settings, channel sidebar/root, DM/channel headers, invite surfaces, message loading, and invite cards with their loaded UI structure.
- Match the latest Forum responsive contract: 28px chips, single-line mobile horizontal rail, fixed action ownership, desktop wrapping, and responsive post-list padding.
- Add focused regression coverage for shell ownership, route-aware pending frames, skeleton geometry, and inertness.

## Validation

- Focused skeleton suite: 19 files / 102 tests PASS
- `pnpm typecheck`: 11/11 tasks PASS
- Web `typecheck`, `lint`, and `knip`: PASS
- Independent `/c` QA: PASS, including 320/375/390/414/640/1440 responsive checks and Forum action E2E 1/1
- `git diff --check`: PASS
- Full web suite: 607 files / 5206 tests pass; one unrelated `bundle-events.test.ts` forum-sidebar unread assertion fails identically on this branch and on clean `origin/main` (3/3 clean-main reproductions). This PR does not touch that WS path.

## Checklist

- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other
