### PR TITLE
fix: align first-touch thread sends

### DIFF
--- a/src/daemon/src/cli/index.test.ts
+++ b/src/daemon/src/cli/index.test.ts
@@ -274,7 +274,7 @@ describe("channel alignment (message send)", () => {
     expect(env.error).toContain("not aligned");
     expect(env.error).toContain("3 unread");
     expect(env.error).toContain("#12");
-    expect(env.error).toContain("inbox pull");
+    expect(env.error).toContain("inbox pull --channel /s#0042/general");
     expect(env.error).toContain("READ the new messages");
     expect(env.error).toContain("before deciding");
     expect(env.error).toContain("resend, adjust, or skip");
@@ -453,6 +453,28 @@ describe("message send --reply", () => {
 });
 
 describe("inbox pull", () => {
+  it("passes an exact --channel target through while preserving normal ack", async () => {
+    const pullSpy = vi.fn(async () => ({
+      messages: [{ seq: "#8", channel: "/s#0042/general/#3", sender: "@x", content: { text: "context" }, time: "" }],
+      hasMore: true,
+      markedCount: 0,
+    }));
+    const ackSpy = vi.fn(async (req: { cursors: Array<{ channel: string; seq: number }> }) => ({
+      ok: true, applied: req.cursors, failed: [],
+    }));
+    setApiForTesting(stubApi({ inboxPull: pullSpy, ack: ackSpy }));
+
+    await main(["inbox", "pull", "--channel", "/s#0042/general/#3", "--max", "10"]);
+
+    expect(pullSpy).toHaveBeenCalledWith(expect.objectContaining({
+      channel: "/s#0042/general/#3",
+      max: 10,
+    }));
+    expect(ackSpy).toHaveBeenCalledWith(expect.objectContaining({
+      cursors: [{ channel: "/s#0042/general/#3", seq: 8 }],
+    }));
+  });
+
   it("never acks a rejected pull and only advances the returned cursor after repair", async () => {
     const ackSpy = vi.fn(async (req: { cursors: Array<{ channel: string; seq: number }> }) => ({
       ok: true, applied: req.cursors, failed: [],

--- a/src/daemon/src/cli/index.ts
+++ b/src/daemon/src/cli/index.ts
@@ -367,7 +367,7 @@ async function cmdMessageSend(opts: Record<string, unknown>, stdin: CliInputStre
   if (res.state === "blocked") {
     throw new CliError(
       `channel not aligned: ${res.unreadCount} unread message(s) in ${channel} (latest #${res.latestSeq}). ` +
-        `Run \`alook inbox pull\` and READ the new messages before deciding whether to resend, ` +
+        `Run \`alook inbox pull --channel ${channel}\` and READ the new messages before deciding whether to resend, ` +
         `adjust, or skip your message.`,
     );
   }
@@ -603,7 +603,12 @@ async function cmdInboxPull(opts: Record<string, unknown>): Promise<unknown> {
   const api = getApi();
   const agent = agentId(opts);
   const max = opts.max ? Number(opts.max) : undefined;
-  const { messages, hasMore, markedCount } = await api.inboxPull({ agentId: agent, max });
+  const channel = opts.channel as string | undefined;
+  const { messages, hasMore, markedCount } = await api.inboxPull({
+    agentId: agent,
+    ...(max !== undefined ? { max } : {}),
+    ...(channel ? { channel } : {}),
+  });
   const pulledAt = nowLocalISO();
 
   let acked = 0;
@@ -878,8 +883,9 @@ function buildProgram(stdin: CliInputStream): Command {
 
   inbox
     .command("pull")
-    .description("fetch unread messages from all channels")
+    .description("fetch unread messages globally or from one exact target")
     .option("--max <n>", "max messages to return")
+    .option("--channel <ref>", "fetch readable unread from one exact channel, DM, or thread")
     .option("--no-ack", "do not advance read waterlines (peek only)")
     .exitOverride()
     .configureOutput({ writeOut: () => {}, writeErr: () => {} })

--- a/src/daemon/src/cli/proxyServerApi.test.ts
+++ b/src/daemon/src/cli/proxyServerApi.test.ts
@@ -416,18 +416,19 @@ describe("createProxyServerApi — inbox trinity pull/snapshot/ack (retargeted t
   });
 
 
-  it("inboxPull POSTs users/me/inbox/pull with {max} in body, agentId stripped", async () => {
+  it("inboxPull POSTs users/me/inbox/pull with {max,channel} in body, agentId stripped", async () => {
     const seen: Array<{ url: string; init?: RequestInit }> = [];
     const fetchImpl: FetchLike = vi.fn(async (url: string, init?: RequestInit) => {
       seen.push({ url, init });
       return jsonBody(JSON.stringify({ messages: [], hasMore: false, markedCount: 0 }), { status: 200 });
     });
     const api = createProxyServerApi({ ...cfg, fetchImpl: fetchImpl as typeof fetch });
-    await api.inboxPull({ agentId: "a1" as never, max: 10 });
+    await api.inboxPull({ agentId: "a1" as never, max: 10, channel: "/s#0042/general/#3" });
     expect(seen[0].url).toBe("http://proxy.test/api/community/users/me/inbox/pull");
     expect(seen[0].init?.method).toBe("POST");
     const body = JSON.parse(String(seen[0].init?.body ?? "{}"));
     expect(body.max).toBe(10);
+    expect(body.channel).toBe("/s#0042/general/#3");
     expect(body.agentId).toBeUndefined();
   });
 

--- a/src/daemon/src/cli/proxyServerApi.ts
+++ b/src/daemon/src/cli/proxyServerApi.ts
@@ -375,7 +375,9 @@ export function createProxyServerApi(config: ProxyServerApiConfig): ServerApi {
     // RETARGETED off the flat `inboxPull` verb onto the caller's own inbox
     // resource POST users/me/inbox/pull (route/disc 轴3). Self-scoped to the
     // voucher's bot — no target-user param on the wire (users/me/* family).
-    // The legacy flat route is deleted. Same optional `{max?}` body.
+    // The legacy flat route is deleted. Optional `channel` requests an explicit
+    // exact-target catch-up; the server keeps ordinary unscoped pulls passive-
+    // notification-filtered.
     const { agentId: _omit, ...wire } = (req ?? {}) as unknown as Record<string, unknown>;
     const res = await fetchImpl(`${base}/api/community/users/me/inbox/pull`, {
       method: "POST",

--- a/src/shared/src/community-cli-contract.ts
+++ b/src/shared/src/community-cli-contract.ts
@@ -294,6 +294,12 @@ export interface InboxPullRequest {
   agentId: AgentId;
   /** Optional: limit how many full messages to drain (inbox notice is unbounded). */
   max?: number;
+  /**
+   * Optional exact target. When present, pull readable unread from only this
+   * concrete scope regardless of passive notification policy. The normal
+   * unscoped inbox remains notification-filtered.
+   */
+  channel?: ChannelRef;
 }
 export interface InboxPullResponse {
   /** Flat agent-facing messages drained this pull (JSONL on the wire). */

--- a/src/shared/src/db/queries/community/agent-inbox.ts
+++ b/src/shared/src/db/queries/community/agent-inbox.ts
@@ -646,65 +646,27 @@ export async function listUnreadMessagesForAgent(
 }
 
 /**
- * Does `botUserId` have any message in `channelId`, beyond seq `seen`, that
- * `inboxPull` would actually DELIVER — i.e. at/after the bot's join baseline
- * and not its own? This is the send route's alignment gate, sharing
- * `listUnreadMessagesForAgent`'s DELIVERABILITY filters (`channelJoinBaselineGuard`
- * + `authorId != bot`) so the gate and the pull can never drift on which
- * messages "count". The `seen` threshold is the gate's own business: the caller
- * passes `seenUpToSeq ?? lastReadSeq ?? 0`, preserving the daemon's forward-seen
- * boundary (a bot may report it has seen past its acked `lastReadSeq`).
+ * The single alignment-eligible row listing for an exact target. Both the send
+ * gate (limit 1 → boolean) and explicit targeted inbox pull call THIS query, so
+ * they cannot drift into "gate blocks but recovery cannot deliver" (or the
+ * reverse). Alignment is about readable target context, not passive delivery:
+ * notification policy and thread notify membership are intentionally absent.
  *
- * Why not `getLatestSeqForScope > seen`: that counts the channel's raw `nextSeq`
- * — including pre-join backlog and the bot's own messages — which the pull's
- * baseline + author filters exclude. A bot @mentioned into a channel/thread with
- * history would then read as permanently "unaligned" (gate sees backlog) while
- * `inboxPull` delivers nothing to advance its `lastReadSeq` — a wedge that only
- * luck (a fresh post-join message) breaks. Gating on the deliverable predicate
- * makes the wedge impossible by construction and needs no read-state migration
- * for already-stuck bots: the gate stops counting messages the pull never hands
- * over.
- *
- * Child-thread notification-set narrowing: the pull's allowed set
- * (`listAgentAllowedChannelIds`) additionally drops child threads
- * the bot holds no `relation='notify'` row on — those are never delivered. The
- * gate MUST mirror that same narrowing (via the SAME `listParticipatingThreadIds`
- * predicate, not a re-derived one) or it counts backlog in a scope where the
- * bot holds no `community_channel_member(relation='notify')` row, which the
- * pull will never hand over — the exact "not aligned: N unread"
- * deadlock a bot hit trying to post into a thread it hadn't engaged. This drops
- * ONLY true spectators: a bot @mentioned into a thread gets a `notify` row on the
- * send hot path (`addThreadParticipants`, source=mention), so its owed mention
- * still counts as deliverable — the narrowing is not-more-not-less than the pull.
+ * Callers authorize the concrete target before entering this query. The row
+ * boundary retains the existing product baseline: non-self messages only,
+ * strictly beyond the caller-provided cursor, and after the bot's access/join
+ * baseline. Results are contiguous seq-ascending so targeted pull can ack the
+ * page and repeat without skipping a gap.
  */
-export async function hasDeliverableUnreadForAgentScope(
+export async function listAlignmentUnreadMessagesForAgentScope(
   db: Database,
   botUserId: string,
   channelId: string,
-  seen: number
-): Promise<boolean> {
-  // Notification-set narrowing, single-channel form of `listAgentAllowedChannelIds`'s
-  // set-wide step: a child thread without a notify row for the bot is never
-  // deliverable, so its backlog must not register as unread here. Short-circuits
-  // before the deliverable scan — cheaper for the common spectator case too.
-  const typeRows = await db
-    .select({ type: communityChannel.type })
-    .from(communityChannel)
-    .where(eq(communityChannel.id, channelId))
-    .limit(1);
-  const type = typeRows[0]?.type;
-  // Same reach `participant-set` narrowing as `listAgentAllowedChannelIds` — via
-  // the SAME reachIsParticipantSet source (B2). This gate and the pull's allowed
-  // set MUST agree on which channels need a notify row to be deliverable, or the
-  // gate counts backlog the pull never delivers (the send-alignment deadlock).
-  // Reading one shared reach value is what makes that agreement structural.
-  if (reachIsParticipantSet(type)) {
-    const participating = await listParticipatingThreadIds(db, [channelId], botUserId);
-    if (participating.length === 0) return false;
-  }
-
-  const rows = await db
-    .select({ seq: communityMessage.seq })
+  opts: { afterSeq: number; max: number }
+): Promise<RawAgentMessage[]> {
+  const max = Math.max(1, Math.floor(opts.max));
+  return db
+    .select(AGENT_MESSAGE_COLUMNS)
     .from(communityMessage)
     .leftJoin(communityChannel, eq(communityChannel.id, communityMessage.channelId))
     .leftJoin(
@@ -726,23 +688,27 @@ export async function hasDeliverableUnreadForAgentScope(
       and(
         eq(communityMessage.channelId, channelId),
         ne(communityMessage.authorId, botUserId),
-        gt(communityMessage.seq, seen),
+        gt(communityMessage.seq, opts.afterSeq),
         channelJoinBaselineGuard,
-        notificationEligibleSql(
-          botUserId,
-          {
-            id: communityChannel.id,
-            serverId: communityChannel.serverId,
-            parentChannelId: communityChannel.parentChannelId,
-          },
-          {
-            id: communityMessage.id,
-          },
-        ),
       )
     )
-    .limit(1);
+    .orderBy(asc(communityMessage.seq))
+    .limit(max);
+}
 
+/** Send's boolean projection of the exact same rows targeted pull delivers. */
+export async function hasAlignmentUnreadForAgentScope(
+  db: Database,
+  botUserId: string,
+  channelId: string,
+  seen: number
+): Promise<boolean> {
+  const rows = await listAlignmentUnreadMessagesForAgentScope(
+    db,
+    botUserId,
+    channelId,
+    { afterSeq: seen, max: 1 },
+  );
   return rows.length > 0;
 }
 

--- a/src/shared/src/schemas.ts
+++ b/src/shared/src/schemas.ts
@@ -1253,6 +1253,7 @@ export type CommunityAgentUpdateProfileRequest = z.infer<
 
 export const CommunityAgentInboxPullRequestSchema = z.object({
   max: z.number().int().min(1).max(200).optional(),
+  channel: z.string().min(1).optional(),
 });
 export type CommunityAgentInboxPullRequest = z.infer<typeof CommunityAgentInboxPullRequestSchema>;
 

--- a/src/shared/test/queries/community-agent-inbox.test.ts
+++ b/src/shared/test/queries/community-agent-inbox.test.ts
@@ -1014,56 +1014,42 @@ describe("listMessagesBySeq", () => {
   });
 });
 
-describe("hasDeliverableUnreadForAgentScope", () => {
-  // Call order (see the query's body):
-  //  1. channel-type lookup (participation-narrowing pre-check)
-  //  2. `listParticipatingThreadIds` — ONLY when (1) is thread
-  //  3. the deliverable-unread existence scan (limit 1)
-  // For a plain (non-thread) channel, (2) is skipped: (1)=type, (2)=scan.
-  it("returns true when a deliverable message beyond `seen` exists", async () => {
-    const db = createSequentialDb([[{ type: "text" }], [{ seq: 7 }]]);
-    const result = await agentInbox.hasDeliverableUnreadForAgentScope(db, "bot_1", "c1", 3);
+describe("alignment unread exact-scope core", () => {
+  it("lists alignment-eligible rows in the requested bounded page", async () => {
+    const rows = [{ seq: 4 }, { seq: 5 }];
+    const db = createSequentialDb([rows]);
+    const result = await agentInbox.listAlignmentUnreadMessagesForAgentScope(
+      db,
+      "bot_1",
+      "thread_x",
+      { afterSeq: 3, max: 2 },
+    );
+    expect(result).toEqual(rows);
+    const chainResult = db.select.mock.results[0]!.value;
+    expect(chainResult.limit).toHaveBeenCalledWith(2);
+  });
+
+  it("send existence is only a limit-1 projection of the same row listing", async () => {
+    const db = createSequentialDb([[{ seq: 7 }]]);
+    const result = await agentInbox.hasAlignmentUnreadForAgentScope(db, "bot_1", "c1", 3);
     expect(result).toBe(true);
-  });
-
-  it("returns false when nothing is deliverable beyond `seen` (pre-join backlog / own / already read)", async () => {
-    const db = createSequentialDb([[{ type: "text" }], []]);
-    const result = await agentInbox.hasDeliverableUnreadForAgentScope(db, "bot_1", "c1", 0);
-    expect(result).toBe(false);
-  });
-
-  it("probes with limit(1) — existence check, not a full scan", async () => {
-    const db = createSequentialDb([[{ type: "text" }], []]);
-    await agentInbox.hasDeliverableUnreadForAgentScope(db, "bot_1", "c1", 0);
-    // The scan is the 2nd select for a non-thread channel (type lookup is 1st).
-    const chainResult = db.select.mock.results[1]!.value;
+    expect(db.select).toHaveBeenCalledTimes(1);
+    const chainResult = db.select.mock.results[0]!.value;
     expect(chainResult.limit).toHaveBeenCalledWith(1);
   });
 
-  // The deadlock this fix closes: a thread the bot doesn't participate in has
-  // unread backlog the pull will NEVER deliver, so the gate must NOT count it
-  // (else send is wedged on "not aligned" forever). Participation narrowing
-  // returns false BEFORE the deliverable scan — mirroring the pull's allowed set.
-  it("returns false for a non-participated thread even with unread beyond `seen` (never-drop deadlock fix)", async () => {
-    // (1) type=thread → (2) listParticipatingThreadIds returns [] (not a
-    // participant). Short-circuits false; the deliverable scan never runs.
-    const db = createSequentialDb([[{ type: "thread" }], []]);
-    const result = await agentInbox.hasDeliverableUnreadForAgentScope(db, "bot_1", "thread_x", 0);
+  it("returns false when the shared alignment listing is empty", async () => {
+    const db = createSequentialDb([[]]);
+    const result = await agentInbox.hasAlignmentUnreadForAgentScope(db, "bot_1", "c1", 0);
     expect(result).toBe(false);
-    // Only two selects: type lookup + participation. No scan (would be a 3rd).
-    expect(db.select).toHaveBeenCalledTimes(2);
   });
 
-  // The other side of the coin (Aigneis's never-drop invariant): a bot
-  // @mentioned into a thread gets a `relation='notify'` row on the send hot
-  // path, so it IS a participant — its owed message must still count as
-  // deliverable. Narrowing is not-more-not-less than the pull.
-  it("returns true for a participated thread with a deliverable message (mention isn't dropped)", async () => {
-    // (1) type=thread → (2) participation returns the channel id (notify row
-    // exists) → (3) the deliverable scan finds an unread message.
-    const db = createSequentialDb([[{ type: "thread" }], [{ channelId: "thread_x" }], [{ seq: 4 }]]);
-    const result = await agentInbox.hasDeliverableUnreadForAgentScope(db, "bot_1", "thread_x", 0);
+  it("does not spectator-short-circuit an existing thread", async () => {
+    // There is no type/notify pre-query: a readable row is alignment-relevant
+    // even when passive notification policy would not deliver it globally.
+    const db = createSequentialDb([[{ seq: 4 }]]);
+    const result = await agentInbox.hasAlignmentUnreadForAgentScope(db, "bot_1", "thread_x", 0);
     expect(result).toBe(true);
-    expect(db.select).toHaveBeenCalledTimes(3);
+    expect(db.select).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/shared/test/queries/community-notification-cursor-clear.test.ts
+++ b/src/shared/test/queries/community-notification-cursor-clear.test.ts
@@ -18,7 +18,8 @@ import { listUserServers } from "../../src/db/queries/community/server";
 import {
   getInboxSnapshotForAgent,
   getLatestUnreadMessageForAgent,
-  hasDeliverableUnreadForAgentScope,
+  hasAlignmentUnreadForAgentScope,
+  listAlignmentUnreadMessagesForAgentScope,
   listUnreadMessagesForAgent,
 } from "../../src/db/queries/community/agent-inbox";
 import { listEligibleUnreadChannels } from "../../src/db/queries/community/inbox";
@@ -534,9 +535,12 @@ describe("notification setting cursor-clear contract", () => {
       hasMention: true,
     }]);
 
-    await expect(hasDeliverableUnreadForAgentScope(db, "u", "a_muted", 0))
-      .resolves.toBe(false);
-    await expect(hasDeliverableUnreadForAgentScope(db, "u", "z_eligible", 0))
+    // Passive inbox delivery stays notification-filtered above, while send
+    // alignment is deliberately readable-scope and therefore still sees the
+    // muted target. Explicit targeted pull shares this exact row predicate.
+    await expect(hasAlignmentUnreadForAgentScope(db, "u", "a_muted", 0))
+      .resolves.toBe(true);
+    await expect(hasAlignmentUnreadForAgentScope(db, "u", "z_eligible", 0))
       .resolves.toBe(true);
 
     await expect(listEligibleUnreadChannels(db, "u", visible)).resolves.toEqual([
@@ -545,6 +549,58 @@ describe("notification setting cursor-clear contract", () => {
         lastMessageAt: "2026-01-01T00:02:30Z",
         mentionCount: 1,
       }),
+    ]);
+  });
+
+  it("exact-scope alignment excludes history before the access or server-join baseline", async () => {
+    sqlite.exec(`
+      UPDATE community_server_member
+      SET joined_at = '2026-01-01T00:00:02Z'
+      WHERE server_id = 'server' AND user_id = 'u';
+      INSERT INTO community_channel (id, server_id, type, name) VALUES
+        ('access-baseline', 'server', 'text', 'access-baseline'),
+        ('server-baseline', 'server', 'text', 'server-baseline');
+      INSERT INTO community_channel_member (channel_id, user_id, relation, added_at)
+      VALUES ('access-baseline', 'u', 'access', '2026-01-01T00:00:02Z');
+      INSERT INTO community_message (id, author_id, channel_id, seq, created_at, content) VALUES
+        ('access-before', 'author', 'access-baseline', 1, '2026-01-01T00:00:01Z', 'before access'),
+        ('access-after', 'author', 'access-baseline', 2, '2026-01-01T00:00:03Z', 'after access'),
+        ('server-before', 'author', 'server-baseline', 1, '2026-01-01T00:00:01Z', 'before join'),
+        ('server-after', 'author', 'server-baseline', 2, '2026-01-01T00:00:03Z', 'after join');
+    `);
+
+    await expect(listAlignmentUnreadMessagesForAgentScope(
+      db,
+      "u",
+      "access-baseline",
+      { afterSeq: 0, max: 10 },
+    )).resolves.toMatchObject([{ id: "access-after", seq: 2 }]);
+    await expect(listAlignmentUnreadMessagesForAgentScope(
+      db,
+      "u",
+      "server-baseline",
+      { afterSeq: 0, max: 10 },
+    )).resolves.toMatchObject([{ id: "server-after", seq: 2 }]);
+  });
+
+  it("exact-scope alignment excludes the bot's own committed rows", async () => {
+    sqlite.exec(`
+      INSERT INTO community_channel (id, server_id, type, name)
+      VALUES ('self-authored', 'server', 'text', 'self-authored');
+      INSERT INTO community_message (id, author_id, channel_id, seq, created_at, content) VALUES
+        ('foreign-before', 'author', 'self-authored', 1, '2026-01-01T00:00:01Z', 'foreign 1'),
+        ('self-row', 'u', 'self-authored', 2, '2026-01-01T00:00:02Z', 'mine'),
+        ('foreign-after', 'author', 'self-authored', 3, '2026-01-01T00:00:03Z', 'foreign 3');
+    `);
+
+    await expect(listAlignmentUnreadMessagesForAgentScope(
+      db,
+      "u",
+      "self-authored",
+      { afterSeq: 0, max: 10 },
+    )).resolves.toMatchObject([
+      { id: "foreign-before", seq: 1 },
+      { id: "foreign-after", seq: 3 },
     ]);
   });
 });

--- a/src/web/src/app/api/community/channels/[id]/messages/route.test.ts
+++ b/src/web/src/app/api/community/channels/[id]/messages/route.test.ts
@@ -9,6 +9,7 @@ const mockGetChannelForMember = vi.fn()
 const mockGetChannel = vi.fn()
 const mockCreateMessage = vi.fn()
 const mockGetMessage = vi.fn()
+const mockGetMessageByChannelAndSeq = vi.fn()
 const mockGetMessageByAuthorAndNonce = vi.fn()
 const mockGetMessageInScope = vi.fn()
 const mockGetMessagesByIdsInScope = vi.fn()
@@ -35,7 +36,9 @@ const mockToAgentMessages = vi.fn()
 const mockToAgentMessage = vi.fn()
 const mockGetLatestSeqForScope = vi.fn()
 const mockGetReadState = vi.fn()
-const mockHasDeliverableUnreadForAgentScope = vi.fn()
+const mockHasAlignmentUnreadForAgentScope = vi.fn()
+const mockAddThreadParticipant = vi.fn()
+const mockListThreadParticipantUserIds = vi.fn()
 const mockBumpBotDailyActivityStatement = vi.fn()
 const mockResolveServerByNameForMember = vi.fn()
 const mockResolveChannelByNameForMember = vi.fn()
@@ -48,6 +51,7 @@ const mockHardDeleteMessage = vi.fn()
 const mockRebindPendingAttachmentsToChild = vi.fn()
 
 const mockFanOutToChannel = vi.fn()
+const mockBroadcastToUserSafe = vi.fn()
 const mockDispatchCommittedMessage = vi.fn(async () => {})
 const mockBroadcastToUser = vi.fn()
 const mockCheckMessageRateLimit = vi.fn()
@@ -82,6 +86,7 @@ vi.mock("@alook/shared", async () => {
       communityMessage: {
         createMessage: (...a: unknown[]) => mockCreateMessage(...a),
         getMessage: (...a: unknown[]) => mockGetMessage(...a),
+        getMessageByChannelAndSeq: (...a: unknown[]) => mockGetMessageByChannelAndSeq(...a),
         getMessageByAuthorAndNonce: (...a: unknown[]) => mockGetMessageByAuthorAndNonce(...a),
         getMessageInScope: (...a: unknown[]) => mockGetMessageInScope(...a),
         getMessagesByIdsInScope: (...a: unknown[]) => mockGetMessagesByIdsInScope(...a),
@@ -101,6 +106,8 @@ vi.mock("@alook/shared", async () => {
       },
       communityThread: {
         addThreadParticipants: vi.fn(async () => undefined),
+        addThreadParticipant: (...a: unknown[]) => mockAddThreadParticipant(...a),
+        listThreadParticipantUserIds: (...a: unknown[]) => mockListThreadParticipantUserIds(...a),
       },
       communityAttachment: {
         listByMessageIds: (...a: unknown[]) => mockListByMessageIds(...a),
@@ -130,7 +137,7 @@ vi.mock("@alook/shared", async () => {
         toAgentMessages: (...a: unknown[]) => mockToAgentMessages(...a),
         toAgentMessage: (...a: unknown[]) => mockToAgentMessage(...a),
         getLatestSeqForScope: (...a: unknown[]) => mockGetLatestSeqForScope(...a),
-        hasDeliverableUnreadForAgentScope: (...a: unknown[]) => mockHasDeliverableUnreadForAgentScope(...a),
+        hasAlignmentUnreadForAgentScope: (...a: unknown[]) => mockHasAlignmentUnreadForAgentScope(...a),
       },
       communityReadState: {
         getReadState: (...a: unknown[]) => mockGetReadState(...a),
@@ -149,6 +156,7 @@ vi.mock("@alook/shared", async () => {
 
 vi.mock("@/lib/community/fanout", () => ({
   fanOutToChannel: (...a: unknown[]) => mockFanOutToChannel(...a),
+  broadcastToUserSafe: (...a: unknown[]) => mockBroadcastToUserSafe(...a),
 }))
 
 vi.mock("@/lib/community/message-dispatcher", () => ({
@@ -216,6 +224,27 @@ function getReq() {
 
 const ctx = { params: { id: "c1" } } as any
 
+function arrangeExistingBotThread() {
+  mockResolveServerByNameForMember.mockResolvedValue([{ id: "s1" }])
+  mockResolveChannelByNameForMember.mockResolvedValue([
+    { id: "parent_1", serverId: "s1", type: "text", parentChannelId: null },
+  ])
+  mockGetMessageByChannelAndSeq.mockResolvedValue({ id: "root_1", authorId: "u_root" })
+  mockGetThreadChannelByParentMessage.mockResolvedValue({ id: "thread_1" })
+  mockGetChannel.mockResolvedValue({
+    id: "thread_1",
+    serverId: "s1",
+    type: "thread",
+    parentChannelId: "parent_1",
+  })
+  mockGetChannelForMember.mockResolvedValue({
+    id: "thread_1",
+    serverId: "s1",
+    type: "thread",
+    parentChannelId: "parent_1",
+  })
+}
+
 describe("POST /api/community/channels/[id]/messages", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -251,7 +280,10 @@ describe("POST /api/community/channels/[id]/messages", () => {
     mockBroadcastToUser.mockResolvedValue(undefined)
     mockGetLatestSeqForScope.mockResolvedValue(0)
     mockGetReadState.mockResolvedValue(null)
-    mockHasDeliverableUnreadForAgentScope.mockResolvedValue(false)
+    mockHasAlignmentUnreadForAgentScope.mockResolvedValue(false)
+    mockAddThreadParticipant.mockResolvedValue(null)
+    mockListThreadParticipantUserIds.mockResolvedValue([])
+    mockBroadcastToUserSafe.mockResolvedValue(undefined)
     mockBumpBotDailyActivityStatement.mockReturnValue({})
     mockToAgentMessage.mockImplementation(async (_db, row, _user, attachments) => ({ ...row, attachments }))
     mockCheckMessageRateLimit.mockResolvedValue({ allowed: true })
@@ -593,7 +625,89 @@ describe("POST /api/community/channels/[id]/messages", () => {
     expect(await replay.json()).toEqual(expect.objectContaining({ state: "sent", deduped: true }))
     expect(mockFindPendingAttachmentsForSender).toHaveBeenCalledTimes(1)
     expect(mockCreateMessage).toHaveBeenCalledTimes(1)
-    expect(mockHasDeliverableUnreadForAgentScope).toHaveBeenCalledTimes(1)
+    expect(mockHasAlignmentUnreadForAgentScope).toHaveBeenCalledTimes(1)
+  })
+
+  it("first-touch existing thread joins + broadcasts before readable alignment blocks", async () => {
+    arrangeExistingBotThread()
+    mockAddThreadParticipant.mockResolvedValue({ id: "member_1" })
+    mockListThreadParticipantUserIds.mockResolvedValue(["bot_1", "u_root"])
+    mockGetLatestSeqForScope.mockResolvedValue(3)
+    mockHasAlignmentUnreadForAgentScope.mockResolvedValue(true)
+
+    const res = await POST(botPostReq({
+      channel: "/demo#0042/text/#1",
+      content: { text: "first touch" },
+    }), ctx)
+
+    expect(await res.json()).toEqual({
+      state: "blocked",
+      reason: "unaligned",
+      unreadCount: 3,
+      latestSeq: 3,
+    })
+    expect(mockAddThreadParticipant).toHaveBeenCalledWith(expect.anything(), {
+      threadChannelId: "thread_1",
+      userId: "bot_1",
+      source: "added",
+    })
+    expect(mockBroadcastToUserSafe).toHaveBeenCalledTimes(2)
+    expect(mockBroadcastToUserSafe).toHaveBeenCalledWith("bot_1", expect.objectContaining({
+      type: WS_EVENTS.CHANNEL_MEMBER_ADD,
+      channelId: "thread_1",
+      userId: "bot_1",
+    }))
+    expect(mockAddThreadParticipant.mock.invocationCallOrder[0]).toBeLessThan(
+      mockHasAlignmentUnreadForAgentScope.mock.invocationCallOrder[0],
+    )
+    expect(mockCreateMessage).not.toHaveBeenCalled()
+  })
+
+  it("idempotent existing-thread rejoin emits no duplicate member event", async () => {
+    arrangeExistingBotThread()
+    mockAddThreadParticipant.mockResolvedValue(null)
+
+    const res = await POST(botPostReq({
+      channel: "/demo#0042/text/#1",
+      content: { text: "already participating" },
+    }), ctx)
+
+    expect(res.status).toBe(200)
+    expect(mockHasAlignmentUnreadForAgentScope).toHaveBeenCalledOnce()
+    expect(mockListThreadParticipantUserIds).not.toHaveBeenCalled()
+    expect(mockBroadcastToUserSafe).not.toHaveBeenCalled()
+  })
+
+  it("invalid pending attachment fails before first-touch participant side effects", async () => {
+    arrangeExistingBotThread()
+    mockFindPendingAttachmentsForSender.mockResolvedValue([])
+
+    const res = await POST(botPostReq({
+      channel: "/demo#0042/text/#1",
+      content: { text: "bad attachment" },
+      attachments: ["missing"],
+    }), ctx)
+
+    expect(res.status).toBe(400)
+    expect(mockAddThreadParticipant).not.toHaveBeenCalled()
+    expect(mockHasAlignmentUnreadForAgentScope).not.toHaveBeenCalled()
+  })
+
+  it("invalid reply target fails before first-touch participant side effects", async () => {
+    arrangeExistingBotThread()
+    mockGetMessageByChannelAndSeq
+      .mockResolvedValueOnce({ id: "root_1", authorId: "u_root" })
+      .mockResolvedValueOnce(null)
+
+    const res = await POST(botPostReq({
+      channel: "/demo#0042/text/#1",
+      content: { text: "bad reply" },
+      replyToSeq: 99,
+    }), ctx)
+
+    expect(res.status).toBe(400)
+    expect(mockAddThreadParticipant).not.toHaveBeenCalled()
+    expect(mockHasAlignmentUnreadForAgentScope).not.toHaveBeenCalled()
   })
 
   it("bot send that loses the post-check seq race returns a fresh unaligned envelope", async () => {
@@ -605,7 +719,7 @@ describe("POST /api/community/channels/[id]/messages", () => {
       .mockResolvedValueOnce(19)
       .mockResolvedValueOnce(20)
     mockGetReadState.mockResolvedValue({ lastReadSeq: 19 })
-    mockHasDeliverableUnreadForAgentScope.mockResolvedValue(false)
+    mockHasAlignmentUnreadForAgentScope.mockResolvedValue(false)
     mockCreateMessage.mockResolvedValue(null)
 
     const res = await POST(botPostReq({

--- a/src/web/src/app/api/community/channels/[id]/messages/route.ts
+++ b/src/web/src/app/api/community/channels/[id]/messages/route.ts
@@ -2,7 +2,15 @@ import { NextRequest, NextResponse } from "next/server"
 import { withCommunityActor } from "@/lib/middleware/community-actor"
 import { writeJSON, writeError } from "@/lib/middleware/helpers"
 import { getDb, getPrimaryDb } from "@/lib/db"
-import { queries, withD1Retry, CommunityAgentSendRequestSchema, MAX_FORUM_TAG_LENGTH, utcDayKey } from "@alook/shared"
+import {
+  queries,
+  withD1Retry,
+  CommunityAgentSendRequestSchema,
+  MAX_FORUM_TAG_LENGTH,
+  PARTICIPANT_SOURCE,
+  WS_EVENTS,
+  utcDayKey,
+} from "@alook/shared"
 import {
   parseCursor,
   parseAnchor,
@@ -15,6 +23,7 @@ import { enrichMessages } from "@/lib/community/enrich-messages"
 import { checkRateLimit } from "@/lib/rate-limit"
 import { createCommunityMessage, getCommunityMessageReplay } from "@/lib/community/message-handler"
 import { createMessageWithThread } from "@/lib/community/create-channels"
+import { broadcastToUserSafe } from "@/lib/community/fanout"
 import {
   resolveMessageTarget,
   type MessageTargetDescriptor,
@@ -392,20 +401,9 @@ async function handleBotSend(
     return NextResponse.json({ state: "sent", message, deduped: true })
   }
 
-  const scopeTarget = { channelId }
-  const [latestSeq, readState] = await Promise.all([
-    withD1Retry(() => queries.communityAgentInbox.getLatestSeqForScope(db, channelId), { route: "community/messages:latest-seq" }),
-    withD1Retry(() => queries.communityReadState.getReadState(db, { userId: botUserId, ...scopeTarget }), { route: "community/messages:read-state" }),
-  ])
-  const seen = body.seenUpToSeq ?? readState?.lastReadSeq ?? 0
-  const hasUnread = await withD1Retry(
-    () => queries.communityAgentInbox.hasDeliverableUnreadForAgentScope(db, botUserId, channelId, seen),
-    { route: "community/messages:has-unread" },
-  )
-  if (hasUnread) {
-    return NextResponse.json({ state: "blocked", reason: "unaligned", unreadCount: Math.max(0, latestSeq - seen), latestSeq })
-  }
-
+  // Finish every target-dependent PURE validation before a first-touch thread
+  // join. A bad attachment/reply must not subscribe the bot or emit a member
+  // event for a message that was never eligible to send.
   if (body.attachments.length > 0) {
     const rows = await withD1Retry(
       () => queries.communityAttachment.findPendingAttachmentsForSender(db, { ids: body.attachments, uploaderId: botUserId, targetId: channelId }),
@@ -419,13 +417,56 @@ async function handleBotSend(
   let replyToId: string | undefined
   if (body.replyToSeq !== undefined) {
     const replyTarget = await withD1Retry(
-      () => queries.communityMessage.getMessageByChannelAndSeq(db, scopeTarget, body.replyToSeq!),
+      () => queries.communityMessage.getMessageByChannelAndSeq(db, { channelId }, body.replyToSeq!),
       { route: "community/messages:reply-lookup" },
     )
     if (!replyTarget) {
       return NextResponse.json({ error: `reply target #${body.replyToSeq} not found in ${body.channel}` }, { status: 400 })
     }
     replyToId = replyTarget.id
+  }
+
+  // Access was already proven by resolveMessageTarget. For an existing thread,
+  // establish the independent participant/notify prerequisite BEFORE freshness
+  // evaluation so first-touch backlog can be recovered. This side effect is
+  // intentionally durable even when alignment blocks the send. `added` records
+  // send-intent self-join accurately; a blocked/abandoned attempt never "spoke".
+  if (target.kind === "thread") {
+    const joined = await withD1Retry(
+      () => queries.communityThread.addThreadParticipant(db, {
+        threadChannelId: channelId,
+        userId: botUserId,
+        source: PARTICIPANT_SOURCE.ADDED,
+      }),
+      { route: "community/messages:thread-participant" },
+    )
+    if (joined) {
+      const recipients = await withD1Retry(
+        () => queries.communityThread.listThreadParticipantUserIds(db, channelId),
+        { route: "community/messages:thread-participant-recipients" },
+      )
+      const event = {
+        type: WS_EVENTS.CHANNEL_MEMBER_ADD,
+        serverId: target.serverId,
+        channelId,
+        userId: botUserId,
+      } as const
+      await Promise.all([...new Set(recipients)].map((userId) => broadcastToUserSafe(userId, event)))
+    }
+  }
+
+  const scopeTarget = { channelId }
+  const [latestSeq, readState] = await Promise.all([
+    withD1Retry(() => queries.communityAgentInbox.getLatestSeqForScope(db, channelId), { route: "community/messages:latest-seq" }),
+    withD1Retry(() => queries.communityReadState.getReadState(db, { userId: botUserId, ...scopeTarget }), { route: "community/messages:read-state" }),
+  ])
+  const seen = body.seenUpToSeq ?? readState?.lastReadSeq ?? 0
+  const hasUnread = await withD1Retry(
+    () => queries.communityAgentInbox.hasAlignmentUnreadForAgentScope(db, botUserId, channelId, seen),
+    { route: "community/messages:has-unread" },
+  )
+  if (hasUnread) {
+    return NextResponse.json({ state: "blocked", reason: "unaligned", unreadCount: Math.max(0, latestSeq - seen), latestSeq })
   }
 
   const result = await createCommunityMessage({

--- a/src/web/src/app/api/community/users/me/inbox/pull/route.test.ts
+++ b/src/web/src/app/api/community/users/me/inbox/pull/route.test.ts
@@ -4,7 +4,12 @@ import { NextRequest } from "next/server"
 vi.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: vi.fn(async () => ({ env: { DB: {} } })),
 }))
-vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }))
+const mockGetDb = vi.fn(() => ({ session: "replica" }))
+const mockGetPrimaryDb = vi.fn(() => ({ session: "primary" }))
+vi.mock("@/lib/db", () => ({
+  getDb: (...a: unknown[]) => mockGetDb(...a),
+  getPrimaryDb: (...a: unknown[]) => mockGetPrimaryDb(...a),
+}))
 vi.mock("@/lib/auth", () => ({
   createAuth: vi.fn(() => ({
     api: { getSession: vi.fn(async () => ({ headers: new Headers(), response: null })) },
@@ -15,10 +20,17 @@ const mockFindActiveAgentRunnerKeyByBearer = vi.fn()
 const mockGetUserInternal = vi.fn()
 const mockGetBotBinding = vi.fn()
 const mockListUnreadMessagesForAgent = vi.fn()
+const mockListAlignmentUnreadMessagesForAgentScope = vi.fn()
 const mockListAccessVisibleChannelIdsForUser = vi.fn()
 const mockToAgentMessages = vi.fn()
 const mockListByMessageIds = vi.fn()
 const mockCountMarksForUser = vi.fn()
+const mockGetReadState = vi.fn()
+const mockResolveMessageTarget = vi.fn()
+
+vi.mock("@/lib/community/message-door", () => ({
+  resolveMessageTarget: (...a: unknown[]) => mockResolveMessageTarget(...a),
+}))
 
 vi.mock("@alook/shared", async () => {
   const actual = await vi.importActual<typeof import("@alook/shared")>("@alook/shared")
@@ -32,7 +44,11 @@ vi.mock("@alook/shared", async () => {
       communityAgentInbox: {
         listAccessVisibleChannelIdsForUser: (...a: unknown[]) => mockListAccessVisibleChannelIdsForUser(...a),
         listUnreadMessagesForAgent: (...a: unknown[]) => mockListUnreadMessagesForAgent(...a),
+        listAlignmentUnreadMessagesForAgentScope: (...a: unknown[]) => mockListAlignmentUnreadMessagesForAgentScope(...a),
         toAgentMessages: (...a: unknown[]) => mockToAgentMessages(...a),
+      },
+      communityReadState: {
+        getReadState: (...a: unknown[]) => mockGetReadState(...a),
       },
       communityMessageMark: {
         countMarksForUser: (...a: unknown[]) => mockCountMarksForUser(...a),
@@ -49,7 +65,8 @@ import { POST } from "./route"
 // Bot arm of POST users/me/inbox/pull (folds the flat inboxPull verb). The pull
 // is self-scoped to the voucher's bot (users/me/* family invariant): the body
 // schema is `{ max? }` only — NO target-user param — so a bot can only pull its
-// own inbox. A no-crk_ request falls to the human arm → 401.
+// own inbox. Its optional channel narrows only that same bot's pull to one
+// exact accessible scope. A no-crk_ request falls to the human arm → 401.
 function req(body?: string, headers: Record<string, string> = {}): NextRequest {
   return new NextRequest("http://localhost/api/community/users/me/inbox/pull", {
     method: "POST",
@@ -68,6 +85,11 @@ describe("POST /api/community/users/me/inbox/pull — bot arm (folds inboxPull)"
     mockListByMessageIds.mockResolvedValue([])
     mockListAccessVisibleChannelIdsForUser.mockResolvedValue(["c_1"])
     mockCountMarksForUser.mockResolvedValue(0)
+    mockGetReadState.mockResolvedValue(null)
+    mockResolveMessageTarget.mockResolvedValue({
+      ok: true,
+      value: { target: { kind: "thread", channelId: "thread_1", parentChannelId: "c_1", serverId: "s_1" }, isDm: false },
+    })
   })
 
   it("401 without Authorization (human arm, no session)", async () => {
@@ -94,6 +116,11 @@ describe("POST /api/community/users/me/inbox/pull — bot arm (folds inboxPull)"
     expect(mockCountMarksForUser).toHaveBeenCalledWith(expect.anything(), "bot_1", {
       visibleChannelIds: ["c_1"],
     })
+    expect(mockListUnreadMessagesForAgent).toHaveBeenCalledWith(
+      { session: "replica" },
+      "bot_1",
+      expect.anything(),
+    )
   })
 
   it("hasMore + probe-row trim behave (unread > max)", async () => {
@@ -102,6 +129,64 @@ describe("POST /api/community/users/me/inbox/pull — bot arm (folds inboxPull)"
     const body = await res.json()
     expect(body.hasMore).toBe(true)
     expect(body.messages).toHaveLength(2)
+  })
+
+  it("exact-target pull resolves without create and uses the shared alignment row core after read state", async () => {
+    mockGetReadState.mockResolvedValue({ lastReadSeq: 7 })
+    mockListAlignmentUnreadMessagesForAgentScope.mockResolvedValue([{ id: "m_8", seq: 8 }])
+
+    const res = await POST(req(
+      JSON.stringify({ max: 5, channel: "/demo#0042/general/#12" }),
+      { Authorization: "Bearer crk_abc" },
+    ))
+
+    expect(res.status).toBe(200)
+    expect(mockResolveMessageTarget).toHaveBeenCalledWith(
+      expect.anything(),
+      "bot_1",
+      { ref: "/demo#0042/general/#12" },
+      "bot",
+    )
+    expect(mockListAlignmentUnreadMessagesForAgentScope).toHaveBeenCalledWith(
+      { session: "primary" },
+      "bot_1",
+      "thread_1",
+      { afterSeq: 7, max: 6 },
+    )
+    expect(mockListUnreadMessagesForAgent).not.toHaveBeenCalled()
+    expect(mockResolveMessageTarget).toHaveBeenCalledWith(
+      { session: "primary" },
+      "bot_1",
+      expect.anything(),
+      "bot",
+    )
+  })
+
+  it("exact-target pull preserves bounded pagination and trims only the probe row", async () => {
+    mockListAlignmentUnreadMessagesForAgentScope.mockResolvedValue([
+      { id: "m_1", seq: 1 },
+      { id: "m_2", seq: 2 },
+      { id: "m_3", seq: 3 },
+    ])
+    const res = await POST(req(
+      JSON.stringify({ max: 2, channel: "/demo#0042/general" }),
+      { Authorization: "Bearer crk_abc" },
+    ))
+    await expect(res.json()).resolves.toMatchObject({
+      messages: [{ id: "m_1", seq: 1 }, { id: "m_2", seq: 2 }],
+      hasMore: true,
+    })
+  })
+
+  it("exact-target pull rejects an inaccessible target before unread queries", async () => {
+    mockResolveMessageTarget.mockResolvedValue({ ok: false, status: 404, error: "channel not found" })
+    const res = await POST(req(
+      JSON.stringify({ channel: "/demo#0042/private" }),
+      { Authorization: "Bearer crk_abc" },
+    ))
+    expect(res.status).toBe(404)
+    expect(mockListAlignmentUnreadMessagesForAgentScope).not.toHaveBeenCalled()
+    expect(mockListUnreadMessagesForAgent).not.toHaveBeenCalled()
   })
 
   it("returns the numeric markedCount in the HTTP response unchanged", async () => {

--- a/src/web/src/app/api/community/users/me/inbox/pull/route.ts
+++ b/src/web/src/app/api/community/users/me/inbox/pull/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse, type NextRequest } from "next/server"
 import { queries, withD1Retry, CommunityAgentInboxPullRequestSchema } from "@alook/shared"
-import { getDb } from "@/lib/db"
+import { getDb, getPrimaryDb } from "@/lib/db"
 import { log } from "@/lib/logger"
 import { withCommunityActor, requireBot } from "@/lib/middleware/community-actor"
+import { resolveMessageTarget } from "@/lib/community/message-door"
 
 const MAX_PULL = 200
 
@@ -27,9 +28,7 @@ export const POST = withCommunityActor(async (req: NextRequest, ctx) => {
   if (!gate.ok) return gate.response
   const { userId: botUserId } = gate.bot
 
-  const db = getDb(ctx.env.DB)
-
-  // Body is optional (`InboxPullRequest = { max? }`) — an empty/missing body is
+  // Body is optional (`InboxPullRequest = { max?, channel? }`) — an empty/missing body is
   // equivalent to `{}`, not a 400. Only a body that parses to JSON but fails
   // schema validation (e.g. `max` out of range) is rejected.
   let raw: unknown = {}
@@ -44,6 +43,32 @@ export const POST = withCommunityActor(async (req: NextRequest, ctx) => {
     return NextResponse.json({ error: "invalid payload", details: parsed.error.flatten() }, { status: 400 })
   }
   const max = Math.min(parsed.data.max ?? MAX_PULL, MAX_PULL)
+  // Targeted pull is the recovery sibling of the primary-backed send gate, so
+  // its readState + alignment rows must come from a primary session too. A
+  // replica-lagged "caught up" page would bounce immediately back to blocked
+  // on the next send. Ordinary passive inbox pull stays replica-capable.
+  const db = parsed.data.channel ? getPrimaryDb(ctx.env.DB) : getDb(ctx.env.DB)
+
+  // Exact-target pull is an explicit catch-up operation, not passive inbox
+  // delivery. Resolve/access-mask the ref without create-if-missing before any
+  // query; a stale DM/thread ref must never materialize state as a read side
+  // effect. The ordinary unscoped branch below remains notification-filtered.
+  let targetedChannelId: string | undefined
+  if (parsed.data.channel) {
+    const resolved = await resolveMessageTarget(
+      db,
+      botUserId,
+      { ref: parsed.data.channel },
+      "bot",
+    )
+    if (!resolved.ok) {
+      return NextResponse.json(
+        { error: resolved.error, ...(resolved.hint ? { hint: resolved.hint } : {}) },
+        { status: resolved.status },
+      )
+    }
+    targetedChannelId = resolved.value.target.channelId
+  }
 
   const visibleChannelIds = await withD1Retry(
     () => queries.communityAgentInbox.listAccessVisibleChannelIdsForUser(db, botUserId),
@@ -63,15 +88,30 @@ export const POST = withCommunityActor(async (req: NextRequest, ctx) => {
     })
     return 0
   })
+  const rowsPromise = targetedChannelId
+    ? withD1Retry(async () => {
+        const readState = await queries.communityReadState.getReadState(
+          db,
+          { userId: botUserId, channelId: targetedChannelId! },
+        )
+        return queries.communityAgentInbox.listAlignmentUnreadMessagesForAgentScope(
+          db,
+          botUserId,
+          targetedChannelId!,
+          { afterSeq: readState?.lastReadSeq ?? 0, max: max + 1 },
+        )
+      }, { route: "community/users/me/inbox/pull:list-target-unread" })
+    : withD1Retry(
+        () => queries.communityAgentInbox.listUnreadMessagesForAgent(
+          db,
+          botUserId,
+          { max: max + 1, visibleChannelIds },
+        ),
+        { route: "community/users/me/inbox/pull:list-unread" },
+      )
+
   const [rows, markedCount] = await Promise.all([
-    withD1Retry(
-      () => queries.communityAgentInbox.listUnreadMessagesForAgent(
-        db,
-        botUserId,
-        { max: max + 1, visibleChannelIds },
-      ),
-      { route: "community/users/me/inbox/pull:list-unread" },
-    ),
+    rowsPromise,
     markedCountPromise,
   ])
   const hasMore = rows.length > max


### PR DESCRIPTION
## Summary

- share one exact-target alignment query core between the send gate and targeted inbox pull
- self-join an accessible existing thread before alignment, after attachment/reply validation, and emit one canonical member-add event
- add primary-backed `inbox pull --channel <ref>` recovery while keeping ordinary pull semantics unchanged
- cover access/server-join baselines, self-authored rows, pagination, mute behavior, and nonce retry with SQLite and end-to-end journeys

## Validation

- architecture review: PASS
- real HTTP + credential proxy + D1 journey QA: PASS
- shared focused suite: 87 PASS
- web focused suite: 87 PASS
- daemon focused suite: 202 PASS
- full pre-commit typecheck, lint, tests, CI scripts, typegrep, and knip: PASS
- exact reviewed head: `2aef17edbebdb46f440c1295ea5bb0caea5267a4`

Draft only; merge is not authorized yet.