### PR TITLE
feat(web): attach long community pastes

### DIFF
--- a/src/web/src/components/community/messages/composer-file-utils.ts
+++ b/src/web/src/components/community/messages/composer-file-utils.ts
@@ -1,6 +1,32 @@
 import type { PendingFile } from "@/hooks/use-file-attachments"
 import type { SendAttachment } from "@/lib/community/models/message"
 
+export const LONG_PASTE_ATTACHMENT_THRESHOLD = 1_000
+
+export type LongPasteAttachment = {
+  file: File
+  nextIndex: number
+}
+
+export function createLongPasteAttachment(
+  text: string | undefined,
+  existingFileNames: readonly string[],
+  startIndex = 1,
+): LongPasteAttachment | null {
+  if (!text || text.length <= LONG_PASTE_ATTACHMENT_THRESHOLD) return null
+
+  const occupiedNames = new Set(existingFileNames)
+  let index = Math.max(1, startIndex)
+  while (occupiedNames.has(`copy-${index}.md`)) index++
+
+  return {
+    file: new File([text], `copy-${index}.md`, {
+      type: "text/markdown",
+    }),
+    nextIndex: index + 1,
+  }
+}
+
 export function pendingFilesToSendAttachments(
   pendingFiles: PendingFile[],
 ): SendAttachment[] | undefined {

--- a/src/web/src/components/community/messages/composer.test.ts
+++ b/src/web/src/components/community/messages/composer.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest"
 import { clipboardFiles, pendingFilesToSendAttachments } from "./composer"
+import {
+  LONG_PASTE_ATTACHMENT_THRESHOLD,
+  createLongPasteAttachment,
+} from "./composer-file-utils"
 import type { ComposerProps } from "./composer"
 import type { PendingFile } from "@/hooks/use-file-attachments"
 
@@ -123,5 +127,41 @@ describe("clipboardFiles", () => {
       { kind: "file", file: png },
     ])
     expect(clipboardFiles(list)).toEqual([png])
+  })
+})
+
+describe("createLongPasteAttachment", () => {
+  it("keeps text at the 1,000-character threshold inline", () => {
+    expect(
+      createLongPasteAttachment(
+        "x".repeat(LONG_PASTE_ATTACHMENT_THRESHOLD),
+        [],
+      ),
+    ).toBeNull()
+  })
+
+  it("creates a Markdown file with the exact long-paste content", async () => {
+    const text = `# Log\n\n${"x".repeat(LONG_PASTE_ATTACHMENT_THRESHOLD)}`
+    const attachment = createLongPasteAttachment(text, [])
+
+    expect(attachment?.file.name).toBe("copy-1.md")
+    expect(attachment?.file.type).toBe("text/markdown")
+    expect(await attachment?.file.text()).toBe(text)
+    expect(attachment?.nextIndex).toBe(2)
+  })
+
+  it("uses the first free name at or after the requested index", () => {
+    expect(
+      createLongPasteAttachment(
+        "x".repeat(LONG_PASTE_ATTACHMENT_THRESHOLD + 1),
+        ["copy-2.md", "notes.md", "copy-3.md"],
+        2,
+      )?.file.name,
+    ).toBe("copy-4.md")
+  })
+
+  it("falls through for missing and empty clipboard text", () => {
+    expect(createLongPasteAttachment(undefined, [])).toBeNull()
+    expect(createLongPasteAttachment("", [])).toBeNull()
   })
 })

--- a/src/web/src/components/community/messages/use-composer-controller.test.ts
+++ b/src/web/src/components/community/messages/use-composer-controller.test.ts
@@ -351,10 +351,41 @@ describe("useComposerController", () => {
     expect(mocks.addPendingFiles).toHaveBeenCalledWith([file])
     expect(
       editorOptions.editorProps.handlePaste({} as never, {
-        clipboardData: { items: { length: 0 } },
+        clipboardData: {
+          items: { length: 0 },
+          getData: () => "x".repeat(1_000),
+        },
         preventDefault: vi.fn(),
       } as unknown as ClipboardEvent),
     ).toBe(false)
+
+    const preventLongPaste = vi.fn()
+    expect(
+      editorOptions.editorProps.handlePaste({} as never, {
+        clipboardData: {
+          items: { length: 0 },
+          getData: () => "x".repeat(1_001),
+        },
+        preventDefault: preventLongPaste,
+      } as unknown as ClipboardEvent),
+    ).toBe(true)
+    expect(preventLongPaste).toHaveBeenCalledOnce()
+    const firstLongPasteFile = mocks.addPendingFiles.mock.calls.at(-1)?.[0][0] as File
+    expect(firstLongPasteFile.name).toBe("copy-1.md")
+    expect(firstLongPasteFile.type).toBe("text/markdown")
+    expect(await firstLongPasteFile.text()).toBe("x".repeat(1_001))
+
+    expect(
+      editorOptions.editorProps.handlePaste({} as never, {
+        clipboardData: {
+          items: { length: 0 },
+          getData: () => "y".repeat(1_001),
+        },
+        preventDefault: vi.fn(),
+      } as unknown as ClipboardEvent),
+    ).toBe(true)
+    const secondLongPasteFile = mocks.addPendingFiles.mock.calls.at(-1)?.[0][0] as File
+    expect(secondLongPasteFile.name).toBe("copy-2.md")
 
     handleRef.current?.focusEditor()
     expect(focus).toHaveBeenCalledWith("end")
@@ -366,6 +397,18 @@ describe("useComposerController", () => {
     expect(setPendingFiles).toHaveBeenCalledWith([])
     expect(resetPopups).toHaveBeenCalled()
     expect(transferPendingFiles).toHaveBeenCalledTimes(transfersBeforeReset)
+
+    expect(
+      editorOptions.editorProps.handlePaste({} as never, {
+        clipboardData: {
+          items: { length: 0 },
+          getData: () => "z".repeat(1_001),
+        },
+        preventDefault: vi.fn(),
+      } as unknown as ClipboardEvent),
+    ).toBe(true)
+    const afterResetFile = mocks.addPendingFiles.mock.calls.at(-1)?.[0][0] as File
+    expect(afterResetFile.name).toBe("copy-1.md")
   })
 
   it("retains one TipTap editor instance while render-time configuration reruns", async () => {

--- a/src/web/src/components/community/messages/use-composer-controller.test.ts
+++ b/src/web/src/components/community/messages/use-composer-controller.test.ts
@@ -411,6 +411,36 @@ describe("useComposerController", () => {
     expect(afterResetFile.name).toBe("copy-1.md")
   })
 
+  it("skips long-paste names already used by pending files", async () => {
+    const props = acceptedProps(() => true)
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(Harness, props))
+    })
+
+    const existingFile = new File(["existing"], "copy-1.md", {
+      type: "text/markdown",
+    })
+    pendingFiles = [
+      { file: existingFile, thumbnailUrl: null, thumbnailBlob: null },
+    ]
+    await act(async () => {
+      renderer.update(createElement(Harness, props))
+    })
+
+    expect(
+      editorOptions.editorProps.handlePaste({} as never, {
+        clipboardData: {
+          items: { length: 0 },
+          getData: () => "x".repeat(1_001),
+        },
+        preventDefault: vi.fn(),
+      } as unknown as ClipboardEvent),
+    ).toBe(true)
+    const attachment = mocks.addPendingFiles.mock.calls.at(-1)?.[0][0] as File
+    expect(attachment.name).toBe("copy-2.md")
+  })
+
   it("retains one TipTap editor instance while render-time configuration reruns", async () => {
     const accept = vi.fn(() => true)
     let renderer!: TestRenderer.ReactTestRenderer

--- a/src/web/src/components/community/messages/use-composer-controller.ts
+++ b/src/web/src/components/community/messages/use-composer-controller.ts
@@ -19,7 +19,11 @@ import {
 } from "@/lib/community/composer-draft"
 import { detectMentionType } from "@/lib/community/mention-extension"
 import { buildPasteDom } from "@/lib/community/paste-plain-text"
-import { clipboardFiles, pendingFilesToSendAttachments } from "./composer-file-utils"
+import {
+  clipboardFiles,
+  createLongPasteAttachment,
+  pendingFilesToSendAttachments,
+} from "./composer-file-utils"
 import type { ComposerHandle, ComposerProps } from "./composer-types"
 import type { ComposerViewProps } from "./composer-view"
 import { useComposerSuggestions } from "./use-composer-suggestions"
@@ -67,6 +71,11 @@ export function useComposerController(
     handleDragOver,
     handleDrop: handleDropRaw,
   } = attachments
+  const pendingFilesRef = useRef(pendingFiles)
+  const nextLongPasteIndexRef = useRef(1)
+  useLayoutEffect(() => {
+    pendingFilesRef.current = pendingFiles
+  }, [pendingFiles])
   const typingTimer = useRef<NodeJS.Timeout | null>(null)
   const sendRef = useRef<() => void>(() => {})
   const sendInFlightRef = useRef<Promise<void> | null>(null)
@@ -79,6 +88,7 @@ export function useComposerController(
     if (sendScopeRef.current !== nextScope) {
       sendScopeRef.current = nextScope
       sendScopeVersionRef.current++
+      nextLongPasteIndexRef.current = 1
     }
     draftKeyRef.current = draftKey
   }, [channel, context, draftKey])
@@ -169,9 +179,22 @@ export function useComposerController(
       },
       handlePaste: (_view, event) => {
         const files = clipboardFiles(event.clipboardData?.items)
-        if (files.length === 0) return false
+        if (files.length > 0) {
+          event.preventDefault()
+          void addPendingFiles(files)
+          return true
+        }
+
+        const attachment = createLongPasteAttachment(
+          event.clipboardData?.getData("text/plain"),
+          pendingFilesRef.current.map(({ file }) => file.name),
+          nextLongPasteIndexRef.current,
+        )
+        if (!attachment) return false
+
         event.preventDefault()
-        addPendingFiles(files)
+        nextLongPasteIndexRef.current = attachment.nextIndex
+        void addPendingFiles([attachment.file])
         return true
       },
       clipboardTextParser: (text, $context) => {
@@ -256,6 +279,7 @@ export function useComposerController(
       editor.commands.clearContent()
       if (draftKeyRef.current) clearComposerDraft(draftKeyRef.current)
       transferPendingFiles()
+      nextLongPasteIndexRef.current = 1
       suggestions.resetPopups()
     })()
     sendInFlightRef.current = attempt
@@ -288,6 +312,7 @@ export function useComposerController(
       if (!editor) return
       editor.commands.clearContent()
       setPendingFiles([])
+      nextLongPasteIndexRef.current = 1
       suggestions.resetPopups()
     },
     isEmpty: () => !editor || (editor.isEmpty && pendingFiles.length === 0),

--- a/src/web/src/test/e2e-ui/02-server-channel-message.spec.ts
+++ b/src/web/src/test/e2e-ui/02-server-channel-message.spec.ts
@@ -27,13 +27,57 @@ test("server → channel → message", async ({ asUser }) => {
   await expect(page.getByTestId(tid.message(firstPayload.message.id))).toHaveCount(1)
   await expect(page.getByTestId(tid.composerInput)).toHaveText("")
 
+  const editable = composerEditable(page)
+  const pastePlainText = (text: string) => editable.evaluate((element, pastedText) => {
+    const clipboardData = new DataTransfer()
+    clipboardData.setData("text/plain", pastedText)
+    element.dispatchEvent(new ClipboardEvent("paste", {
+      bubbles: true,
+      cancelable: true,
+      clipboardData,
+    }))
+  }, text)
+
+  await editable.click()
+  await pastePlainText("x".repeat(1_000))
+  await expect(editable).toHaveText("x".repeat(1_000))
+  await page.keyboard.press("ControlOrMeta+A")
+  await page.keyboard.press("Backspace")
+
+  const firstLongPaste = `# first paste\n\n${"a".repeat(1_001)}`
+  const secondLongPaste = `second paste\n${"b".repeat(1_001)}`
+  await pastePlainText(firstLongPaste)
+  await pastePlainText(secondLongPaste)
+  await expect(editable).toHaveText("")
+  await expect(page.getByText("copy-1.md", { exact: true })).toBeVisible()
+  await expect(page.getByText("copy-2.md", { exact: true })).toBeVisible()
+
+  const longPasteResponsePromise = page.waitForResponse((response) => {
+    const pathname = new URL(response.url()).pathname
+    return response.request().method() === "POST"
+      && /^\/api\/community\/channels\/[^/]+\/messages$/.test(pathname)
+  })
+  await page.keyboard.press("Enter")
+  const longPasteResponse = await longPasteResponsePromise
+  expect(longPasteResponse.status()).toBe(201)
+  const longPasteRequest = longPasteResponse.request().postDataJSON() as {
+    content: string
+    attachments?: string[]
+  }
+  expect(longPasteRequest.content).toBe("")
+  expect(longPasteRequest.attachments).toHaveLength(2)
+  const longPastePayload = await longPasteResponse.json() as { message: { id: string } }
+  const longPasteMessage = page.getByTestId(tid.message(longPastePayload.message.id))
+  await expect(longPasteMessage.getByText("copy-1.md", { exact: true })).toBeVisible()
+  await expect(longPasteMessage.getByText("copy-2.md", { exact: true })).toBeVisible()
+  await expect(page.getByTestId(tid.composerInput).locator("../..").getByText(/^copy-[12]\.md$/)).toHaveCount(0)
+
   let sends = 0
   page.on("request", (request) => {
     const pathname = new URL(request.url()).pathname
     if (request.method() === "POST" && /^\/api\/community\/channels\/[^/]+\/messages$/.test(pathname)) sends++
   })
 
-  const editable = composerEditable(page)
   const imeBody = `ime probe ${Date.now()}`
   await editable.click()
   await editable.pressSequentially(imeBody)


### PR DESCRIPTION
## Summary

- turn Community composer plain-text pastes over 1,000 characters into `copy-N.md` attachments
- preserve exact-threshold inline paste and existing clipboard-file priority
- reuse the existing attachment validation/upload/send path across channels, DMs, and forum bodies

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm typegrep:ws`
- `pnpm typegrep:agent-driver`
- `pnpm knip`
- `ALOOK_E2E_FORCE_FRESH=1 pnpm --filter @alook/web test:e2e-ui src/test/e2e-ui/02-server-channel-message.spec.ts`
- independent `/c` QA: D1 attachment linkage + `community:message.create` WS frame verified
