### PR TITLE
fix(daemon): attribute timeline responses to exact turns

### DIFF
--- a/src/daemon/README.md
+++ b/src/daemon/README.md
@@ -358,7 +358,7 @@ if (!opened.ok) throw new Error(opened.error.message);
 const { session } = opened;
 const eventsDone = (async () => {
   for await (const event of session.events) {
-    if (event.type === "text_delta") process.stdout.write(event.text);
+    if (event.type === "assistant_message_completed") console.log(event.text);
   }
 })();
 

--- a/src/daemon/agent-driver/README.md
+++ b/src/daemon/agent-driver/README.md
@@ -38,7 +38,7 @@ const session = opened.session;
 const observedText: string[] = [];
 const eventsDone = (async () => {
   for await (const event of session.events) {
-    if (event.type === "text_delta") observedText.push(event.text);
+    if (event.type === "assistant_message_completed") observedText.push(event.text);
   }
 })();
 

--- a/src/daemon/agent-driver/RELEASE_NOTES.md
+++ b/src/daemon/agent-driver/RELEASE_NOTES.md
@@ -1,5 +1,25 @@
 # Release notes
 
+## Complete semantic output and payload-free liveness
+
+- Replaced public text/reasoning delta events with
+  `assistant_message_completed` and `assistant_reasoning_completed`.
+- Provider fragments now stay inside the logical session, where they are
+  assembled per exact root turn with a 1 MiB UTF-8 bound and explicit
+  completion truncation metadata.
+- Added payload-free `work_heartbeat` events for real fragment activity. The
+  first fragment emits immediately, later fragments are coalesced to at most
+  one heartbeat per second, and no timer creates trailing activity.
+- Crashes discard incomplete fragment buffers; trusted turn terminals flush
+  delta-only backends before `turn_completed`.
+
+### Compatibility
+
+This is an intentional breaking change to the repository-private event
+contract. Consumers must handle complete semantic events rather than public
+transport chunks. Provider adapter-author fragment/completion events remain
+internal to `@alook/agent-driver`.
+
 ## Persistent built-in sessions and logical diagnostics
 
 - Unified Claude, Codex, Cursor, OpenCode, and Pi behind the persistent

--- a/src/daemon/agent-driver/src/adapters/claude/normalizer.test.ts
+++ b/src/daemon/agent-driver/src/adapters/claude/normalizer.test.ts
@@ -15,11 +15,14 @@ describe("ClaudeEventNormalizer.normalizeLine", () => {
     expect(n.currentSessionId).toBe("s1");
   });
 
-  it("assistant text block → text", () => {
+  it("combines assistant text blocks into one completed message", () => {
     const out = new ClaudeEventNormalizer().normalizeLine(
-      J({ type: "assistant", message: { content: [{ type: "text", text: "hi there" }] } }),
+      J({ type: "assistant", message: { content: [
+        { type: "text", text: "hi " },
+        { type: "text", text: "there" },
+      ] } }),
     );
-    expect(out).toEqual([{ kind: "text", text: "hi there" }]);
+    expect(out).toEqual([{ kind: "assistant_message_completed", text: "hi there" }]);
   });
 
   it("assistant thinking + tool_use blocks", () => {
@@ -35,7 +38,7 @@ describe("ClaudeEventNormalizer.normalizeLine", () => {
       }),
     );
     expect(out).toEqual([
-      { kind: "thinking", text: "hmm" },
+      { kind: "assistant_reasoning_completed", text: "hmm" },
       { kind: "tool_call", name: "Bash", input: { cmd: "ls" } },
     ]);
   });

--- a/src/daemon/agent-driver/src/adapters/claude/normalizer.ts
+++ b/src/daemon/agent-driver/src/adapters/claude/normalizer.ts
@@ -77,16 +77,20 @@ export class ClaudeEventNormalizer {
   private handleAssistant(event: any, out: AdapterEvent[]): void {
     const content = event?.message?.content;
     if (!Array.isArray(content)) return;
+    const completedText: string[] = [];
     for (const block of content) {
       if (block?.type === "thinking") {
-        out.push({ kind: "thinking", text: block.thinking ?? "" });
+        out.push({ kind: "assistant_reasoning_completed", text: block.thinking ?? "" });
       } else if (block?.type === "text") {
         const text: string = block.text ?? "";
         if (API_ERROR_RE.test(text)) out.push({ kind: "error", message: text });
-        else out.push({ kind: "text", text });
+        else completedText.push(text);
       } else if (block?.type === "tool_use") {
         out.push({ kind: "tool_call", name: block.name ?? "unknown_tool", input: block.input });
       }
+    }
+    if (completedText.length > 0) {
+      out.push({ kind: "assistant_message_completed", text: completedText.join("") });
     }
   }
 

--- a/src/daemon/agent-driver/src/adapters/codex/normalizer.test.ts
+++ b/src/daemon/agent-driver/src/adapters/codex/normalizer.test.ts
@@ -206,7 +206,6 @@ describe("CodexEventNormalizer — turn id tracking (for turn/steer expectedTurn
         receipt: "codex:root-thread:next-turn",
         nativeTurnId: "next-turn",
       },
-      { kind: "thinking", text: "" },
     ]);
     expect(n.normalizeLine(completed)).toEqual([]);
     expect(n.currentTurnId).toBe("next-turn");
@@ -320,13 +319,13 @@ describe("CodexEventNormalizer — complete owned event family", () => {
     expect(n.normalizeLine(notify("turn/started", { threadId: "root", turn: {} }))).toEqual([]);
     n.normalizeLine(notify("turn/started", { threadId: "root", turn: { id: "turn" } }));
     expect(n.normalizeLine(notify("item/reasoning/textDelta", { threadId: "root", turnId: "turn", delta: "why-now" }))).toEqual([
-      { kind: "thinking", text: "why-now" },
+      { kind: "assistant_reasoning_delta", text: "why-now" },
     ]);
     expect(n.normalizeLine(notify("item/reasoning/summaryTextDelta", { threadId: "root", turnId: "turn", delta: "why" }))).toEqual([
-      { kind: "thinking", text: "why" },
+      { kind: "assistant_reasoning_delta", text: "why" },
     ]);
     expect(n.normalizeLine(notify("item/agentMessage/delta", { threadId: "root", turnId: "turn", delta: "answer" }))).toEqual([
-      { kind: "text", text: "answer" },
+      { kind: "assistant_message_delta", text: "answer" },
     ]);
     expect(n.normalizeLine(notify("warning", { threadId: "root", message: "careful" }))).toEqual([
       { kind: "runtime_diagnostic", severity: "warning", source: "warning", message: "careful" },
@@ -343,8 +342,8 @@ describe("CodexEventNormalizer — complete owned event family", () => {
     expect(n.normalizeLine(notify("item/started", { threadId: "root", turnId: "turn", item: { type: "unknown" } }))).toEqual([]);
     expect(n.normalizeLine(notify("item/completed", { threadId: "root", turnId: "turn", item: { type: "contextCompaction" } }))).toEqual([{ kind: "compaction_finished" }]);
     expect(n.normalizeLine(notify("item/completed", { threadId: "root", turnId: "turn", item: { type: "exitedReviewMode" } }))).toEqual([{ kind: "review_finished" }]);
-    expect(n.normalizeLine(notify("item/completed", { threadId: "root", turnId: "turn", item: { type: "agentMessage", text: "final" } }))).toEqual([{ kind: "text", text: "final" }]);
-    expect(n.normalizeLine(notify("item/completed", { threadId: "root", turnId: "turn", item: { type: "reasoning", text: "thought" } }))).toEqual([{ kind: "thinking", text: "thought" }]);
+    expect(n.normalizeLine(notify("item/completed", { threadId: "root", turnId: "turn", item: { type: "agentMessage", text: "final" } }))).toEqual([{ kind: "assistant_message_completed", text: "final" }]);
+    expect(n.normalizeLine(notify("item/completed", { threadId: "root", turnId: "turn", item: { type: "reasoning", text: "thought" } }))).toEqual([{ kind: "assistant_reasoning_completed", text: "thought" }]);
     expect(n.normalizeLine(notify("item/completed", { threadId: "root", turnId: "turn", item: { type: "unknown" } }))).toEqual([]);
     expect(n.normalizeLine(notify("thread/tokenUsage/updated", { threadId: "root", tokenUsage: {} }))).toHaveLength(1);
     expect(n.normalizeLine(notify("account/rateLimits/updated", { threadId: "root", rateLimits: {} }))).toHaveLength(1);

--- a/src/daemon/agent-driver/src/adapters/codex/normalizer.ts
+++ b/src/daemon/agent-driver/src/adapters/codex/normalizer.ts
@@ -108,15 +108,14 @@ export class CodexEventNormalizer {
             receipt: this.turnReceipt(params.threadId, params.turn.id),
             nativeTurnId: params.turn.id,
           },
-          { kind: "thinking", text: "" },
         ];
 
       case "item/reasoning/textDelta":
       case "item/reasoning/summaryTextDelta":
-        return [{ kind: "thinking", text: params?.delta ?? "" }];
+        return [{ kind: "assistant_reasoning_delta", text: params?.delta ?? "" }];
 
       case "item/agentMessage/delta":
-        return [{ kind: "text", text: params?.delta ?? "" }];
+        return [{ kind: "assistant_message_delta", text: params?.delta ?? "" }];
 
       case "item/started":
         return this.handleItemStarted(params);
@@ -273,9 +272,9 @@ export class CodexEventNormalizer {
       case "collabAgentToolCall":
         return [{ kind: "tool_output", name: "collab_tool_call" }];
       case "agentMessage":
-        return [{ kind: "text", text: params?.item?.text ?? "" }];
+        return [{ kind: "assistant_message_completed", text: params?.item?.text ?? "" }];
       case "reasoning":
-        return [{ kind: "thinking", text: params?.item?.text ?? "" }];
+        return [{ kind: "assistant_reasoning_completed", text: params?.item?.text ?? "" }];
       default:
         return [];
     }

--- a/src/daemon/agent-driver/src/adapters/cursor/acp-lane.ts
+++ b/src/daemon/agent-driver/src/adapters/cursor/acp-lane.ts
@@ -623,14 +623,14 @@ export class CursorAcpLane implements RuntimeLane {
       case "agent_message_chunk": {
         const content = record(update.content);
         if (content?.type === "text" && typeof content.text === "string") {
-          this.events.emit("runtime_event", { kind: "text", text: content.text } satisfies AdapterEvent);
+          this.events.emit("runtime_event", { kind: "assistant_message_delta", text: content.text } satisfies AdapterEvent);
         }
         return;
       }
       case "agent_thought_chunk": {
         const content = record(update.content);
         if (content?.type === "text" && typeof content.text === "string") {
-          this.events.emit("runtime_event", { kind: "thinking", text: content.text } satisfies AdapterEvent);
+          this.events.emit("runtime_event", { kind: "assistant_reasoning_delta", text: content.text } satisfies AdapterEvent);
         }
         return;
       }

--- a/src/daemon/agent-driver/src/adapters/cursor/index.test.ts
+++ b/src/daemon/agent-driver/src/adapters/cursor/index.test.ts
@@ -553,7 +553,7 @@ describe("CursorDriver persistent ACP transport", () => {
     ].join("\n"));
 
     expect(events.findIndex((event) => event.kind === "turn_end")).toBeGreaterThanOrEqual(0);
-    expect(events.some((event) => event.kind === "text")).toBe(false);
+    expect(events.some((event) => event.kind === "assistant_message_delta")).toBe(false);
     expect(events.at(-1)).toMatchObject({
       kind: "runtime_diagnostic",
       severity: "warning",
@@ -595,7 +595,7 @@ describe("CursorDriver persistent ACP transport", () => {
       },
     })}\n`);
 
-    expect(events.some((event) => event.kind === "text")).toBe(false);
+    expect(events.some((event) => event.kind === "assistant_message_delta")).toBe(false);
     expect(events).toContainEqual(expect.objectContaining({
       kind: "runtime_diagnostic",
       message: "Cursor ACP emitted a session update without an active prompt",
@@ -1028,8 +1028,8 @@ describe("CursorDriver persistent ACP transport", () => {
       content: { type: "text", text: "must-not-project" },
     });
 
-    expect(events).toContainEqual({ kind: "text", text: "hello" });
-    expect(events).toContainEqual({ kind: "thinking", text: "thinking" });
+    expect(events).toContainEqual({ kind: "assistant_message_delta", text: "hello" });
+    expect(events).toContainEqual({ kind: "assistant_reasoning_delta", text: "thinking" });
     expect(events).toContainEqual({ kind: "tool_call", name: "Read", input: { path: "README.md" } });
     expect(events).toContainEqual({ kind: "tool_output", name: "Read" });
     expect(events).toContainEqual({ kind: "internal_progress", source: "cursor.acp", itemType: "plan" });

--- a/src/daemon/agent-driver/src/adapters/opencode/service-lane.test.ts
+++ b/src/daemon/agent-driver/src/adapters/opencode/service-lane.test.ts
@@ -939,7 +939,7 @@ describe("OpenCodeServiceLane authenticated persistent protocol", () => {
       durable: { aggregateID: service.sessionId, seq: 3, version: 1 },
       data: { sessionID: service.sessionId, assistantMessageID: "msg_assistant", textID: "text_3", text: "done" },
     });
-    await vi.waitFor(() => expect(laneEvents.runtime).toContainEqual({ kind: "text", text: "done" }));
+    await vi.waitFor(() => expect(laneEvents.runtime).toContainEqual({ kind: "assistant_message_completed", text: "done" }));
     service.releaseHistory();
     await expect(catchingUp).rejects.toThrow("OpenCode emitted an unseen durable event below the replay cursor");
     expect(laneEvents.runtime.some((event) => event.kind === "turn_end")).toBe(false);
@@ -1157,8 +1157,8 @@ describe("OpenCodeServiceLane authenticated persistent protocol", () => {
     service.active = false;
 
     await waitForTurn(runtime, 1);
-    expect(runtime).toContainEqual({ kind: "thinking", text: "" });
-    expect(runtime).toContainEqual({ kind: "thinking", text: "considering" });
+    expect(runtime).toContainEqual({ kind: "internal_progress", source: "opencode.service", itemType: "step_started" });
+    expect(runtime).toContainEqual({ kind: "assistant_reasoning_completed", text: "considering" });
     expect(runtime).toContainEqual({ kind: "tool_call", name: "Read", input: { path: "README.md" } });
     expect(runtime).toContainEqual({ kind: "tool_output", name: "Read" });
     expect(runtime).toContainEqual({ kind: "tool_output", name: "OpenCode tool" });

--- a/src/daemon/agent-driver/src/adapters/opencode/service-lane.ts
+++ b/src/daemon/agent-driver/src/adapters/opencode/service-lane.ts
@@ -798,16 +798,20 @@ export class OpenCodeServiceLane implements RuntimeLane {
     }
     switch (event.type) {
       case "session.next.step.started":
-        this.events.emit("runtime_event", { kind: "thinking", text: "" } satisfies AdapterEvent);
+        this.events.emit("runtime_event", {
+          kind: "internal_progress",
+          source: "opencode.service",
+          itemType: "step_started",
+        } satisfies AdapterEvent);
         break;
       case "session.next.text.ended":
         if (typeof data.text === "string" && data.text.length > 0) {
-          this.events.emit("runtime_event", { kind: "text", text: data.text } satisfies AdapterEvent);
+          this.events.emit("runtime_event", { kind: "assistant_message_completed", text: data.text } satisfies AdapterEvent);
         }
         break;
       case "session.next.reasoning.ended":
         if (typeof data.text === "string" && data.text.length > 0) {
-          this.events.emit("runtime_event", { kind: "thinking", text: data.text } satisfies AdapterEvent);
+          this.events.emit("runtime_event", { kind: "assistant_reasoning_completed", text: data.text } satisfies AdapterEvent);
         }
         break;
       case "session.next.tool.called":

--- a/src/daemon/agent-driver/src/adapters/pi/index.test.ts
+++ b/src/daemon/agent-driver/src/adapters/pi/index.test.ts
@@ -101,7 +101,7 @@ describe("PiDriver.openLane — does not fire the initial prompt itself", () => 
     // Simulate the SDK emitting a text_delta while handling a prompt sent
     // later, via the subscribe callback deps.session.subscribe captured.
     const subscribeCb = deps.session.subscribe.mock.calls[0][0];
-    subscribeCb({ type: "message_update", delta: { type: "text_delta", delta: "hi" } });
+    subscribeCb({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "hi" } });
 
     expect(received).toEqual([
       { kind: "session_init", sessionId: "sess_1" },
@@ -239,10 +239,10 @@ describe("Pi SDK event-family coverage", () => {
   it("maps every supported family and explicitly no-ops every known unsupported family", () => {
     const state = { sawTextDelta: false };
     const supported = [
-      { input: { type: "message_update", delta: { type: "thinking_delta", delta: "t" } }, kind: "assistant_reasoning_delta" },
-      { input: { type: "message_update", delta: { type: "text_delta", delta: "x" } }, kind: "assistant_message_delta" },
-      { input: { type: "message_update", delta: { type: "text_end", content: "x" } }, kind: "assistant_message_completed" },
-      { input: { type: "message_update", delta: { type: "error", message: "e" } }, kind: "error" },
+      { input: { type: "message_update", assistantMessageEvent: { type: "thinking_delta", delta: "t" } }, kind: "assistant_reasoning_delta" },
+      { input: { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "x" } }, kind: "assistant_message_delta" },
+      { input: { type: "message_update", assistantMessageEvent: { type: "text_end", content: "x" } }, kind: "assistant_message_completed" },
+      { input: { type: "message_update", assistantMessageEvent: { type: "error", error: { errorMessage: "e" } } }, kind: "error" },
       { input: { type: "tool_execution_start", toolName: "bash", args: {} }, kind: "tool_call" },
       { input: { type: "tool_execution_end", toolName: "bash" }, kind: "tool_output" },
       { input: { type: "compaction_start" }, kind: "compaction_started" },
@@ -251,6 +251,14 @@ describe("Pi SDK event-family coverage", () => {
     for (const item of supported) {
       expect(mapPiSdkEvent(item.input, "session", state)[0]?.kind).toBe(item.kind);
     }
+    expect(mapPiSdkEvent({
+      type: "message_update",
+      assistantMessageEvent: { type: "error", error: { errorMessage: "provider failed" } },
+    }, "session", state)).toEqual([{ kind: "error", message: "provider failed" }]);
+    expect(mapPiSdkEvent({
+      type: "message_update",
+      delta: { type: "text_end", content: "wrong outer field" },
+    }, "session", state)).toEqual([]);
     for (const type of PI_IGNORED_EVENT_TYPES) {
       expect(mapPiSdkEvent({ type }, "session", state)).toEqual([]);
     }

--- a/src/daemon/agent-driver/src/adapters/pi/index.test.ts
+++ b/src/daemon/agent-driver/src/adapters/pi/index.test.ts
@@ -105,7 +105,7 @@ describe("PiDriver.openLane — does not fire the initial prompt itself", () => 
 
     expect(received).toEqual([
       { kind: "session_init", sessionId: "sess_1" },
-      { kind: "text", text: "hi" },
+      { kind: "assistant_message_delta", text: "hi" },
     ]);
   });
 
@@ -239,8 +239,9 @@ describe("Pi SDK event-family coverage", () => {
   it("maps every supported family and explicitly no-ops every known unsupported family", () => {
     const state = { sawTextDelta: false };
     const supported = [
-      { input: { type: "message_update", delta: { type: "thinking_delta", delta: "t" } }, kind: "thinking" },
-      { input: { type: "message_update", delta: { type: "text_delta", delta: "x" } }, kind: "text" },
+      { input: { type: "message_update", delta: { type: "thinking_delta", delta: "t" } }, kind: "assistant_reasoning_delta" },
+      { input: { type: "message_update", delta: { type: "text_delta", delta: "x" } }, kind: "assistant_message_delta" },
+      { input: { type: "message_update", delta: { type: "text_end", content: "x" } }, kind: "assistant_message_completed" },
       { input: { type: "message_update", delta: { type: "error", message: "e" } }, kind: "error" },
       { input: { type: "tool_execution_start", toolName: "bash", args: {} }, kind: "tool_call" },
       { input: { type: "tool_execution_end", toolName: "bash" }, kind: "tool_output" },

--- a/src/daemon/agent-driver/src/adapters/pi/index.ts
+++ b/src/daemon/agent-driver/src/adapters/pi/index.ts
@@ -161,12 +161,14 @@ export function mapPiSdkEvent(event: any, sessionId: string, state: { sawTextDel
     const d = event.delta ?? {};
     switch (d.type) {
       case "thinking_delta":
-        return [{ kind: "thinking", text: d.delta ?? "" }];
+        return [{ kind: "assistant_reasoning_delta", text: d.delta ?? "" }];
       case "text_delta":
         state.sawTextDelta = true;
-        return [{ kind: "text", text: d.delta ?? "" }];
-      case "text_end":
-        return state.sawTextDelta ? [] : [{ kind: "text", text: d.content ?? "" }];
+        return [{ kind: "assistant_message_delta", text: d.delta ?? "" }];
+      case "text_end": {
+        state.sawTextDelta = false;
+        return [{ kind: "assistant_message_completed", text: d.content ?? "" }];
+      }
       case "error":
         return [{ kind: "error", message: d.message ?? "Pi error" }];
       default:

--- a/src/daemon/agent-driver/src/adapters/pi/index.ts
+++ b/src/daemon/agent-driver/src/adapters/pi/index.ts
@@ -158,7 +158,7 @@ export const PI_IGNORED_EVENT_TYPES = [
 /** Map a Pi SDK event to zero or more normalized events. */
 export function mapPiSdkEvent(event: any, sessionId: string, state: { sawTextDelta: boolean }): AdapterEvent[] {
   if (event?.type === "message_update") {
-    const d = event.delta ?? {};
+    const d = event.assistantMessageEvent ?? {};
     switch (d.type) {
       case "thinking_delta":
         return [{ kind: "assistant_reasoning_delta", text: d.delta ?? "" }];
@@ -170,7 +170,7 @@ export function mapPiSdkEvent(event: any, sessionId: string, state: { sawTextDel
         return [{ kind: "assistant_message_completed", text: d.content ?? "" }];
       }
       case "error":
-        return [{ kind: "error", message: d.message ?? "Pi error" }];
+        return [{ kind: "error", message: d.error?.errorMessage ?? "Pi error" }];
       default:
         return [];
     }

--- a/src/daemon/agent-driver/src/contract.ts
+++ b/src/daemon/agent-driver/src/contract.ts
@@ -292,8 +292,19 @@ export type CoreAgentEventPayload =
     }
   | { readonly type: "turn_started"; readonly turnId: string; readonly commandIds: readonly string[] }
   | { readonly type: "backend_turn_started"; readonly turnId: string; readonly backendTurnId: string }
-  | { readonly type: "thinking_delta"; readonly turnId: string; readonly text: string }
-  | { readonly type: "text_delta"; readonly turnId: string; readonly text: string }
+  | { readonly type: "work_heartbeat"; readonly turnId: string }
+  | {
+      readonly type: "assistant_reasoning_completed";
+      readonly turnId: string;
+      readonly text: string;
+      readonly truncated: boolean;
+    }
+  | {
+      readonly type: "assistant_message_completed";
+      readonly turnId: string;
+      readonly text: string;
+      readonly truncated: boolean;
+    }
   | {
       readonly type: "tool_started";
       readonly turnId: string;

--- a/src/daemon/agent-driver/src/controller/logical-session.test.ts
+++ b/src/daemon/agent-driver/src/controller/logical-session.test.ts
@@ -334,12 +334,140 @@ describe.each(["claude", "codex", "cursor", "opencode", "pi"] as const)("%s logi
     const pending = take(iterator, 5);
     await session.start({ id: "one", kind: "user", text: "hello" });
     await emit(driver, { kind: "session_init", sessionId: backend === "pi" ? "sdk-session" : `${backend}-session` });
-    await emit(driver, { kind: "thinking", text: "think" });
-    await emit(driver, { kind: "text", text: "answer" });
+    await emit(driver, { kind: "assistant_reasoning_completed", text: "think" });
+    await emit(driver, { kind: "assistant_message_completed", text: "answer" });
     const events = await pending;
     expect(events.map((event) => event.type)).toEqual([
-      "command_accepted", "turn_started", "session_started", "thinking_delta", "text_delta",
+      "command_accepted", "turn_started", "session_started", "assistant_reasoning_completed", "assistant_message_completed",
     ]);
+    await session.stop({ reason: "shutdown", forceAfterMs: 10 });
+  });
+});
+
+describe("root-turn text assembly", () => {
+  it("keeps provider deltas private, emits payload-free heartbeats, and publishes one authoritative message", async () => {
+    const lane = new ControlledRuntimeLane();
+    const { session } = makeSession("claude", { lane });
+    const iterator = session.events[Symbol.asyncIterator]();
+    await session.start({ id: "one", kind: "user", text: "start" });
+
+    lane.emit({ kind: "assistant_message_delta", text: "hel" });
+    lane.emit({ kind: "assistant_message_delta", text: "lo" });
+    lane.emit({ kind: "assistant_message_completed", text: "hello" });
+    lane.emit({ kind: "turn_end", sessionId: "vendor-session", turnOwner: "claude:test:1" });
+
+    const events = await take(iterator as never, 6);
+    expect(events.map((event) => event.type)).toEqual([
+      "command_accepted",
+      "turn_started",
+      "work_heartbeat",
+      "assistant_message_completed",
+      "session_started",
+      "turn_completed",
+    ]);
+    expect(events.filter((event) => event.type === "assistant_message_completed"))
+      .toMatchObject([{ text: "hello", truncated: false }]);
+    for (const heartbeat of events.filter((event) => event.type === "work_heartbeat")) {
+      expect(heartbeat).not.toHaveProperty("text");
+    }
+    await session.stop({ reason: "shutdown", forceAfterMs: 10 });
+  });
+
+  it("flushes a delta-only backend once at its trusted turn boundary", async () => {
+    const lane = new ControlledRuntimeLane();
+    lane.startAdmission = { ok: true, acceptedAs: "prompt", receipt: "cursor:test:1" };
+    const { session } = makeSession("cursor", { lane });
+    const iterator = session.events[Symbol.asyncIterator]();
+    await session.start({ id: "one", kind: "user", text: "start" });
+
+    lane.emit({ kind: "assistant_message_delta", text: "hel" });
+    lane.emit({ kind: "assistant_message_delta", text: "lo" });
+    lane.emit({ kind: "turn_end", sessionId: "vendor-session", turnOwner: "cursor:test:1" });
+
+    const events = await take(iterator as never, 6);
+    expect(events.filter((event) => event.type === "assistant_message_completed"))
+      .toMatchObject([{ text: "hello", truncated: false }]);
+    expect(events.findIndex((event) => event.type === "assistant_message_completed"))
+      .toBeLessThan(events.findIndex((event) => event.type === "turn_completed"));
+    await session.stop({ reason: "shutdown", forceAfterMs: 10 });
+  });
+
+  it("drops an unfinished delta buffer when the runtime crashes before a boundary", async () => {
+    const { session, driver } = makeSession("claude");
+    const observed: Array<AgentEvent<BuiltinBackendSpecs, BuiltinBackendId>> = [];
+    const collecting = (async () => { for await (const event of session.events) observed.push(event); })();
+    await session.start({ id: "one", kind: "user", text: "start" });
+    await emit(driver, { kind: "assistant_message_delta", text: "partial" });
+
+    driver.processes[0]!.emit("exit", 7, null);
+    await session.closed;
+    await collecting;
+
+    expect(observed.filter((event) => event.type === "work_heartbeat")).toHaveLength(1);
+    expect(observed.filter((event) => event.type === "assistant_message_completed")).toHaveLength(0);
+  });
+
+  it("coalesces fragment activity to one immediate heartbeat and at most one per second", async () => {
+    let nowMs = 10_000;
+    const lane = new ControlledRuntimeLane();
+    const { session } = makeSession("claude", { lane, now: () => nowMs });
+    const iterator = session.events[Symbol.asyncIterator]();
+    await session.start({ id: "one", kind: "user", text: "start" });
+
+    lane.emit({ kind: "assistant_message_delta", text: "a" });
+    lane.emit({ kind: "assistant_message_delta", text: "b" });
+    nowMs += 999;
+    lane.emit({ kind: "assistant_reasoning_delta", text: "c" });
+    nowMs += 1;
+    lane.emit({ kind: "assistant_message_delta", text: "d" });
+    lane.emit({ kind: "turn_end", sessionId: "vendor-session", turnOwner: "claude:test:1" });
+
+    const events = await take(iterator as never, 8);
+    expect(events.filter((event) => event.type === "work_heartbeat")).toHaveLength(2);
+    for (const heartbeat of events.filter((event) => event.type === "work_heartbeat")) {
+      expect(heartbeat).toEqual(expect.objectContaining({ type: "work_heartbeat", turnId: expect.any(String) }));
+      expect(heartbeat).not.toHaveProperty("text");
+    }
+    expect(events.filter((event) => event.type === "assistant_reasoning_completed"))
+      .toMatchObject([{ text: "c", truncated: false }]);
+    expect(events.filter((event) => event.type === "assistant_message_completed"))
+      .toMatchObject([{ text: "abd", truncated: false }]);
+    await session.stop({ reason: "shutdown", forceAfterMs: 10 });
+  });
+
+  it("replaces matching fragments with an authoritative completed reasoning snapshot", async () => {
+    const lane = new ControlledRuntimeLane();
+    const { session } = makeSession("claude", { lane });
+    const iterator = session.events[Symbol.asyncIterator]();
+    await session.start({ id: "one", kind: "user", text: "start" });
+
+    lane.emit({ kind: "assistant_reasoning_delta", text: "partial" });
+    lane.emit({ kind: "assistant_reasoning_completed", text: "authoritative" });
+    lane.emit({ kind: "turn_end", sessionId: "vendor-session", turnOwner: "claude:test:1" });
+
+    const events = await take(iterator as never, 6);
+    expect(events.filter((event) => event.type === "assistant_reasoning_completed"))
+      .toMatchObject([{ text: "authoritative", truncated: false }]);
+    expect(JSON.stringify(events)).not.toContain("partial");
+    await session.stop({ reason: "shutdown", forceAfterMs: 10 });
+  });
+
+  it("bounds delta-only multibyte output at one MiB without splitting UTF-8", async () => {
+    const lane = new ControlledRuntimeLane();
+    const { session } = makeSession("claude", { lane });
+    const iterator = session.events[Symbol.asyncIterator]();
+    await session.start({ id: "one", kind: "user", text: "start" });
+
+    lane.emit({ kind: "assistant_message_delta", text: "🙂".repeat(300_000) });
+    lane.emit({ kind: "turn_end", sessionId: "vendor-session", turnOwner: "claude:test:1" });
+
+    const events = await take(iterator as never, 6);
+    const completed = events.find((event) => event.type === "assistant_message_completed");
+    expect(completed).toMatchObject({ truncated: true });
+    if (completed?.type !== "assistant_message_completed") throw new Error("missing completed message");
+    expect(Buffer.byteLength(completed.text, "utf8")).toBeLessThanOrEqual(1_048_576);
+    expect(completed.text.endsWith("🙂")).toBe(true);
+    expect(completed.text).not.toContain("�");
     await session.stop({ reason: "shutdown", forceAfterMs: 10 });
   });
 });
@@ -487,9 +615,9 @@ describe("runtime-lane admission state machine", () => {
       receipt: "claude:test:1",
       nativeTurnId: "OPENAI_API_KEY=native-secret /Users/private",
     });
-    hostileLane.emit({ kind: "text", text: "next safe event" });
+    hostileLane.emit({ kind: "assistant_message_delta", text: "next safe event" });
     const hostileEvents = await take(hostileIterator as never, 3);
-    expect(hostileEvents.map((event) => event.type)).toEqual(["command_accepted", "turn_started", "text_delta"]);
+    expect(hostileEvents.map((event) => event.type)).toEqual(["command_accepted", "turn_started", "work_heartbeat"]);
     expect(JSON.stringify(hostileEvents)).not.toMatch(/native-secret|\/Users\/private/);
     await hostileSession.stop({ reason: "shutdown", forceAfterMs: 10 });
   });
@@ -962,13 +1090,30 @@ describe("closed physical-lane tombstone", () => {
     await session.start({ id: "one", kind: "user", text: "first" });
     await emit(driver, { kind: "turn_end", sessionId: "root" });
     const reopened = (session as any).reopenClosedLaneForWork(
-      { kind: "text", text: "stale" },
+      { kind: "assistant_message_completed", text: "stale" },
       new SdkLane({ prompt: async () => {}, steer: async () => {} }, "other"),
       99,
     );
     expect(reopened).toBeUndefined();
     expect(session.snapshot().activeTurn).toBeUndefined();
     await session.stop({ reason: "shutdown", forceAfterMs: 10 });
+  });
+
+  it("does not let post-terminal content fragments reopen or heartbeat a closed root turn", async () => {
+    const { session, driver } = makeSession("claude");
+    const observed: Array<AgentEvent<BuiltinBackendSpecs, BuiltinBackendId>> = [];
+    const collecting = (async () => { for await (const event of session.events) observed.push(event); })();
+    await session.start({ id: "one", kind: "user", text: "first" });
+    await emit(driver, { kind: "turn_end", sessionId: "root" });
+    await emit(driver, { kind: "assistant_message_delta", text: "late" });
+    await emit(driver, { kind: "assistant_reasoning_delta", text: "late reasoning" });
+
+    expect(session.snapshot().activeTurn).toBeUndefined();
+    await session.stop({ reason: "shutdown", forceAfterMs: 10 });
+    await collecting;
+    expect(observed.filter((event) => event.type === "work_heartbeat")).toHaveLength(0);
+    expect(observed.filter((event) => event.type === "assistant_message_completed")).toHaveLength(0);
+    expect(observed.filter((event) => event.type === "assistant_reasoning_completed")).toHaveLength(0);
   });
 });
 
@@ -1483,7 +1628,10 @@ describe("logical-session terminal facts", () => {
   it("fails and releases a session when its unread event buffer overflows", async () => {
     const { session, driver, host } = makeSession("pi");
     await session.start({ id: "one", kind: "user", text: "start" });
-    driver.lane!.emitEvents([{ kind: "text", text: "x".repeat(session.events.maxBufferedBytes) }]);
+    driver.lane!.emitEvents(Array.from({ length: 5 }, () => ({
+      kind: "assistant_message_completed" as const,
+      text: "x".repeat(1_048_576),
+    })));
     await expect(session.closed).resolves.toMatchObject({
       outcome: "crashed",
       error: { code: "event_buffer_overflow" },
@@ -1499,7 +1647,10 @@ describe("logical-session terminal facts", () => {
       const iterator = session.events[Symbol.asyncIterator]();
       driver.hangDispose = true;
       await session.start({ id: "one", kind: "user", text: "start" });
-      driver.lane!.emitEvents([{ kind: "text", text: "x".repeat(session.events.maxBufferedBytes) }]);
+      driver.lane!.emitEvents(Array.from({ length: 5 }, () => ({
+        kind: "assistant_message_completed" as const,
+        text: "x".repeat(1_048_576),
+      })));
       await expect(session.stop({ reason: "shutdown", forceAfterMs: 10 })).resolves.toMatchObject({
         status: "already_stopping",
         requestId: expect.any(String),

--- a/src/daemon/agent-driver/src/controller/logical-session.ts
+++ b/src/daemon/agent-driver/src/controller/logical-session.ts
@@ -84,6 +84,69 @@ interface ActiveTurn {
   turnId: string;
   commandIds: string[];
   terminalOwner?: string;
+  pendingMessage: SemanticAssembler;
+  pendingReasoning: SemanticAssembler;
+  lastWorkHeartbeatAt: number | null;
+}
+
+interface SemanticAssembler {
+  chunks: string[];
+  bytes: number;
+  truncated: boolean;
+}
+
+const SEMANTIC_ASSEMBLER_MAX_BYTES = 1_048_576;
+const WORK_HEARTBEAT_MIN_INTERVAL_MS = 1_000;
+
+function emptySemanticAssembler(): SemanticAssembler {
+  return { chunks: [], bytes: 0, truncated: false };
+}
+
+function utf8Prefix(text: string, maxBytes: number): string {
+  if (maxBytes <= 0 || text.length === 0) return "";
+  if (Buffer.byteLength(text, "utf8") <= maxBytes) return text;
+  let low = 0;
+  let high = text.length;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    let end = mid;
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) end -= 1;
+    if (Buffer.byteLength(text.slice(0, end), "utf8") <= maxBytes) low = mid;
+    else high = mid - 1;
+  }
+  let end = low;
+  const code = text.charCodeAt(end - 1);
+  if (code >= 0xd800 && code <= 0xdbff) end -= 1;
+  while (end > 0 && Buffer.byteLength(text.slice(0, end), "utf8") > maxBytes) end -= 1;
+  return text.slice(0, end);
+}
+
+function appendSemanticFragment(buffer: SemanticAssembler, text: string): void {
+  if (text.length === 0 || buffer.truncated) return;
+  const remaining = SEMANTIC_ASSEMBLER_MAX_BYTES - buffer.bytes;
+  const bytes = Buffer.byteLength(text, "utf8");
+  if (bytes <= remaining) {
+    buffer.chunks.push(text);
+    buffer.bytes += bytes;
+    return;
+  }
+  const prefix = utf8Prefix(text, remaining);
+  if (prefix.length > 0) {
+    buffer.chunks.push(prefix);
+    buffer.bytes += Buffer.byteLength(prefix, "utf8");
+  }
+  buffer.truncated = true;
+}
+
+function finishSemanticAssembler(buffer: SemanticAssembler): { text: string; truncated: boolean } {
+  return { text: buffer.chunks.join(""), truncated: buffer.truncated };
+}
+
+function boundedSemanticCompletion(text: string): { text: string; truncated: boolean } {
+  const buffer = emptySemanticAssembler();
+  appendSemanticFragment(buffer, text);
+  return finishSemanticAssembler(buffer);
 }
 
 interface ClosedLaneTombstone {
@@ -423,7 +486,14 @@ implements AgentSession<Specs, Id> {
     const turnId = this.host.createId();
     const commandIds = messages.map((message) => message.id);
     const terminalOwner = this.adapter.beginTurn?.();
-    this.activeTurn = { turnId, commandIds: [...commandIds], ...(terminalOwner ? { terminalOwner } : {}) };
+    this.activeTurn = {
+      turnId,
+      commandIds: [...commandIds],
+      ...(terminalOwner ? { terminalOwner } : {}),
+      pendingMessage: emptySemanticAssembler(),
+      pendingReasoning: emptySemanticAssembler(),
+      lastWorkHeartbeatAt: null,
+    };
     this.turnError = undefined;
     this.interruptedTurnId = undefined;
     this.processTurnEnded = false;
@@ -646,11 +716,35 @@ implements AgentSession<Specs, Id> {
           });
         }
         return;
-      case "thinking":
-        if (turnId) this.emit({ type: "thinking_delta", turnId, text: event.text });
+      case "assistant_reasoning_delta":
+      case "assistant_message_delta":
+        if (turnId && this.activeTurn?.turnId === turnId && event.text.length > 0) {
+          appendSemanticFragment(
+            event.kind === "assistant_message_delta"
+              ? this.activeTurn.pendingMessage
+              : this.activeTurn.pendingReasoning,
+            event.text,
+          );
+          const now = this.host.now();
+          if (
+            this.activeTurn.lastWorkHeartbeatAt === null
+            || now - this.activeTurn.lastWorkHeartbeatAt >= WORK_HEARTBEAT_MIN_INTERVAL_MS
+          ) {
+            this.activeTurn.lastWorkHeartbeatAt = now;
+            this.emit({ type: "work_heartbeat", turnId });
+          }
+        }
         return;
-      case "text":
-        if (turnId) this.emit({ type: "text_delta", turnId, text: event.text });
+      case "assistant_reasoning_completed":
+      case "assistant_message_completed":
+        if (turnId && this.activeTurn?.turnId === turnId) {
+          const field = event.kind === "assistant_message_completed" ? "pendingMessage" : "pendingReasoning";
+          this.activeTurn[field] = emptySemanticAssembler();
+          if (event.text.length > 0) {
+            const completed = boundedSemanticCompletion(event.text);
+            this.emit({ type: event.kind, turnId, ...completed });
+          }
+        }
         return;
       case "tool_call":
         this.outstandingToolUses += 1;
@@ -721,6 +815,18 @@ implements AgentSession<Specs, Id> {
         });
         return;
       case "turn_end":
+        if (turnId && this.activeTurn?.turnId === turnId) {
+          const reasoning = finishSemanticAssembler(this.activeTurn.pendingReasoning);
+          const message = finishSemanticAssembler(this.activeTurn.pendingMessage);
+          this.activeTurn.pendingReasoning = emptySemanticAssembler();
+          this.activeTurn.pendingMessage = emptySemanticAssembler();
+          if (reasoning.text.length > 0) {
+            this.emit({ type: "assistant_reasoning_completed", turnId, ...reasoning });
+          }
+          if (message.text.length > 0) {
+            this.emit({ type: "assistant_message_completed", turnId, ...message });
+          }
+        }
         this.completeTurn(event.sessionId, physicalOwner, generation, event.turnOwner);
         return;
     }
@@ -747,9 +853,7 @@ implements AgentSession<Specs, Id> {
     // every event from a closed per-turn transport before any shared-state side
     // effect in onAdapterEvent's switch can run.
     if (this.adapter.execution.lifetime === "turn") return undefined;
-    const isRootWork = event.kind === "thinking"
-      || event.kind === "text"
-      || event.kind === "tool_call"
+    const isRootWork = event.kind === "tool_call"
       || event.kind === "tool_output"
       || event.kind === "compaction_started"
       || event.kind === "compaction_finished"
@@ -769,6 +873,9 @@ implements AgentSession<Specs, Id> {
       turnId: tombstone.localTurnId,
       commandIds: tombstone.commandIds,
       ...(tombstone.terminalOwner ? { terminalOwner: tombstone.terminalOwner } : {}),
+      pendingMessage: emptySemanticAssembler(),
+      pendingReasoning: emptySemanticAssembler(),
+      lastWorkHeartbeatAt: null,
     };
     this.state = "working";
     return tombstone.localTurnId;

--- a/src/daemon/agent-driver/src/controller/process-host.test.ts
+++ b/src/daemon/agent-driver/src/controller/process-host.test.ts
@@ -164,7 +164,7 @@ describe("ProcessLane — raw stdout tap (P0-1)", () => {
   });
 
   it("continues through normalizeLine and runtime_event when the tap throws", async () => {
-    const parsedEvent = { kind: "text", text: "ok" } as const;
+    const parsedEvent = { kind: "assistant_message_completed", text: "ok" } as const;
     const normalizeLine = vi.fn(() => [parsedEvent]);
     const { driver, stdout } = controllableDriver(normalizeLine);
     const session = new ProcessLane(driver, minimalCtx(), {

--- a/src/daemon/agent-driver/src/internal/adapter.ts
+++ b/src/daemon/agent-driver/src/internal/adapter.ts
@@ -53,8 +53,10 @@ export interface EncodeMessageOptions { mode?: InputMode }
 
 export type AdapterEvent =
   | { kind: "session_init"; sessionId: string }
-  | { kind: "thinking"; text: string }
-  | { kind: "text"; text: string }
+  | { kind: "assistant_reasoning_delta"; text: string }
+  | { kind: "assistant_reasoning_completed"; text: string }
+  | { kind: "assistant_message_delta"; text: string }
+  | { kind: "assistant_message_completed"; text: string }
   | { kind: "tool_call"; name: string; input: unknown }
   | { kind: "tool_output"; name: string }
   | { kind: "compaction_started" }

--- a/src/daemon/agent-driver/src/pack.test.ts
+++ b/src/daemon/agent-driver/src/pack.test.ts
@@ -70,7 +70,7 @@ const session = opened.session;
 const observedText: string[] = [];
 const eventsDone = (async () => {
   for await (const event of session.events) {
-    if (event.type === "text_delta") observedText.push(event.text);
+    if (event.type === "assistant_message_completed") observedText.push(event.text);
   }
 })();
 const receipt = await session.start({ id: "command-example", kind: "user", text: "Explain this repository." });
@@ -163,7 +163,7 @@ if (receipt.status !== "accepted") throw new Error(JSON.stringify(receipt));
 await done;
 await opened.session.stop({ reason: "owner_request", forceAfterMs: 1_000 });
 await opened.session.closed;
-if (!events.some((event) => event.type === "text_delta" && event.text === "packed-ok")) throw new Error("missing packed text event: " + JSON.stringify(events));
+if (!events.some((event) => event.type === "assistant_message_completed" && event.text === "packed-ok")) throw new Error("missing packed text event: " + JSON.stringify(events));
 try {
   await import("@alook/agent-driver/internal/adapter");
   throw new Error("private subpath unexpectedly exported");

--- a/src/daemon/agent-driver/src/testing/builtin-adapter-conformance.test.ts
+++ b/src/daemon/agent-driver/src/testing/builtin-adapter-conformance.test.ts
@@ -58,7 +58,7 @@ describe("builtin adapter protocol conformance", () => {
           })),
         ];
       },
-      expectedEventKinds: ["session_init", "thinking", "tool_call", "tool_output", "text", "turn_end"],
+      expectedEventKinds: ["session_init", "assistant_reasoning_completed", "tool_call", "tool_output", "assistant_message_completed", "turn_end"],
     });
     expect(events.at(-1)).toMatchObject({ kind: "turn_end", sessionId: "claude-root", turnOwner: expect.stringMatching(/^claude:/) });
   });
@@ -78,7 +78,7 @@ describe("builtin adapter protocol conformance", () => {
           ...adapter.normalizeLine(line({ jsonrpc: "2.0", method: "turn/completed", params: { threadId: rootThread, turn: { id: rootTurn, status: "completed" } } })),
         ];
       },
-      expectedEventKinds: ["session_init", "turn_owner", "thinking", "tool_call", "tool_output", "turn_end"],
+      expectedEventKinds: ["session_init", "turn_owner", "tool_call", "tool_output", "turn_end"],
     });
     expect(JSON.stringify(events)).not.toContain("must not leak");
   });
@@ -120,11 +120,12 @@ describe("builtin adapter protocol conformance", () => {
           { type: "tool_execution_start", toolName: "read", args: {} },
           { type: "tool_execution_end", toolName: "read" },
           { type: "message_update", delta: { type: "text_delta", delta: "done" } },
+          { type: "message_update", delta: { type: "text_end", content: "done" } },
           { type: "agent_end" },
         ];
         return vendorEvents.flatMap((event) => mapPiSdkEvent(event, "pi-root", state)) as AdapterEvent[];
       },
-      expectedEventKinds: ["thinking", "tool_call", "tool_output", "text"],
+      expectedEventKinds: ["assistant_reasoning_delta", "tool_call", "tool_output", "assistant_message_delta", "assistant_message_completed"],
       terminalSource: "transport_invocation",
     });
   });

--- a/src/daemon/agent-driver/src/testing/builtin-adapter-conformance.test.ts
+++ b/src/daemon/agent-driver/src/testing/builtin-adapter-conformance.test.ts
@@ -116,11 +116,11 @@ describe("builtin adapter protocol conformance", () => {
         });
         const state = { sawTextDelta: false };
         const vendorEvents = [
-          { type: "message_update", delta: { type: "thinking_delta", delta: "plan" } },
+          { type: "message_update", assistantMessageEvent: { type: "thinking_delta", delta: "plan" } },
           { type: "tool_execution_start", toolName: "read", args: {} },
           { type: "tool_execution_end", toolName: "read" },
-          { type: "message_update", delta: { type: "text_delta", delta: "done" } },
-          { type: "message_update", delta: { type: "text_end", content: "done" } },
+          { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "done" } },
+          { type: "message_update", assistantMessageEvent: { type: "text_end", content: "done" } },
           { type: "agent_end" },
         ];
         return vendorEvents.flatMap((event) => mapPiSdkEvent(event, "pi-root", state)) as AdapterEvent[];

--- a/src/daemon/agent-driver/src/testing/builtin-session-conformance.test.ts
+++ b/src/daemon/agent-driver/src/testing/builtin-session-conformance.test.ts
@@ -271,11 +271,11 @@ function installVendorHarness(backend: BuiltinBackendId): VendorHarness {
         case "cursor":
           break;
         case "opencode":
-          openCodeLanes[0]!.emit({ kind: "thinking", text: `turn-${turn}` });
+          openCodeLanes[0]!.emit({ kind: "assistant_reasoning_completed", text: `turn-${turn}` });
           break;
         case "pi":
           handles[0]!.isStreaming = true;
-          lanes[0]!.emitEvents([{ kind: "thinking", text: `turn-${turn}` }]);
+          lanes[0]!.emitEvents([{ kind: "assistant_reasoning_delta", text: `turn-${turn}` }]);
           break;
       }
     },
@@ -1088,7 +1088,7 @@ describe("claude persistent transport ownership", () => {
     });
     harness.emitProvider({ type: "system", subtype: "status", status: "late-progress" });
     await settle();
-    expect(events.filter((event) => event.type === "text_delta")).toHaveLength(0);
+    expect(events.filter((event) => event.type === "assistant_message_completed")).toHaveLength(0);
     expect(events.filter((event) => event.type === "tool_started")).toHaveLength(0);
     expect(events.filter((event) => event.type === "internal_progress")).toHaveLength(0);
 
@@ -1107,7 +1107,7 @@ describe("claude persistent transport ownership", () => {
     await vi.waitFor(() => {
       expect(events.filter((event) => event.type === "turn_completed")).toHaveLength(2);
     });
-    expect(events.filter((event) => event.type === "text_delta")).toMatchObject([{ text: "B_TEXT" }]);
+    expect(events.filter((event) => event.type === "assistant_message_completed")).toMatchObject([{ text: "B_TEXT" }]);
     expect(events.filter((event) => event.type === "tool_started")).toMatchObject([{ name: "CurrentTool" }]);
     expect(harness.processes).toHaveLength(1);
 
@@ -1145,7 +1145,7 @@ describe("claude persistent transport ownership", () => {
       ], sameChunk);
       await settle();
       expect(opened.session.snapshot().activeTurn).toBeUndefined();
-      expect(events.filter((event) => event.type === "text_delta")).toHaveLength(0);
+      expect(events.filter((event) => event.type === "assistant_message_completed")).toHaveLength(0);
       expect(events.filter((event) => event.type === "tool_started")).toHaveLength(0);
       expect(events.filter((event) => event.type === "internal_progress")).toHaveLength(0);
 

--- a/src/daemon/src/daemon/createDaemon.test.ts
+++ b/src/daemon/src/daemon/createDaemon.test.ts
@@ -58,11 +58,25 @@ const credentialProxyHarness = vi.hoisted(() => ({
   onInboxPullObservationError: undefined as ((failure: Record<string, unknown>) => void) | undefined,
 }));
 
+const timelineRecorderHarness = vi.hoisted(() => ({
+  pulls: [] as Array<{ agentId: string; owner: unknown; messages: unknown[] }>,
+}));
+
 vi.mock("../timeline/index.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../timeline/index.js")>();
   return {
     ...actual,
     sweepTimelineHistory: (workingDirectoryBase: string) => timelineSweepHarness.run(workingDirectoryBase),
+    createTimelineRecorder: (...args: Parameters<typeof actual.createTimelineRecorder>) => {
+      const recorder = actual.createTimelineRecorder(...args);
+      return {
+        ...recorder,
+        recordInboxPull(agentId: string, owner: Parameters<typeof recorder.recordInboxPull>[1], messages: Parameters<typeof recorder.recordInboxPull>[2]) {
+          timelineRecorderHarness.pulls.push({ agentId, owner, messages });
+          recorder.recordInboxPull(agentId, owner, messages);
+        },
+      };
+    },
   };
 });
 
@@ -93,6 +107,7 @@ afterEach(() => {
   credentialProxyHarness.onInboxPullStart = undefined;
   credentialProxyHarness.onInboxPullResponse = undefined;
   credentialProxyHarness.onInboxPullObservationError = undefined;
+  timelineRecorderHarness.pulls.splice(0);
   for (const dir of startupSweepDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 
@@ -252,7 +267,7 @@ function daemonFakeSession(options: {
         } else if (runtime.kind === "turn_end") {
           emit({ type: "turn_completed", turnId: "daemon-test-turn", commandIds: [], result: { outcome: "success", backendSessionId: runtime.sessionId } } as never);
         } else if (runtime.kind === "text") {
-          emit({ type: "text_delta", turnId: "daemon-test-turn", text: runtime.text ?? "" } as never);
+          emit({ type: "assistant_message_completed", turnId: "daemon-test-turn", text: runtime.text ?? "", truncated: false } as never);
         }
       } else if (event === "exit") {
         const result: AgentSessionResult = { outcome: "stopped", requested: true, exitCode: null, signal: null, cleanup: { status: "released" } };
@@ -1259,6 +1274,80 @@ describe("createDaemon — logging", () => {
       observePull(7);
       await vi.waitFor(() => expect(sends).toHaveLength(3));
       expect(sends[2]).toMatchObject({ sequence: 8 });
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("uses only the immutable pull-start owner when the active turn changes before response", async () => {
+    global.fetch = vi.fn(async (url: string | URL) => {
+      if (String(url).includes("/enroll-agent")) {
+        return new Response(JSON.stringify({ runnerKey: "rk_pull_owner" }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ bots: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const workingDirectoryBase = mkdtempSync(join(tmpdir(), "timeline-pull-owner-"));
+    startupSweepDirs.push(workingDirectoryBase);
+    mkdirSync(join(workingDirectoryBase, "bot_1"));
+    const sockets: FakeSocket[] = [];
+    let session: DaemonFakeSession | undefined;
+    const daemon = await createDaemon({
+      machineKey: "cmk_pull_owner",
+      serverUrl: "http://localhost:9999",
+      serverWsUrl: "ws://x",
+      webSocketFactory: factory(sockets) as any,
+      runtimeReport: [{ id: "codex" }],
+      driverFor: () => fullFakeDriver("codex"),
+      sessionFactory: () => {
+        session = daemonFakeSession();
+        return session;
+      },
+      capabilities: [],
+      workingDirectoryBase,
+    });
+
+    try {
+      const ownerlessToken = credentialProxyHarness.onInboxPullStart?.("bot_1");
+      sockets[0].emit("open");
+      sockets[0].emit("message", JSON.stringify({
+        type: "bot:added",
+        botId: "bot_1",
+        name: "Bot One",
+        discriminator: "0001",
+      }));
+      sockets[0].emit("message", JSON.stringify({
+        type: "agent:wake",
+        agentId: "bot_1",
+        config: { version: 1, runtime: "codex", model: { kind: "default" }, mode: { kind: "default" } },
+        launchId: "launch_1",
+        unreadNotice: { kind: "unread_notice", channel: "/demo#1234/general", latestSeq: 1 },
+      }));
+      await vi.waitFor(() => expect(session).toBeDefined());
+      await vi.waitFor(() => {
+        const token = credentialProxyHarness.onInboxPullStart?.("bot_1") as { owner?: unknown } | undefined;
+        expect(token?.owner).toMatchObject({ sessionInstanceId: "daemon-test", rootTurnId: "daemon-test-turn" });
+      });
+      const ownedToken = credentialProxyHarness.onInboxPullStart?.("bot_1");
+      await session!.fire("runtime_event", { kind: "turn_end", sessionId: "test-session" });
+
+      const observed = (seq: string, text: string) => [{
+        seq,
+        channel: "/demo#1234/general",
+        sender: "@gus#1813",
+        content: { text },
+        time: "2026-08-24T12:00:00Z",
+      }];
+      credentialProxyHarness.onInboxPullResponse?.("bot_1", observed("#1", "late owned"), ownedToken);
+      credentialProxyHarness.onInboxPullResponse?.("bot_1", observed("#2", "late ownerless"), ownerlessToken);
+
+      expect(timelineRecorderHarness.pulls).toHaveLength(2);
+      expect(timelineRecorderHarness.pulls[0]!.owner).toMatchObject({
+        sessionInstanceId: "daemon-test",
+        rootTurnId: "daemon-test-turn",
+        barrierGeneration: 0,
+      });
+      expect(timelineRecorderHarness.pulls[1]!.owner).toBeNull();
     } finally {
       await daemon.stop();
     }

--- a/src/daemon/src/daemon/createDaemon.test.ts
+++ b/src/daemon/src/daemon/createDaemon.test.ts
@@ -22,6 +22,7 @@ import type {
   BuiltinBackendSpecs,
 } from "@alook/agent-driver";
 import { AgentRouter } from "../manager/agentRouter";
+import { WsControlChannel } from "../server/wsControlChannel";
 import { CredentialBroker } from "../credentials/credentialProxy";
 import type { AgentBackend as Driver } from "../drivers/index.js";
 import type { Logger } from "../logger";
@@ -958,6 +959,37 @@ for await (const line of createInterface({ input: process.stdin })) {
     ]]);
     expect(JSON.stringify(warnings)).not.toContain("private");
     expect(JSON.stringify(warnings)).not.toContain("Bearer");
+    await daemon.stop();
+  });
+
+  it("treats non-object or absent pull observation tokens as ownerless without model-seen updates", async () => {
+    const sockets: FakeSocket[] = [];
+    const workingDirectoryBase = mkdtempSync(join(tmpdir(), "timeline-invalid-token-"));
+    startupSweepDirs.push(workingDirectoryBase);
+    const recordModelSeen = vi.spyOn(WsControlChannel.prototype, "recordModelSeen");
+    const daemon = await createDaemon({
+      machineKey: "cmk_invalid_observation_token",
+      serverUrl: "http://localhost:9999",
+      serverWsUrl: "ws://x",
+      webSocketFactory: factory(sockets) as any,
+      runtimeReport: [],
+      driverFor: () => fakeDriver,
+      capabilities: [],
+      workingDirectoryBase,
+    });
+    const messages = [{
+      seq: "#1",
+      channel: "/demo#1234/general",
+      sender: "@gus#1813",
+      content: { text: "ownerless" },
+      time: "2026-08-24T12:00:00Z",
+    }];
+
+    credentialProxyHarness.onInboxPullResponse?.("bot_1", messages, "invalid-token");
+    credentialProxyHarness.onInboxPullResponse?.("bot_1", messages);
+
+    expect(timelineRecorderHarness.pulls.map((pull) => pull.owner)).toEqual([null, null]);
+    expect(recordModelSeen).not.toHaveBeenCalled();
     await daemon.stop();
   });
 

--- a/src/daemon/src/daemon/createDaemon.ts
+++ b/src/daemon/src/daemon/createDaemon.ts
@@ -453,11 +453,20 @@ export async function createDaemon(opts: CreateDaemonOptions): Promise<RunningDa
 
   const broker = new CredentialBroker({ upstreamBaseUrl: opts.serverUrl });
   const proxy = await startCredentialProxy(broker, {
-    onInboxPullStart: (agentId) => channelRef?.modelSeenGeneration(agentId),
+    onInboxPullStart: (agentId) => ({
+      modelSeenGeneration: channelRef?.modelSeenGeneration(agentId),
+      owner: managerRef?.timelineTurnOwner(agentId) ?? null,
+    }),
     onInboxPullResponse: (agentId, messages, observationToken) => {
-      timeline.appendEntryForAgent(agentId, messages);
-      if (typeof observationToken === "number") {
-        channelRef?.recordModelSeen(agentId, messages, observationToken);
+      const token = observationToken && typeof observationToken === "object"
+        ? observationToken as {
+            modelSeenGeneration?: unknown;
+            owner?: ReturnType<AgentProcessManager["timelineTurnOwner"]>;
+          }
+        : null;
+      timeline.recordInboxPull(agentId, token?.owner ?? null, messages);
+      if (typeof token?.modelSeenGeneration === "number") {
+        channelRef?.recordModelSeen(agentId, messages, token.modelSeenGeneration);
       }
     },
     onInboxPullObservationError: ({ agentId, reason, contentEncoding }) => {

--- a/src/daemon/src/manager/managerRuntime.test.ts
+++ b/src/daemon/src/manager/managerRuntime.test.ts
@@ -2238,6 +2238,23 @@ describe("truncateThinking", () => {
 });
 
 describe("AgentProcessManager — bot audit event emission", () => {
+  it("contains audit observer failures for reasoning and tool-start events", async () => {
+    const logger = stubLogger();
+    const onBotAuditEvent = vi.fn(() => { throw new Error("observer failed"); });
+    const { mgr, session } = makeManager({ logger, onBotAuditEvent });
+    mgr.deliver("a1", { seq: 1, text: "hello" });
+
+    await expect(session.fire("runtime_event", { kind: "thinking", text: "completed reasoning" }))
+      .resolves.toBeUndefined();
+    await expect(session.fire("runtime_event", { kind: "tool_call", name: "Read", input: { file_path: "/x" } }))
+      .resolves.toBeUndefined();
+
+    expect(logger.calls.debug.map(([message]) => message)).toEqual(expect.arrayContaining([
+      "audit emit failed (thinking)",
+      "audit emit failed (tool_call)",
+    ]));
+  });
+
   it("emits completed reasoning with truncated+chars fields immediately", async () => {
     const onBotAuditEvent = vi.fn();
     const { mgr, session } = makeManager({ onBotAuditEvent });

--- a/src/daemon/src/manager/managerRuntime.test.ts
+++ b/src/daemon/src/manager/managerRuntime.test.ts
@@ -179,8 +179,8 @@ function fakeSession(sessionInstanceId = "test-instance"): FakeSession {
           case "session_init":
             push({ type: "session_started", backendSessionId: event.sessionId ?? "test-session" } as never);
             break;
-          case "thinking": push({ type: "thinking_delta", turnId, text: event.text ?? "" } as never); break;
-          case "text": push({ type: "text_delta", turnId, text: event.text ?? "" } as never); break;
+          case "thinking": push({ type: "assistant_reasoning_completed", turnId, text: event.text ?? "", truncated: false } as never); break;
+          case "text": push({ type: "assistant_message_completed", turnId, text: event.text ?? "", truncated: false } as never); break;
           case "tool_call": push({ type: "tool_started", turnId, name: event.name ?? "unknown", input: (event.input ?? null) as never } as never); break;
           case "tool_output": push({ type: "tool_finished", turnId, name: event.name ?? "unknown" } as never); break;
           case "compaction_started":
@@ -303,6 +303,32 @@ function makeManager(opts: { logger?: Logger; tickIntervalMs?: number; idleTimeo
   return { mgr, session, onRuntimeSpawnFailed, onRuntimeSessionEstablished };
 }
 
+function exactTimelineLifecycleStub() {
+  return {
+    barrierGeneration: () => 0,
+    beginTurn: vi.fn(),
+    recordAssistantMessage: vi.fn(),
+    finalizeTurn: vi.fn(),
+    fenceSession: vi.fn(),
+  };
+}
+
+function recordObservedTurn(
+  recorder: ReturnType<typeof createTimelineRecorder>,
+  agentId: string,
+  rootTurnId: string,
+  messages: Parameters<ReturnType<typeof createTimelineRecorder>["recordInboxPull"]>[2],
+): void {
+  const owner = {
+    sessionInstanceId: `fixture-${rootTurnId}`,
+    rootTurnId,
+    barrierGeneration: recorder.barrierGeneration(agentId),
+  };
+  recorder.beginTurn(agentId, owner);
+  recorder.recordInboxPull(agentId, owner, messages);
+  recorder.finalizeTurn(agentId, owner);
+}
+
 describe("AgentProcessManager — repeated backend-session stall recovery", () => {
   it("rejects a backend session before publishing it when setSession cannot persist control", async () => {
     const session = fakeSession("set-session-control-failure");
@@ -321,8 +347,8 @@ describe("AgentProcessManager — repeated backend-session stall recovery", () =
       }),
       sessionFactory: (hooks) => bindFactorySession(hooks, session),
       timeline: {
+        ...exactTimelineLifecycleStub(),
         setSession: () => false,
-        appendResponseToLatest: vi.fn(),
         resumeSessionId: () => null,
         recordSessionStall: () => true,
         clearSessionStall: () => true,
@@ -364,8 +390,8 @@ describe("AgentProcessManager — repeated backend-session stall recovery", () =
         }),
         sessionFactory: (hooks) => bindFactorySession(hooks, session),
         timeline: {
+          ...exactTimelineLifecycleStub(),
           setSession: () => true,
-          appendResponseToLatest: vi.fn(),
           resumeSessionId: () => null,
           recordSessionStall,
           clearSessionStall: () => true,
@@ -433,8 +459,8 @@ describe("AgentProcessManager — repeated backend-session stall recovery", () =
         }),
         sessionFactory: (hooks) => bindFactorySession(hooks, session),
         timeline: {
+          ...exactTimelineLifecycleStub(),
           setSession: () => true,
-          appendResponseToLatest: vi.fn(),
           resumeSessionId: () => "sess-poison",
           resolveResumeSession: () => ({
             kind: "session",
@@ -495,8 +521,8 @@ describe("AgentProcessManager — repeated backend-session stall recovery", () =
       }),
       sessionFactory: (hooks) => bindFactorySession(hooks, session),
       timeline: {
+        ...exactTimelineLifecycleStub(),
         setSession: () => true,
-        appendResponseToLatest: vi.fn(),
         resumeSessionId: () => "sess-poison",
         resolveResumeSession: () => ({
           kind: "session",
@@ -533,8 +559,8 @@ describe("AgentProcessManager — repeated backend-session stall recovery", () =
         }),
         sessionFactory,
         timeline: {
+          ...exactTimelineLifecycleStub(),
           setSession: () => true,
-          appendResponseToLatest: vi.fn(),
           resumeSessionId: () => null,
           recordSessionStall: () => true,
           clearSessionStall: () => true,
@@ -604,7 +630,7 @@ describe("AgentProcessManager — repeated backend-session stall recovery", () =
       });
       writer.forgetSession("a1", "stall_recovery", "sess-poison");
       writer.setSession("a1", "sess-healthy");
-      writer.appendEntryForAgent("a1", [{
+      recordObservedTurn(writer, "a1", "healthy-after-fence", [{
         seq: "#1",
         channel: "/test/general",
         sender: "@tester#0001",
@@ -659,7 +685,7 @@ describe("AgentProcessManager — repeated backend-session stall recovery", () =
         now: () => new Date(now),
       });
       writer.setSession("a1", "sess-healthy");
-      writer.appendEntryForAgent("a1", [{
+      recordObservedTurn(writer, "a1", "healthy-clean-marker", [{
         seq: "#1",
         channel: "/test/general",
         sender: "@tester#0001",
@@ -810,7 +836,7 @@ describe("AgentProcessManager — repeated backend-session stall recovery", () =
       firstManager.deliver("a1", { id: "wake-before-restart", seq: 1, text: "first" });
       firstSession.startResolver?.();
       await firstSession.fire("runtime_event", { kind: "session_init", sessionId: "sess-poison" });
-      firstRecorder.appendEntryForAgent("a1", [{
+      recordObservedTurn(firstRecorder, "a1", "before-daemon-restart", [{
         seq: "#1",
         channel: "/test/general",
         sender: "@tester#0001",
@@ -924,8 +950,8 @@ describe("AgentProcessManager — repeated backend-session stall recovery", () =
           return bindFactorySession(hooks, session);
         },
         timeline: {
+          ...exactTimelineLifecycleStub(),
           setSession,
-          appendResponseToLatest: vi.fn(),
           resumeSessionId: () => resolution.kind === "session" ? resolution.sessionId : null,
           resolveResumeSession: () => resolution,
           recordSessionStall,
@@ -1428,6 +1454,121 @@ describe("AgentProcessManager — session race conditions", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("renews only the exact root lease from payload-free heartbeats and stalls when they stop", async () => {
+    vi.useFakeTimers();
+    try {
+      let currentTime = 0;
+      const { mgr, session } = makeManager({ now: () => currentTime, tickIntervalMs: 5 });
+      const baseSnapshot = session.snapshot.bind(session);
+      session.snapshot = () => ({
+        ...baseSnapshot(),
+        diagnostics: {
+          deliveryPhase: "working",
+          turnSilence: {
+            nativeIdleTimeoutMs: 80,
+            daemonGraceMs: 20,
+            recoveryGraceMs: 50,
+            maxRecoveryExtensions: 1,
+            normalBudgetMs: 100,
+          },
+          metrics: {
+            physicalOpenCount: 1,
+            turnCount: 1,
+            commandAdmissionCount: 1,
+            commandAdmissionLatencyTotalMs: 0,
+            queueDwellCount: 0,
+            queueDwellTotalMs: 0,
+            sseReconnectCount: 0,
+            resumeOutcome: "not_requested",
+            terminalOwnerKind: "transport_request",
+          },
+        },
+      });
+      const stop = vi.spyOn(session, "stop");
+      mgr.start();
+      mgr.deliver("a1", { id: "heartbeat-stall", seq: 1, text: "hello" });
+      session.startResolver?.();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      currentTime = 90;
+      await session.pushAgentEvent({ type: "work_heartbeat", turnId: "test-turn" });
+      expect(mgr.snapshot().agents.a1).toMatchObject({
+        lastNativeActivityAt: 90,
+        lastNativeActivityKind: "internal_progress",
+        runtimePhase: "inference",
+      });
+      expect(mgr.snapshot().agents.a1.execution.lease).toMatchObject({ nativeDeadlineAt: 190 });
+
+      currentTime = 189;
+      await vi.advanceTimersByTimeAsync(5);
+      expect(stop).not.toHaveBeenCalled();
+      currentTime = 190;
+      await vi.advanceTimersByTimeAsync(5);
+      expect(stop).toHaveBeenCalledWith({ reason: "stalled", forceAfterMs: 2_000 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects stale heartbeat ownership and maps complete semantic events to typed native evidence", async () => {
+    let currentTime = 0;
+    const { mgr, session } = makeManager({ now: () => currentTime });
+    mgr.deliver("a1", { id: "typed-evidence", seq: 1, text: "hello" });
+    session.startResolver?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    const internal = mgr as unknown as {
+      activeSpawnState: Map<string, object>;
+      onAgentEvent(agentId: string, event: AgentEvent<BuiltinBackendSpecs, "codex">, runtimeId: "codex", owner: object): void;
+    };
+    const owner = internal.activeSpawnState.get("a1")!;
+
+    currentTime = 40;
+    internal.onAgentEvent("a1", {
+      type: "work_heartbeat",
+      turnId: "test-turn",
+      sequence: 100,
+      sessionInstanceId: "stale-epoch",
+      at: currentTime,
+    }, "codex", owner);
+    await session.pushAgentEvent({ type: "work_heartbeat", turnId: "child-turn" });
+    await session.pushAgentEvent({
+      type: "diagnostic",
+      turnId: "test-turn",
+      severity: "info",
+      source: "test",
+      message: "observational only",
+    });
+    expect(mgr.snapshot().agents.a1).toMatchObject({
+      lastNativeActivityAt: 0,
+      lastNativeActivityKind: "turn_started",
+    });
+
+    await session.pushAgentEvent({
+      type: "assistant_reasoning_completed",
+      turnId: "test-turn",
+      text: "reasoning",
+      truncated: false,
+    });
+    expect(mgr.snapshot().agents.a1).toMatchObject({
+      lastNativeActivityAt: 40,
+      lastNativeActivityKind: "thinking",
+    });
+    currentTime = 50;
+    await session.pushAgentEvent({
+      type: "assistant_message_completed",
+      turnId: "test-turn",
+      text: "answer",
+      truncated: false,
+    });
+    expect(mgr.snapshot().agents.a1).toMatchObject({
+      lastNativeActivityAt: 50,
+      lastNativeActivityKind: "text",
+    });
+    await mgr.stopAll();
   });
 
   it("does not let turn-scoped telemetry or diagnostics refresh the native silence deadline", async () => {
@@ -2097,14 +2238,12 @@ describe("truncateThinking", () => {
 });
 
 describe("AgentProcessManager — bot audit event emission", () => {
-  it("emits `thinking` with truncated+chars fields (flushed at the next event)", async () => {
+  it("emits completed reasoning with truncated+chars fields immediately", async () => {
     const onBotAuditEvent = vi.fn();
     const { mgr, session } = makeManager({ onBotAuditEvent });
     mgr.deliver("a1", { seq: 1, text: "hello" });
 
     await session.fire("runtime_event", { kind: "thinking", text: "think about it" });
-    expect(onBotAuditEvent).not.toHaveBeenCalled();
-    await session.fire("runtime_event", { kind: "turn_end" });
 
     expect(onBotAuditEvent).toHaveBeenCalledWith(
       "a1",
@@ -2120,16 +2259,14 @@ describe("AgentProcessManager — bot audit event emission", () => {
     );
   });
 
-  it("coalesces delta-streamed thinking into ONE row and drops empty deltas", async () => {
+  it("emits one bounded audit row per completed reasoning item and drops empty items", async () => {
     const onBotAuditEvent = vi.fn();
     const { mgr, session } = makeManager({ onBotAuditEvent });
     mgr.deliver("a1", { seq: 1, text: "hello" });
 
     await session.fire("runtime_event", { kind: "thinking", text: "" });
-    await session.fire("runtime_event", { kind: "thinking", text: "let me " });
-    await session.fire("runtime_event", { kind: "thinking", text: "count" });
+    await session.fire("runtime_event", { kind: "thinking", text: "let me count" });
     await session.fire("runtime_event", { kind: "thinking", text: "" });
-    await session.fire("runtime_event", { kind: "tool_call", name: "Read", input: { file_path: "/x" } });
 
     const thinkingCalls = onBotAuditEvent.mock.calls.filter(
       ([, ev]) => (ev as { kind?: string })?.kind === "thinking"
@@ -4347,8 +4484,19 @@ describe("B1 red gate — exact-once terminal matrix", () => {
     publish({ type: "diagnostic", severity: "warning", source: "codex", message: "warning" });
     publish({ type: "token_usage", turnId: "test-turn", source: "codex", usage: {}, details: {} });
     publish({ type: "rate_limits", turnId: "test-turn", source: "codex", details: {} });
-    publish({ type: "thinking_delta", turnId: "test-turn", text: "" });
-    publish({ type: "text_delta", turnId: "test-turn", text: "" });
+    publish({ type: "work_heartbeat", turnId: "test-turn" });
+    publish({
+      type: "assistant_reasoning_completed",
+      turnId: "test-turn",
+      text: "reasoning",
+      truncated: false,
+    });
+    publish({
+      type: "assistant_message_completed",
+      turnId: "test-turn",
+      text: "answer",
+      truncated: false,
+    });
     publish({ type: "command_queued", commandId: "queued", reason: "runtime_busy" });
     publish({ type: "command_accepted", commandId: "accepted", turnId: "test-turn", delivery: "steer" });
     publish({
@@ -4358,7 +4506,7 @@ describe("B1 red gate — exact-once terminal matrix", () => {
     });
     publish({ type: "turn_started", turnId: "test-turn", commandIds: ["accepted"] });
 
-    expect(rows.filter((row) => row.event === "runtime_signal")).toHaveLength(baselineSignals + 4);
+    expect(rows.filter((row) => row.event === "runtime_signal")).toHaveLength(baselineSignals + 6);
   });
 
   it("keeps tail telemetry observational while turn-correlated work can recover a false terminal", async () => {
@@ -4723,14 +4871,14 @@ describe("AgentProcessManager — defensive owner fences", () => {
     const owner = internal.activeSpawnState.get("a1")!;
     owner.sessionInstanceId = "test-instance";
     internal.onAgentEvent("a1", {
-      type: "thinking_delta", turnId: "turn", text: "stale", sequence: 1,
+      type: "assistant_reasoning_completed", turnId: "turn", text: "stale", truncated: false, sequence: 1,
       sessionInstanceId: "stale-instance", at: Date.now(),
     }, "codex", owner);
     owner.superseded = true;
     (mgr as unknown as { state: { agents: { a1: { execution: { sessionInstanceId: string } } } } })
       .state.agents.a1.execution.sessionInstanceId = "replacement-instance";
     internal.onAgentEvent("a1", {
-      type: "thinking_delta", turnId: "turn", text: "superseded", sequence: 2,
+      type: "assistant_reasoning_completed", turnId: "turn", text: "superseded", truncated: false, sequence: 2,
       sessionInstanceId: "test-instance", at: Date.now(),
     }, "codex", owner);
     expect(logger.calls.warn.map(([message]) => message)).toEqual([
@@ -5010,8 +5158,8 @@ describe("Codex root event ownership — subagent completion isolation", () => {
         for (const event of events) {
           if (event.kind === "session_init") {
             await session.pushAgentEvent({ type: "session_started", backendSessionId: event.sessionId });
-          } else if (event.kind === "thinking") {
-            await session.pushAgentEvent({ type: "thinking_delta", turnId: "test-turn", text: event.text });
+          } else if (event.kind === "assistant_reasoning_completed") {
+            await session.pushAgentEvent({ type: "assistant_reasoning_completed", turnId: "test-turn", text: event.text, truncated: false });
           } else if (event.kind === "tool_call") {
             await session.pushAgentEvent({ type: "tool_started", turnId: "test-turn", name: event.name, input: event.input as never });
           } else if (event.kind === "tool_output") {

--- a/src/daemon/src/manager/managerRuntime.ts
+++ b/src/daemon/src/manager/managerRuntime.ts
@@ -30,6 +30,7 @@ import { nowLocalISO } from "../util/localTime.js";
 import type { ResumeSessionResolution } from "../timeline/timeline.js";
 import type { SystemEntryType } from "../timeline/types.js";
 import { randomUUID } from "node:crypto";
+import type { TimelineTurnOwner } from "../timeline/recorder.js";
 const SESSION_STOP_GRACE_MS = 2_000;
 export type AgentActivityState = "idle" | "starting" | "running" | "stopping";
 export type DaemonAgentSession = AgentSession<BuiltinBackendSpecs, BuiltinBackendId>;
@@ -83,6 +84,7 @@ interface ActiveSpawnState {
   launchIdSnapshot: string | null;
   nextTurnOrdinal: number;
   activeSpan: ActiveTurnSpan | null;
+  timelineTurnOwner: TimelineTurnOwner | null;
   pendingDeliverySpans: Map<string, PendingDeliveryTrace>;
 }
 interface TraceRecordBase {
@@ -246,8 +248,12 @@ export interface ManagerRuntimeOpts {
   logger?: Logger;
 }
 export interface TimelineRecorder {
-  setSession(agentId: string, sessionId: string): boolean;
-  appendResponseToLatest(agentId: string, text: string): void;
+  barrierGeneration(agentId: string): number;
+  beginTurn(agentId: string, owner: TimelineTurnOwner): void;
+  recordAssistantMessage(agentId: string, owner: TimelineTurnOwner, text: string, truncated?: boolean): void;
+  finalizeTurn(agentId: string, owner: TimelineTurnOwner): void;
+  fenceSession(agentId: string): void;
+  setSession(agentId: string, sessionId: string, sessionInstanceId?: string): boolean;
   resumeSessionId(agentId: string, provider: string | null): string | null;
   resolveResumeSession?(agentId: string, provider: string | null): ResumeSessionResolution;
   recordSessionStall?(agentId: string, sessionId: string): boolean;
@@ -422,7 +428,6 @@ export class AgentProcessManager {
   private readonly resumeSessions = new Map<string, string>();
   private readonly launchIds = new Map<string, string>();
   private readonly liveSessions = new Map<string, string>();
-  private readonly thinkingBuffers = new Map<string, string>();
   private readonly activeSpawnState = new Map<string, ActiveSpawnState>();
   private readonly publishedAgentActivity = new Map<string, AgentActivityState>();
   private readonly traceProcessNonce = randomUUID();
@@ -571,6 +576,7 @@ export class AgentProcessManager {
       throw new Error("Reset aborted because resume control could not be persisted");
     }
     this.register(agentId, { runtimeConfig: opts.runtimeConfig, launchId: opts.launchId });
+    if (!opts.forgetSession) this.opts.timeline?.fenceSession(agentId);
     this.abortCurrentTurn(agentId, opts.abortCause);
     this.markResetting(agentId);
     const status = this.state.agents[agentId]?.status;
@@ -642,6 +648,10 @@ export class AgentProcessManager {
       sessionId: this.liveSessions.get(agentId) ?? null,
       launchId: this.launchIds.get(agentId) ?? null,
     };
+  }
+  timelineTurnOwner(agentId: string): TimelineTurnOwner | null {
+    const owner = this.traceOwnerFor(agentId);
+    return owner?.timelineTurnOwner ? { ...owner.timelineTurnOwner } : null;
   }
   liveSessionReports(): Array<{ agentId: string; sessionId: string; launchId: string }> {
     return [...this.liveSessions.entries()].map(([agentId, sessionId]) => ({
@@ -723,6 +733,9 @@ export class AgentProcessManager {
   ): boolean {
     if (!expectedSpan || owner.activeSpan !== expectedSpan) return false;
     owner.activeSpan = null;
+    const timelineTurnOwner = owner.timelineTurnOwner;
+    owner.timelineTurnOwner = null;
+    if (timelineTurnOwner) this.opts.timeline?.finalizeTurn(owner.agentId, timelineTurnOwner);
     const nowMs = this.now();
     const base = {
       recordKind: "turn_span" as const,
@@ -1315,6 +1328,7 @@ export class AgentProcessManager {
       launchIdSnapshot: typeof ctx.launchId === "string" && ctx.launchId.length > 0 ? ctx.launchId : null,
       nextTurnOrdinal: 1,
       activeSpan: null,
+      timelineTurnOwner: null,
       pendingDeliverySpans: new Map(),
     };
     const previousOwner = this.activeSpawnState.get(agentId);
@@ -1368,7 +1382,6 @@ export class AgentProcessManager {
           this.emitErrorAudit(agentId, "exit", "abnormal_exit", `Session ended unexpectedly (${detail})`);
         }
       }
-      this.flushThinkingAudit(agentId);
       if (state.sessionInstanceId) {
         this.dispatch({ type: "session_closed", agentId, sessionInstanceId: state.sessionInstanceId }, state);
       }
@@ -1399,7 +1412,11 @@ export class AgentProcessManager {
         reportSpawnFailure(event.error.code || "failed_to_start", { message: event.error.message });
       }
       if (event.type === "session_started") {
-        const persisted = this.opts.timeline?.setSession(agentId, event.backendSessionId);
+        const persisted = this.opts.timeline?.setSession(
+          agentId,
+          event.backendSessionId,
+          event.sessionInstanceId,
+        );
         if (persisted === false) {
           state.discardEvents = true;
           reportSpawnFailure("resume_control_update_failed", {
@@ -1579,24 +1596,6 @@ export class AgentProcessManager {
       this.log.debug("audit emit failed (error)", { agentId, err: String(err) });
     }
   }
-  private flushThinkingAudit(agentId: string): void {
-    const buffered = this.thinkingBuffers.get(agentId);
-    if (!buffered) return;
-    this.thinkingBuffers.delete(agentId);
-    if (!this.opts.onBotAuditEvent) return;
-    const { text, truncated, chars } = truncateThinking(buffered);
-    try {
-      this.opts.onBotAuditEvent(agentId, {
-        kind: "thinking",
-        payload: { text, truncated, chars },
-      }, {
-        sessionId: this.liveSessions.get(agentId) ?? null,
-        launchId: this.launchIds.get(agentId) ?? null,
-      });
-    } catch (err) {
-      this.log.debug("audit emit failed (thinking)", { agentId, err: String(err) });
-    }
-  }
   private onAgentEvent(
     agentId: string,
     event: ManagedEvent,
@@ -1644,26 +1643,33 @@ export class AgentProcessManager {
       }
     }
     if (this.opts.onBotAuditEvent) {
-      if (event.type === "thinking_delta") {
-        if (event.text.length > 0) {
-          this.thinkingBuffers.set(agentId, (this.thinkingBuffers.get(agentId) ?? "") + event.text);
+      if (event.type === "assistant_reasoning_completed" && event.text.length > 0) {
+        const { text, truncated, chars } = truncateThinking(event.text);
+        try {
+          this.opts.onBotAuditEvent(agentId, {
+            kind: "thinking",
+            payload: { text, truncated: truncated || event.truncated, chars },
+          }, {
+            sessionId: this.liveSessions.get(agentId) ?? null,
+            launchId: this.launchIds.get(agentId) ?? null,
+          });
+        } catch (err) {
+          this.log.debug("audit emit failed (thinking)", { agentId, err: String(err) });
         }
-      } else {
-        this.flushThinkingAudit(agentId);
-        if (event.type === "tool_started") {
-          const audit = extractToolAudit(event.name, event.input);
-          if (!audit.suppressed) {
-            const payload = audit.target !== undefined
-              ? { name: audit.name, target: audit.target }
-              : { name: audit.name };
-            try {
-              this.opts.onBotAuditEvent(agentId, { kind: "tool_call", payload }, {
-                sessionId: this.liveSessions.get(agentId) ?? null,
-                launchId: this.launchIds.get(agentId) ?? null,
-              });
-            } catch (err) {
-              this.log.debug("audit emit failed (tool_call)", { agentId, err: String(err) });
-            }
+      }
+      if (event.type === "tool_started") {
+        const audit = extractToolAudit(event.name, event.input);
+        if (!audit.suppressed) {
+          const payload = audit.target !== undefined
+            ? { name: audit.name, target: audit.target }
+            : { name: audit.name };
+          try {
+            this.opts.onBotAuditEvent(agentId, { kind: "tool_call", payload }, {
+              sessionId: this.liveSessions.get(agentId) ?? null,
+              launchId: this.launchIds.get(agentId) ?? null,
+            });
+          } catch (err) {
+            this.log.debug("audit emit failed (tool_call)", { agentId, err: String(err) });
           }
         }
       }
@@ -1687,8 +1693,29 @@ export class AgentProcessManager {
         runtime: runtimeId,
       });
     }
-    if (event.type === "text_delta" && event.text.length > 0) {
-      this.opts.timeline?.appendResponseToLatest(agentId, event.text);
+    if (event.type === "turn_started") {
+      const timelineTurnOwner: TimelineTurnOwner = {
+        sessionInstanceId: event.sessionInstanceId,
+        rootTurnId: event.turnId,
+        barrierGeneration: this.opts.timeline?.barrierGeneration(agentId) ?? 0,
+      };
+      owner.timelineTurnOwner = timelineTurnOwner;
+      this.opts.timeline?.beginTurn(agentId, timelineTurnOwner);
+    }
+    if (event.type === "assistant_message_completed" && event.text.length > 0) {
+      const timelineTurnOwner = owner.timelineTurnOwner;
+      if (
+        timelineTurnOwner
+        && timelineTurnOwner.sessionInstanceId === event.sessionInstanceId
+        && timelineTurnOwner.rootTurnId === event.turnId
+      ) {
+        this.opts.timeline?.recordAssistantMessage(
+          agentId,
+          timelineTurnOwner,
+          event.text,
+          event.truncated,
+        );
+      }
     }
     if (event.type === "command_queued") this.acknowledgePendingDelivery(owner, event.commandId);
     if (event.type === "command_accepted") this.settlePendingDelivery(owner, event.commandId, "accepted");
@@ -1704,9 +1731,10 @@ export class AgentProcessManager {
       switch (event.type) {
         case "turn_started":
           return { type: "turn_started" as const, turnId: event.turnId, commandIds: event.commandIds };
-        case "thinking_delta":
-        case "text_delta":
-          return event.text.length > 0 ? { type: "turn_work" as const, turnId: event.turnId } : null;
+        case "work_heartbeat":
+        case "assistant_reasoning_completed":
+        case "assistant_message_completed":
+          return { type: "turn_work" as const, turnId: event.turnId };
         case "tool_started":
           return { type: "turn_tool_started" as const, turnId: event.turnId };
         case "tool_finished":
@@ -1743,12 +1771,12 @@ export class AgentProcessManager {
             turnId: event.turnId,
             backendTurnId: event.backendTurnId,
           };
-        case "thinking_delta":
+        case "assistant_reasoning_completed":
           return { kind: "thinking" as const, phase: "inference" as const, turnId: event.turnId };
-        case "text_delta":
-          return event.text.length > 0
-            ? { kind: "text" as const, phase: "inference" as const, turnId: event.turnId }
-            : null;
+        case "assistant_message_completed":
+          return { kind: "text" as const, phase: "inference" as const, turnId: event.turnId };
+        case "work_heartbeat":
+          return { kind: "internal_progress" as const, phase: "inference" as const, turnId: event.turnId };
         case "tool_started":
           return { kind: "tool_call" as const, phase: "tool" as const, turnId: event.turnId };
         case "tool_finished":

--- a/src/daemon/src/manager/managerSwitchModel.test.ts
+++ b/src/daemon/src/manager/managerSwitchModel.test.ts
@@ -260,11 +260,15 @@ describe("AgentProcessManager.switchModel", () => {
     expect((spawnLog![1][0] as { model?: string }).model).toBe("default");
   });
 
-  it("writes NO timeline reset_session barrier — forgetSession is never called, so resume still resolves", async () => {
+  it("writes no durable reset barrier but fences old in-memory turn ownership", async () => {
     const timelineCalls: string[] = [];
     const timeline: TimelineRecorder = {
+      barrierGeneration: () => 0,
+      beginTurn: () => {},
+      recordAssistantMessage: () => {},
+      finalizeTurn: () => {},
+      fenceSession: (a) => timelineCalls.push(`fence:${a}`),
       setSession: (a, s) => timelineCalls.push(`session:${a}:${s}`),
-      appendResponseToLatest: () => {},
       resumeSessionId: () => "resumable-sess",
       forgetSession: (a) => timelineCalls.push(`forget:${a}`),
     };
@@ -294,6 +298,7 @@ describe("AgentProcessManager.switchModel", () => {
     await session.fire("exit");
     // forgetSession — the writer of the reset_session barrier — must never run.
     expect(timelineCalls.some((c) => c.startsWith("forget:"))).toBe(false);
+    expect(timelineCalls).toContain("fence:a1");
   });
 
   // #910 verify-by-test (Cecilia FINAL LOCK §7 / bot-provider-switch plan):
@@ -340,16 +345,20 @@ describe("AgentProcessManager.switchModel", () => {
   });
 
   // Convergence contract (B1): resetSession and switchModel now both route
-  // through the shared `restartAgent`; the ONLY behavioral difference is whether
-  // it calls forgetSession (reset does + writes its barrier; switch does not).
+  // through the shared `restartAgent`; reset writes a durable barrier while a
+  // model switch preserves resume state but still fences old in-memory owners.
   // This pins that contract in one place so a future refactor can't silently
   // make switchModel forget or resetSession preserve.
-  it("resetSession forgets (with its barrier) while switchModel preserves — the sole restartAgent divergence", async () => {
+  it("resetSession writes a barrier while switchModel uses only an in-memory fence", async () => {
     const mk = () => {
       const timelineCalls: string[] = [];
       const timeline: TimelineRecorder = {
+        barrierGeneration: () => 0,
+        beginTurn: () => {},
+        recordAssistantMessage: () => {},
+        finalizeTurn: () => {},
+        fenceSession: (a) => timelineCalls.push(`fence:${a}`),
         setSession: () => {},
-        appendResponseToLatest: () => {},
         resumeSessionId: () => "resumable-sess",
         forgetSession: (a, barrierType) => timelineCalls.push(`forget:${a}:${barrierType ?? "reset_session"}`),
       };
@@ -380,5 +389,6 @@ describe("AgentProcessManager.switchModel", () => {
     const s = mk();
     await s.mgr.switchModel("a1", { runtimeConfig: NAMED_CFG, launchId: "l1", rewakePrompt: REWAKE });
     expect(s.timelineCalls.some((c) => c.startsWith("forget:"))).toBe(false);
+    expect(s.timelineCalls).toContain("fence:a1");
   });
 });

--- a/src/daemon/src/manager/managerTimeline.test.ts
+++ b/src/daemon/src/manager/managerTimeline.test.ts
@@ -7,8 +7,12 @@ import type { AgentEvent, AgentSessionResult, BuiltinBackendSpecs } from "@alook
 function fakeRecorder(resume: Record<string, string> = {}) {
   const calls: string[] = [];
   const rec: TimelineRecorder = {
+    barrierGeneration: () => 0,
+    beginTurn: (agentId, owner) => calls.push(`begin:${agentId}:${owner.rootTurnId}`),
+    recordAssistantMessage: (agentId, owner, text) => calls.push(`resp:${agentId}:${owner.rootTurnId}:${text}`),
+    finalizeTurn: (agentId, owner) => calls.push(`final:${agentId}:${owner.rootTurnId}`),
+    fenceSession: (agentId) => calls.push(`fence:${agentId}`),
     setSession: (agentId, sessionId) => calls.push(`session:${agentId}:${sessionId}`),
-    appendResponseToLatest: (agentId, text) => calls.push(`resp:${agentId}:${text}`),
     resumeSessionId: (agentId) => resume[agentId] ?? null,
     forgetSession: (agentId) => calls.push(`forget:${agentId}`),
   };
@@ -49,6 +53,14 @@ function manager(rec: TimelineRecorder, capture: { ctx?: LaunchContext }) {
         },
         closed,
         async start(message: { id: string }) {
+          publish({
+            sequence: ++sequence,
+            sessionInstanceId: "timeline-test",
+            at: Date.now(),
+            type: "turn_started",
+            turnId: "test-turn",
+            commandIds: [message.id],
+          });
           return { status: "accepted" as const, delivery: "prompt" as const, commandId: message.id, turnId: "test-turn" };
         },
         async send(message: { id: string }) {
@@ -74,7 +86,7 @@ function manager(rec: TimelineRecorder, capture: { ctx?: LaunchContext }) {
       if (event.kind === "session_init") {
         publish({ ...base, type: "session_started", backendSessionId: event.sessionId ?? "test-session" });
       } else if (event.kind === "text") {
-        publish({ ...base, type: "text_delta", turnId: "test-turn", text: event.text ?? "" });
+        publish({ ...base, type: "assistant_message_completed", turnId: "test-turn", text: event.text ?? "", truncated: false });
       }
     } else if (ev === "exit") {
       resolveClosed({ outcome: "crashed", requested: false, exitCode: 0, signal: null, cleanup: { status: "released" } });
@@ -86,7 +98,7 @@ function manager(rec: TimelineRecorder, capture: { ctx?: LaunchContext }) {
 }
 
 describe("manager ↔ timeline (daily log + resume)", () => {
-  it("annotates the latest entry on session_init / text / exit (by agent, not task id)", async () => {
+  it("binds session/completed messages/finalization to the exact driver turn", async () => {
     const { rec, calls } = fakeRecorder();
     const cap: { ctx?: LaunchContext } = {};
     const { mgr, emit } = manager(rec, cap);
@@ -99,13 +111,12 @@ describe("manager ↔ timeline (daily log + resume)", () => {
     await emit("runtime_event", { kind: "text", text: "" }); // empty text ignored
     await emit("exit");
 
-    // The manager does NOT open the entry (that's the data plane / inbox pull)
-    // and there's no status close — it records the session id and accumulates the
-    // agent's text onto the latest row.
     expect(calls).toEqual([
+      "begin:agent_1:test-turn",
       "session:agent_1:sess-7",
-      "resp:agent_1:part 1",
-      "resp:agent_1:part 2",
+      "resp:agent_1:test-turn:part 1",
+      "resp:agent_1:test-turn:part 2",
+      "final:agent_1:test-turn",
     ]);
   });
 

--- a/src/daemon/src/timeline/recorder.test.ts
+++ b/src/daemon/src/timeline/recorder.test.ts
@@ -5,20 +5,21 @@ import { syncBuiltinESMExports } from "node:module";
 import * as os from "os";
 import * as path from "path";
 import { createTimelineRecorder } from "./recorder";
-import { createTimelineEntry, filenameForDate, readRecentEntries } from "./timeline";
+import type { TimelineRecorderLike, TimelineTurnOwner } from "./recorder";
+import { createTimelineEntry, filenameForDate, readRecentEntries, TIMELINE_MAX_BYTES } from "./timeline";
 import { acquireLock, lockPathFor, releaseLock } from "./filelock";
 import type { Message } from "../server/contract";
 
 const tmpDirs: string[] = [];
 function mkDir(): string {
-  const d = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "recorder-"));
-  tmpDirs.push(d);
-  return d;
+  const dir = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "recorder-"));
+  tmpDirs.push(dir);
+  return dir;
 }
-afterEach(() => {
-  for (const d of tmpDirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
-});
 
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
 const NOW = () => new Date("2026-06-25T12:00:00");
 const msg = (seq: string, text: string): Message => ({
   seq,
@@ -28,126 +29,369 @@ const msg = (seq: string, text: string): Message => ({
   time: "2026-06-25T12:00:00+00:00",
 });
 
-describe("createTimelineRecorder (append-only, 4-field schema)", () => {
-  it("treats an empty pull as a no-op before resolving or preparing the timeline directory", () => {
+function begin(
+  recorder: TimelineRecorderLike,
+  turnId: string,
+  sessionInstanceId = "epoch-1",
+  agentId = "a",
+): TimelineTurnOwner {
+  const owner = {
+    sessionInstanceId,
+    rootTurnId: turnId,
+    barrierGeneration: recorder.barrierGeneration(agentId),
+  };
+  recorder.beginTurn(agentId, owner);
+  return owner;
+}
+
+function observe(
+  recorder: TimelineRecorderLike,
+  agentId: string,
+  rootTurnId: string,
+  messages: Message[],
+): TimelineTurnOwner {
+  const owner = begin(recorder, rootTurnId, `epoch-${rootTurnId}`, agentId);
+  recorder.recordInboxPull(agentId, owner, messages);
+  recorder.finalizeTurn(agentId, owner);
+  return owner;
+}
+
+describe("createTimelineRecorder exact turn ownership", () => {
+  it("keeps an empty pull as a no-op without resolving a directory", () => {
     const timelineDirFor = vi.fn(() => {
       throw new Error("must not resolve a directory for an empty pull");
     });
-    const rec = createTimelineRecorder({ timelineDirFor, now: NOW });
+    const recorder = createTimelineRecorder({ timelineDirFor, now: NOW });
 
-    expect(() => rec.appendEntryForAgent("agent_1", [])).not.toThrow();
+    expect(() => recorder.recordInboxPull("a", null, [])).not.toThrow();
     expect(timelineDirFor).not.toHaveBeenCalled();
   });
 
-  it("bakes the session id (set before the pull) into the opened entry, then accumulates responses", () => {
+  it("records complete messages against one exact row and finalizes idempotently", () => {
     const dir = mkDir();
-    const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "claude", now: NOW });
-
-    // session_init lands first (control plane), then the agent pulls (data plane).
-    rec.setSession("agent_1", "sess-42");
-    rec.appendEntryForAgent("agent_1", [msg("#1", "hello team")]);
-    rec.appendResponseToLatest("agent_1", "thinking…");
-    rec.appendResponseToLatest("agent_1", "hi!");
-
-    const [row] = readRecentEntries(dir, { now: NOW() });
-    expect(row.messages.map((m) => m.content.text)).toEqual(["hello team"]);
-    expect(row.session_id).toBe("sess-42");
-    expect(row.provider).toBe("claude");
-    expect(row.agent_responses).toEqual(["thinking…", "hi!"]);
-  });
-
-  it("a pull AFTER the latest row already has a response opens a new entry", () => {
-    const dir = mkDir();
-    const rec = createTimelineRecorder({ timelineDirFor: () => dir, now: NOW });
-
-    rec.appendEntryForAgent("agent_1", [msg("#1", "first")]);
-    rec.appendResponseToLatest("agent_1", "reply to first");
-    rec.appendEntryForAgent("agent_1", [msg("#2", "second")]); // latest had a response → new entry
-    rec.appendResponseToLatest("agent_1", "reply to second");
-
-    const rows = readRecentEntries(dir, { now: NOW() });
-    expect(rows).toHaveLength(2);
-    expect(rows[0].messages[0].content.text).toBe("first");
-    expect(rows[0].agent_responses).toEqual(["reply to first"]);
-    expect(rows[1].messages[0].content.text).toBe("second");
-    expect(rows[1].agent_responses).toEqual(["reply to second"]);
-  });
-
-  it("consecutive pulls with NO response between merge into one entry (same session/provider)", () => {
-    const dir = mkDir();
-    const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "claude", now: NOW });
-    rec.setSession("agent_1", "sess-1");
-
-    rec.appendEntryForAgent("agent_1", [msg("#1", "first")]);
-    rec.appendEntryForAgent("agent_1", [msg("#2", "second")]); // no response yet → merge
-    rec.appendResponseToLatest("agent_1", "reply to both");
+    const recorder = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "claude", now: NOW });
+    recorder.setSession("a", "sess-1", "epoch-1");
+    const owner = begin(recorder, "turn-1");
+    recorder.recordInboxPull("a", owner, [msg("#1", "hello")]);
+    for (let index = 1; index <= 6; index++) recorder.recordAssistantMessage("a", owner, `response-${index}`);
+    recorder.finalizeTurn("a", owner);
+    recorder.finalizeTurn("a", owner);
 
     const rows = readRecentEntries(dir, { now: NOW() });
     expect(rows).toHaveLength(1);
-    expect(rows[0].messages.map((m) => m.content.text)).toEqual(["first", "second"]);
-    expect(rows[0].agent_responses).toEqual(["reply to both"]);
+    expect(rows[0]).toMatchObject({ session_id: "sess-1", provider: "claude" });
+    expect(rows[0].messages.map((message) => message.content.text)).toEqual(["hello"]);
+    expect(rows[0].agent_responses).toEqual([
+      "response-2", "response-3", "response-4", "response-5", "response-6",
+    ]);
   });
 
-  it("writes a non-empty pull after local midnight only to the new day's file", () => {
+  it("does not let pre-pull output from turn B mutate turn A", () => {
     const dir = mkDir();
-    let current = new Date("2026-06-25T12:00:00");
-    const rec = createTimelineRecorder({
-      timelineDirFor: () => dir,
-      providerFor: () => "claude",
-      now: () => current,
-    });
-    rec.setSession("agent_1", "sess-1");
-    rec.appendEntryForAgent("agent_1", [msg("#1", "before midnight")]);
+    const recorder = createTimelineRecorder({ timelineDirFor: () => dir, now: NOW });
+    const ownerA = begin(recorder, "turn-a");
+    recorder.recordInboxPull("a", ownerA, [msg("#1", "for A")]);
+    recorder.recordAssistantMessage("a", ownerA, "answer A");
+    recorder.finalizeTurn("a", ownerA);
 
-    current = new Date("2026-06-26T12:00:00");
-    rec.appendEntryForAgent("agent_1", [msg("#2", "after midnight")]);
-
-    const firstDay = fs.readFileSync(path.join(dir, filenameForDate(new Date("2026-06-25T12:00:00"))), "utf8");
-    const secondDay = fs.readFileSync(path.join(dir, filenameForDate(current)), "utf8");
-    expect(firstDay).toContain("before midnight");
-    expect(firstDay).not.toContain("after midnight");
-    expect(secondDay).toContain("after midnight");
-    expect(secondDay).not.toContain("before midnight");
-  });
-
-  it("does NOT merge when session_id differs (new session = new entry)", () => {
-    const dir = mkDir();
-    const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "claude", now: NOW });
-    rec.setSession("agent_1", "sess-1");
-    rec.appendEntryForAgent("agent_1", [msg("#1", "first")]);
-    rec.setSession("agent_1", "sess-2");
-    rec.appendEntryForAgent("agent_1", [msg("#2", "second")]);
+    const ownerB = begin(recorder, "turn-b");
+    recorder.recordAssistantMessage("a", ownerB, "opening B");
+    recorder.finalizeTurn("a", ownerB);
 
     const rows = readRecentEntries(dir, { now: NOW() });
     expect(rows).toHaveLength(2);
-    expect(rows[0].session_id).toBe("sess-1");
-    expect(rows[1].session_id).toBe("sess-2");
+    expect(rows[0].agent_responses).toEqual(["answer A"]);
+    expect(rows[1].messages).toEqual([]);
+    expect(rows[1].agent_responses).toEqual(["opening B"]);
   });
 
-  it("resumeSessionId returns the latest session id for the agent", () => {
+  it("binds a late pull response to captured turn A after turn B begins", () => {
     const dir = mkDir();
-    const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "claude", now: NOW });
+    const recorder = createTimelineRecorder({ timelineDirFor: () => dir, now: NOW });
+    const ownerA = begin(recorder, "turn-a");
+    recorder.recordAssistantMessage("a", ownerA, "answer A");
+    recorder.finalizeTurn("a", ownerA);
 
-    rec.setSession("agent_1", "sess-old");
-    rec.appendEntryForAgent("agent_1", [msg("#1", "a")]);
-    expect(rec.resumeSessionId("agent_1", "claude")).toBe("sess-old");
+    const ownerB = begin(recorder, "turn-b");
+    recorder.recordInboxPull("a", ownerA, [msg("#1", "late observation for A")]);
+    recorder.recordAssistantMessage("a", ownerB, "answer B");
+    recorder.finalizeTurn("a", ownerB);
 
-    rec.setSession("agent_1", "sess-new");
-    rec.appendEntryForAgent("agent_1", [msg("#2", "b")]);
-    expect(rec.resumeSessionId("agent_1", "claude")).toBe("sess-new");
+    const rows = readRecentEntries(dir, { now: NOW() });
+    expect(rows).toHaveLength(2);
+    expect(rows[0].messages.map((message) => message.content.text)).toEqual(["late observation for A"]);
+    expect(rows[0].agent_responses).toEqual(["answer A"]);
+    expect(rows[1].agent_responses).toEqual(["answer B"]);
   });
 
-  it("does not resume across providers", () => {
+  it("keeps an ownerless pull unowned when a later turn starts", () => {
     const dir = mkDir();
-    const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "claude", now: NOW });
-    rec.setSession("a", "sess-claude");
-    rec.appendEntryForAgent("a", [msg("#1", "x")]);
-    expect(rec.resumeSessionId("a", "codex")).toBeNull();
-    expect(rec.resumeSessionId("a", "claude")).toBe("sess-claude");
+    const recorder = createTimelineRecorder({ timelineDirFor: () => dir, now: NOW });
+    recorder.recordInboxPull("a", null, [msg("#1", "ownerless")]);
+    const owner = begin(recorder, "turn-b");
+    recorder.recordAssistantMessage("a", owner, "answer B");
+    recorder.finalizeTurn("a", owner);
+
+    const rows = readRecentEntries(dir, { now: NOW() });
+    expect(rows).toHaveLength(2);
+    expect(rows[0].messages.map((message) => message.content.text)).toEqual(["ownerless"]);
+    expect(rows[0].agent_responses).toEqual([]);
+    expect(rows[1].agent_responses).toEqual(["answer B"]);
+  });
+
+  it("refreshes a captured handle across unrelated writes and updates only its row", () => {
+    const dir = mkDir();
+    const recorder = createTimelineRecorder({ timelineDirFor: () => dir, now: NOW });
+    const owner = begin(recorder, "turn-a");
+    recorder.recordInboxPull("a", owner, [msg("#1", "first A")]);
+    recorder.recordInboxPull("a", null, [msg("#2", "unrelated newer row")]);
+    recorder.recordInboxPull("a", owner, [msg("#3", "busy A")]);
+
+    const rows = readRecentEntries(dir, { now: NOW() });
+    expect(rows).toHaveLength(2);
+    expect(rows[0].messages.map((message) => message.content.text)).toEqual(["first A", "busy A"]);
+    expect(rows[1].messages.map((message) => message.content.text)).toEqual(["unrelated newer row"]);
+  });
+
+  it("commits after midnight to the prior day's captured row", () => {
+    const dir = mkDir();
+    let current = new Date("2026-06-25T12:00:00");
+    const recorder = createTimelineRecorder({ timelineDirFor: () => dir, now: () => current });
+    const owner = begin(recorder, "turn-a");
+    recorder.recordInboxPull("a", owner, [msg("#1", "before midnight")]);
+
+    current = new Date("2026-06-26T12:00:00");
+    recorder.recordAssistantMessage("a", owner, "after midnight response");
+    recorder.finalizeTurn("a", owner);
+
+    const firstFile = path.join(dir, filenameForDate(new Date("2026-06-25T12:00:00")));
+    expect(fs.readFileSync(firstFile, "utf8")).toContain("after midnight response");
+    expect(fs.existsSync(path.join(dir, filenameForDate(current)))).toBe(false);
+  });
+
+  it("opens a new-day target when the same turn pulls after midnight", () => {
+    const dir = mkDir();
+    let current = new Date("2026-06-25T12:00:00");
+    const recorder = createTimelineRecorder({ timelineDirFor: () => dir, now: () => current });
+    const owner = begin(recorder, "turn-a");
+    recorder.recordInboxPull("a", owner, [msg("#1", "day one")]);
+    current = new Date("2026-06-26T12:00:00");
+    recorder.recordInboxPull("a", owner, [msg("#2", "day two")]);
+    recorder.recordAssistantMessage("a", owner, "day two response");
+    recorder.finalizeTurn("a", owner);
+
+    const first = fs.readFileSync(path.join(dir, filenameForDate(new Date("2026-06-25T12:00:00"))), "utf8");
+    const second = fs.readFileSync(path.join(dir, filenameForDate(current)), "utf8");
+    expect(first).toContain("day one");
+    expect(first).not.toContain("day two response");
+    expect(second).toContain("day two");
+    expect(second).toContain("day two response");
+  });
+
+  it("bounds multibyte complete messages and row-fit truncation with one explicit marker", () => {
+    const dir = mkDir();
+    const recorder = createTimelineRecorder({ timelineDirFor: () => dir, now: NOW });
+    const owner = begin(recorder, "turn-a");
+    recorder.recordInboxPull("a", owner, [msg("#1", "x".repeat(1_020_000))]);
+    recorder.recordAssistantMessage("a", owner, "你".repeat(30_000));
+    recorder.finalizeTurn("a", owner);
+
+    const [row] = readRecentEntries(dir, { now: NOW() });
+    expect(Buffer.byteLength(`${JSON.stringify(row)}\n`, "utf8")).toBeLessThanOrEqual(TIMELINE_MAX_BYTES);
+    expect(Buffer.byteLength(row.agent_responses[0]!, "utf8")).toBeLessThanOrEqual(65_536);
+    expect(row.agent_responses[0]).toMatch(/… \[truncated\]$/u);
+    expect(row.agent_responses[0]!.match(/… \[truncated\]/gu)).toHaveLength(1);
+  });
+
+  it("rejects an externally rewritten captured row instead of falling back to latest", () => {
+    const dir = mkDir();
+    const diagnostics: string[] = [];
+    const recorder = createTimelineRecorder({
+      timelineDirFor: () => dir,
+      now: NOW,
+      onDiagnostic: (event) => diagnostics.push(`${event.code}:${event.reason ?? ""}`),
+    });
+    const owner = begin(recorder, "turn-a");
+    recorder.recordInboxPull("a", owner, [msg("#1", "original")]);
+    recorder.recordAssistantMessage("a", owner, "must not redirect");
+    const file = path.join(dir, filenameForDate(NOW()));
+    fs.writeFileSync(file, fs.readFileSync(file, "utf8").replace("original", "external"));
+    recorder.finalizeTurn("a", owner);
+
+    const rows = readRecentEntries(dir, { now: NOW() });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].messages[0].content.text).toBe("external");
+    expect(rows[0].agent_responses).toEqual([]);
+    expect(diagnostics).toContain("timeline_exact_write_rejected:generation");
   });
 });
 
-describe("forgetSession — inline system row", () => {
+describe("createTimelineRecorder barriers and pending commits", () => {
+  it("lets a retained pre-reset handle update in place before the durable barrier", () => {
+    const dir = mkDir();
+    const recorder = createTimelineRecorder({ timelineDirFor: () => dir, now: NOW });
+    const owner = begin(recorder, "turn-a");
+    recorder.recordInboxPull("a", owner, [msg("#1", "old turn")]);
+    recorder.recordAssistantMessage("a", owner, "completed before reset");
+    recorder.forgetSession("a");
+    recorder.finalizeTurn("a", owner);
+
+    const rows = readRecentEntries(dir, { now: NOW() });
+    expect(rows).toHaveLength(2);
+    expect(rows[0].agent_responses).toEqual(["completed before reset"]);
+    expect(rows[1].system?.type).toBe("reset_session");
+  });
+
+  it("drops an old no-handle fallback across reset and model replacement fences", () => {
+    for (const fence of ["reset", "model"] as const) {
+      const dir = mkDir();
+      const diagnostics: string[] = [];
+      const recorder = createTimelineRecorder({
+        timelineDirFor: () => dir,
+        now: NOW,
+        onDiagnostic: (event) => diagnostics.push(`${event.code}:${event.reason ?? ""}`),
+      });
+      const owner = begin(recorder, `turn-${fence}`);
+      recorder.recordAssistantMessage("a", owner, "must be dropped");
+      if (fence === "reset") recorder.forgetSession("a");
+      else recorder.fenceSession("a");
+      recorder.finalizeTurn("a", owner);
+
+      const rows = readRecentEntries(dir, { now: NOW() });
+      expect(rows.flatMap((row) => row.agent_responses)).not.toContain("must be dropped");
+      expect(diagnostics.some((entry) => entry.includes("timeline_fallback_rejected"))).toBe(true);
+    }
+  });
+
+  it("retains a lock-missed exact commit and retries only on later recorder activity", () => {
+    const dir = mkDir();
+    const recorder = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "claude", now: NOW });
+    recorder.setSession("a", "sess-1", "epoch-1");
+    const owner = begin(recorder, "turn-a");
+    recorder.recordInboxPull("a", owner, [msg("#1", "hello")]);
+    recorder.recordAssistantMessage("a", owner, "pending response");
+    const lock = lockPathFor(dir, filenameForDate(NOW()));
+    expect(acquireLock(lock)).toBe(true);
+    try {
+      recorder.finalizeTurn("a", owner);
+    } finally {
+      releaseLock(lock);
+    }
+
+    expect(recorder.resumeSessionId("a", "claude")).toBe("sess-1");
+    expect(readRecentEntries(dir, { now: NOW() })[0].agent_responses).toEqual([]);
+    begin(recorder, "turn-b", "epoch-2");
+    expect(readRecentEntries(dir, { now: NOW() })[0].agent_responses).toEqual(["pending response"]);
+  });
+
+  it("retains an authorized pre-pull fallback commit when the next turn begins", () => {
+    const dir = mkDir();
+    const recorder = createTimelineRecorder({ timelineDirFor: () => dir, now: NOW });
+    const owner = begin(recorder, "turn-a");
+    recorder.recordAssistantMessage("a", owner, "pending fallback");
+    const lock = lockPathFor(dir, filenameForDate(NOW()));
+    expect(acquireLock(lock)).toBe(true);
+    try {
+      recorder.finalizeTurn("a", owner);
+    } finally {
+      releaseLock(lock);
+    }
+
+    begin(recorder, "turn-b", "epoch-2");
+    const rows = readRecentEntries(dir, { now: NOW() });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].messages).toEqual([]);
+    expect(rows[0].agent_responses).toEqual(["pending fallback"]);
+  });
+
+  it("retains a write-failed exact commit and retries after later real activity", () => {
+    if (process.platform === "win32") return;
+    const dir = mkDir();
+    const recorder = createTimelineRecorder({ timelineDirFor: () => dir, now: NOW });
+    const owner = begin(recorder, "turn-a");
+    recorder.recordInboxPull("a", owner, [msg("#1", "hello")]);
+    recorder.recordAssistantMessage("a", owner, "write retry");
+    fs.chmodSync(dir, 0o500);
+    try {
+      recorder.finalizeTurn("a", owner);
+    } finally {
+      fs.chmodSync(dir, 0o700);
+    }
+
+    expect(readRecentEntries(dir, { now: NOW() })[0].agent_responses).toEqual([]);
+    begin(recorder, "turn-b", "epoch-2");
+    expect(readRecentEntries(dir, { now: NOW() })[0].agent_responses).toEqual(["write retry"]);
+  });
+
+  it("expires a pending commit after 15 minutes and never redirects it", () => {
+    const dir = mkDir();
+    let current = new Date("2026-06-25T12:00:00");
+    const diagnostics: string[] = [];
+    const recorder = createTimelineRecorder({
+      timelineDirFor: () => dir,
+      now: () => current,
+      onDiagnostic: (event) => diagnostics.push(event.code),
+    });
+    const owner = begin(recorder, "turn-a");
+    recorder.recordInboxPull("a", owner, [msg("#1", "hello")]);
+    recorder.recordAssistantMessage("a", owner, "expired response");
+    const lock = lockPathFor(dir, filenameForDate(current));
+    expect(acquireLock(lock)).toBe(true);
+    try {
+      recorder.finalizeTurn("a", owner);
+    } finally {
+      releaseLock(lock);
+    }
+    current = new Date(current.getTime() + 15 * 60_000 + 1);
+    recorder.setSession("a", "new-session", "epoch-2");
+
+    expect(readRecentEntries(dir, { now: current })[0].agent_responses).toEqual([]);
+    expect(diagnostics).toContain("timeline_pending_commit_expired");
+  });
+
+  it("bounds pending exact commits to eight per agent", () => {
+    const dir = mkDir();
+    const diagnostics: string[] = [];
+    const recorder = createTimelineRecorder({
+      timelineDirFor: () => dir,
+      now: NOW,
+      onDiagnostic: (event) => diagnostics.push(event.code),
+    });
+    const owners: TimelineTurnOwner[] = [];
+    for (let index = 1; index <= 9; index++) {
+      const owner = begin(recorder, `turn-${index}`, `epoch-${index}`);
+      recorder.recordInboxPull("a", owner, [msg(`#${index}`, `message-${index}`)]);
+      owners.push(owner);
+    }
+    const lock = lockPathFor(dir, filenameForDate(NOW()));
+    expect(acquireLock(lock)).toBe(true);
+    try {
+      for (const [index, owner] of owners.entries()) {
+        recorder.recordAssistantMessage("a", owner, `response-${index + 1}`);
+        recorder.finalizeTurn("a", owner);
+      }
+    } finally {
+      releaseLock(lock);
+    }
+
+    expect(diagnostics).toContain("timeline_pending_commit_overflow");
+    expect(readRecentEntries(dir, { now: NOW() }).flatMap((row) => row.agent_responses)).toEqual([]);
+  });
+});
+
+describe("createTimelineRecorder durable resume control", () => {
+  it("resolves only the latest provider-compatible exact turn", () => {
+    const dir = mkDir();
+    const recorder = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "claude", now: NOW });
+    expect(recorder.setSession("a", "sess-old", "epoch-old")).toBe(true);
+    observe(recorder, "a", "old", [msg("#1", "old")]);
+    expect(recorder.setSession("a", "sess-new", "epoch-new")).toBe(true);
+    observe(recorder, "a", "new", [msg("#2", "new")]);
+
+    expect(recorder.resumeSessionId("a", "claude")).toBe("sess-new");
+    expect(recorder.resumeSessionId("a", "codex")).toBeNull();
+  });
+
   it("keeps resume resolution at a fixed open-file bound with 1,000 historical day files", () => {
     const dir = mkDir();
     const emptyTurn = `${JSON.stringify(createTimelineEntry({ messages: [] }))}\n`;
@@ -162,20 +406,20 @@ describe("forgetSession — inline system row", () => {
       day.setDate(day.getDate() - index);
       fs.writeFileSync(path.join(dir, filenameForDate(day)), emptyTurn);
     }
-    fs.writeFileSync(path.join(dir, ".resume-control.json"), JSON.stringify({
+    fs.writeFileSync(path.join(dir, ".resume-control.json"), `${JSON.stringify({
       version: 1,
       attemptedSessionId: null,
       fencedSessionId: null,
       fullBarrier: null,
-    }) + "\n");
+    })}\n`);
 
     const originalOpenSync = nodeFs.openSync;
     const open = vi.fn(originalOpenSync);
     nodeFs.openSync = open as typeof nodeFs.openSync;
     syncBuiltinESMExports();
     try {
-      const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "codex", now: NOW });
-      expect(rec.resolveResumeSession("agent_1", "codex")).toEqual({
+      const recorder = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "codex", now: NOW });
+      expect(recorder.resolveResumeSession("a", "codex")).toEqual({
         kind: "none",
         stalledSessionId: null,
         fencedSessionId: null,
@@ -187,69 +431,28 @@ describe("forgetSession — inline system row", () => {
     }
   });
 
-  it("uses recent history only when control state is missing and fails closed for corrupt control inputs", () => {
-    const makeSessionHistory = (): { dir: string; controlPath: string } => {
+  it("uses history only when control is missing and fails closed for corrupt control", () => {
+    const makeHistory = (): { dir: string; control: string } => {
       const dir = mkDir();
-      const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "codex", now: NOW });
-      rec.setSession("agent_1", "sess-existing");
-      rec.appendEntryForAgent("agent_1", [msg("#1", "existing")]);
-      return { dir, controlPath: path.join(dir, ".resume-control.json") };
+      const recorder = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "codex", now: NOW });
+      recorder.setSession("a", "sess-existing", "epoch-existing");
+      observe(recorder, "a", "existing", [msg("#1", "existing")]);
+      return { dir, control: path.join(dir, ".resume-control.json") };
     };
     const resolve = (dir: string) => createTimelineRecorder({
       timelineDirFor: () => dir,
       providerFor: () => "codex",
       now: NOW,
-    }).resolveResumeSession("agent_1", "codex");
+    }).resolveResumeSession("a", "codex");
 
-    const missing = makeSessionHistory();
-    fs.unlinkSync(missing.controlPath);
-    expect(resolve(missing.dir)).toEqual({
-      kind: "session",
-      sessionId: "sess-existing",
-      stalledSessionId: null,
-      fencedSessionId: null,
-    });
+    const missing = makeHistory();
+    fs.unlinkSync(missing.control);
+    expect(resolve(missing.dir)).toMatchObject({ kind: "session", sessionId: "sess-existing" });
 
-    const corrupt = makeSessionHistory();
-    fs.writeFileSync(corrupt.controlPath, "{not-json}\n");
-    expect(resolve(corrupt.dir)).toEqual({
-      kind: "barrier",
-      type: "reset_session",
-      forgottenSessionId: null,
-      fencedSessionId: null,
-    });
-
-    const oversized = makeSessionHistory();
-    fs.writeFileSync(oversized.controlPath, "x".repeat(4_097));
-    expect(resolve(oversized.dir)).toEqual({
-      kind: "barrier",
-      type: "reset_session",
-      forgottenSessionId: null,
-      fencedSessionId: null,
-    });
-
-    const nonRegular = makeSessionHistory();
-    fs.unlinkSync(nonRegular.controlPath);
-    fs.mkdirSync(nonRegular.controlPath);
-    expect(resolve(nonRegular.dir)).toEqual({
-      kind: "barrier",
-      type: "reset_session",
-      forgottenSessionId: null,
-      fencedSessionId: null,
-    });
-
-    if (process.platform !== "win32") {
-      const linked = makeSessionHistory();
-      const outside = path.join(mkDir(), "outside-control.json");
-      fs.writeFileSync(outside, JSON.stringify({
-        version: 1,
-        attemptedSessionId: null,
-        fencedSessionId: null,
-        fullBarrier: null,
-      }));
-      fs.unlinkSync(linked.controlPath);
-      fs.symlinkSync(outside, linked.controlPath);
-      expect(resolve(linked.dir)).toEqual({
+    for (const body of ["{not-json}\n", "x".repeat(4_097)]) {
+      const corrupt = makeHistory();
+      fs.writeFileSync(corrupt.control, body);
+      expect(resolve(corrupt.dir)).toEqual({
         kind: "barrier",
         type: "reset_session",
         forgottenSessionId: null,
@@ -260,48 +463,38 @@ describe("forgetSession — inline system row", () => {
 
   it("persists and clears the one-stall recovery allowance", () => {
     const dir = mkDir();
-    const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "codex", now: NOW });
-    rec.setSession("agent_1", "sess-poison");
-    rec.appendEntryForAgent("agent_1", [msg("#1", "before stall")]);
+    const recorder = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "codex", now: NOW });
+    recorder.setSession("a", "sess-poison", "epoch-poison");
+    observe(recorder, "a", "before-stall", [msg("#1", "before stall")]);
 
-    rec.recordSessionStall("agent_1", "sess-poison");
-    const controlPath = path.join(dir, ".resume-control.json");
-    const controlStat = fs.statSync(controlPath);
-    expect(controlStat.isFile()).toBe(true);
-    if (process.platform !== "win32") expect(controlStat.mode & 0o777).toBe(0o600);
-    expect(fs.readdirSync(dir).filter((name) => name.includes("resume-control") && name.endsWith(".tmp"))).toEqual([]);
-    expect(rec.resolveResumeSession("agent_1", "codex")).toEqual({
+    expect(recorder.recordSessionStall("a", "sess-poison")).toBe(true);
+    expect(recorder.resolveResumeSession("a", "codex")).toMatchObject({
       kind: "session",
       sessionId: "sess-poison",
       stalledSessionId: "sess-poison",
-      fencedSessionId: null,
     });
-
-    rec.clearSessionStall("agent_1", "sess-poison");
-    expect(rec.resolveResumeSession("agent_1", "codex")).toEqual({
+    expect(recorder.clearSessionStall("a", "sess-poison")).toBe(true);
+    expect(recorder.resolveResumeSession("a", "codex")).toMatchObject({
       kind: "session",
       sessionId: "sess-poison",
       stalledSessionId: null,
-      fencedSessionId: null,
     });
   });
 
   for (const failureMode of ["lock", "rename"] as const) {
     for (const transition of ["attempt", "fence", "reset_session", "nap", "clear"] as const) {
-      it(`does not append a ${transition} forensic row when the control ${failureMode} transition fails`, () => {
+      it(`does not advance ${transition} when the control ${failureMode} transition fails`, () => {
         const dir = mkDir();
-        const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "codex", now: NOW });
-        expect(rec.setSession("agent_1", "sess-poison")).toBe(true);
-        rec.appendEntryForAgent("agent_1", [msg("#1", "before transition")]);
+        const recorder = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "codex", now: NOW });
+        expect(recorder.setSession("a", "sess-poison", "epoch-poison")).toBe(true);
+        observe(recorder, "a", "before-transition", [msg("#1", "before transition")]);
         if (transition === "fence" || transition === "clear") {
-          expect(rec.recordSessionStall("agent_1", "sess-poison")).toBe(true);
+          expect(recorder.recordSessionStall("a", "sess-poison")).toBe(true);
         }
 
         const controlPath = path.join(dir, ".resume-control.json");
         const beforeControl = fs.readFileSync(controlPath, "utf8");
-        const beforeSystemRows = readRecentEntries(dir, { now: NOW() })
-          .filter((row) => row.system)
-          .map((row) => row.system);
+        const beforeSystems = readRecentEntries(dir, { now: NOW() }).filter((row) => row.system).map((row) => row.system);
         const lockPath = lockPathFor(dir, ".resume-control.json");
         const originalRenameSync = nodeFs.renameSync;
         if (failureMode === "lock") expect(acquireLock(lockPath)).toBe(true);
@@ -312,15 +505,14 @@ describe("forgetSession — inline system row", () => {
           }) as typeof nodeFs.renameSync;
           syncBuiltinESMExports();
         }
-
         try {
           const result = transition === "attempt"
-            ? rec.recordSessionStall("agent_1", "sess-poison")
+            ? recorder.recordSessionStall("a", "sess-poison")
             : transition === "fence"
-              ? rec.forgetSession("agent_1", "stall_recovery", "sess-poison")
+              ? recorder.forgetSession("a", "stall_recovery", "sess-poison")
               : transition === "clear"
-                ? rec.clearSessionStall("agent_1", "sess-poison")
-                : rec.forgetSession("agent_1", transition);
+                ? recorder.clearSessionStall("a", "sess-poison")
+                : recorder.forgetSession("a", transition);
           expect(result).toBe(false);
         } finally {
           if (failureMode === "lock") releaseLock(lockPath);
@@ -331,320 +523,83 @@ describe("forgetSession — inline system row", () => {
         }
 
         expect(fs.readFileSync(controlPath, "utf8")).toBe(beforeControl);
-        expect(readRecentEntries(dir, { now: NOW() })
-          .filter((row) => row.system)
-          .map((row) => row.system)).toEqual(beforeSystemRows);
-        const rebuilt = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "codex", now: NOW });
-        expect(rebuilt.resolveResumeSession("agent_1", "codex")).toEqual({
-          kind: "session",
-          sessionId: "sess-poison",
-          stalledSessionId: transition === "fence" || transition === "clear" ? "sess-poison" : null,
-          fencedSessionId: null,
-        });
+        expect(readRecentEntries(dir, { now: NOW() }).filter((row) => row.system).map((row) => row.system))
+          .toEqual(beforeSystems);
       });
     }
-
-    it(`keeps the prior in-memory session when setSession hits a control ${failureMode} failure`, () => {
-      const dir = mkDir();
-      const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "codex", now: NOW });
-      expect(rec.setSession("agent_1", "sess-old")).toBe(true);
-      const controlPath = path.join(dir, ".resume-control.json");
-      const beforeControl = fs.readFileSync(controlPath, "utf8");
-      const lockPath = lockPathFor(dir, ".resume-control.json");
-      const originalRenameSync = nodeFs.renameSync;
-      if (failureMode === "lock") expect(acquireLock(lockPath)).toBe(true);
-      else {
-        nodeFs.renameSync = ((oldPath: fs.PathLike, newPath: fs.PathLike) => {
-          if (String(newPath) === controlPath) throw new Error("injected control rename failure");
-          return originalRenameSync(oldPath, newPath);
-        }) as typeof nodeFs.renameSync;
-        syncBuiltinESMExports();
-      }
-      try {
-        expect(rec.setSession("agent_1", "sess-new")).toBe(false);
-      } finally {
-        if (failureMode === "lock") releaseLock(lockPath);
-        else {
-          nodeFs.renameSync = originalRenameSync;
-          syncBuiltinESMExports();
-        }
-      }
-      expect(fs.readFileSync(controlPath, "utf8")).toBe(beforeControl);
-      rec.appendEntryForAgent("agent_1", [msg("#1", "after failed set")]);
-      expect(readRecentEntries(dir, { now: NOW() }).at(-1)?.session_id).toBe("sess-old");
-    });
   }
 
-  it("resolves an attempt marker outside the seven-day turn-history window", () => {
+  it("keeps the prior in-memory session when setSession cannot persist", () => {
     const dir = mkDir();
-    const oldRecorder = createTimelineRecorder({
-      timelineDirFor: () => dir,
-      providerFor: () => "codex",
-      now: () => new Date("2026-06-01T12:00:00Z"),
-    });
-    oldRecorder.recordSessionStall("agent_1", "sess-poison");
-
-    const rebuiltRecorder = createTimelineRecorder({
-      timelineDirFor: () => dir,
-      providerFor: () => "codex",
-      now: () => new Date("2026-06-25T12:00:00Z"),
-    });
-    expect(rebuiltRecorder.resolveResumeSession("agent_1", "codex")).toEqual({
-      kind: "none",
-      stalledSessionId: "sess-poison",
-      fencedSessionId: null,
-    });
+    const recorder = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "codex", now: NOW });
+    expect(recorder.setSession("a", "sess-old", "epoch-old")).toBe(true);
+    const lock = lockPathFor(dir, ".resume-control.json");
+    expect(acquireLock(lock)).toBe(true);
+    try {
+      expect(recorder.setSession("a", "sess-new", "epoch-new")).toBe(false);
+    } finally {
+      releaseLock(lock);
+    }
+    observe(recorder, "a", "after-failed-set", [msg("#1", "after failed set")]);
+    expect(readRecentEntries(dir, { now: NOW() }).at(-1)?.session_id).toBe("sess-old");
   });
 
-  it("persists the exact repeatedly stalled session in a stall_recovery barrier", () => {
+  it("persists the exact repeatedly stalled session in a durable fence", () => {
     const dir = mkDir();
-    const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "codex", now: NOW });
-    rec.setSession("agent_1", "sess-poison");
+    const recorder = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "codex", now: NOW });
+    recorder.setSession("a", "sess-poison", "epoch-poison");
+    expect(recorder.forgetSession("a", "stall_recovery", "sess-poison")).toBe(true);
 
-    rec.forgetSession("agent_1", "stall_recovery", "sess-poison");
-
-    const rows = readRecentEntries(dir, { now: NOW() });
-    expect(rows).toHaveLength(1);
-    expect(rows[0].system).toEqual({
+    expect(readRecentEntries(dir, { now: NOW() })[0].system).toEqual({
       type: "stall_recovery",
       time: NOW().toISOString(),
       backend_session_id: "sess-poison",
     });
-    expect(rec.resolveResumeSession("agent_1", "codex")).toEqual({
+    expect(recorder.resolveResumeSession("a", "codex")).toEqual({
       kind: "barrier",
       type: "stall_recovery",
       forgottenSessionId: "sess-poison",
       fencedSessionId: "sess-poison",
     });
   });
-
-  it("appends a bare reset_session system row (no forgot_session_id) and clears the map", () => {
-    const dir = mkDir();
-    const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "claude", now: NOW });
-    rec.setSession("agent_1", "sess-1");
-
-    rec.forgetSession("agent_1");
-    const rows = readRecentEntries(dir, { now: NOW() });
-    const last = rows[rows.length - 1];
-    expect(last.system?.type).toBe("reset_session");
-    expect((last.system as unknown as { forgot_session_id?: unknown }).forgot_session_id).toBeUndefined();
-    expect(last.session_id).toBeNull();
-    expect(last.messages).toEqual([]);
-    expect(last.agent_responses).toEqual([]);
-
-    // A subsequent append proves the in-memory session id was cleared —
-    // the new turn row carries null for session_id.
-    rec.appendEntryForAgent("agent_1", [msg("#1", "post-reset")]);
-    const afterRows = readRecentEntries(dir, { now: NOW() });
-    expect(afterRows[afterRows.length - 1].session_id).toBeNull();
-  });
-
-  it("writes a valid reset_session row on a fresh workdir with no in-memory session and no prior rows", () => {
-    const dir = mkDir();
-    const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "claude", now: NOW });
-
-    rec.forgetSession("agent_1");
-    const rows = readRecentEntries(dir, { now: NOW() });
-    expect(rows).toHaveLength(1);
-    expect(rows[0].system?.type).toBe("reset_session");
-  });
 });
 
-describe("appendResponseToLatest — text-before-first-pull fallback", () => {
-  it("after a reset barrier, a text event before the first inbox pull opens a fresh turn row (does NOT clobber the barrier)", () => {
+describe("createTimelineRecorder session and filesystem safety", () => {
+  it("honors reset barriers for resume and allows a later exact session", () => {
     const dir = mkDir();
-    const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "claude", now: NOW });
+    const recorder = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "claude", now: NOW });
+    recorder.setSession("a", "sess-1", "epoch-1");
+    const first = begin(recorder, "turn-1", "epoch-1");
+    recorder.recordInboxPull("a", first, [msg("#1", "old")]);
+    recorder.finalizeTurn("a", first);
+    expect(recorder.resumeSessionId("a", "claude")).toBe("sess-1");
 
-    rec.setSession("a", "sess-1");
-    rec.appendEntryForAgent("a", [msg("#1", "hi")]);
-    rec.appendResponseToLatest("a", "old reply");
-
-    // Owner-triggered reset — barrier is the newest line now.
-    rec.forgetSession("a");
-
-    // Fresh spawn: session_init lands, then a text event BEFORE the agent
-    // pulls its inbox.
-    rec.setSession("a", "sess-2");
-    rec.appendResponseToLatest("a", "I'll check for unfinished work.");
-
-    const rows = readRecentEntries(dir, { now: NOW() });
-    // Row 0: original turn — untouched.
-    expect(rows[0].messages.map((m) => m.content.text)).toEqual(["hi"]);
-    expect(rows[0].agent_responses).toEqual(["old reply"]);
-    // Row 1: the barrier — MUST NOT carry the response.
-    expect(rows[1].system?.type).toBe("reset_session");
-    expect(rows[1].agent_responses).toEqual([]);
-    // Row 2: the fallback turn row, opened by appendResponseToLatest.
-    expect(rows[2].system).toBeUndefined();
-    expect(rows[2].session_id).toBe("sess-2");
-    expect(rows[2].provider).toBe("claude");
-    expect(rows[2].messages).toEqual([]);
-    expect(rows[2].agent_responses).toEqual(["I'll check for unfinished work."]);
+    recorder.forgetSession("a");
+    expect(recorder.resumeSessionId("a", "claude")).toBeNull();
+    recorder.setSession("a", "sess-2", "epoch-2");
+    const second = begin(recorder, "turn-2", "epoch-2");
+    recorder.recordInboxPull("a", second, [msg("#2", "new")]);
+    expect(recorder.resumeSessionId("a", "claude")).toBe("sess-2");
+    expect(recorder.resumeSessionId("a", "codex")).toBeNull();
   });
 
-  it("subsequent inbox pull appends its OWN turn row (fallback row has a response, so appendOrMergeEntry won't merge)", () => {
-    const dir = mkDir();
-    const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "claude", now: NOW });
-
-    rec.forgetSession("a"); // barrier
-    rec.setSession("a", "sess-2");
-    rec.appendResponseToLatest("a", "pre-pull chatter");
-    // Now the fresh spawn actually pulls inbox.
-    rec.appendEntryForAgent("a", [msg("#1", "unread")]);
-    rec.appendResponseToLatest("a", "post-pull reply");
-
-    const rows = readRecentEntries(dir, { now: NOW() });
-    // [barrier, fallback, pull]
-    expect(rows).toHaveLength(3);
-    expect(rows[0].system?.type).toBe("reset_session");
-    expect(rows[1].agent_responses).toEqual(["pre-pull chatter"]);
-    expect(rows[1].messages).toEqual([]);
-    expect(rows[2].messages.map((m) => m.content.text)).toEqual(["unread"]);
-    expect(rows[2].agent_responses).toEqual(["post-pull reply"]);
-  });
-
-  it("first-ever text event with no prior rows opens a fallback turn row", () => {
-    const dir = mkDir();
-    const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "claude", now: NOW });
-
-    rec.setSession("a", "sess-1");
-    rec.appendResponseToLatest("a", "hello");
-
-    const rows = readRecentEntries(dir, { now: NOW() });
-    expect(rows).toHaveLength(1);
-    expect(rows[0].session_id).toBe("sess-1");
-    expect(rows[0].agent_responses).toEqual(["hello"]);
-    expect(rows[0].messages).toEqual([]);
-  });
-
-  it("keeps only the latest five normal responses in FIFO order", () => {
-    const dir = mkDir();
-    const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "claude", now: NOW });
-    rec.appendEntryForAgent("a", [msg("#1", "hello")]);
-    for (let index = 1; index <= 6; index++) rec.appendResponseToLatest("a", `r${index}`);
-    expect(readRecentEntries(dir, { now: NOW() })[0].agent_responses).toEqual(["r2", "r3", "r4", "r5", "r6"]);
-  });
-
-  it("keeps only the latest five text-before-first-pull fallback responses", () => {
-    const dir = mkDir();
-    const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "claude", now: NOW });
-    rec.setSession("a", "sess-1");
-    for (let index = 1; index <= 6; index++) rec.appendResponseToLatest("a", `r${index}`);
-    const rows = readRecentEntries(dir, { now: NOW() });
-    expect(rows).toHaveLength(1);
-    expect(rows[0].agent_responses).toEqual(["r2", "r3", "r4", "r5", "r6"]);
-  });
-
-  it("does not create a fallback row when the latest-day lock is busy", () => {
-    const dir = mkDir();
-    const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "claude", now: NOW });
-    rec.appendEntryForAgent("a", [msg("#1", "hello")]);
-    const filename = filenameForDate(NOW());
-    const file = path.join(dir, filename);
-    const before = fs.readFileSync(file);
-    const lock = lockPathFor(dir, filename);
-    expect(acquireLock(lock)).toBe(true);
-    try {
-      rec.appendResponseToLatest("a", "must not fall back");
-    } finally {
-      releaseLock(lock);
-    }
-
-    expect(fs.readFileSync(file)).toEqual(before);
-    expect(readRecentEntries(dir, { now: NOW() })).toHaveLength(1);
-    expect(readRecentEntries(dir, { now: NOW() })[0].agent_responses).toEqual([]);
-  });
-});
-
-describe("recorder timeline directory safety", () => {
-  it("does not create an outside timeline through an agent-directory symlink", () => {
+  it("does not create or mutate an outside timeline through an agent-directory symlink", () => {
     if (process.platform === "win32") return;
     const base = mkDir();
-    const outsideAgent = mkDir();
+    const outside = mkDir();
     const agentLink = path.join(base, "agent-link");
-    fs.symlinkSync(outsideAgent, agentLink);
-    const linkedTimeline = path.join(agentLink, ".context_timeline");
-    const rec = createTimelineRecorder({
-      timelineDirFor: () => linkedTimeline,
+    fs.symlinkSync(outside, agentLink);
+    const recorder = createTimelineRecorder({
+      timelineDirFor: () => path.join(agentLink, ".context_timeline"),
       providerFor: () => "claude",
       now: NOW,
     });
+    const owner = begin(recorder, "turn-a");
+    recorder.recordInboxPull("a", owner, [msg("#1", "blocked")]);
+    recorder.recordAssistantMessage("a", owner, "blocked");
+    recorder.finalizeTurn("a", owner);
+    recorder.forgetSession("a");
 
-    rec.setSession("a", "outside-session");
-    rec.appendEntryForAgent("a", [msg("#1", "blocked")]);
-    rec.appendResponseToLatest("a", "blocked");
-    rec.forgetSession("a");
-
-    expect(fs.readdirSync(outsideAgent)).toEqual([]);
-  });
-
-  it("does not read or modify an existing outside timeline through an agent-directory symlink", () => {
-    if (process.platform === "win32") return;
-    const base = mkDir();
-    const outsideAgent = mkDir();
-    const outsideTimeline = path.join(outsideAgent, ".context_timeline");
-    fs.mkdirSync(outsideTimeline);
-    const file = path.join(outsideTimeline, filenameForDate(NOW()));
-    fs.writeFileSync(file, `${JSON.stringify(createTimelineEntry({
-      messages: [msg("#1", "outside")],
-      sessionId: "outside-session",
-      provider: "claude",
-    }))}\n`);
-    const before = fs.readFileSync(file);
-    const agentLink = path.join(base, "agent-link");
-    fs.symlinkSync(outsideAgent, agentLink);
-    const linkedTimeline = path.join(agentLink, ".context_timeline");
-    const rec = createTimelineRecorder({
-      timelineDirFor: () => linkedTimeline,
-      providerFor: () => "claude",
-      now: NOW,
-    });
-
-    expect(rec.resumeSessionId("a", "claude")).toBeNull();
-    rec.appendEntryForAgent("a", [msg("#1", "blocked")]);
-    rec.appendResponseToLatest("a", "blocked");
-    rec.forgetSession("a");
-
-    expect(fs.readdirSync(outsideTimeline)).toEqual([filenameForDate(NOW())]);
-    expect(fs.readFileSync(file)).toEqual(before);
-  });
-});
-
-describe("resumeSessionId honors the reset_session barrier", () => {
-  it("multi-turn survival: three rows all carrying sess-1 then reset → null", () => {
-    const dir = mkDir();
-    const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "claude", now: NOW });
-    rec.setSession("a", "sess-1");
-    rec.appendEntryForAgent("a", [msg("#1", "t1")]);
-    rec.appendResponseToLatest("a", "r1");
-    rec.appendEntryForAgent("a", [msg("#2", "t2")]);
-    rec.appendResponseToLatest("a", "r2");
-    rec.appendEntryForAgent("a", [msg("#3", "t3")]);
-    rec.appendResponseToLatest("a", "r3");
-    rec.forgetSession("a");
-
-    expect(rec.resumeSessionId("a", "claude")).toBeNull();
-  });
-
-  it("future sessions unaffected: reset + newer row carrying sess-2 → returns sess-2", () => {
-    const dir = mkDir();
-    const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "claude", now: NOW });
-    rec.setSession("a", "sess-1");
-    rec.appendEntryForAgent("a", [msg("#1", "old")]);
-    rec.appendResponseToLatest("a", "reply1");
-    rec.forgetSession("a");
-    rec.setSession("a", "sess-2");
-    rec.appendEntryForAgent("a", [msg("#2", "fresh")]);
-
-    expect(rec.resumeSessionId("a", "claude")).toBe("sess-2");
-  });
-
-  it("no reset → unchanged behavior (returns newest non-null session_id)", () => {
-    const dir = mkDir();
-    const rec = createTimelineRecorder({ timelineDirFor: () => dir, providerFor: () => "claude", now: NOW });
-    rec.setSession("a", "sess-only");
-    rec.appendEntryForAgent("a", [msg("#1", "x")]);
-
-    expect(rec.resumeSessionId("a", "claude")).toBe("sess-only");
+    expect(fs.readdirSync(outside)).toEqual([]);
   });
 });

--- a/src/daemon/src/timeline/recorder.test.ts
+++ b/src/daemon/src/timeline/recorder.test.ts
@@ -429,7 +429,7 @@ describe("createTimelineRecorder durable resume control", () => {
       nodeFs.openSync = originalOpenSync;
       syncBuiltinESMExports();
     }
-  });
+  }, 30_000);
 
   it("uses history only when control is missing and fails closed for corrupt control", () => {
     const makeHistory = (): { dir: string; control: string } => {

--- a/src/daemon/src/timeline/recorder.test.ts
+++ b/src/daemon/src/timeline/recorder.test.ts
@@ -203,6 +203,20 @@ describe("createTimelineRecorder exact turn ownership", () => {
     expect(row.agent_responses[0]!.match(/… \[truncated\]/gu)).toHaveLength(1);
   });
 
+  it("adds one marker when row fitting truncates an otherwise unbounded response", () => {
+    const dir = mkDir();
+    const recorder = createTimelineRecorder({ timelineDirFor: () => dir, now: NOW });
+    const owner = begin(recorder, "turn-row-fit");
+    recorder.recordInboxPull("a", owner, [msg("#1", "x".repeat(1_040_000))]);
+    recorder.recordAssistantMessage("a", owner, "r".repeat(20_000));
+    recorder.finalizeTurn("a", owner);
+
+    const [row] = readRecentEntries(dir, { now: NOW() });
+    expect(Buffer.byteLength(`${JSON.stringify(row)}\n`, "utf8")).toBeLessThanOrEqual(TIMELINE_MAX_BYTES);
+    expect(row.agent_responses[0]).toMatch(/… \[truncated\]$/u);
+    expect(row.agent_responses[0]!.match(/… \[truncated\]/gu)).toHaveLength(1);
+  });
+
   it("rejects an externally rewritten captured row instead of falling back to latest", () => {
     const dir = mkDir();
     const diagnostics: string[] = [];
@@ -224,9 +238,138 @@ describe("createTimelineRecorder exact turn ownership", () => {
     expect(rows[0].agent_responses).toEqual([]);
     expect(diagnostics).toContain("timeline_exact_write_rejected:generation");
   });
+
+  it("fences a captured handle omitted by an external rewrite remap", () => {
+    const dir = mkDir();
+    const diagnostics: string[] = [];
+    const recorder = createTimelineRecorder({
+      timelineDirFor: () => dir,
+      now: NOW,
+      onDiagnostic: (event) => diagnostics.push(`${event.code}:${event.reason ?? ""}`),
+    });
+    const owner = begin(recorder, "turn-rewritten");
+    recorder.recordInboxPull("a", owner, [msg("#1", "captured")]);
+    recorder.recordAssistantMessage("a", owner, "must not redirect");
+    const file = path.join(dir, filenameForDate(NOW()));
+    fs.writeFileSync(file, `${JSON.stringify(createTimelineEntry({ messages: [msg("#9", "external")] }))}\n`);
+
+    recorder.recordInboxPull("a", null, [msg("#10", "unrelated")]);
+    recorder.finalizeTurn("a", owner);
+
+    expect(diagnostics).toContain("timeline_handle_fenced:rewrite_remap");
+    expect(readRecentEntries(dir, { now: NOW() }).flatMap((row) => row.agent_responses))
+      .not.toContain("must not redirect");
+  });
+
+  it("rejects an oversized no-handle fallback before writing a row", () => {
+    const dir = mkDir();
+    const diagnostics: string[] = [];
+    const recorder = createTimelineRecorder({
+      timelineDirFor: () => dir,
+      now: NOW,
+      onDiagnostic: (event) => diagnostics.push(`${event.code}:${event.reason ?? ""}`),
+    });
+    expect(recorder.setSession("a", "s".repeat(TIMELINE_MAX_BYTES), "epoch-large")).toBe(true);
+    const owner = begin(recorder, "turn-large", "epoch-large");
+    recorder.recordAssistantMessage("a", owner, "pre-pull output");
+    recorder.finalizeTurn("a", owner);
+
+    expect(diagnostics).toContain("timeline_response_did_not_fit:oversized");
+    expect(readRecentEntries(dir, { now: NOW() })).toEqual([]);
+  });
+
+  it("records a never-begun pull owner as ownerless", () => {
+    const dir = mkDir();
+    const recorder = createTimelineRecorder({ timelineDirFor: () => dir, now: NOW });
+    const owner: TimelineTurnOwner = {
+      sessionInstanceId: "missing-epoch",
+      rootTurnId: "missing-turn",
+      barrierGeneration: recorder.barrierGeneration("a"),
+    };
+    recorder.recordInboxPull("a", owner, [msg("#1", "never begun")]);
+
+    const [row] = readRecentEntries(dir, { now: NOW() });
+    expect(row.messages.map((message) => message.content.text)).toEqual(["never begun"]);
+    expect(row.agent_responses).toEqual([]);
+  });
+
+  it("falls back to an ownerless append when the barrier changes during pull recording", () => {
+    const dir = mkDir();
+    let recorder!: TimelineRecorderLike;
+    let nowCalls = 0;
+    let reentered = false;
+    const now = () => {
+      nowCalls++;
+      if (nowCalls === 2 && !reentered) {
+        reentered = true;
+        recorder.fenceSession("a");
+      }
+      return NOW();
+    };
+    recorder = createTimelineRecorder({ timelineDirFor: () => dir, now });
+    const owner = begin(recorder, "turn-barrier-race");
+    nowCalls = 0;
+
+    recorder.recordInboxPull("a", owner, [msg("#1", "barrier-raced")]);
+
+    const [row] = readRecentEntries(dir, { now: NOW() });
+    expect(row.messages.map((message) => message.content.text)).toEqual(["barrier-raced"]);
+    expect(row.agent_responses).toEqual([]);
+  });
+
+  it("rejects completed output delivered after finalization", () => {
+    const dir = mkDir();
+    const diagnostics: string[] = [];
+    const recorder = createTimelineRecorder({
+      timelineDirFor: () => dir,
+      now: NOW,
+      onDiagnostic: (event) => diagnostics.push(`${event.code}:${event.reason ?? ""}`),
+    });
+    const owner = begin(recorder, "turn-finalized");
+    recorder.finalizeTurn("a", owner);
+    recorder.recordAssistantMessage("a", owner, "too late");
+
+    expect(diagnostics).toContain("timeline_completed_message_rejected:stale_owner");
+    expect(readRecentEntries(dir, { now: NOW() })).toEqual([]);
+  });
+
+  it("rejects a no-handle fallback after another turn becomes active", () => {
+    const dir = mkDir();
+    const diagnostics: string[] = [];
+    const recorder = createTimelineRecorder({
+      timelineDirFor: () => dir,
+      now: NOW,
+      onDiagnostic: (event) => diagnostics.push(`${event.code}:${event.reason ?? ""}`),
+    });
+    const ownerA = begin(recorder, "turn-a");
+    recorder.recordAssistantMessage("a", ownerA, "buffered A");
+    begin(recorder, "turn-b", "epoch-b");
+    recorder.finalizeTurn("a", ownerA);
+
+    expect(diagnostics).toContain("timeline_fallback_rejected:fenced_owner");
+    expect(readRecentEntries(dir, { now: NOW() })).toEqual([]);
+  });
 });
 
 describe("createTimelineRecorder barriers and pending commits", () => {
+  it("rejects beginTurn owners captured before a barrier advance", () => {
+    const diagnostics: string[] = [];
+    const recorder = createTimelineRecorder({
+      timelineDirFor: () => mkDir(),
+      now: NOW,
+      onDiagnostic: (event) => diagnostics.push(`${event.code}:${event.reason ?? ""}`),
+    });
+    const staleOwner: TimelineTurnOwner = {
+      sessionInstanceId: "stale-epoch",
+      rootTurnId: "stale-turn",
+      barrierGeneration: recorder.barrierGeneration("a"),
+    };
+    recorder.fenceSession("a");
+    recorder.beginTurn("a", staleOwner);
+
+    expect(diagnostics).toContain("timeline_turn_begin_fenced:barrier_generation");
+  });
+
   it("lets a retained pre-reset handle update in place before the durable barrier", () => {
     const dir = mkDir();
     const recorder = createTimelineRecorder({ timelineDirFor: () => dir, now: NOW });
@@ -347,6 +490,72 @@ describe("createTimelineRecorder barriers and pending commits", () => {
 
     expect(readRecentEntries(dir, { now: current })[0].agent_responses).toEqual([]);
     expect(diagnostics).toContain("timeline_pending_commit_expired");
+  });
+
+  it("removes a successful finalized state after the retention TTL", () => {
+    const dir = mkDir();
+    let current = new Date("2026-06-25T12:00:00");
+    const recorder = createTimelineRecorder({ timelineDirFor: () => dir, now: () => current });
+    const owner = begin(recorder, "turn-reusable");
+    recorder.finalizeTurn("a", owner);
+
+    current = new Date(current.getTime() + 15 * 60_000 + 1);
+    recorder.beginTurn("a", owner);
+    recorder.recordAssistantMessage("a", owner, "recreated after ttl");
+    recorder.finalizeTurn("a", owner);
+
+    expect(readRecentEntries(dir, { now: current }).flatMap((row) => row.agent_responses))
+      .toEqual(["recreated after ttl"]);
+  });
+
+  it("deletes a pending exact commit when its row becomes terminally stale", () => {
+    const dir = mkDir();
+    const diagnostics: string[] = [];
+    const recorder = createTimelineRecorder({
+      timelineDirFor: () => dir,
+      now: NOW,
+      onDiagnostic: (event) => diagnostics.push(`${event.code}:${event.reason ?? ""}`),
+    });
+    const owner = begin(recorder, "turn-pending-terminal");
+    recorder.recordInboxPull("a", owner, [msg("#1", "captured")]);
+    recorder.recordAssistantMessage("a", owner, "must not redirect");
+    const filename = filenameForDate(NOW());
+    const file = path.join(dir, filename);
+    const lock = lockPathFor(dir, filename);
+    expect(acquireLock(lock)).toBe(true);
+    try {
+      recorder.finalizeTurn("a", owner);
+    } finally {
+      releaseLock(lock);
+    }
+    fs.writeFileSync(file, `${JSON.stringify(createTimelineEntry({ messages: [msg("#2", "replacement")] }))}\n`);
+
+    begin(recorder, "turn-trigger", "epoch-trigger");
+
+    expect(diagnostics).toContain("timeline_exact_write_rejected:generation");
+    expect(readRecentEntries(dir, { now: NOW() }).flatMap((row) => row.agent_responses))
+      .not.toContain("must not redirect");
+  });
+
+  it("prunes the oldest of more than eight retained finalized states", () => {
+    const dir = mkDir();
+    let current = new Date("2026-06-25T12:00:00");
+    const recorder = createTimelineRecorder({ timelineDirFor: () => dir, now: () => current });
+    const owners: TimelineTurnOwner[] = [];
+    for (let index = 0; index < 9; index++) {
+      const owner = begin(recorder, `turn-${index}`, `epoch-${index}`);
+      owners.push(owner);
+      recorder.finalizeTurn("a", owner);
+      current = new Date(current.getTime() + 1);
+    }
+    begin(recorder, "turn-trigger", "epoch-trigger");
+
+    recorder.beginTurn("a", owners[0]!);
+    recorder.recordAssistantMessage("a", owners[0]!, "oldest recreated");
+    recorder.finalizeTurn("a", owners[0]!);
+
+    expect(readRecentEntries(dir, { now: current }).flatMap((row) => row.agent_responses))
+      .toEqual(["oldest recreated"]);
   });
 
   it("bounds pending exact commits to eight per agent", () => {

--- a/src/daemon/src/timeline/recorder.ts
+++ b/src/daemon/src/timeline/recorder.ts
@@ -1,18 +1,11 @@
 /**
  * A timeline recorder backed by the JSONL module, injected into the daemon.
  *
- * Append-only, correlated by "this agent's latest entry" (no cross-layer task
- * id). Two planes write one entry:
- *   - DATA plane (the credential proxy's onInboxPullResponse): each inbox pull opens an entry
- *     via `appendEntryForAgent`, capturing the messages the agent saw + the
- *     session_id known so far + provider. A pull that arrives while the latest
- *     row is still unanswered (same session/provider, empty agent_responses)
- *     MERGES into it rather than splitting the turn (see appendOrMergeEntry) —
- *     which also removes the late-text misattribution race.
- *   - CONTROL plane (the manager): `setSession` records the runtime session id as
- *     soon as session_init fires (kept in memory and baked into the NEXT entry,
- *     since the pull that opens an entry happens after session_init);
- *     `appendResponseToLatest` accumulates the agent's text onto the latest row.
+ * Inbox observations and complete assistant messages are correlated by an
+ * in-memory exact root-turn owner. A pull captures that owner at request start;
+ * the recorder opens or updates one row and retains an opaque process-local
+ * handle. Finalization can update only that captured row. There is deliberately
+ * no "latest row" fallback.
  *
  * Each agent's rows live in its own `<workdir>/.context_timeline`. Pure daily log
  * — records turns + answers resume lookups; never participates in steering.
@@ -21,38 +14,141 @@
  * agent_responses, provider}` — no task id / datetime / status / pid.
  */
 import {
-  appendOrMergeEntry,
-  updateLatestEntryResult,
   readRecentEntries,
   readResumeControlState,
   updateResumeControlState,
   createTimelineEntry,
   createSystemEntry,
   resolveResumableSession,
-  appendEntry,
+  appendTrackedEntry,
+  updateTrackedEntry,
+  refreshTimelineEntryHandle,
+  filenameForDate,
+  TIMELINE_MAX_BYTES,
   prepareTimelineDirectory,
 } from "./timeline.js";
+import type {
+  ResumeSessionResolution,
+  TimelineEntryHandle,
+  TimelineFileRewrite,
+  TimelineTrackedWriteResult,
+} from "./timeline.js";
 import type { Message } from "../server/contract.js";
-import type { SystemEntryType } from "./types.js";
-import type { ResumeSessionResolution } from "./timeline.js";
+import type { ContextTimelineEntry, SystemEntryType } from "./types.js";
 
 const MAX_AGENT_RESPONSES = 5;
+const MAX_AGENT_RESPONSE_BYTES = 65_536;
+const MAX_PENDING_COMMITS_PER_AGENT = 8;
+const PENDING_COMMIT_TTL_MS = 15 * 60_000;
+const TRUNCATION_MARKER = "\n… [truncated]";
 
-function appendAgentResponse(entry: { agent_responses: string[] }, text: string): void {
-  entry.agent_responses.push(text);
-  if (entry.agent_responses.length > MAX_AGENT_RESPONSES) {
-    entry.agent_responses.splice(0, entry.agent_responses.length - MAX_AGENT_RESPONSES);
+export interface TimelineTurnOwner {
+  sessionInstanceId: string;
+  rootTurnId: string;
+  barrierGeneration: number;
+}
+
+interface TurnRecorderState {
+  owner: TimelineTurnOwner;
+  provider: string | null;
+  backendSessionId: string | null;
+  responses: string[];
+  handle?: TimelineEntryHandle;
+  rowFenced: boolean;
+  finalized: boolean;
+  completedAtMs?: number;
+  pendingSinceMs?: number;
+  pendingMode?: "handle" | "fallback";
+}
+
+function turnKey(agentId: string, owner: TimelineTurnOwner): string {
+  return `${agentId}\0${owner.sessionInstanceId}\0${owner.rootTurnId}\0${owner.barrierGeneration}`;
+}
+
+function sameOwner(left: TimelineTurnOwner, right: TimelineTurnOwner): boolean {
+  return left.sessionInstanceId === right.sessionInstanceId
+    && left.rootTurnId === right.rootTurnId
+    && left.barrierGeneration === right.barrierGeneration;
+}
+
+function utf8Prefix(text: string, maxBytes: number): string {
+  if (maxBytes <= 0) return "";
+  if (Buffer.byteLength(text, "utf8") <= maxBytes) return text;
+  let low = 0;
+  let high = text.length;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    let end = mid;
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) end -= 1;
+    if (Buffer.byteLength(text.slice(0, end), "utf8") <= maxBytes) low = mid;
+    else high = mid - 1;
   }
+  let end = low;
+  const code = text.charCodeAt(end - 1);
+  if (code >= 0xd800 && code <= 0xdbff) end -= 1;
+  while (end > 0 && Buffer.byteLength(text.slice(0, end), "utf8") > maxBytes) end -= 1;
+  return text.slice(0, end);
+}
+
+function boundedResponse(text: string, alreadyTruncated: boolean): string {
+  const markerBytes = Buffer.byteLength(TRUNCATION_MARKER, "utf8");
+  const needsTruncation = alreadyTruncated || Buffer.byteLength(text, "utf8") > MAX_AGENT_RESPONSE_BYTES;
+  if (!needsTruncation) return text;
+  return utf8Prefix(text, MAX_AGENT_RESPONSE_BYTES - markerBytes) + TRUNCATION_MARKER;
+}
+
+function serializedTimelineBytes(entry: ContextTimelineEntry): number {
+  return Buffer.byteLength(JSON.stringify(entry), "utf8") + 1;
+}
+
+function fitResponsesToRow(entry: ContextTimelineEntry, responses: readonly string[]): string[] | null {
+  let fitted = [...entry.agent_responses];
+  for (const response of responses) {
+    fitted = [...fitted, response].slice(-MAX_AGENT_RESPONSES);
+    if (serializedTimelineBytes({ ...entry, agent_responses: fitted }) <= TIMELINE_MAX_BYTES) continue;
+    const truncationBase = response.endsWith(TRUNCATION_MARKER)
+      ? response.slice(0, -TRUNCATION_MARKER.length)
+      : response;
+    let low = 0;
+    let high = truncationBase.length;
+    let replacement: string | null = null;
+    while (low <= high) {
+      const mid = Math.floor((low + high) / 2);
+      let end = mid;
+      const code = truncationBase.charCodeAt(end - 1);
+      if (code >= 0xd800 && code <= 0xdbff) end -= 1;
+      const candidateResponse = truncationBase.slice(0, end) + TRUNCATION_MARKER;
+      const candidate = [...fitted.slice(0, -1), candidateResponse];
+      if (serializedTimelineBytes({ ...entry, agent_responses: candidate }) <= TIMELINE_MAX_BYTES) {
+        replacement = candidateResponse;
+        low = mid + 1;
+      } else {
+        high = mid - 1;
+      }
+    }
+    if (replacement === null) return null;
+    fitted[fitted.length - 1] = replacement;
+  }
+  return fitted;
 }
 
 /** Manager/daemon-facing recorder interface (structural, avoids a cyclic import). */
 export interface TimelineRecorderLike {
-  /** CONTROL plane: remember the runtime session id; false means no state may advance. */
-  setSession(agentId: string, sessionId: string): boolean;
-  /** DATA plane: a successful inbox pull opens a new entry of what the agent saw. */
-  appendEntryForAgent(agentId: string, messages: Message[]): void;
-  /** CONTROL plane: append the agent's text output to its latest open entry. */
-  appendResponseToLatest(agentId: string, text: string): void;
+  /** Current in-memory barrier epoch captured by pull-start owner snapshots. */
+  barrierGeneration(agentId: string): number;
+  /** Begin one exact root turn before any completed semantic output can arrive. */
+  beginTurn(agentId: string, owner: TimelineTurnOwner): void;
+  /** Record a pull against its immutable request-start owner, or as explicitly ownerless. */
+  recordInboxPull(agentId: string, owner: TimelineTurnOwner | null, messages: Message[]): void;
+  /** Retain one completed assistant message for its exact live turn. */
+  recordAssistantMessage(agentId: string, owner: TimelineTurnOwner, text: string, truncated?: boolean): void;
+  /** Finalize exactly once; fallback is allowed only for the still-active unfenced owner. */
+  finalizeTurn(agentId: string, owner: TimelineTurnOwner): void;
+  /** Fence ownership for model/session replacement without writing a durable reset row. */
+  fenceSession(agentId: string): void;
+  /** CONTROL plane: persist and remember the runtime session id; false means no state may advance. */
+  setSession(agentId: string, sessionId: string, sessionInstanceId?: string): boolean;
   /** Latest session id recorded for this agent (resume target), or null. */
   resumeSessionId(agentId: string, provider: string | null): string | null;
   /** Latest resume target or the durable barrier that supersedes older sources. */
@@ -68,9 +164,9 @@ export interface TimelineRecorderLike {
    * an exact-session barrier — every superseded turn
    * becomes invisible to `resumeSessionId` — and the agent's own history read
    * (for recall) sees it in-line with turns. Also clears the in-memory session
-   * cache so a racing `appendEntryForAgent` can't bake the stale id into a
-   * fresh row. Returns false unless the authoritative control transition was
-   * committed; the forensic row is appended only after that precondition.
+   * cache so a racing pull cannot bake the stale id into a fresh row.
+   * Returns false unless the authoritative control transition was committed;
+   * the forensic row is appended only after that precondition.
    */
   forgetSession(agentId: string, barrierType?: SystemEntryType, forgottenSessionId?: string): boolean;
 }
@@ -82,6 +178,8 @@ export interface TimelineRecorderOptions {
   providerFor?: (agentId: string) => string | null;
   /** Injectable clock (tests). */
   now?: () => Date;
+  /** Bounded fail-closed diagnostics; never receives response/reasoning content. */
+  onDiagnostic?: (event: { agentId: string; code: string; reason?: string }) => void;
 }
 
 export function createTimelineRecorder(opts: TimelineRecorderOptions): TimelineRecorderLike {
@@ -131,8 +229,288 @@ export function createTimelineRecorder(opts: TimelineRecorderOptions): TimelineR
     return { kind: "none", stalledSessionId: attemptedSessionId, fencedSessionId };
   };
 
+  const sessionByEpoch = new Map<string, string>();
+  const barrierByAgent = new Map<string, number>();
+  const turnsByAgent = new Map<string, Map<string, TurnRecorderState>>();
+  const activeTurnByAgent = new Map<string, string>();
+  const epochKey = (agentId: string, sessionInstanceId: string) => `${agentId}\0${sessionInstanceId}`;
+  const currentBarrier = (agentId: string) => barrierByAgent.get(agentId) ?? 0;
+  const statesFor = (agentId: string): Map<string, TurnRecorderState> => {
+    let states = turnsByAgent.get(agentId);
+    if (!states) {
+      states = new Map();
+      turnsByAgent.set(agentId, states);
+    }
+    return states;
+  };
+  const diagnostic = (agentId: string, code: string, reason?: string): void => {
+    try { opts.onDiagnostic?.({ agentId, code, ...(reason ? { reason } : {}) }); } catch { /* observer only */ }
+  };
+  const applyRewrite = (agentId: string, rewrite: TimelineFileRewrite): void => {
+    for (const state of statesFor(agentId).values()) {
+      if (!state.handle) continue;
+      const refreshed = refreshTimelineEntryHandle(state.handle, rewrite);
+      if (refreshed) {
+        state.handle = refreshed;
+      } else if (state.handle.filename === rewrite.filename) {
+        state.handle = undefined;
+        state.rowFenced = true;
+        diagnostic(agentId, "timeline_handle_fenced", "rewrite_remap");
+      }
+    }
+  };
+  const handleTrackedResult = (
+    agentId: string,
+    state: TurnRecorderState | null,
+    result: TimelineTrackedWriteResult,
+  ): "written" | "retryable" | "terminal" => {
+    if (result.status === "written") {
+      applyRewrite(agentId, result.rewrite);
+      if (state && result.handle) {
+        state.handle = result.handle;
+        state.rowFenced = false;
+      }
+      return "written";
+    }
+    if (result.reason === "lock" || result.reason === "write") return "retryable";
+    if (state && result.reason !== "oversized") state.rowFenced = true;
+    diagnostic(agentId, "timeline_exact_write_rejected", result.reason);
+    return "terminal";
+  };
+  const tryCommit = (agentId: string, state: TurnRecorderState): "written" | "retryable" | "terminal" => {
+    if (state.responses.length === 0) return "written";
+    const dir = dirFor(agentId);
+    if (!prepareTimelineDirectory(dir)) {
+      diagnostic(agentId, "timeline_directory_unavailable");
+      return "terminal";
+    }
+    if (state.handle) {
+      const result = updateTrackedEntry(dir, state.handle, (entry) => {
+        const fitted = fitResponsesToRow(entry, state.responses);
+        return { ...entry, agent_responses: fitted ?? [...entry.agent_responses, ...state.responses] };
+      });
+      return handleTrackedResult(agentId, state, result);
+    }
+    if (state.rowFenced || state.pendingMode === "handle") return "terminal";
+    if (state.owner.barrierGeneration !== currentBarrier(agentId)) return "terminal";
+    const entry = createTimelineEntry({
+      messages: [],
+      sessionId: state.backendSessionId,
+      provider: state.provider,
+    });
+    const fitted = fitResponsesToRow(entry, state.responses);
+    if (!fitted) {
+      diagnostic(agentId, "timeline_response_did_not_fit", "oversized");
+      return "terminal";
+    }
+    entry.agent_responses = fitted;
+    const result = appendTrackedEntry(dir, entry, now());
+    return handleTrackedResult(agentId, state, result);
+  };
+  const deleteState = (agentId: string, key: string): void => {
+    const states = statesFor(agentId);
+    states.delete(key);
+    if (activeTurnByAgent.get(agentId) === key) activeTurnByAgent.delete(agentId);
+    if (states.size === 0) turnsByAgent.delete(agentId);
+  };
+  const retryPending = (agentId: string): void => {
+    const states = turnsByAgent.get(agentId);
+    if (!states) return;
+    const nowMs = now().getTime();
+    for (const [key, state] of [...states]) {
+      if (
+        state.finalized
+        && state.pendingSinceMs === undefined
+        && state.completedAtMs !== undefined
+        && nowMs - state.completedAtMs >= PENDING_COMMIT_TTL_MS
+      ) {
+        deleteState(agentId, key);
+        continue;
+      }
+      if (!state.finalized || state.pendingSinceMs === undefined) continue;
+      if (nowMs - state.pendingSinceMs >= PENDING_COMMIT_TTL_MS) {
+        diagnostic(agentId, "timeline_pending_commit_expired");
+        deleteState(agentId, key);
+        continue;
+      }
+      const result = tryCommit(agentId, state);
+      if (result === "written") {
+        state.responses = [];
+        state.pendingSinceMs = undefined;
+        state.pendingMode = undefined;
+        state.completedAtMs = nowMs;
+      } else if (result === "terminal") {
+        deleteState(agentId, key);
+      }
+    }
+    const completed = [...states.entries()]
+      .filter(([, state]) => state.finalized && state.pendingSinceMs === undefined)
+      .sort((left, right) => (left[1].completedAtMs ?? 0) - (right[1].completedAtMs ?? 0));
+    while (completed.length > MAX_PENDING_COMMITS_PER_AGENT) {
+      const oldest = completed.shift();
+      if (oldest) deleteState(agentId, oldest[0]);
+    }
+  };
+  const retainPending = (agentId: string, key: string, state: TurnRecorderState): void => {
+    const states = statesFor(agentId);
+    const pending = [...states.values()].filter((candidate) => candidate.finalized && candidate.pendingSinceMs !== undefined);
+    if (pending.length >= MAX_PENDING_COMMITS_PER_AGENT) {
+      diagnostic(agentId, "timeline_pending_commit_overflow");
+      deleteState(agentId, key);
+      return;
+    }
+    state.pendingSinceMs ??= now().getTime();
+    state.pendingMode = state.handle ? "handle" : "fallback";
+  };
+  const appendOwnerless = (agentId: string, messages: Message[]): void => {
+    if (messages.length === 0) return;
+    const dir = dirFor(agentId);
+    if (!prepareTimelineDirectory(dir)) return;
+    const result = appendTrackedEntry(
+      dir,
+      createTimelineEntry({
+        messages,
+        sessionId: sessionByAgent.get(agentId) ?? null,
+        provider: opts.providerFor?.(agentId) ?? null,
+      }),
+      now(),
+    );
+    handleTrackedResult(agentId, null, result);
+  };
+
   return {
-    setSession(agentId, sessionId) {
+    barrierGeneration(agentId) {
+      return currentBarrier(agentId);
+    },
+    beginTurn(agentId, owner) {
+      retryPending(agentId);
+      const states = statesFor(agentId);
+      if (owner.barrierGeneration !== currentBarrier(agentId)) {
+        diagnostic(agentId, "timeline_turn_begin_fenced", "barrier_generation");
+        return;
+      }
+      const key = turnKey(agentId, owner);
+      if (!states.has(key)) {
+        states.set(key, {
+          owner: { ...owner },
+          provider: opts.providerFor?.(agentId) ?? null,
+          backendSessionId: sessionByEpoch.get(epochKey(agentId, owner.sessionInstanceId))
+            ?? sessionByAgent.get(agentId)
+            ?? null,
+          responses: [],
+          rowFenced: false,
+          finalized: false,
+        });
+      }
+      activeTurnByAgent.set(agentId, key);
+    },
+    recordInboxPull(agentId, owner, messages) {
+      retryPending(agentId);
+      if (messages.length === 0) return;
+      if (!owner) {
+        appendOwnerless(agentId, messages);
+        return;
+      }
+      const key = turnKey(agentId, owner);
+      const state = turnsByAgent.get(agentId)?.get(key);
+      if (!state || state.rowFenced || !sameOwner(state.owner, owner)) {
+        appendOwnerless(agentId, messages);
+        return;
+      }
+      const dir = dirFor(agentId);
+      if (!prepareTimelineDirectory(dir)) return;
+      const stamp = now();
+      let result: TimelineTrackedWriteResult;
+      if (
+        state.handle
+        && (
+          state.handle.filename === filenameForDate(stamp)
+          || state.owner.barrierGeneration !== currentBarrier(agentId)
+        )
+      ) {
+        result = updateTrackedEntry(dir, state.handle, (entry) => ({
+          ...entry,
+          messages: [...entry.messages, ...messages],
+          session_id: state.backendSessionId,
+          provider: state.provider,
+        }));
+      } else if (state.owner.barrierGeneration === currentBarrier(agentId)) {
+        result = appendTrackedEntry(
+          dir,
+          createTimelineEntry({
+            messages,
+            sessionId: state.backendSessionId,
+            provider: state.provider,
+          }),
+          stamp,
+        );
+      } else {
+        appendOwnerless(agentId, messages);
+        return;
+      }
+      handleTrackedResult(agentId, state, result);
+    },
+    recordAssistantMessage(agentId, owner, text, truncated = false) {
+      retryPending(agentId);
+      const key = turnKey(agentId, owner);
+      const state = turnsByAgent.get(agentId)?.get(key);
+      if (
+        !state
+        || state.finalized
+        || state.owner.barrierGeneration !== currentBarrier(agentId)
+        || !sameOwner(state.owner, owner)
+      ) {
+        diagnostic(agentId, "timeline_completed_message_rejected", "stale_owner");
+        return;
+      }
+      state.responses.push(boundedResponse(text, truncated));
+      if (state.responses.length > MAX_AGENT_RESPONSES) {
+        state.responses.splice(0, state.responses.length - MAX_AGENT_RESPONSES);
+      }
+    },
+    finalizeTurn(agentId, owner) {
+      retryPending(agentId);
+      const key = turnKey(agentId, owner);
+      const state = turnsByAgent.get(agentId)?.get(key);
+      if (!state || state.finalized || !sameOwner(state.owner, owner)) return;
+      const fallbackAuthorized = activeTurnByAgent.get(agentId) === key
+        && owner.barrierGeneration === currentBarrier(agentId);
+      state.finalized = true;
+      activeTurnByAgent.delete(agentId);
+      if (state.responses.length === 0) {
+        state.completedAtMs = now().getTime();
+        return;
+      }
+      if (!state.handle && !fallbackAuthorized) {
+        diagnostic(agentId, "timeline_fallback_rejected", "fenced_owner");
+        deleteState(agentId, key);
+        return;
+      }
+      const result = tryCommit(agentId, state);
+      if (result === "written") {
+        state.responses = [];
+        state.completedAtMs = now().getTime();
+      } else if (result === "terminal") {
+        deleteState(agentId, key);
+      } else {
+        retainPending(agentId, key, state);
+      }
+    },
+    fenceSession(agentId) {
+      retryPending(agentId);
+      barrierByAgent.set(agentId, currentBarrier(agentId) + 1);
+      activeTurnByAgent.delete(agentId);
+      const states = turnsByAgent.get(agentId);
+      if (!states) return;
+      for (const [key, state] of [...states]) {
+        if (!state.handle) {
+          diagnostic(agentId, "timeline_fallback_rejected", "session_fence");
+          deleteState(agentId, key);
+        }
+      }
+    },
+    setSession(agentId, sessionId, sessionInstanceId) {
+      retryPending(agentId);
       const dir = dirFor(agentId);
       if (!prepareTimelineDirectory(dir)) return false;
       const persisted = updateResumeControlState(dir, (state) => ({
@@ -142,42 +520,13 @@ export function createTimelineRecorder(opts: TimelineRecorderOptions): TimelineR
       }));
       if (!persisted) return false;
       sessionByAgent.set(agentId, sessionId);
+      if (sessionInstanceId) {
+        sessionByEpoch.set(epochKey(agentId, sessionInstanceId), sessionId);
+        for (const state of statesFor(agentId).values()) {
+          if (state.owner.sessionInstanceId === sessionInstanceId) state.backendSessionId = sessionId;
+        }
+      }
       return true;
-    },
-    appendEntryForAgent(agentId, messages) {
-      if (messages.length === 0) return;
-      const dir = dirFor(agentId);
-      if (!prepareTimelineDirectory(dir)) return;
-      appendOrMergeEntry(
-        dir,
-        createTimelineEntry({
-          messages,
-          sessionId: sessionByAgent.get(agentId) ?? null,
-          provider: opts.providerFor?.(agentId) ?? null,
-        }),
-        now(),
-      );
-    },
-    appendResponseToLatest(agentId, text) {
-      const dir = dirFor(agentId);
-      if (!prepareTimelineDirectory(dir)) return;
-      const result = updateLatestEntryResult(dir, (entry) => appendAgentResponse(entry, text), { now: now() });
-      if (result === "updated" || result === "rejected") return;
-      // No turn row exists yet (or the newest row is a system barrier) — open
-      // a fresh, empty-messages turn row carrying the current session/provider
-      // and stamp this response onto it. Happens whenever a `text` event
-      // arrives before the fresh spawn's first inbox pull opened a row, e.g.
-      // right after `reset_session` where the barrier is the file's latest
-      // line and the rewake prompt makes the agent talk before pulling. A
-      // later inbox pull with real messages appends its own row (since this
-      // one already has a response, `appendOrMergeEntry` won't merge into it).
-      const entry = createTimelineEntry({
-        messages: [],
-        sessionId: sessionByAgent.get(agentId) ?? null,
-        provider: opts.providerFor?.(agentId) ?? null,
-      });
-      appendAgentResponse(entry, text);
-      appendEntry(dir, entry, now());
     },
     resumeSessionId(agentId, provider) {
       const resolution = resolveForAgent(agentId, provider);
@@ -193,6 +542,7 @@ export function createTimelineRecorder(opts: TimelineRecorderOptions): TimelineR
       return appendStallMarker(agentId, "stall_recovery_clear", sessionId);
     },
     forgetSession(agentId, barrierType = "reset_session", forgottenSessionId) {
+      retryPending(agentId);
       const dir = dirFor(agentId);
       // Persist the authoritative transition before clearing the in-memory
       // session map or appending its best-effort forensic row.
@@ -220,12 +570,32 @@ export function createTimelineRecorder(opts: TimelineRecorderOptions): TimelineR
       }
       if (!persisted) return false;
       sessionByAgent.delete(agentId);
-      appendEntry(dir, createSystemEntry(barrierType, stamp.toISOString(), forgottenSessionId), stamp);
+      for (const key of [...sessionByEpoch.keys()]) {
+        if (key.startsWith(`${agentId}\0`)) sessionByEpoch.delete(key);
+      }
+      barrierByAgent.set(agentId, currentBarrier(agentId) + 1);
+      activeTurnByAgent.delete(agentId);
+      const states = turnsByAgent.get(agentId);
+      if (states) {
+        for (const [key, state] of [...states]) {
+          if (!state.handle) {
+            diagnostic(agentId, "timeline_fallback_rejected", "barrier");
+            deleteState(agentId, key);
+          }
+        }
+      }
+      const result = appendTrackedEntry(
+        dir,
+        createSystemEntry(barrierType, stamp.toISOString(), forgottenSessionId),
+        stamp,
+      );
+      handleTrackedResult(agentId, null, result);
       return true;
     },
   };
 
   function appendStallMarker(agentId: string, type: SystemEntryType, sessionId: string): boolean {
+    retryPending(agentId);
     const dir = dirFor(agentId);
     if (!prepareTimelineDirectory(dir)) return false;
     const stamp = now();
@@ -235,7 +605,8 @@ export function createTimelineRecorder(opts: TimelineRecorderOptions): TimelineR
       fullBarrier: null,
     }));
     if (!persisted) return false;
-    appendEntry(dir, createSystemEntry(type, stamp.toISOString(), sessionId), stamp);
+    const result = appendTrackedEntry(dir, createSystemEntry(type, stamp.toISOString(), sessionId), stamp);
+    handleTrackedResult(agentId, null, result);
     return true;
   }
 }

--- a/src/daemon/src/timeline/timeline.test.ts
+++ b/src/daemon/src/timeline/timeline.test.ts
@@ -4,7 +4,10 @@ import * as os from "os";
 import * as path from "path";
 import {
   appendEntry,
+  appendTrackedEntry,
   appendOrMergeEntry,
+  updateTrackedEntry,
+  refreshTimelineEntryHandle,
   updateLatestEntry,
   updateLatestEntryResult,
   readRecentEntries,
@@ -17,6 +20,7 @@ import {
   sweepTimelineHistory,
   TIMELINE_MAX_BYTES,
 } from "./timeline";
+import type { TimelineEntryHandle } from "./timeline";
 import { acquireLock, lockPathFor, releaseLock } from "./filelock";
 import type { Message } from "../server/contract";
 
@@ -79,6 +83,103 @@ describe("timeline append / read (4-field schema)", () => {
     );
     const rows = readRecentEntries(dir, { now: NOW });
     expect(rows.map((r) => r.session_id)).toEqual(["ok"]);
+  });
+});
+
+describe("exact tracked row handles", () => {
+  it("refreshes an older handle across recorder-owned appends and updates only its captured row", () => {
+    const dir = mkDir();
+    const first = appendTrackedEntry(
+      dir,
+      createTimelineEntry({ messages: [msg("first")], sessionId: "s1", provider: "claude" }),
+      NOW,
+    );
+    expect(first.status).toBe("written");
+    if (first.status !== "written" || !first.handle) throw new Error("missing first handle");
+
+    const second = appendTrackedEntry(
+      dir,
+      createTimelineEntry({ messages: [msg("second")], sessionId: "s2", provider: "codex" }),
+      NOW,
+    );
+    expect(second.status).toBe("written");
+    if (second.status !== "written") throw new Error("missing second rewrite");
+    const refreshed = refreshTimelineEntryHandle(first.handle, second.rewrite);
+    expect(refreshed).not.toBeNull();
+
+    const updated = updateTrackedEntry(dir, refreshed!, (entry) => ({
+      ...entry,
+      agent_responses: ["response for first"],
+    }));
+    expect(updated.status).toBe("written");
+    const rows = readRecentEntries(dir, { now: NOW });
+    expect(rows.map((row) => row.agent_responses)).toEqual([["response for first"], []]);
+  });
+
+  it("rejects a stale generation without falling through to the latest row", () => {
+    const dir = mkDir();
+    const first = appendTrackedEntry(dir, createTimelineEntry({ messages: [msg("first")] }), NOW);
+    if (first.status !== "written" || !first.handle) throw new Error("missing first handle");
+    expect(appendTrackedEntry(dir, createTimelineEntry({ messages: [msg("latest")] }), NOW).status)
+      .toBe("written");
+
+    const rejected = updateTrackedEntry(dir, first.handle, (entry) => ({
+      ...entry,
+      agent_responses: ["must not land"],
+    }));
+    expect(rejected).toEqual({ status: "rejected", reason: "generation" });
+    expect(readRecentEntries(dir, { now: NOW }).map((row) => row.agent_responses)).toEqual([[], []]);
+  });
+
+  it("rejects an external rewrite even when the captured row remains at the same ordinal", () => {
+    const dir = mkDir();
+    const tracked = appendTrackedEntry(dir, createTimelineEntry({ messages: [msg("captured")] }), NOW);
+    if (tracked.status !== "written" || !tracked.handle) throw new Error("missing tracked handle");
+    expect(appendEntry(dir, createTimelineEntry({ messages: [msg("external")] }), NOW)).toBe(true);
+
+    expect(updateTrackedEntry(dir, tracked.handle, (entry) => entry))
+      .toEqual({ status: "rejected", reason: "generation" });
+  });
+
+  it("fails closed on ordinal or hash mismatch", () => {
+    const dir = mkDir();
+    const tracked = appendTrackedEntry(dir, createTimelineEntry({ messages: [msg("captured")] }), NOW);
+    if (tracked.status !== "written" || !tracked.handle) throw new Error("missing tracked handle");
+    const wrongOrdinal: TimelineEntryHandle = { ...tracked.handle, rowOrdinal: 99 };
+    const wrongHash: TimelineEntryHandle = { ...tracked.handle, expectedHash: "0".repeat(64) };
+
+    expect(updateTrackedEntry(dir, wrongOrdinal, (entry) => entry))
+      .toEqual({ status: "rejected", reason: "ordinal" });
+    expect(updateTrackedEntry(dir, wrongHash, (entry) => entry))
+      .toEqual({ status: "rejected", reason: "hash" });
+  });
+
+  it("fences a handle when compaction evicts its row", () => {
+    const dir = mkDir();
+    const first = appendTrackedEntry(dir, entryWithPayloadBytes(240_000, "old"), NOW);
+    if (first.status !== "written" || !first.handle) throw new Error("missing first handle");
+    let handle: TimelineEntryHandle | null = first.handle;
+    for (let index = 0; index < 6 && handle; index++) {
+      const write = appendTrackedEntry(dir, entryWithPayloadBytes(240_000, `new-${index}`), NOW);
+      if (write.status !== "written") throw new Error("append failed");
+      handle = refreshTimelineEntryHandle(handle, write.rewrite);
+    }
+    expect(handle).toBeNull();
+    expect(readRecentEntries(dir, { now: NOW }).some((row) => row.session_id === "old")).toBe(false);
+  });
+
+  it("updates the captured prior-day file after midnight", () => {
+    const dir = mkDir();
+    const yesterday = new Date("2026-06-24T23:59:59");
+    const tracked = appendTrackedEntry(dir, createTimelineEntry({ messages: [msg("before midnight")] }), yesterday);
+    if (tracked.status !== "written" || !tracked.handle) throw new Error("missing prior-day handle");
+    expect(appendTrackedEntry(dir, createTimelineEntry({ messages: [msg("new day")] }), NOW).status)
+      .toBe("written");
+
+    expect(updateTrackedEntry(dir, tracked.handle, (entry) => ({ ...entry, agent_responses: ["old-day response"] })).status)
+      .toBe("written");
+    const rows = readRecentEntries(dir, { now: NOW });
+    expect(rows.map((row) => row.agent_responses)).toEqual([["old-day response"], []]);
   });
 });
 

--- a/src/daemon/src/timeline/timeline.test.ts
+++ b/src/daemon/src/timeline/timeline.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import * as fs from "fs";
+import nodeFs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
 import * as os from "os";
 import * as path from "path";
 import {
@@ -87,6 +89,47 @@ describe("timeline append / read (4-field schema)", () => {
 });
 
 describe("exact tracked row handles", () => {
+  it("uses the current date when a tracked append omits now", () => {
+    const dir = mkDir();
+    const result = appendTrackedEntry(dir, createTimelineEntry({ messages: [msg("default now")] }));
+
+    expect(result.status).toBe("written");
+    expect(fs.readdirSync(dir).filter((name) => name.endsWith(".jsonl"))).toHaveLength(1);
+  });
+
+  it("reports write when lock acquisition throws a non-contention error", () => {
+    const dir = mkDir();
+    const lock = lockPathFor(dir, filenameForDate(NOW));
+    const originalMkdirSync = nodeFs.mkdirSync;
+    nodeFs.mkdirSync = ((target: fs.PathLike, ...args: unknown[]) => {
+      if (String(target) === lock) {
+        const error = new Error("lock parent failure") as NodeJS.ErrnoException;
+        error.code = "EACCES";
+        throw error;
+      }
+      return (originalMkdirSync as (...values: unknown[]) => unknown)(target, ...args);
+    }) as typeof nodeFs.mkdirSync;
+    syncBuiltinESMExports();
+    try {
+      expect(appendTrackedEntry(dir, createTimelineEntry({ messages: [msg("blocked")] }), NOW))
+        .toEqual({ status: "rejected", reason: "write" });
+    } finally {
+      nodeFs.mkdirSync = originalMkdirSync;
+      syncBuiltinESMExports();
+    }
+  });
+
+  it("reports write and releases the lock when append serialization throws", () => {
+    const dir = mkDir();
+    const entry = createTimelineEntry({ messages: [msg("circular")] }) as ReturnType<typeof createTimelineEntry> & { circular?: unknown };
+    entry.circular = entry;
+
+    expect(appendTrackedEntry(dir, entry, NOW)).toEqual({ status: "rejected", reason: "write" });
+    const lock = lockPathFor(dir, filenameForDate(NOW));
+    expect(acquireLock(lock)).toBe(true);
+    releaseLock(lock);
+  });
+
   it("refreshes an older handle across recorder-owned appends and updates only its captured row", () => {
     const dir = mkDir();
     const first = appendTrackedEntry(
@@ -152,6 +195,39 @@ describe("exact tracked row handles", () => {
       .toEqual({ status: "rejected", reason: "ordinal" });
     expect(updateTrackedEntry(dir, wrongHash, (entry) => entry))
       .toEqual({ status: "rejected", reason: "hash" });
+  });
+
+  it("rejects an unsafe forged handle filename without touching outside files", () => {
+    const base = mkDir();
+    const dir = path.join(base, "timeline");
+    fs.mkdirSync(dir);
+    const outside = path.join(base, "outside.jsonl");
+    fs.writeFileSync(outside, "outside unchanged\n");
+    const forged: TimelineEntryHandle = {
+      filename: "../outside.jsonl",
+      fileGeneration: "0".repeat(64),
+      rowOrdinal: 0,
+      expectedHash: "0".repeat(64),
+    };
+
+    expect(updateTrackedEntry(dir, forged, (entry) => entry))
+      .toEqual({ status: "rejected", reason: "unsafe" });
+    expect(fs.readFileSync(outside, "utf8")).toBe("outside unchanged\n");
+  });
+
+  it("reports write, preserves bytes, and releases the lock when an update callback throws", () => {
+    const dir = mkDir();
+    const tracked = appendTrackedEntry(dir, createTimelineEntry({ messages: [msg("captured")] }), NOW);
+    if (tracked.status !== "written" || !tracked.handle) throw new Error("missing tracked handle");
+    const file = path.join(dir, tracked.handle.filename);
+    const before = fs.readFileSync(file);
+
+    expect(updateTrackedEntry(dir, tracked.handle, () => { throw new Error("update failed"); }))
+      .toEqual({ status: "rejected", reason: "write" });
+    expect(fs.readFileSync(file)).toEqual(before);
+    const lock = lockPathFor(dir, tracked.handle.filename);
+    expect(acquireLock(lock)).toBe(true);
+    releaseLock(lock);
   });
 
   it("fences a handle when compaction evicts its row", () => {

--- a/src/daemon/src/timeline/timeline.ts
+++ b/src/daemon/src/timeline/timeline.ts
@@ -12,7 +12,7 @@
  * except behind the default param.
  */
 import * as fs from "node:fs";
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { basename, dirname, join } from "node:path";
 import { acquireLock, releaseLock, lockPathFor } from "./filelock.js";
 import type { ContextTimelineEntry, SystemEntryType } from "./types.js";
@@ -52,6 +52,31 @@ interface TimelineLine {
   entry: ContextTimelineEntry;
   barrier: boolean;
 }
+
+/** Process-local exact-row identity. Never persisted in the timeline schema. */
+export interface TimelineEntryHandle {
+  readonly filename: string;
+  readonly fileGeneration: string;
+  readonly rowOrdinal: number;
+  readonly expectedHash: string;
+}
+
+/** Remaps every row from one recorder-owned atomic file rewrite to the next. */
+export interface TimelineFileRewrite {
+  readonly filename: string;
+  readonly previousFileGeneration: string | null;
+  readonly fileGeneration: string;
+  readonly previousRowHashes: readonly string[];
+  readonly rowOrdinals: readonly (number | null)[];
+  readonly rowHashes: readonly string[];
+}
+
+export type TimelineTrackedWriteResult =
+  | { readonly status: "written"; readonly rewrite: TimelineFileRewrite; readonly handle?: TimelineEntryHandle }
+  | {
+      readonly status: "rejected";
+      readonly reason: "unsafe" | "lock" | "missing" | "generation" | "ordinal" | "hash" | "system" | "oversized" | "write" | "evicted";
+    };
 
 function isBarrier(entry: ContextTimelineEntry): boolean {
   return entry.system !== undefined;
@@ -101,6 +126,56 @@ function timelineLine(entry: ContextTimelineEntry): TimelineLine | null {
   const bytes = Buffer.byteLength(text, "utf8") + 1;
   if (bytes > TIMELINE_MAX_BYTES) return null;
   return { text, bytes, entry: boundedEntry, barrier: isBarrier(boundedEntry) };
+}
+
+function timelineRowHash(line: TimelineLine): string {
+  return createHash("sha256").update(line.text, "utf8").digest("hex");
+}
+
+function timelineFileGeneration(filePath: string, lines: readonly TimelineLine[]): string | null {
+  try {
+    const stat = fs.lstatSync(filePath, { bigint: true });
+    if (!stat.isFile()) return null;
+    const digest = createHash("sha256");
+    digest.update(`${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeNs}:${stat.ctimeNs}\n`);
+    for (const line of lines) digest.update(line.text, "utf8").update("\n");
+    return digest.digest("hex");
+  } catch {
+    return null;
+  }
+}
+
+function handleFor(
+  filename: string,
+  generation: string,
+  lines: readonly TimelineLine[],
+  rowOrdinal: number,
+): TimelineEntryHandle {
+  return {
+    filename,
+    fileGeneration: generation,
+    rowOrdinal,
+    expectedHash: timelineRowHash(lines[rowOrdinal]!),
+  };
+}
+
+export function refreshTimelineEntryHandle(
+  handle: TimelineEntryHandle,
+  rewrite: TimelineFileRewrite,
+): TimelineEntryHandle | null {
+  if (handle.filename !== rewrite.filename) return handle;
+  if (handle.fileGeneration !== rewrite.previousFileGeneration) return null;
+  if (rewrite.previousRowHashes[handle.rowOrdinal] !== handle.expectedHash) return null;
+  const rowOrdinal = rewrite.rowOrdinals[handle.rowOrdinal];
+  if (rowOrdinal === null || rowOrdinal === undefined) return null;
+  const expectedHash = rewrite.rowHashes[rowOrdinal];
+  if (!expectedHash) return null;
+  return {
+    filename: handle.filename,
+    fileGeneration: rewrite.fileGeneration,
+    rowOrdinal,
+    expectedHash,
+  };
 }
 
 function compactLines(input: readonly TimelineLine[]): TimelineLine[] {
@@ -320,6 +395,42 @@ function writeRequiredTimeline(
   return atomicReplaceTimeline(filePath, compacted);
 }
 
+function writeTrackedTimeline(
+  filePath: string,
+  filename: string,
+  existing: readonly TimelineLine[],
+  input: readonly TimelineLine[],
+  required: TimelineLine,
+  replacement?: { oldOrdinal: number; line: TimelineLine },
+): TimelineTrackedWriteResult {
+  const previousFileGeneration = timelineFileGeneration(filePath, existing);
+  const previousRowHashes = existing.map(timelineRowHash);
+  const compacted = compactLines(input);
+  const targetOrdinal = compacted.indexOf(required);
+  if (targetOrdinal < 0) return { status: "rejected", reason: "evicted" };
+  if (!atomicReplaceTimeline(filePath, compacted)) return { status: "rejected", reason: "write" };
+  const fileGeneration = timelineFileGeneration(filePath, compacted);
+  if (!fileGeneration) return { status: "rejected", reason: "write" };
+  const rowOrdinals = existing.map((line, oldOrdinal) => {
+    if (replacement?.oldOrdinal === oldOrdinal) return compacted.indexOf(replacement.line);
+    const nextOrdinal = compacted.indexOf(line);
+    return nextOrdinal < 0 ? null : nextOrdinal;
+  });
+  const rewrite: TimelineFileRewrite = {
+    filename,
+    previousFileGeneration,
+    fileGeneration,
+    previousRowHashes,
+    rowOrdinals,
+    rowHashes: compacted.map(timelineRowHash),
+  };
+  return {
+    status: "written",
+    rewrite,
+    handle: handleFor(filename, fileGeneration, compacted, targetOrdinal),
+  };
+}
+
 /* ------------------------------------------------------------------ */
 /* Date / filename helpers (injectable clock)                          */
 /* ------------------------------------------------------------------ */
@@ -487,6 +598,93 @@ export function updateResumeControlState(
 /* ------------------------------------------------------------------ */
 /* Write (lock-guarded)                                                */
 /* ------------------------------------------------------------------ */
+
+/** Append one row and return its exact process-local handle plus rewrite remap. */
+export function appendTrackedEntry(
+  timelineDir: string,
+  entry: ContextTimelineEntry,
+  now: Date = new Date(),
+): TimelineTrackedWriteResult {
+  if (timelineDirectoryState(timelineDir) !== "safe") return { status: "rejected", reason: "unsafe" };
+  const filename = filenameForDate(now);
+  const filePath = join(timelineDir, filename);
+  const lockPath = lockPathFor(timelineDir, filename);
+  try {
+    if (!acquireLock(lockPath)) return { status: "rejected", reason: "lock" };
+  } catch {
+    return { status: "rejected", reason: "write" };
+  }
+  try {
+    const existing = scanTimelineFile(filePath);
+    const required = timelineLine(entry);
+    if (!existing) return { status: "rejected", reason: "unsafe" };
+    if (!required) return { status: "rejected", reason: "oversized" };
+    return writeTrackedTimeline(filePath, filename, existing, [...existing, required], required);
+  } catch {
+    return { status: "rejected", reason: "write" };
+  } finally {
+    releaseLock(lockPath);
+  }
+}
+
+/**
+ * Rewrite only the exact captured row. Generation, ordinal, and row hash must
+ * all match under the captured file's lock; there is deliberately no latest-row
+ * fallback.
+ */
+export function updateTrackedEntry(
+  timelineDir: string,
+  handle: TimelineEntryHandle,
+  update: (entry: ContextTimelineEntry) => ContextTimelineEntry,
+): TimelineTrackedWriteResult {
+  if (timelineDirectoryState(timelineDir) !== "safe") return { status: "rejected", reason: "unsafe" };
+  if (!DATE_FILENAME_PATTERN.test(handle.filename) || basename(handle.filename) !== handle.filename) {
+    return { status: "rejected", reason: "unsafe" };
+  }
+  const filePath = join(timelineDir, handle.filename);
+  const lockPath = lockPathFor(timelineDir, handle.filename);
+  try {
+    if (!acquireLock(lockPath)) return { status: "rejected", reason: "lock" };
+  } catch {
+    return { status: "rejected", reason: "write" };
+  }
+  try {
+    const existing = scanTimelineFile(filePath);
+    if (!existing) return { status: "rejected", reason: "unsafe" };
+    if (existing.length === 0) return { status: "rejected", reason: "missing" };
+    const generation = timelineFileGeneration(filePath, existing);
+    if (!generation || generation !== handle.fileGeneration) {
+      return { status: "rejected", reason: "generation" };
+    }
+    const captured = existing[handle.rowOrdinal];
+    if (!captured) return { status: "rejected", reason: "ordinal" };
+    if (timelineRowHash(captured) !== handle.expectedHash) {
+      return { status: "rejected", reason: "hash" };
+    }
+    if (captured.entry.system) return { status: "rejected", reason: "system" };
+    const nextEntry = update({
+      ...captured.entry,
+      messages: [...captured.entry.messages],
+      agent_responses: [...captured.entry.agent_responses],
+    });
+    const replacement = timelineLine(nextEntry);
+    if (!replacement) return { status: "rejected", reason: "oversized" };
+    const input = [...existing];
+    input[handle.rowOrdinal] = replacement;
+    return writeTrackedTimeline(
+      filePath,
+      handle.filename,
+      existing,
+      input,
+      replacement,
+      { oldOrdinal: handle.rowOrdinal, line: replacement },
+    );
+  } catch {
+    return { status: "rejected", reason: "write" };
+  } finally {
+    releaseLock(lockPath);
+  }
+}
 
 /** Append a new entry to today's file. Best-effort: logs nothing, swallows lock miss. */
 export function appendEntry(timelineDir: string, entry: ContextTimelineEntry, now: Date = new Date()): boolean {


### PR DESCRIPTION
# Why we need this PR?

Daemon timeline responses were attributed by whichever row happened to be latest when a terminal or delayed event arrived. A new turn, busy delivery, abort, restart, or cross-midnight boundary could therefore mutate the wrong timeline row or persist partial/token-level output.

## What changed

- Give each root turn a stable captured timeline-row handle and bind response commits to that exact owner.
- Normalize all built-in agent adapters onto complete semantic assistant messages plus payload-free activity heartbeats.
- Buffer bounded, UTF-8-safe text/reasoning and commit only complete messages at clean terminal or manager abort boundaries.
- Fence stale epochs, replacement sessions, reset/nap/model switches, and late events so they fail closed instead of falling back to the latest row.
- Preserve busy-delivery merge behavior, retryable pending commits, timeline compaction, symlink hardening, and restart recovery.
- Add regression coverage across the driver contract, logical sessions, daemon manager/runtime, recorder, and timeline storage.

## Verification

- Agent-driver focused: 132/132; full: 530 passed, 4 skipped.
- Daemon focused: 384/384; full: 1,228 passed.
- Repository workspace tests: 11/11; CI script tests: 78/78.
- Lint, typecheck, builds, both typegrep checks, workspace knip, package checks, and `git diff --check` passed.
- Independent exact-head QA passed four real Codex journeys: persistent turn, pre-pull next-turn race, busy delivery, and abort/recovery.

## Checklist

- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [x] Other: daemon timeline recorder and embedded agent-driver
