### PR TITLE
fix(web): hydrate canonical self profile name

### DIFF
--- a/src/web/src/app/api/community/users/me/profile/route.test.ts
+++ b/src/web/src/app/api/community/users/me/profile/route.test.ts
@@ -83,7 +83,12 @@ describe("GET /api/community/users/me/profile", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     actorKind = "human"
-    getUser.mockResolvedValue({ id: "u1", discriminator: "4242", image: "/api/community/users/u1/avatar" })
+    getUser.mockResolvedValue({
+      id: "u1",
+      name: "Jane Roe",
+      discriminator: "4242",
+      image: "/api/community/users/u1/avatar",
+    })
   })
 
   it("returns defaults when no profile row exists", async () => {
@@ -95,12 +100,13 @@ describe("GET /api/community/users/me/profile", () => {
       avatar: "/api/community/users/u1/avatar",
       bannerColor: null,
       discriminator: "4242",
+      name: "Jane Roe",
       statusEmoji: null,
       statusText: "",
     })
   })
 
-  it("returns the stored profile fields when they exist", async () => {
+  it("returns the canonical user name and stored profile fields when they exist", async () => {
     getProfile.mockResolvedValue({ aboutMe: "hi", bannerColor: "#aabbcc", statusEmoji: "🎧", statusText: "Vibing" })
     const res = await GET(new NextRequest("http://localhost/api/community/users/me/profile"), {} as never)
     expect(await res.json()).toEqual({
@@ -108,6 +114,7 @@ describe("GET /api/community/users/me/profile", () => {
       avatar: "/api/community/users/u1/avatar",
       bannerColor: "#aabbcc",
       discriminator: "4242",
+      name: "Jane Roe",
       statusEmoji: "🎧",
       statusText: "Vibing",
     })
@@ -122,6 +129,7 @@ describe("GET /api/community/users/me/profile", () => {
       avatar: "",
       bannerColor: null,
       discriminator: "0000",
+      name: "",
       statusEmoji: null,
       statusText: "",
     })

--- a/src/web/src/app/api/community/users/me/profile/route.ts
+++ b/src/web/src/app/api/community/users/me/profile/route.ts
@@ -33,6 +33,7 @@ export const GET = withCommunityActor(async (_req, ctx) => {
     avatar: viewer?.image ?? "",
     bannerColor: profile?.bannerColor ?? null,
     discriminator: viewer?.discriminator ?? "0000",
+    name: viewer?.name ?? "",
     statusEmoji: profile?.statusEmoji ?? null,
     statusText: profile?.statusText ?? "",
   })

--- a/src/web/src/app/c/community-shell.identity.test.ts
+++ b/src/web/src/app/c/community-shell.identity.test.ts
@@ -2,9 +2,35 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import React, { useState } from "react"
 import TestRenderer, { act } from "react-test-renderer"
 
-let activeUser = { id: "user-a", name: "A", email: "a@example.com", avatar: "A" }
+type TestUser = {
+  id: string
+  name: string
+  email: string
+  avatar: string
+  aboutMe?: string
+  discriminator?: string
+  statusEmoji?: string | null
+  statusText?: string | null
+}
+
+type ProfileResponse = {
+  aboutMe: string
+  avatar: string
+  discriminator: string
+  name: string
+  statusEmoji: string | null
+  statusText: string
+}
+
+let activeUser: TestUser = { id: "user-a", name: "A", email: "a@example.com", avatar: "A" }
 let providerInstance = 0
 const renderedProviders: Array<{ userId: string | null; instance: number }> = []
+const { apiFetch } = vi.hoisted(() => ({
+  apiFetch: vi.fn<() => Promise<ProfileResponse>>(),
+}))
+const setCurrentUser = vi.fn((updater: (user: TestUser) => TestUser) => {
+  activeUser = updater(activeUser)
+})
 
 vi.mock("./QueryProvider", () => ({
   QueryProvider: ({ children, userId }: { children: React.ReactNode; userId: string | null }) => {
@@ -19,10 +45,10 @@ vi.mock("./QueryProvider", () => ({
 vi.mock("@/contexts/community/current-user", () => ({
   CurrentUserProvider: ({ children }: { children: React.ReactNode }) => children,
   useCurrentUser: () => activeUser,
-  useSetCurrentUser: () => vi.fn(),
+  useSetCurrentUser: () => setCurrentUser,
 }))
 vi.mock("@/hooks/community/use-community-ws", () => ({ useCommunityWs: vi.fn() }))
-vi.mock("@/lib/api/client", () => ({ apiFetch: vi.fn(() => new Promise(() => undefined)) }))
+vi.mock("@/lib/api/client", () => ({ apiFetch }))
 vi.mock("@/components/perf/perf-trace-bootstrap", () => ({ PerfTraceBootstrap: () => null }))
 vi.mock("@/components/community/onboarding/community-onboarding-guide", () => ({
   CommunityOnboardingGuide: () => null,
@@ -34,6 +60,9 @@ beforeEach(() => {
   activeUser = { id: "user-a", name: "A", email: "a@example.com", avatar: "A" }
   providerInstance = 0
   renderedProviders.length = 0
+  apiFetch.mockReset()
+  apiFetch.mockImplementation(() => new Promise(() => undefined))
+  setCurrentUser.mockClear()
 })
 
 describe("CommunityShell identity boundary", () => {
@@ -59,6 +88,72 @@ describe("CommunityShell identity boundary", () => {
 
     expect(renderedProviders.at(-1)).toEqual({ userId: "user-b", instance: 2 })
     expect(userAInstance).toBe(1)
+    renderer.unmount()
+  })
+
+  it("hydrates a stale session name from the canonical self profile", async () => {
+    activeUser = { id: "user-a", name: "Alice", email: "a@example.com", avatar: "old-avatar" }
+    apiFetch.mockResolvedValueOnce({
+      aboutMe: "hello",
+      avatar: "new-avatar",
+      discriminator: "4242",
+      name: "Jane Roe",
+      statusEmoji: "🌱",
+      statusText: "Growing",
+    })
+
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(React.createElement(
+        CommunityShell,
+        { currentUser: activeUser },
+        React.createElement("span", null, "content"),
+      ))
+      await Promise.resolve()
+    })
+
+    expect(apiFetch).toHaveBeenCalledWith("/api/community/users/me/profile")
+    expect(setCurrentUser).toHaveBeenCalledOnce()
+    expect(activeUser).toMatchObject({
+      name: "Jane Roe",
+      aboutMe: "hello",
+      avatar: "new-avatar",
+      discriminator: "4242",
+      statusEmoji: "🌱",
+      statusText: "Growing",
+    })
+    renderer.unmount()
+  })
+
+  it("preserves the session name when the self profile has no canonical name", async () => {
+    activeUser = { id: "user-a", name: "Alice", email: "a@example.com", avatar: "old-avatar" }
+    apiFetch.mockResolvedValueOnce({
+      aboutMe: "hello",
+      avatar: "",
+      discriminator: "4242",
+      name: "",
+      statusEmoji: null,
+      statusText: "",
+    })
+
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(React.createElement(
+        CommunityShell,
+        { currentUser: activeUser },
+        React.createElement("span", null, "content"),
+      ))
+      await Promise.resolve()
+    })
+
+    expect(activeUser).toMatchObject({
+      name: "Alice",
+      aboutMe: "hello",
+      avatar: "old-avatar",
+      discriminator: "4242",
+      statusEmoji: null,
+      statusText: "",
+    })
     renderer.unmount()
   })
 })

--- a/src/web/src/app/c/community-shell.tsx
+++ b/src/web/src/app/c/community-shell.tsx
@@ -64,7 +64,7 @@ function CommunityBootstrap({ children }: { children: ReactNode }) {
   // row alongside the community profile fields.
   const currentUserId = currentUser.id
   useEffect(() => {
-    apiFetch<{ aboutMe: string; avatar: string; discriminator: string; statusEmoji: string | null; statusText: string }>(
+    apiFetch<{ aboutMe: string; avatar: string; discriminator: string; name: string; statusEmoji: string | null; statusText: string }>(
       "/api/community/users/me/profile",
     )
       .then((data) => {
@@ -73,6 +73,7 @@ function CommunityBootstrap({ children }: { children: ReactNode }) {
           aboutMe: data.aboutMe,
           avatar: data.avatar || u.avatar,
           discriminator: data.discriminator,
+          name: data.name || u.name,
           statusEmoji: data.statusEmoji,
           statusText: data.statusText,
         }))


### PR DESCRIPTION
# Why we need this PR?
Self profile cards can render a stale session name after the canonical user name has changed. The existing self-profile GET did not return the canonical name, so bootstrap could not refresh `currentUser.name`.

## What changed
- Return the authenticated viewer's canonical `name` from the existing self-profile GET.
- Hydrate the session user with a non-empty canonical name during community bootstrap.
- Preserve the existing session name when the profile response omits or empties `name`.
- Add route and identity regression coverage for canonical-name hydration and fallback behavior.

## Validation
- Focused route + identity tests: 32/32
- Web typecheck: PASS
- Four-file ESLint: PASS
- Root typecheck: 11/11 packages
- Root test: 11/11 package tasks; Web 634 files / 5,568 tests; CI scripts 11 files / 124 tests
- Real stack spec 13→30: 15/15 across three runs
- Two-context stale Alice → canonical Jane Roe journey: PASS, including D1, self GET, owner card, reload, zero hydration PATCHes, and zero identity/member WebSocket events
- Current shard 2 clean rerun: 10/10; teardown clean
- Preserved QA evidence: initial shard 2 run had spec11 intermittent 9/10; isolated spec11 rerun was 3/3 PASS. No scope expansion.

## Checklist
- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other
