### PR TITLE
fix(web): keep forum tags within shared limits

### DIFF
--- a/src/web/src/components/community/channels/forum-view.test.ts
+++ b/src/web/src/components/community/channels/forum-view.test.ts
@@ -265,7 +265,7 @@ describe("ForumView filter bar / composer swap", () => {
     expect(html).toContain("#help")
   })
 
-  it("keeps mobile filter tags in their own single-line scroller beside the fixed action", () => {
+  it("keeps filter tags in one horizontal scroller at every checkpoint beside the fixed action", () => {
     const html = render([makePost({ tags: ["alpha", "beta", "gamma", "delta"] })])
     const railIndex = html.indexOf(tid.forumTagScroller)
     const listIndex = html.indexOf(tid.forumPostList)
@@ -279,8 +279,8 @@ describe("ForumView filter bar / composer swap", () => {
     expect(railMarkup).toContain("flex-nowrap")
     expect(railMarkup).toContain("overflow-x-auto")
     expect(railMarkup).toContain("thin-scrollbar")
-    expect(railMarkup).toContain("sm:flex-wrap")
-    expect(railMarkup).toContain("sm:overflow-x-visible")
+    expect(railMarkup).not.toContain("sm:flex-wrap")
+    expect(railMarkup).not.toContain("sm:overflow-x-visible")
     expect(railMarkup).toContain('tabindex="0"')
     expect(html).not.toContain(tid.forumTagFadeLeft)
     expect(html).not.toContain(tid.forumTagFadeRight)

--- a/src/web/src/components/community/channels/forum-view.tsx
+++ b/src/web/src/components/community/channels/forum-view.tsx
@@ -330,7 +330,7 @@ export function ForumView({
                   syncTagFades()
                 }
               }}
-              className="flex w-full min-w-0 flex-nowrap items-center gap-2 overflow-x-auto overscroll-x-contain thin-scrollbar sm:flex-wrap sm:overflow-x-visible"
+              className="flex w-full min-w-0 flex-nowrap items-center gap-2 overflow-x-auto overscroll-x-contain thin-scrollbar"
             >
               {filterTags.length > 0 && (
                 <>
@@ -370,14 +370,14 @@ export function ForumView({
               <span
                 aria-hidden
                 data-testid={tid.forumTagFadeLeft}
-                className="pointer-events-none absolute inset-y-0 left-0 z-10 w-3.5 bg-linear-to-r from-background to-transparent sm:hidden"
+                className="pointer-events-none absolute inset-y-0 left-0 z-10 w-3.5 bg-linear-to-r from-background to-transparent"
               />
             )}
             {tagFades.right && (
               <span
                 aria-hidden
                 data-testid={tid.forumTagFadeRight}
-                className="pointer-events-none absolute inset-y-0 right-0 z-10 w-3.5 bg-linear-to-l from-background to-transparent sm:hidden"
+                className="pointer-events-none absolute inset-y-0 right-0 z-10 w-3.5 bg-linear-to-l from-background to-transparent"
               />
             )}
           </div>

--- a/src/web/src/components/community/channels/post-tag-dialog.test.ts
+++ b/src/web/src/components/community/channels/post-tag-dialog.test.ts
@@ -1,0 +1,183 @@
+import { createElement, type ReactNode } from "react"
+import TestRenderer, { act, type ReactTestInstance } from "react-test-renderer"
+import { MAX_FORUM_TAG_LENGTH, MAX_FORUM_TAGS_PER_POST } from "@alook/shared"
+import { describe, expect, it, vi } from "vitest"
+import { tid } from "@/lib/community/testids"
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock("@/components/ui/popover", async () => {
+  const { createElement, Fragment } = await import("react")
+  return {
+    Popover: ({ children, onOpenChange }: { children: ReactNode; onOpenChange?: (open: boolean) => void }) =>
+      createElement("mock-popover", { onOpenChange }, children),
+    PopoverTrigger: ({ render }: { render: ReactNode }) => createElement(Fragment, null, render),
+    PopoverContent: ({ children, ...props }: { children: ReactNode }) =>
+      createElement("div", props, children),
+  }
+})
+
+vi.mock("@/components/ui/input", async () => {
+  const { createElement } = await import("react")
+  return {
+    Input: (props: Record<string, unknown>) => createElement("input", props),
+  }
+})
+
+import { PostTagDialog } from "./post-tag-dialog"
+
+function renderDialog({
+  current = [],
+  allTags = [],
+  onSave = vi.fn(),
+}: {
+  current?: string[]
+  allTags?: string[]
+  onSave?: (tags: string[]) => void
+} = {}) {
+  let renderer: TestRenderer.ReactTestRenderer
+  act(() => {
+    renderer = TestRenderer.create(createElement(PostTagDialog, {
+      trigger: createElement("button", { type: "button" }, "Edit tags"),
+      postName: "A post",
+      current,
+      allTags,
+      onSave,
+    }))
+  })
+  return { renderer: renderer!, onSave }
+}
+
+function buttonText(button: ReactTestInstance): string {
+  return button.children.map((child) => (
+    typeof child === "string" ? child : buttonText(child)
+  )).join("")
+}
+
+function tagButton(root: ReactTestInstance, tag: string): ReactTestInstance {
+  return root.findAllByType("button").find((button) => buttonText(button) === `#${tag}`)!
+}
+
+function setOpen(root: ReactTestInstance, open: boolean): void {
+  act(() => root.findByType("mock-popover").props.onOpenChange(open))
+}
+
+function pressEnter(input: ReactTestInstance): void {
+  act(() => input.props.onKeyDown({
+    key: "Enter",
+    preventDefault: vi.fn(),
+  }))
+}
+
+describe("PostTagDialog frontend limits", () => {
+  it("uses the shared length limit and right-aligns the close-save hint", () => {
+    const { renderer } = renderDialog()
+    const input = renderer.root.findByType("input")
+    const hint = renderer.root.findAllByType("p")
+      .find((node) => node.children.includes("↵ to add · saves on close"))
+
+    expect(input.props.maxLength).toBe(MAX_FORUM_TAG_LENGTH)
+    expect(hint?.props.className).toContain("text-right")
+  })
+
+  it("blocks a sixth chip while keeping selected chips removable", () => {
+    const selected = Array.from({ length: MAX_FORUM_TAGS_PER_POST }, (_, index) => `tag-${index + 1}`)
+    const replacement = "replacement"
+    const onSave = vi.fn()
+    const { renderer } = renderDialog({
+      current: selected,
+      allTags: [...selected, replacement],
+      onSave,
+    })
+    setOpen(renderer.root, true)
+
+    expect(tagButton(renderer.root, replacement).props.disabled).toBe(true)
+    expect(renderer.root.findByType("input").props.disabled).toBe(true)
+
+    act(() => tagButton(renderer.root, replacement).props.onClick())
+    setOpen(renderer.root, false)
+    expect(onSave).not.toHaveBeenCalled()
+
+    setOpen(renderer.root, true)
+    act(() => tagButton(renderer.root, selected[0]).props.onClick())
+    expect(tagButton(renderer.root, replacement).props.disabled).toBe(false)
+    expect(renderer.root.findByType("input").props.disabled).toBe(false)
+    act(() => tagButton(renderer.root, replacement).props.onClick())
+    setOpen(renderer.root, false)
+
+    expect(onSave).toHaveBeenCalledWith([...selected.slice(1), replacement])
+  })
+
+  it("caps draft input and blocks duplicate or over-count Enter additions", () => {
+    const selected = Array.from({ length: MAX_FORUM_TAGS_PER_POST }, (_, index) => `tag-${index + 1}`)
+    const onSave = vi.fn()
+    const { renderer } = renderDialog({ current: selected, onSave })
+    setOpen(renderer.root, true)
+    let input = renderer.root.findByType("input")
+
+    act(() => input.props.onChange({ target: { value: "x".repeat(MAX_FORUM_TAG_LENGTH + 8) } }))
+    input = renderer.root.findByType("input")
+    expect(input.props.value).toBe("x".repeat(MAX_FORUM_TAG_LENGTH))
+    pressEnter(input)
+    setOpen(renderer.root, false)
+    expect(onSave).not.toHaveBeenCalled()
+
+    const duplicateSave = vi.fn()
+    const duplicate = renderDialog({ current: ["existing"], onSave: duplicateSave })
+    setOpen(duplicate.renderer.root, true)
+    let duplicateInput = duplicate.renderer.root.findByType("input")
+    act(() => duplicateInput.props.onChange({ target: { value: "existing" } }))
+    duplicateInput = duplicate.renderer.root.findByType("input")
+    pressEnter(duplicateInput)
+    setOpen(duplicate.renderer.root, false)
+    expect(duplicateSave).not.toHaveBeenCalled()
+  })
+
+  it("adds a valid normalized draft until the shared count cap", () => {
+    const current = Array.from({ length: MAX_FORUM_TAGS_PER_POST - 1 }, (_, index) => `tag-${index + 1}`)
+    const onSave = vi.fn()
+    const { renderer } = renderDialog({ current, onSave })
+    setOpen(renderer.root, true)
+    let input = renderer.root.findByType("input")
+
+    act(() => input.props.onChange({ target: { value: "  New-Tag  " } }))
+    input = renderer.root.findByType("input")
+    pressEnter(input)
+    expect(renderer.root.findByType("input").props.disabled).toBe(true)
+    setOpen(renderer.root, false)
+
+    expect(onSave).toHaveBeenCalledWith([...current, "new-tag"])
+  })
+
+  it("does not allow an over-length existing vocabulary chip to be selected", () => {
+    const invalid = "x".repeat(MAX_FORUM_TAG_LENGTH + 1)
+    const { renderer } = renderDialog({ allTags: [invalid] })
+    setOpen(renderer.root, true)
+    expect(tagButton(renderer.root, invalid).props.disabled).toBe(true)
+  })
+
+  it.each([
+    ["English", "w".repeat(MAX_FORUM_TAG_LENGTH)],
+    ["Chinese", "标签".repeat(MAX_FORUM_TAG_LENGTH / 2)],
+  ])("contains a maximum-length %s chip with an accessible truncated label and fixed remove icon", (_kind, tag) => {
+    const { renderer } = renderDialog({ current: [tag], allTags: [tag] })
+    setOpen(renderer.root, true)
+
+    const button = tagButton(renderer.root, tag)
+    const label = button.findByType("span")
+    const removeIcon = button.findByType("svg")
+
+    expect(tag).toHaveLength(MAX_FORUM_TAG_LENGTH)
+    expect(button.props.className).toContain("max-w-full")
+    expect(button.props.className).toContain("min-w-0")
+    expect(button.props["data-testid"]).toBe(tid.forumTagDialogChip(tag))
+    expect(button.props.title).toBe(`#${tag}`)
+    expect(button.props["aria-label"]).toBe(`Remove tag ${tag}`)
+    expect(buttonText(button)).toBe(`#${tag}`)
+    expect(label.props.className).toContain("min-w-0")
+    expect(label.props.className).toContain("truncate")
+    expect(buttonText(label)).toBe(`#${tag}`)
+    expect(removeIcon.props.className).toContain("shrink-0")
+    expect(removeIcon.props["aria-hidden"]).toBe("true")
+  })
+})

--- a/src/web/src/components/community/channels/post-tag-dialog.tsx
+++ b/src/web/src/components/community/channels/post-tag-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, type ReactElement } from "react"
 import { X } from "lucide-react"
+import { MAX_FORUM_TAG_LENGTH, MAX_FORUM_TAGS_PER_POST } from "@alook/shared"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Input } from "@/components/ui/input"
 import { onEnterSubmit } from "@/lib/ime"
@@ -33,16 +34,23 @@ export function PostTagDialog({
   }, [current, open])
 
   const toggle = (tag: string) => {
-    setSelected((previous) => previous.includes(tag)
-      ? previous.filter((candidate) => candidate !== tag)
-      : [...previous, tag])
+    setSelected((previous) => {
+      if (previous.includes(tag)) return previous.filter((candidate) => candidate !== tag)
+      if (previous.length >= MAX_FORUM_TAGS_PER_POST || tag.length > MAX_FORUM_TAG_LENGTH) {
+        return previous
+      }
+      return [...previous, tag]
+    })
   }
 
   const addDraft = () => {
     const tag = draft.trim().toLowerCase()
+    if (!tag || tag.length > MAX_FORUM_TAG_LENGTH) return
+    setSelected((previous) => {
+      if (previous.length >= MAX_FORUM_TAGS_PER_POST || previous.includes(tag)) return previous
+      return [...previous, tag]
+    })
     setDraft("")
-    if (!tag || selected.includes(tag)) return
-    setSelected((previous) => [...previous, tag])
   }
 
   const close = () => {
@@ -83,20 +91,28 @@ export function PostTagDialog({
             <p className="text-xs text-muted-foreground">No tags yet</p>
           ) : chips.map((tag) => {
             const active = selected.includes(tag)
+            const additionBlocked = !active && (
+              selected.length >= MAX_FORUM_TAGS_PER_POST
+              || tag.length > MAX_FORUM_TAG_LENGTH
+            )
             return (
               <button
                 key={tag}
                 type="button"
+                data-testid={tid.forumTagDialogChip(tag)}
+                disabled={saving || additionBlocked}
+                aria-label={`${active ? "Remove" : "Add"} tag ${tag}`}
+                title={`#${tag}`}
                 style={tagColorStyle(tag)}
                 className={cn(
-                  "inline-flex items-center rounded-lg px-2 py-1 text-xs transition-opacity",
+                  "inline-flex max-w-full min-w-0 items-center rounded-lg px-2 py-1 text-xs transition-opacity disabled:cursor-not-allowed disabled:opacity-40",
                   tagColorClassName,
                   active ? "opacity-100 ring-1 ring-current/20" : "opacity-55 hover:opacity-80",
                 )}
                 onClick={() => toggle(tag)}
               >
-                #{tag}
-                {active && <X className="ml-1 size-3" />}
+                <span className="min-w-0 truncate">#{tag}</span>
+                {active && <X aria-hidden="true" className="ml-1 size-3 shrink-0" />}
               </button>
             )
           })}
@@ -104,14 +120,15 @@ export function PostTagDialog({
 
         <Input
           value={draft}
-          onChange={(event) => setDraft(event.target.value)}
+          onChange={(event) => setDraft(event.target.value.slice(0, MAX_FORUM_TAG_LENGTH))}
           onKeyDown={onEnterSubmit(addDraft)}
+          maxLength={MAX_FORUM_TAG_LENGTH}
           placeholder="Add a tag…"
           className="h-8 text-sm"
-          disabled={saving}
+          disabled={saving || selected.length >= MAX_FORUM_TAGS_PER_POST}
         />
 
-        <p className="text-[11px] text-muted-foreground">
+        <p className="text-right text-[11px] text-muted-foreground">
           {saving ? "Saving…" : "↵ to add · saves on close"}
         </p>
       </PopoverContent>

--- a/src/web/src/lib/community/testids.ts
+++ b/src/web/src/lib/community/testids.ts
@@ -53,6 +53,7 @@ export const tid = {
   botAvatarPickerTrigger: "community-bot-avatar-picker-trigger",
 
   forumTagDialog: "community-forum-tag-dialog",
+  forumTagDialogChip: (tag: string) => `community-forum-tag-dialog-chip-${tag}`,
   imageLightbox: "community-image-lightbox",
   imageLightboxThumbnail: "community-image-lightbox-thumbnail",
   imageLightboxOriginal: "community-image-lightbox-original",

--- a/src/web/src/test/e2e-ui/14-forum-post-tags-presence.spec.ts
+++ b/src/web/src/test/e2e-ui/14-forum-post-tags-presence.spec.ts
@@ -62,7 +62,7 @@ test.describe.serial("forum post tags + participant avatars", () => {
     await expect(page.getByTestId(tid.forumTagDialog)).toBeVisible({ timeout: 10_000 })
     // The active (selected) chips carry a remove affordance; click #beta to
     // deselect, then close to save.
-    await page.getByTestId(tid.forumTagDialog).getByRole("button", { name: "#beta" }).click()
+    await page.getByTestId(tid.forumTagDialogChip("beta")).click()
     await page.keyboard.press("Escape")
     await expect(page.getByTestId(tid.forumTagDialog)).toHaveCount(0)
 

--- a/src/web/src/test/e2e-ui/26-mobile-forum-post-actions.spec.ts
+++ b/src/web/src/test/e2e-ui/26-mobile-forum-post-actions.spec.ts
@@ -6,7 +6,16 @@ import { tid } from "./_fixtures/testids"
 import { WEB_URL } from "./_setup/paths"
 
 const MOBILE_WIDTHS = [320, 390] as const
+const FILTER_RAIL_WIDTHS = [320, 390, 1280] as const
 const TAGS = ["alpha-long-tag", "beta-long-tag", "gamma", "delta", "epsilon"]
+const DESKTOP_OVERFLOW_TAGS = [
+  "desktop-overflow-tag-one",
+  "desktop-overflow-tag-two",
+  "desktop-overflow-tag-three",
+  "desktop-overflow-tag-four",
+  "desktop-overflow-tag-five",
+] as const
+const LAST_FILTER_TAG = [...TAGS, ...DESKTOP_OVERFLOW_TAGS].sort().at(-1)!
 
 type Rect = { left: number; right: number; top: number; bottom: number; width: number; height: number }
 
@@ -31,7 +40,7 @@ async function rect(locator: Locator): Promise<Rect | null> {
 
 async function expectNewPostGeometry(
   page: Page,
-  width: (typeof MOBILE_WIDTHS)[number],
+  width: (typeof FILTER_RAIL_WIDTHS)[number],
   state: string,
   expected?: Rect,
 ): Promise<Rect> {
@@ -223,16 +232,16 @@ async function expectMobileGeometry(
   expect(documentWidth.scroll, `${role}@${width}: horizontal overflow`).toBe(documentWidth.client)
 }
 
-async function expectMobileFilterRail(
+async function expectFilterRail(
   page: Page,
-  width: (typeof MOBILE_WIDTHS)[number],
+  width: (typeof FILTER_RAIL_WIDTHS)[number],
   testInfo: TestInfo,
 ): Promise<Rect> {
   await page.setViewportSize({ width, height: 844 })
   const bar = page.getByTestId(tid.forumFilterBar)
   const rail = page.getByTestId(tid.forumTagScroller)
   const all = page.getByTestId(tid.forumTagAll)
-  const last = page.getByTestId(tid.forumTagChip(TAGS.at(-1)!))
+  const last = page.getByTestId(tid.forumTagChip(LAST_FILTER_TAG))
   const fadeLeft = page.getByTestId(tid.forumTagFadeLeft)
   const fadeRight = page.getByTestId(tid.forumTagFadeRight)
   const originalColorScheme = await page.evaluate(() => matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light")
@@ -333,8 +342,11 @@ async function expectMobileFilterRail(
     await expect(page.locator("html")).not.toHaveClass(/dark/)
   }
 
-  await page.keyboard.press("End")
-  await expect.poll(() => rail.evaluate((element) => element.scrollLeft)).toBeGreaterThan(0)
+  await rail.press("End")
+  await expect(rail).toBeFocused()
+  await expect.poll(() => rail.evaluate((element) => (
+    element.scrollWidth - element.clientWidth - element.scrollLeft
+  ))).toBeLessThanOrEqual(1)
   await expect(fadeLeft).toBeVisible()
   await expect(fadeRight).toHaveCount(0)
   const [railAtEnd, lastAtEnd] = await Promise.all([rect(rail), rect(last)])
@@ -362,8 +374,7 @@ async function expectMobileFilterRail(
   const [railWithLastActive, activeLast] = await Promise.all([rect(rail), rect(last)])
   expect(activeLast!.left).toBeGreaterThanOrEqual(railWithLastActive!.left - 0.5)
   expect(activeLast!.right).toBeLessThanOrEqual(railWithLastActive!.right + 0.5)
-  await rail.focus()
-  await page.keyboard.press("Home")
+  await rail.press("Home")
   await expect.poll(() => rail.evaluate((element) => element.scrollLeft)).toBe(0)
   await expect(fadeLeft).toHaveCount(0)
   await expect(fadeRight).toBeVisible()
@@ -393,7 +404,7 @@ async function expectMobileFilterRail(
 
 async function expectNoOverflowFilterRail(
   page: Page,
-  width: (typeof MOBILE_WIDTHS)[number],
+  width: (typeof FILTER_RAIL_WIDTHS)[number],
   route: string,
   postId: string,
   expectedNewPost: Rect,
@@ -452,7 +463,7 @@ async function seedTags(forumId: string, threadId: string, tags: string[]): Prom
 }
 
 test("forum post actions stay discoverable on mobile without changing permissions", async ({ asUser }, testInfo) => {
-  test.setTimeout(120_000)
+  test.setTimeout(180_000)
   const stamp = Date.now().toString().slice(-6)
   const serverId = await seedServer("alice", `Mobile forum actions ${Date.now()}`)
   const forumId = await seedChannel("alice", serverId, "mobile-actions", "forum")
@@ -485,11 +496,11 @@ test("forum post actions stay discoverable on mobile without changing permission
   )
   await seedMessage("carol", primaryPostId, "participant and reply-count coverage")
   await seedTags(forumId, primaryPostId, TAGS)
-  await seedTags(forumId, cjkPostId, TAGS.slice(0, 2))
+  await seedTags(forumId, cjkPostId, [...DESKTOP_OVERFLOW_TAGS])
   await seedTags(compactForumId, compactPostId, ["solo"])
   const postCases = [
     { id: primaryPostId, tags: TAGS.slice(0, 2), titleState: "truncated" as const },
-    { id: cjkPostId, tags: TAGS.slice(0, 2), titleState: "double" as const },
+    { id: cjkPostId, tags: [], titleState: "double" as const },
     { id: noTagPostId, tags: [], titleState: "single" as const },
   ]
   const route = `/c/channels/${serverId}/${forumId}`
@@ -504,9 +515,11 @@ test("forum post actions stay discoverable on mobile without changing permission
 
   const authorWrites = observeClientWrites(author.page)
   authorWrites.active = true
-  const newPostGeometry = new Map<(typeof MOBILE_WIDTHS)[number], Rect>()
+  const newPostGeometry = new Map<(typeof FILTER_RAIL_WIDTHS)[number], Rect>()
+  for (const width of FILTER_RAIL_WIDTHS) {
+    newPostGeometry.set(width, await expectFilterRail(author.page, width, testInfo))
+  }
   for (const width of MOBILE_WIDTHS) {
-    newPostGeometry.set(width, await expectMobileFilterRail(author.page, width, testInfo))
     for (const post of postCases) {
       await expectMobileGeometry(
         author.page,
@@ -524,7 +537,7 @@ test("forum post actions stay discoverable on mobile without changing permission
     })
   }
   authorWrites.active = false
-  for (const width of MOBILE_WIDTHS) {
+  for (const width of FILTER_RAIL_WIDTHS) {
     const expectedNewPost = newPostGeometry.get(width)
     expect(expectedNewPost, `filter rail@${width}: expected baseline New Post geometry`).toBeDefined()
     await expectNoOverflowFilterRail(author.page, width, compactRoute, compactPostId, expectedNewPost!, testInfo)


### PR DESCRIPTION
# Why

Forum filter tags wrapped on desktop, which made the header jump between checkpoints, while the tag editor relied on server-only enforcement for the shared five-tag / 30-character limits.

## What changed

- Keep the forum filter rail single-line and horizontally scrollable at every viewport, with conditional overflow fades and a fixed New Post action.
- Right-align the tag-editor footer hint and reuse the shared forum tag count/length constants for existing selections, chip clicks, Enter additions, and the input limit.
- Add component and Chromium regression coverage for limits, overflow, fade states, pointer pass-through, and 320/390/1280 checkpoints.

## Checklist

- [x] Tests added or updated for behavior changes
- [x] Local typecheck, lint, full tests, and focused Chromium checks pass
- [ ] All remote CI checks pass
- [x] Targets `main`

## Impact

- [x] Web
- [ ] CLI
- [ ] Desktop
- [ ] Workers
- [ ] Shared API
