### PR TITLE
fix(web): correct mobile keyboard popover positioning

### DIFF
--- a/src/web/src/hooks/use-anchored-popover.test.ts
+++ b/src/web/src/hooks/use-anchored-popover.test.ts
@@ -14,18 +14,16 @@ function rect(top: number, left: number, height = 16): AnchorRect {
 }
 
 describe("anchoredPopoverStyle", () => {
-  it("converts visual coordinates to layout-fixed coordinates exactly once", () => {
+  it("keeps layout coordinates unchanged inside a non-zero visual viewport", () => {
     const style = anchoredPopoverStyle(rect(400, 40), VIEWPORT, 256, 240)
-    expect(style.top).toBe(496)
-    expect(style.left).toBe(60)
-    expect(Number(style.top) - VIEWPORT.top).toBe(396)
-    expect(Number(style.left) - VIEWPORT.left).toBe(40)
+    expect(style.top).toBe(396)
+    expect(style.left).toBe(40)
     expect(style.transform).toBe("translateY(-100%)")
     expect(style["--anchored-popover-max-height"]).toBe("240px")
   })
 
   it("flips below a caret near the visual viewport top", () => {
-    const style = anchoredPopoverStyle(rect(20, 40), VIEWPORT, 256, 240)
+    const style = anchoredPopoverStyle(rect(120, 40), VIEWPORT, 256, 240)
     expect(style.top).toBe(140)
     expect(Number(style.top) - VIEWPORT.top).toBe(40)
     expect(style.transform).toBeUndefined()
@@ -38,9 +36,24 @@ describe("anchoredPopoverStyle", () => {
 
   it("uses the roomier side and reduces list height when neither side fully fits", () => {
     const shortViewport = { top: 100, left: 0, width: 320, height: 220 }
-    const style = anchoredPopoverStyle(rect(80, 20), shortViewport, 256, 240)
+    const style = anchoredPopoverStyle(rect(180, 20), shortViewport, 256, 240)
     expect(style.transform).toBeUndefined()
     expect(style["--anchored-popover-max-height"]).toBe("102px")
+  })
+
+  it("does not add the keyboard-panned viewport offset to the fixed anchor", () => {
+    const keyboardViewport = { top: 364, left: 0, width: 390, height: 480 }
+    const style = anchoredPopoverStyle(rect(797, 76, 21), keyboardViewport, 256, 240)
+    expect(style.top).toBe(793)
+    expect(style.left).toBe(76)
+    expect(style.transform).toBe("translateY(-100%)")
+  })
+
+  it("keeps the left margin when the visible viewport is narrower than the popup", () => {
+    const narrowViewport = { top: 100, left: 50, width: 200, height: 300 }
+    const style = anchoredPopoverStyle(rect(220, 200), narrowViewport, 256, 240)
+    expect(style.left).toBe(58)
+    expect(style.maxWidth).toBe(184)
   })
 
   it("keeps zero-offset desktop geometry unchanged", () => {

--- a/src/web/src/hooks/use-anchored-popover.ts
+++ b/src/web/src/hooks/use-anchored-popover.ts
@@ -144,23 +144,20 @@ export function anchoredPopoverStyle(
   popupWidth: number,
   popupMaxHeight: number,
 ): AnchoredPopoverStyle {
-  // `getBoundingClientRect()` / TipTap's `clientRect()` report coordinates in
-  // the visual viewport, while iOS lays out `position: fixed` descendants
-  // against the layout viewport. Convert only the final CSS coordinates back
-  // to layout space; all fit calculations stay in visual-viewport space.
-  const minVisibleLeft = VIEWPORT_MARGIN
+  const viewportRight = viewport.left + viewport.width
+  const viewportBottom = viewport.top + viewport.height
+  const minVisibleLeft = viewport.left + VIEWPORT_MARGIN
   const maxVisibleLeft = Math.max(
     minVisibleLeft,
-    viewport.width - popupWidth - VIEWPORT_MARGIN,
+    viewportRight - popupWidth - VIEWPORT_MARGIN,
   )
-  const visibleLeft = Math.min(
+  const left = Math.min(
     Math.max(rect.left, minVisibleLeft),
     maxVisibleLeft,
   )
-  const left = viewport.left + visibleLeft
 
-  const spaceAbove = rect.top
-  const spaceBelow = viewport.height - rect.bottom
+  const spaceAbove = rect.top - viewport.top
+  const spaceBelow = viewportBottom - rect.bottom
   const fullHeight = popupMaxHeight + POPOVER_CHROME_HEIGHT + POPOVER_GAP + VIEWPORT_MARGIN
   const placeBelow = spaceAbove < fullHeight
     && (spaceBelow >= fullHeight || spaceBelow > spaceAbove)
@@ -176,10 +173,10 @@ export function anchoredPopoverStyle(
   }
 
   return placeBelow
-    ? { ...common, top: viewport.top + rect.bottom + POPOVER_GAP }
+    ? { ...common, top: rect.bottom + POPOVER_GAP }
     : {
         ...common,
-        top: viewport.top + rect.top - POPOVER_GAP,
+        top: rect.top - POPOVER_GAP,
         transform: "translateY(-100%)",
       }
 }

--- a/src/web/src/test/e2e-ui/31-mention-candidate-pagination.spec.ts
+++ b/src/web/src/test/e2e-ui/31-mention-candidate-pagination.spec.ts
@@ -32,7 +32,35 @@ test("@ candidates page to completion, expose first search page, and keep status
   const serverId = await seedServer("alice", `Mention pages ${Date.now()}`)
   const channelId = await seedChannel("alice", serverId, "mention-pages")
   const { page } = await asUser("alice")
-  await page.setViewportSize({ width: 390, height: 640 })
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.addInitScript(() => {
+    const geometry = {
+      offsetTop: 0,
+      offsetLeft: 0,
+      width: 390,
+      height: 844,
+    }
+    const viewport = new EventTarget()
+    for (const property of ["offsetTop", "offsetLeft", "width", "height"] as const) {
+      Object.defineProperty(viewport, property, {
+        configurable: true,
+        get: () => geometry[property],
+      })
+    }
+    Object.defineProperty(viewport, "scale", { configurable: true, value: 1 })
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: viewport,
+    })
+    Object.defineProperty(window, "__setMentionTestVisualViewport", {
+      configurable: true,
+      value: (next: Partial<typeof geometry>) => {
+        Object.assign(geometry, next)
+        viewport.dispatchEvent(new Event("resize"))
+        viewport.dispatchEvent(new Event("scroll"))
+      },
+    })
+  })
 
   const browse = Array.from({ length: 12 }, (_, index) => candidate("Browse", index + 1))
   const matches = Array.from({ length: 205 }, (_, index) => candidate("CapMatch", index + 1))
@@ -110,22 +138,54 @@ test("@ candidates page to completion, expose first search page, and keep status
   await expect(page.getByTestId(tid.mentionOption(matches[204]!.id))).toHaveCount(1)
   await expect(mentionOptions).toHaveCount(205)
 
-  const bounds = await page.getByTestId(tid.mentionPopup).evaluate((element) => {
-    const rect = element.getBoundingClientRect()
+  const readBounds = () => page.getByTestId(tid.mentionPopup).evaluate((element) => {
+    const popup = element.getBoundingClientRect()
+    const selection = window.getSelection()
+    if (!selection || selection.rangeCount === 0) throw new Error("Missing composer caret")
+    const caret = selection.getRangeAt(0).getBoundingClientRect()
     const viewport = window.visualViewport
     return {
-      top: rect.top,
-      bottom: rect.bottom,
-      left: rect.left,
-      right: rect.right,
-      width: viewport?.width ?? window.innerWidth,
-      height: viewport?.height ?? window.innerHeight,
+      popup: {
+        top: popup.top,
+        bottom: popup.bottom,
+        left: popup.left,
+        right: popup.right,
+      },
+      caret: { top: caret.top, bottom: caret.bottom },
+      viewport: {
+        top: viewport?.offsetTop ?? 0,
+        bottom: (viewport?.offsetTop ?? 0) + (viewport?.height ?? window.innerHeight),
+        left: viewport?.offsetLeft ?? 0,
+        right: (viewport?.offsetLeft ?? 0) + (viewport?.width ?? window.innerWidth),
+      },
     }
   })
-  expect(bounds.top).toBeGreaterThanOrEqual(0)
-  expect(bounds.left).toBeGreaterThanOrEqual(0)
-  expect(bounds.bottom).toBeLessThanOrEqual(bounds.height)
-  expect(bounds.right).toBeLessThanOrEqual(bounds.width)
+
+  const expectAnchoredAbove = (bounds: Awaited<ReturnType<typeof readBounds>>) => {
+    expect(bounds.caret.top).toBeGreaterThanOrEqual(bounds.viewport.top)
+    expect(bounds.caret.bottom).toBeLessThanOrEqual(bounds.viewport.bottom)
+    expect(bounds.popup.top).toBeGreaterThanOrEqual(bounds.viewport.top)
+    expect(bounds.popup.bottom).toBeLessThanOrEqual(bounds.viewport.bottom)
+    expect(bounds.popup.left).toBeGreaterThanOrEqual(bounds.viewport.left)
+    expect(bounds.popup.right).toBeLessThanOrEqual(bounds.viewport.right)
+    expect(bounds.popup.bottom - bounds.caret.top).toBeGreaterThanOrEqual(-5)
+    expect(bounds.popup.bottom - bounds.caret.top).toBeLessThanOrEqual(-3)
+  }
+
+  expectAnchoredAbove(await readBounds())
+  await page.evaluate(() => {
+    const setViewport = Reflect.get(window, "__setMentionTestVisualViewport") as
+      | ((geometry: { offsetTop: number; height: number }) => void)
+      | undefined
+    if (!setViewport) throw new Error("Missing controlled visual viewport")
+    setViewport({ offsetTop: 364, height: 480 })
+  })
+  await page.evaluate(() => new Promise<void>((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+  }))
+  expectAnchoredAbove(await readBounds())
+  await page.waitForTimeout(250)
+  expectAnchoredAbove(await readBounds())
 
   await page.keyboard.press("Escape")
   await editable.press("ControlOrMeta+A")


### PR DESCRIPTION
# Why we need this PR?

When the mobile keyboard pans the visual viewport, anchored composer popovers can move below the visible screen. The shared helper mixed layout-viewport caret coordinates with visual-viewport offsets and added `offsetTop`/`offsetLeft` twice. In the reproduced 390px case, the popup was displaced downward by exactly the `364px` viewport offset.

# What changed

- Defined anchor rects and fixed CSS coordinates in layout-viewport CSS pixels.
- Used `visualViewport` only to define the visible fit/clamp bounds.
- Preserved the existing above-first placement, roomier-side fallback, narrow-viewport guard, event subscriptions, RAF refresh, and 200ms settle refresh.
- Added unit coverage for non-zero top/left, the exact keyboard reproduction, ultra-narrow clamping, flip/shrink behavior, and zero-origin regressions.
- Extended the existing #31 Playwright journey with one controllable pre-navigation visual viewport that switches to `height=480, offsetTop=364` and verifies real caret/popup geometry immediately and after settle.

The product helper is shared by four verified entry families: forum/community `@`, community channel-reference `/`, agent-chat `/`, and agent-chat `@`. No consumer state, API, loading behavior, schema, or dependency changed.

The PR changes exactly three files:

- `src/web/src/hooks/use-anchored-popover.ts`
- `src/web/src/hooks/use-anchored-popover.test.ts`
- `src/web/src/test/e2e-ui/31-mention-candidate-pagination.spec.ts`

## Verification

- Focused unit: 9/9 passed.
- Focused #31 Playwright: 1/1 passed on the final base.
- `pnpm typecheck`: 11/11 tasks passed.
- Full pre-commit hook passed: typecheck, lint, tests, typegrep checks, and knip.
- Two independent QA gates passed. At `390×480, offsetTop=364`, forum `@`, community `/`, agent `/`, and agent `@` all kept the caret and popup inside `[364,844]`; immediate and settled anchor gaps were exactly `-4px`.
- Final QA teardown restored state; backup was absent and service/inspector ports were free.

## Checklist

- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...
