### PR TITLE
fix(cli): strip malformed Alook heredoc tail

### DIFF
--- a/src/daemon/src/cli/index.test.ts
+++ b/src/daemon/src/cli/index.test.ts
@@ -1763,6 +1763,47 @@ describe("message send — literal stdin/file body contract", () => {
     expect(fs.existsSync(marker)).toBe(false);
   });
 
+  it.each([
+    ["body\nALOOK_MESSAGE_5211_MERGE_POLICY_2'\n", "body\n"],
+    ['body\r\nALOOK_MESSAGE_7F3C"\r\n', "body\r\n"],
+    ["body\n'ALOOK_MESSAGE_7F3C'\n", "body\n"],
+  ])("removes a malformed final Alook heredoc marker from stdin", async (input, expected) => {
+    let sentText: string | undefined;
+    setApiForTesting(stubApi({
+      send: async (request: Parameters<ServerApi["send"]>[0]) => {
+        sentText = request.content.text;
+        return { state: "sent", message: { seq: "#1", channel: "/s/c", sender: "@a", content: { text: "" }, time: "" } };
+      },
+    }));
+
+    await mainWithStdin(
+      ["message", "send", "--target", "/s#0042/general", "--stdin", "--remind-after", "0"],
+      input,
+    );
+
+    expect(sentText).toBe(expected);
+  });
+
+  it.each([
+    ["body\nALOOK_MESSAGE_7F3C\n"],
+    ["body\nALOOK_MESSAGE_7F3C'\nmore\n"],
+  ])("preserves marker-like stdin outside the malformed terminal boundary", async (input) => {
+    let sentText: string | undefined;
+    setApiForTesting(stubApi({
+      send: async (request: Parameters<ServerApi["send"]>[0]) => {
+        sentText = request.content.text;
+        return { state: "sent", message: { seq: "#1", channel: "/s/c", sender: "@a", content: { text: "" }, time: "" } };
+      },
+    }));
+
+    await mainWithStdin(
+      ["message", "send", "--target", "/s#0042/general", "--stdin", "--remind-after", "0"],
+      input,
+    );
+
+    expect(sentText).toBe(input);
+  });
+
   it("decodes UTF-8 once after joining split stdin byte chunks", async () => {
     const literal = "中文 🎉";
     const bytes = Buffer.from(literal, "utf8");
@@ -1784,7 +1825,7 @@ describe("message send — literal stdin/file body contract", () => {
     const path = await import("path");
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "cli-esc-"));
     const file = path.join(dir, "body.txt");
-    const literal = "  a\\\\nb\n总部 🎉  \n";
+    const literal = "  a\\\\nb\n总部 🎉\nALOOK_MESSAGE_FILE'\n";
     fs.writeFileSync(file, literal);
     let sentText: string | undefined;
     setApiForTesting(
@@ -1832,6 +1873,31 @@ describe("message send — literal stdin/file body contract", () => {
       "   \n",
     );
     expect(sendSpy).toHaveBeenCalledWith(expect.objectContaining({ content: { text: "   \n" } }));
+  });
+
+  it("validates the repaired body before sending", async () => {
+    const sendSpy = vi.fn(async () => ({
+      state: "sent" as const,
+      message: { seq: "#1", channel: "/s/c", sender: "@a", content: { text: "" }, time: "" },
+    }));
+    setApiForTesting(stubApi({ send: sendSpy }));
+
+    await mainWithStdin(
+      ["message", "send", "--target", "/s#0042/general", "--stdin", "--remind-after", "0"],
+      "ALOOK_MESSAGE_ONLY'\n",
+    );
+    expect(parseEnvelope(cap.lines()).error).toContain("--stdin");
+    expect(sendSpy).not.toHaveBeenCalled();
+
+    cap.lines().length = 0;
+    await mainWithStdin(
+      [
+        "message", "send", "--target", "/s#0042/general", "--stdin", "--remind-after", "0",
+        "--attachment", "att_1",
+      ],
+      "ALOOK_MESSAGE_ONLY'\n",
+    );
+    expect(sendSpy).toHaveBeenCalledWith(expect.objectContaining({ content: { text: "" } }));
   });
 
   it("keeps attachment-only sends valid without reading stdin", async () => {

--- a/src/daemon/src/cli/index.ts
+++ b/src/daemon/src/cli/index.ts
@@ -196,6 +196,13 @@ async function readLiteralInput(args: {
   return undefined;
 }
 
+const MALFORMED_ALOOK_HEREDOC_TAIL =
+  /(^|\r?\n)(?:["']ALOOK_MESSAGE_[A-Z0-9_]+["']?|ALOOK_MESSAGE_[A-Z0-9_]+["'])(?:\r?\n)?$/;
+
+function stripMalformedAlookHeredocTail(input: string): string {
+  return input.replace(MALFORMED_ALOOK_HEREDOC_TAIL, "$1");
+}
+
 /* ------------------------------------------------------------------ */
 /* Commands                                                            */
 /* ------------------------------------------------------------------ */
@@ -302,13 +309,16 @@ async function cmdMessageSend(opts: Record<string, unknown>, stdin: CliInputStre
   if (!channel) throw new CliError("message send: --target <ref> is required (e.g. /demo-workspace#1234/general)");
 
   const fileFlag = opts.file as string | undefined;
-  const text = await readLiteralInput({
+  const literalText = await readLiteralInput({
     command: "message send",
     stdinSelected: opts.stdin === true,
     stdin,
     filePath: fileFlag,
     fileOption: "--file <path>",
   });
+  const text = opts.stdin === true && literalText !== undefined
+    ? stripMalformedAlookHeredocTail(literalText)
+    : literalText;
 
   // `--attachment` may repeat. Commander wires this via `.option(..., collect, [])`
   // below; treat a missing flag as an empty list.


### PR DESCRIPTION
# Why we need this PR?

When an agent accidentally leaves a quote on the closing delimiter from the documented `message send --stdin` heredoc form, the shell passes that malformed delimiter line into stdin. The CLI currently sends it as part of the message body.

Alook tracking: `/Alook#5620/gus-issues/#14`

## What changed

- remove only a final standalone reserved `ALOOK_MESSAGE_*` marker carrying an adjacent stray single or double quote
- apply the repair only to `message send --stdin`; keep the shared literal reader and `--file` unchanged
- preserve the body newline that preceded the leaked marker
- keep unquoted and non-terminal marker-like text literal
- validate empty/attachment-only sends against the repaired effective body

## Checklist

- [x] Tests added/updated as needed
- [x] All local CI-equivalent checks pass
- [x] PR targets the correct branch

## Validation

- focused CLI: 156/156
- daemon: 57/57 files, 1177/1177 tests
- `pnpm typecheck`
- `pnpm test`
- `pnpm lint`
- `pnpm knip`
- `pnpm typegrep:ws`
- `pnpm typegrep:agent-driver`
- independent exact-head review PASS on `47a84858f4565f2a984b39ef9c1f73bb2c9059cc`

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [x] Other: daemon-hosted Alook CLI message input
