### PR TITLE
docs: list all nine workspace packages in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ pnpm dev:cli
 
 ## Project Structure
 
-Alook is a monorepo with five packages:
+Alook is a monorepo with nine packages:
 
 | Package | Location | What it does |
 |---------|----------|-------------|
@@ -35,6 +35,10 @@ Alook is a monorepo with five packages:
 | `@alook/shared` | `src/shared` | Types, constants, DB schema, validation |
 | `@alook/email-worker` | `src/email-worker` | Inbound email parsing and storage |
 | `@alook/ws-do` | `src/ws-do` | Real-time WebSocket channels |
+| `@alook/app` | `src/app` | One-command local bootstrap (`npx @alook/app onboard`) |
+| `@alook/daemon` | `src/daemon` | Host-side runtime backend, process manager, credential proxy |
+| `@alook/desktop` | `src/desktop` | Desktop app (Tauri) |
+| `@alook/wake-worker` | `src/wake-worker` | Wakes offline agents with unread messages |
 
 ## Making Changes
 


### PR DESCRIPTION
# Why we need this PR?

The Project Structure section in CONTRIBUTING.md still describes the monorepo as having **five** packages. It now has nine — `@alook/app`, `@alook/daemon`, `@alook/desktop`, and `@alook/wake-worker` are missing from the table, so new contributors get an outdated map of the repo.

## What changed

- Updated the package count from five to nine
- Added the four missing packages to the table, with descriptions sourced from each package's `package.json` / entry point:
  - `@alook/app` — one-command local bootstrap (`npx @alook/app onboard`)
  - `@alook/daemon` — host-side runtime backend, process manager, credential proxy
  - `@alook/desktop` — desktop app (Tauri)
  - `@alook/wake-worker` — wakes offline agents with unread messages

## Checklist

- [x] Tests added/updated as needed — docs-only change, no test surface
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [x] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [x] CLI (`@alook/cli`)
- [x] Email Worker (`@alook/email-worker`)
- [x] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [x] Other: documentation only (`CONTRIBUTING.md`)
