### PR TITLE
test(web): isolate shared UI fixtures

### DIFF
--- a/src/web/src/test/e2e-ui/13-mentions.spec.ts
+++ b/src/web/src/test/e2e-ui/13-mentions.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, userId } from "./_fixtures/community-fixture"
+import { test, expect, userId, userName } from "./_fixtures/community-fixture"
 import { tid } from "./_fixtures/testids"
 import { composerEditable } from "./_fixtures/actions"
 import {
@@ -21,6 +21,7 @@ import {
 // its own auto-assigned discriminator — so the same journey exercises the
 // spaced-name pill and the same-name disambiguation.
 test.describe.serial("mentions — mandatory discriminator", () => {
+  const identityKeys = ["alice", "bob", "carol"] as const
   let serverId: string
   let channelId: string
   let bob: { id: string; discriminator: string }
@@ -38,6 +39,26 @@ test.describe.serial("mentions — mandatory discriminator", () => {
     // Distinct discriminators are what the disambiguation hinges on — if the
     // two happened to collide the journey couldn't prove per-user resolution.
     expect(bob.discriminator).not.toBe(carol.discriminator)
+  })
+
+  test.afterAll(async () => {
+    const restorations = await Promise.allSettled(identityKeys.map(async (key) => {
+      await renameUser(key, userName(key))
+      return key
+    }))
+    const verifiedMembers = await Promise.allSettled(identityKeys.map(async (key) => {
+      const member = await memberInfo("alice", serverId, userId(key))
+      return { key, name: member.name }
+    }))
+
+    expect(restorations).toEqual(identityKeys.map((key) => ({
+      status: "fulfilled",
+      value: key,
+    })))
+    expect(verifiedMembers).toEqual(identityKeys.map((key) => ({
+      status: "fulfilled",
+      value: { key, name: userName(key) },
+    })))
   })
 
   // Types `@John`, waits for the popup, and picks the member whose row id is

--- a/src/web/src/test/e2e-ui/29-multi-device-read-state.spec.ts
+++ b/src/web/src/test/e2e-ui/29-multi-device-read-state.spec.ts
@@ -77,6 +77,11 @@ test("one human account converges read state across two browser profiles", async
   await expect(deviceB.page.getByTestId(tid.inboxUnreadDm(dmId))).toBeVisible({ timeout: 20_000 })
   await expect(deviceB.page.getByTestId(tid.inboxUnreadChannel(channelId))).toBeVisible({ timeout: 20_000 })
 
+  const expectJourneyUnreadsCleared = async () => {
+    await expect(deviceB.page.getByTestId(tid.inboxUnreadChannel(channelId))).toHaveCount(0)
+    await expect(deviceB.page.getByTestId(tid.inboxUnreadDm(dmId))).toHaveCount(0)
+  }
+
   const accountSnapshot = async () => await (await deviceB.page.request.get(
     "/api/community/users/me/read-state",
   )).json() as {
@@ -149,8 +154,7 @@ test("one human account converges read state across two browser profiles", async
   await expect.poll(() => readStateEventsSince(proxyB.frames, dmFrameStart).length,
     { timeout: 20_000 }).toBeGreaterThan(0)
   expect((await dmRepair).status()).toBe(200)
-  await expect(deviceB.page.getByTestId(tid.inboxUnreadDm(dmId))).toHaveCount(0)
-  await expect(deviceB.page.getByText("Caught up", { exact: true })).toBeVisible()
+  await expectJourneyUnreadsCleared()
   await deviceA.page.waitForTimeout(1_200) // duplicate DM-read repair exclusion window
   expect(dmResponses).toEqual([200])
   const afterDmRead = await accountSnapshot()
@@ -164,7 +168,7 @@ test("one human account converges read state across two browser profiles", async
   const firstReadFrame = orderedReadFrames[0]
   expect(firstReadFrame).toBeTruthy()
   proxyB.replay(firstReadFrame!)
-  await expect(deviceB.page.getByText("Caught up", { exact: true })).toBeVisible()
+  await expectJourneyUnreadsCleared()
 
   await seedMessage("alice", channelId, `offline channel ${stamp}`)
   await seedDmMessage("alice", dmId, `offline dm ${stamp}`)
@@ -239,7 +243,9 @@ test("one human account converges read state across two browser profiles", async
     .slice(start)
     .flatMap((frame) => communityFrameEvents(frame))
     .filter((event): event is CapturedReadStateEvent => (
-      isCapturedReadStateEvent(event) && event.type === "community:inbox.changed"
+      isCapturedReadStateEvent(event)
+      && event.type === "community:inbox.changed"
+      && event.reason === "read_all"
     ))
   await expect.poll(() => readAllEvents(proxyA.frames, readAllFrameStarts[0]!).length, {
     timeout: 20_000,


### PR DESCRIPTION
## Summary

- restore Alice, Bob, and Carol's shared seeded display names after the mentions journey, with authoritative member read-back
- scope the multi-device read-state journey to its own channel and DM instead of assuming a globally empty shared inbox
- correlate concurrent channel/DM read-all WebSocket events by `reason: "read_all"`, excluding the separate mention cleanup event

## Why

PR #565's added weighted UI spec changed the greedy shard order and exposed two pre-existing shared-fixture leaks: spec 22 leaves unrelated unread fixtures before spec 29, and spec 13 left shared user names mutated before spec 30. Production WebSocket and profile behavior are unchanged.

## Validation

- exact generated shard 1: 19/19
- exact generated shard 2: 10/10
- focused spec 29: 6/6
- ordered 22 → 29: 11/11
- ordered 13 → 30: 5/5
- Web lint/typecheck: pass
- repository typecheck/test and commit hooks: pass
- independent real `/c` QA: pass with D1/API/WS/identity evidence

Plan: `/Users/gustavoye/Desktop/memodb_w/alook/plans/mainline-ui-e2e-isolation.md` (SHA-256 `4b8506cacbdb458bd1742d41e4d4ff70c80aed0ff93036449345bdbd2a88bd86`)
