### PR TITLE
fix(ci): eliminate first-run test races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,17 @@ jobs:
         run: pnpm --filter @alook/agent-driver build
       - name: Run full tests with coverage
         if: env.RUN_COVERAGE == 'true'
-        run: pnpm vitest run --coverage --coverage.reporter=json --coverage.reporter=text
+        run: |
+          pnpm vitest run --coverage --coverage.reporter=json --coverage.reporter=text \
+            --exclude src/daemon/agent-driver/src/pack.test.ts \
+            --exclude src/daemon/src/version.packed.test.ts \
+            --exclude src/daemon/src/agent-driver-bundle.packed.test.ts \
+            --exclude src/daemon/src/cli/daemonSelfUpdate.real.test.ts
+      - name: Run package artifact tests after coverage
+        if: env.RUN_COVERAGE == 'true'
+        run: |
+          pnpm --filter @alook/agent-driver exec vitest run --no-file-parallelism src/pack.test.ts
+          pnpm --filter @alook/daemon exec vitest run --no-file-parallelism src/version.packed.test.ts src/agent-driver-bundle.packed.test.ts src/cli/daemonSelfUpdate.real.test.ts
       - name: Run daemon tests in isolation
         if: env.RUN_COVERAGE != 'true'
         env:

--- a/scripts/ci/workflow-contract.test.ts
+++ b/scripts/ci/workflow-contract.test.ts
@@ -428,7 +428,7 @@ describe("Turbo CI execution", () => {
     )
   })
 
-  it("runs tests once and uploads the single Istanbul report only for coverage events", () => {
+  it("keeps package builds away from dist consumers and uploads one Istanbul report", () => {
     const linux = ciJob("test-linux")
     expect(linux).toContain(
       "RUN_COVERAGE: ${{ github.event_name != 'push' || startsWith(github.event.head_commit.message, 'release:') }}",
@@ -438,6 +438,26 @@ describe("Turbo CI execution", () => {
     expect(linux).toContain("if: env.RUN_COVERAGE == 'true'")
     expect(linux).toContain("if: env.RUN_COVERAGE != 'true'")
     expect(linux).toContain("files: ./coverage/coverage-final.json")
+    for (const testPath of [
+      "src/daemon/agent-driver/src/pack.test.ts",
+      "src/daemon/src/version.packed.test.ts",
+      "src/daemon/src/agent-driver-bundle.packed.test.ts",
+      "src/daemon/src/cli/daemonSelfUpdate.real.test.ts",
+    ]) {
+      expect(linux).toContain(`--exclude ${testPath}`)
+    }
+    expect(linux).toContain(
+      "pnpm --filter @alook/agent-driver exec vitest run --no-file-parallelism src/pack.test.ts",
+    )
+    expect(linux).toContain(
+      "pnpm --filter @alook/daemon exec vitest run --no-file-parallelism src/version.packed.test.ts src/agent-driver-bundle.packed.test.ts src/cli/daemonSelfUpdate.real.test.ts",
+    )
+    const coverageRun = linux.indexOf("- name: Run full tests with coverage")
+    const packageRuns = linux.indexOf("- name: Run package artifact tests after coverage")
+    const coverageUpload = linux.indexOf("- name: Upload coverage")
+    expect(coverageRun).toBeGreaterThan(-1)
+    expect(packageRuns).toBeGreaterThan(coverageRun)
+    expect(coverageUpload).toBeGreaterThan(packageRuns)
     expect(linux).not.toContain("coverage:workers")
     expect(linux).not.toContain("workers-runtime")
     expect(ciWorkflow).not.toMatch(/^  coverage:/m)

--- a/tests/integration/cli/community-rate-limit.test.ts
+++ b/tests/integration/cli/community-rate-limit.test.ts
@@ -11,6 +11,7 @@
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest"
 import { randomUUID } from "crypto"
+import { DEV_WS_DO_URL, RATE_LIMITS, type RateLimitResult } from "@alook/shared"
 import {
   seedTestData,
   cleanupTestData,
@@ -76,44 +77,44 @@ afterAll(() => {
 
 describe("community message rate limit — DO-backed", () => {
   it("accepts up to the per-window max, then returns 429 with Retry-After", async () => {
-    // Policy: community:msgSend = 30 sends / 10s fixed window (see
-    // `RATE_LIMITS` in src/shared/src/lib/rate-limits.ts). Fire the whole
-    // burst CONCURRENTLY so every request provably lands inside one window —
-    // a sequential loop can take >10s on a slow runner, letting the fixed
-    // window reset mid-loop so the counter never reaches the ceiling and no
-    // 429 is ever emitted (the old flake). The DO counter is
-    // strongly-consistent, so concurrency still yields a deterministic split.
-    const MAX = 30
-    const responses = await Promise.all(
-      Array.from({ length: MAX + 1 }, (_, i) =>
-        sessionRequest(
-          `/api/community/channels/${channelId}/messages`,
-          cookie,
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ content: `rate-limit-e2e ${i}` }),
-          },
-        ),
-      ),
+    const name = "community:msgSend" as const
+    const policy = RATE_LIMITS[name]
+    const sendMessage = (content: string) => sessionRequest(
+      `/api/community/channels/${channelId}/messages`,
+      cookie,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content }),
+      },
     )
 
-    const accepted = responses.filter((r) => r.status === 201).length
-    const rejected = responses.filter((r) => r.status === 429)
+    // Keep the two assertions that matter on the real community route, but
+    // avoid making a cold CI runner perform 31 full auth + D1 message writes.
+    // The first write creates the exact (name, userId) DO window used by the
+    // route. Lightweight calls to the real ws-do service then fill that same
+    // strongly-consistent counter before the overflow request exercises the
+    // route's 429 response.
+    const accepted = await sendMessage("rate-limit-e2e accepted")
+    expect(accepted.status).toBe(201)
 
-    // Exactly the ceiling is accepted; the overflow is blocked (not fail-open).
-    // If `accepted` < 30, the counter started with stale state from a previous
-    // run — reset with `pnpm db:reset`.
-    expect(accepted).toBe(MAX)
-    expect(rejected).toHaveLength(1)
+    const primed = await Promise.all(
+      Array.from({ length: policy.max - 1 }, async () => {
+        const response = await fetch(`${DEV_WS_DO_URL}/rate-limit/check`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name, key: seed.userId, ...policy }),
+        })
+        expect(response.status).toBe(200)
+        return (await response.json()) as RateLimitResult
+      }),
+    )
+    expect(primed).toEqual(Array.from({ length: policy.max - 1 }, () => ({ allowed: true })))
 
-    // Every 429 carries a positive Retry-After (set by writeError() when the
-    // DO returns { allowed: false }). Asserted per-response so a fail-open
-    // (429 without the header) is caught regardless of ordering.
-    for (const res of rejected) {
-      const retryAfter = res.headers.get("retry-after")
-      expect(retryAfter).toBeTruthy()
-      expect(Number(retryAfter)).toBeGreaterThan(0)
-    }
+    const rejected = await sendMessage("rate-limit-e2e rejected")
+    expect(rejected.status).toBe(429)
+    const retryAfter = rejected.headers.get("retry-after")
+    expect(retryAfter).toBeTruthy()
+    expect(Number(retryAfter)).toBeGreaterThan(0)
   }, 30_000)
 })


### PR DESCRIPTION
## Summary

- keep the community rate-limit E2E assertions on the real message route while priming the same real Durable Object with lightweight checks
- exclude all four tests that rebuild `agent-driver/dist` from the parallel coverage invocation
- run those artifact-building tests serially after coverage and preserve the single Istanbul report
- lock the exclusions and workflow ordering in the CI contract test

## Root causes

The rate-limit test issued 31 complete authenticated message writes. On a cold first-run runner, auth, Next.js compilation, D1 writes, and delivery work consumed the test's existing 30-second budget.

The coverage invocation ran all Vitest projects concurrently. Three packaging tests and `daemonSelfUpdate.real.test.ts` invoke package builds that rewrite the shared `src/daemon/agent-driver/dist` tree while daemon real-process tests import it, allowing consumers to observe a partially rebuilt ESM graph.

## Verification

- exact revised coverage command: 964 files passed, 10,762 tests passed, 4 skipped
- serialized artifact lane: 4 files passed, 7 tests passed; `coverage/coverage-final.json` preserved
- community rate-limit E2E: 6/6 fresh randomized runs passed; warm test body about 0.5s
- daemon lifecycle real-process: 9/9 passed
- workflow contract: 32/32 passed
- `pnpm typecheck`, `pnpm lint`
- normal pre-commit hook: full workspace tests, typegrep checks, and knip passed

Prerequisite for clean first-run CI validation of #555. #556 had already merged into main before this prerequisite branch was cut.
