### PR TITLE
test(web): freeze bundle expiry clock

### DIFF
--- a/src/web/src/hooks/community/community-ws/bundle-events.test.ts
+++ b/src/web/src/hooks/community/community-ws/bundle-events.test.ts
@@ -273,6 +273,8 @@ describe("useCommunityWs — operation bundles", () => {
   })
 
   it("replays every legal committed-message child idempotently after a partial parent projection", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-08-21T12:00:00.000Z"))
     await mountHook({ viewerUserId: "viewer-1" })
     useCommunityStore.getState().subscribe({ channelId: "other-channel" })
     capturedQueryClient.setQueryData(communityKeys.server("s1"), {


### PR DESCRIPTION
# Why we need this PR?

A committed-message bundle regression test uses synthetic activity at 2026-08-21T00:00:00Z. Production correctly derives a 72-hour forum-sidebar expiry, but the test did not freeze wall time. Once CI crossed 2026-08-24T00:00:00Z, the child row became legitimately expired and the unread assertion became date-dependent.

# What changed

- Freeze wall time inside the single affected regression test to 2026-08-21T12:00:00Z.
- Keep production code, the 72-hour expiry behavior, batch ordering, fault injection, and replay assertions unchanged.

# Verification

- Focused bundle suite: 8/8 passed.
- Target regression: 10/10 independent repeated runs passed.
- Adjacent social/member/structure/sidebar suites: 88/88 passed.
- Full web suite: 601 files / 5,186 tests passed.
- Full repository tests: 11/11 packages plus 9 CI-script files / 78 tests passed.
- Repository typecheck, lint, typegrep, and knip hooks passed.
- Independent exact-diff and exact-commit review passed.

## Checklist

- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (\`@alook/shared\`)
- [x] Web app (\`@alook/web\`)
- [ ] CLI (\`@alook/cli\`)
- [ ] Email Worker (\`@alook/email-worker\`)
- [ ] WebSocket DO (\`@alook/ws-do\`)
- [ ] CI/CD
- [ ] Other
