### PR TITLE
fix(config): make predev dev-vars generation cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "turbo run build",
     "test": "turbo run test && vitest run --project ci-scripts",
-    "predev": "[ -f src/web/.dev.vars ] || (cp src/web/.dev.vars.example src/web/.dev.vars && sed -i '' \"s|^BETTER_AUTH_SECRET=$|BETTER_AUTH_SECRET=$(openssl rand -base64 32)|\" src/web/.dev.vars && sed -i '' \"s|^ENCRYPTION_KEY=$|ENCRYPTION_KEY=$(openssl rand -base64 32)|\" src/web/.dev.vars && echo '✓ Generated src/web/.dev.vars (fill in OAuth keys if needed)'); [ -f src/email-worker/.dev.vars ] || (cp src/email-worker/.dev.vars.example src/email-worker/.dev.vars && KEY=$(grep '^ENCRYPTION_KEY=' src/web/.dev.vars | cut -d= -f2-) && sed -i '' \"s|^ENCRYPTION_KEY=$|ENCRYPTION_KEY=$KEY|\" src/email-worker/.dev.vars && echo '✓ Generated src/email-worker/.dev.vars (synced ENCRYPTION_KEY from web)')",
+    "predev": "node scripts/generate-dev-vars.mjs",
     "dev": "turbo run dev --filter=@alook/web --filter=@alook/email-worker --filter=@alook/ws-do --filter=@alook/wake-worker --filter=@alook/shared",
     "clean": "rm -rf node_modules src/*/node_modules src/*/dist src/*/.turbo src/daemon/agent-driver/node_modules src/daemon/agent-driver/dist src/daemon/agent-driver/.turbo .turbo src/web/.next src/web/.open-next src/*/.wrangler .alook",
     "clean:builds": "rm -rf src/*/dist src/daemon/agent-driver/dist src/web/.next src/web/.open-next .turbo src/*/.turbo src/daemon/agent-driver/.turbo",

--- a/scripts/ci/generate-dev-vars.test.ts
+++ b/scripts/ci/generate-dev-vars.test.ts
@@ -1,0 +1,87 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { fillEmptyKey, generateDevVars, readKey } from "../generate-dev-vars.mjs"
+
+const repoRoot = resolve(import.meta.dirname, "../..")
+
+const sandboxes: string[] = []
+
+function makeSandbox() {
+  const dir = mkdtempSync(join(tmpdir(), "alook-dev-vars-"));
+  sandboxes.push(dir);
+  mkdirSync(join(dir, "web"), { recursive: true });
+  mkdirSync(join(dir, "email"), { recursive: true });
+  return {
+    webVars: join(dir, "web/.dev.vars"),
+    webExample: join(dir, "web/.dev.vars.example"),
+    emailVars: join(dir, "email/.dev.vars"),
+    emailExample: join(dir, "email/.dev.vars.example"),
+  };
+}
+
+function copyRealExamples(paths: ReturnType<typeof makeSandbox>) {
+  writeFileSync(paths.webExample, readFileSync(join(repoRoot, "src/web/.dev.vars.example")));
+  writeFileSync(paths.emailExample, readFileSync(join(repoRoot, "src/email-worker/.dev.vars.example")));
+}
+
+afterEach(() => {
+  while (sandboxes.length > 0) rmSync(sandboxes.pop()!, { recursive: true, force: true });
+});
+
+describe("fillEmptyKey", () => {
+  it("fills only the exact empty assignment line", () => {
+    const content = "ENCRYPTION_KEY=\nENCRYPTION_KEY_URL=x\nOTHER=y\nENCRYPTION_KEY=kept\n";
+    const filled = fillEmptyKey(content, "ENCRYPTION_KEY", "abc");
+    expect(filled).toBe("ENCRYPTION_KEY=abc\nENCRYPTION_KEY_URL=x\nOTHER=y\nENCRYPTION_KEY=kept\n");
+  });
+
+  it("leaves content unchanged when no empty assignment exists", () => {
+    const content = "ENCRYPTION_KEY=already-set\n";
+    expect(fillEmptyKey(content, "ENCRYPTION_KEY", "abc")).toBe(content);
+  });
+});
+
+describe("readKey", () => {
+  it("reads the value including base64 padding", () => {
+    expect(readKey("ENCRYPTION_KEY=abc/def+x==\n", "ENCRYPTION_KEY")).toBe("abc/def+x==");
+  });
+
+  it("returns an empty string when the key is absent", () => {
+    expect(readKey("OTHER=1\n", "ENCRYPTION_KEY")).toBe("");
+  });
+});
+
+describe("generateDevVars", () => {
+  it("generates web vars with both secrets filled and other keys left empty", () => {
+    const paths = makeSandbox();
+    copyRealExamples(paths);
+    generateDevVars(paths);
+    const content = readFileSync(paths.webVars, "utf8");
+    expect(readKey(content, "BETTER_AUTH_SECRET")).toMatch(/^[A-Za-z0-9+/]{43}=$/);
+    expect(readKey(content, "ENCRYPTION_KEY")).toMatch(/^[A-Za-z0-9+/]{43}=$/);
+    expect(readKey(content, "GITHUB_CLIENT_ID")).toBe("");
+    expect(readKey(content, "DEVICE_CLIENT_IDS")).toBe("alook-cli");
+  });
+
+  it("syncs the email worker key from the web vars", () => {
+    const paths = makeSandbox();
+    copyRealExamples(paths);
+    generateDevVars(paths);
+    const web = readFileSync(paths.webVars, "utf8");
+    const email = readFileSync(paths.emailVars, "utf8");
+    expect(readKey(email, "ENCRYPTION_KEY")).toBe(readKey(web, "ENCRYPTION_KEY"));
+    expect(readKey(email, "ENCRYPTION_KEY")).not.toBe("");
+  });
+
+  it("skips generation when both files already exist", () => {
+    const paths = makeSandbox();
+    copyRealExamples(paths);
+    writeFileSync(paths.webVars, "ENCRYPTION_KEY=existing\n");
+    writeFileSync(paths.emailVars, "ENCRYPTION_KEY=existing\n");
+    generateDevVars(paths);
+    expect(readFileSync(paths.webVars, "utf8")).toBe("ENCRYPTION_KEY=existing\n");
+    expect(readFileSync(paths.emailVars, "utf8")).toBe("ENCRYPTION_KEY=existing\n");
+  });
+});

--- a/scripts/generate-dev-vars.mjs
+++ b/scripts/generate-dev-vars.mjs
@@ -1,0 +1,41 @@
+import { randomBytes } from "node:crypto";
+import { copyFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("../", import.meta.url));
+
+export function fillEmptyKey(content, key, value) {
+  return content.replace(new RegExp(`^${key}=$`, "m"), `${key}=${value}`);
+}
+
+export function readKey(content, key) {
+  return content.match(new RegExp(`^${key}=(.*)$`, "m"))?.[1] ?? "";
+}
+
+export function generateDevVars({ webVars, webExample, emailVars, emailExample }) {
+  if (!existsSync(webVars)) {
+    copyFileSync(webExample, webVars);
+    let content = readFileSync(webVars, "utf8");
+    content = fillEmptyKey(content, "BETTER_AUTH_SECRET", randomBytes(32).toString("base64"));
+    content = fillEmptyKey(content, "ENCRYPTION_KEY", randomBytes(32).toString("base64"));
+    writeFileSync(webVars, content);
+    console.log("✓ Generated src/web/.dev.vars (fill in OAuth keys if needed)");
+  }
+  if (!existsSync(emailVars)) {
+    copyFileSync(emailExample, emailVars);
+    const key = readKey(readFileSync(webVars, "utf8"), "ENCRYPTION_KEY");
+    const content = fillEmptyKey(readFileSync(emailVars, "utf8"), "ENCRYPTION_KEY", key);
+    writeFileSync(emailVars, content);
+    console.log("✓ Generated src/email-worker/.dev.vars (synced ENCRYPTION_KEY from web)");
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  generateDevVars({
+    webVars: join(root, "src/web/.dev.vars"),
+    webExample: join(root, "src/web/.dev.vars.example"),
+    emailVars: join(root, "src/email-worker/.dev.vars"),
+    emailExample: join(root, "src/email-worker/.dev.vars.example"),
+  });
+}


### PR DESCRIPTION
# Why we need this PR?

> Closes #541

The `predev` script used BSD-only `sed -i ''` for in-place edits. On Linux, GNU sed treats `''` as a filename argument, so a fresh clone followed by `pnpm dev` fails with exit code 2 before any dev server starts.

## What changed

- Replaced the inline sed pipeline with `scripts/generate-dev-vars.mjs` (Node built-ins only), so the same command works on macOS, Linux, and Windows. `predev` is now `node scripts/generate-dev-vars.mjs`.
- Behavior is unchanged: still gated on missing `.dev.vars` files, same messages, fills `BETTER_AUTH_SECRET` / `ENCRYPTION_KEY` with 44-char base64 (`randomBytes(32)` ≡ `openssl rand -base64 32`), and syncs the email worker's `ENCRYPTION_KEY` from the web one. Note: simply dropping the `''` (as suggested in the issue) would break macOS, since BSD sed requires the backup argument.
- Added `scripts/ci/generate-dev-vars.test.ts` covering key filling, key syncing, and the already-exists skip path, following the existing `logo-assets.test.ts` pattern of testing root scripts from `scripts/ci/`.

## How I verified

- `pnpm vitest run --project ci-scripts` — 10 files, 85 tests pass (7 new)
- Ran the script against an existing checkout with real `.dev.vars` — no output, files untouched (skip path)
- Fresh-generation path exercised in a temp sandbox against the repo's real `.dev.vars.example` files: both keys filled, email key matches web key, other keys left untouched, rerun is a no-op

## Checklist

- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [x] Other: local dev tooling (root `package.json` `predev` + `scripts/`)
