### PR TITLE
fix(web): harden picker async states

### DIFF
--- a/scripts/ci/e2e-shards.mjs
+++ b/scripts/ci/e2e-shards.mjs
@@ -41,6 +41,7 @@ export const SPEC_SECONDS = {
   "30-bot-profile-audit-preview.spec.ts": 35,
   "31-mention-candidate-pagination.spec.ts": 10,
   "32-mobile-ws-foreground-validation.spec.ts": 80,
+  "33-picker-async-layout.spec.ts": 57,
 }
 
 function walk(directory) {

--- a/scripts/ci/e2e-shards.test.ts
+++ b/scripts/ci/e2e-shards.test.ts
@@ -70,7 +70,7 @@ describe("planE2eShards", () => {
     expect(first).toHaveLength(E2E_SHARD_COUNT)
     expect([...assigned].sort()).toEqual(specs)
     expect(new Set(assigned).size).toBe(specs.length)
-    expect(totals.sort((left, right) => left - right)).toEqual([234, 238, 238, 239, 239])
+    expect(totals.sort((left, right) => left - right)).toEqual([248, 249, 249, 249, 250])
     expect(Math.max(...totals) / Math.min(...totals)).toBeLessThanOrEqual(1.15)
   })
 

--- a/src/web/src/components/community/members/add-members-dialog.test.ts
+++ b/src/web/src/components/community/members/add-members-dialog.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { createElement } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
+import { readFileSync } from "node:fs"
 
 // Spy on toastApiError so the reject path can be asserted without a real DOM
 // (sonner injects a <style> at import time). Mock before importing the module.
@@ -36,6 +37,16 @@ describe("AddMemberRow", () => {
 
   it("renders the candidate's display name", () => {
     expect(render(false)).toContain("Alice")
+  })
+
+  it("uses the shared resolved/loading/error/retry picker contract", () => {
+    const source = readFileSync(new URL("./add-members-dialog.tsx", import.meta.url), "utf8")
+    expect(source).toContain("resolved: queryState.resolved")
+    expect(source).toContain("loading: queryState.loading")
+    expect(source).toContain("error: queryState.error")
+    expect(source).toContain('errorMessage="Couldn\'t load people."')
+    expect(source).toContain('emptyMessage="Everyone is already here."')
+    expect(source).toContain("onRetry={queryState.retry}")
   })
 })
 

--- a/src/web/src/components/community/members/add-members-dialog.tsx
+++ b/src/web/src/components/community/members/add-members-dialog.tsx
@@ -7,6 +7,13 @@ import { Dialog, DialogContent } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Avatar } from "../avatar"
+import {
+  PeoplePickerBody,
+  PeoplePickerHeader,
+  PeoplePickerRowsSkeleton,
+  resolvePeoplePickerViewState,
+  type PeoplePickerAsyncState,
+} from "../people-picker"
 import { displayName } from "@/lib/community/display-name"
 import { toastApiError } from "@/lib/api/client"
 
@@ -84,12 +91,14 @@ export function AddMembersDialog({
   title,
   subtitle,
   candidates,
+  queryState,
   onAdd,
   onClose,
 }: {
   title: string
   subtitle: string
   candidates: AddableCandidate[]
+  queryState: PeoplePickerAsyncState
   onAdd: (userId: string) => Promise<unknown> | void
   onClose: () => void
 }) {
@@ -104,15 +113,21 @@ export function AddMembersDialog({
     return candidates.filter((m) => (m.name ?? "").toLowerCase().includes(q))
   }, [candidates, query])
 
+  const pickerState = resolvePeoplePickerViewState({
+    resolved: queryState.resolved,
+    loading: queryState.loading,
+    error: queryState.error,
+    sourceCount: candidates.length,
+    visibleCount: filtered.length,
+    query,
+  })
+
   const add = (userId: string) => void runAdd(userId, onAdd, setAddingIds)
 
   return (
     <Dialog open onOpenChange={(o) => { if (!o) onClose() }}>
       <DialogContent className="flex max-h-[80vh] w-full flex-col gap-0 p-0 sm:max-w-md">
-        <header className="border-b border-border/50 px-4 py-3">
-          <h2 className="truncate text-sm font-semibold">{title}</h2>
-          <p className="text-xs text-muted-foreground">{subtitle}</p>
-        </header>
+        <PeoplePickerHeader title={title} subtitle={subtitle} />
 
         <div className="min-h-0 flex-1 overflow-y-auto thin-scrollbar px-2 py-2">
           <label className="relative mx-2 mb-2 block">
@@ -124,20 +139,23 @@ export function AddMembersDialog({
               className="pl-9"
             />
           </label>
-          {filtered.length === 0 ? (
-            <p className="py-4 text-center text-sm text-muted-foreground">
-              {query ? "No matches." : "Everyone is already here."}
-            </p>
-          ) : (
-            filtered.map((m) => (
+          <PeoplePickerBody
+            state={pickerState}
+            loading={<PeoplePickerRowsSkeleton actionClassName="w-14" />}
+            errorMessage="Couldn't load people."
+            emptyMessage="Everyone is already here."
+            retrying={queryState.retrying}
+            onRetry={queryState.retry}
+          >
+            {filtered.map((m) => (
               <AddMemberRow
                 key={m.userId}
                 candidate={m}
                 adding={addingIds.has(m.userId)}
                 onAdd={add}
               />
-            ))
-          )}
+            ))}
+          </PeoplePickerBody>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/web/src/components/community/members/channel-add-members-dialog.test.ts
+++ b/src/web/src/components/community/members/channel-add-members-dialog.test.ts
@@ -1,0 +1,88 @@
+import { createElement } from "react"
+import TestRenderer, { act } from "react-test-renderer"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { AddMembersDialog } from "./add-members-dialog"
+import { ChannelAddMembersDialog } from "./channel-add-members-dialog"
+
+const mocks = vi.hoisted(() => ({
+  members: [{ userId: "user_1", name: "Alice", avatar: "A" }],
+  data: undefined as { members: Array<{ userId: string; name: string; avatar: string }> } | undefined,
+  isLoading: true,
+  isError: false,
+  isFetching: true,
+  refetch: vi.fn(),
+  add: vi.fn(),
+}))
+
+vi.mock("@/hooks/community/use-channel-members", () => ({
+  useAddableMembers: () => ({
+    members: mocks.members,
+    data: mocks.data,
+    isLoading: mocks.isLoading,
+    isError: mocks.isError,
+    isFetching: mocks.isFetching,
+    refetch: mocks.refetch,
+  }),
+  useAddChannelMember: () => ({ mutateAsync: mocks.add }),
+}))
+vi.mock("./add-members-dialog", () => ({
+  AddMembersDialog: vi.fn(() => null),
+}))
+
+const mockedDialog = vi.mocked(AddMembersDialog)
+
+describe("ChannelAddMembersDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.data = undefined
+    mocks.isLoading = true
+    mocks.isError = false
+    mocks.isFetching = true
+    mocks.refetch.mockResolvedValue({})
+    mocks.add.mockResolvedValue({})
+  })
+
+  it("forwards unresolved addable-member state and Retry", () => {
+    act(() => {
+      TestRenderer.create(createElement(ChannelAddMembersDialog, {
+        serverId: "server_1",
+        channelId: "channel_1",
+        channelName: "private",
+        onClose: vi.fn(),
+      }))
+    })
+
+    const props = mockedDialog.mock.calls.at(-1)![0]
+    expect(props.candidates).toEqual(mocks.members)
+    expect(props.queryState).toEqual(expect.objectContaining({
+      resolved: false,
+      loading: true,
+      error: false,
+      retrying: true,
+    }))
+    act(() => props.queryState.retry())
+    expect(mocks.refetch).toHaveBeenCalledTimes(1)
+  })
+
+  it("treats cached data as resolved during a background error", () => {
+    mocks.data = { members: mocks.members }
+    mocks.isLoading = false
+    mocks.isError = true
+    mocks.isFetching = true
+    act(() => {
+      TestRenderer.create(createElement(ChannelAddMembersDialog, {
+        serverId: "server_1",
+        channelId: "channel_1",
+        channelName: "private",
+        onClose: vi.fn(),
+      }))
+    })
+
+    expect(mockedDialog.mock.calls.at(-1)![0].queryState).toEqual(expect.objectContaining({
+      resolved: true,
+      loading: false,
+      error: true,
+      retrying: false,
+    }))
+  })
+})

--- a/src/web/src/components/community/members/channel-add-members-dialog.tsx
+++ b/src/web/src/components/community/members/channel-add-members-dialog.tsx
@@ -23,7 +23,8 @@ export function ChannelAddMembersDialog({
   channelName: string
   onClose: () => void
 }) {
-  const { members: addable } = useAddableMembers(serverId, channelId)
+  const addableQuery = useAddableMembers(serverId, channelId)
+  const { members: addable } = addableQuery
   const addMember = useAddChannelMember(channelId)
 
   const candidates = addable.map((m) => ({
@@ -37,6 +38,13 @@ export function ChannelAddMembersDialog({
       title={`Add members to /${channelName}`}
       subtitle="Added members can see and post in this channel."
       candidates={candidates}
+      queryState={{
+        resolved: addableQuery.data !== undefined,
+        loading: addableQuery.isLoading,
+        error: addableQuery.isError,
+        retrying: addableQuery.data === undefined && addableQuery.isFetching,
+        retry: () => { void addableQuery.refetch() },
+      }}
       onAdd={(userId) => addMember.mutateAsync(userId)}
       onClose={onClose}
     />

--- a/src/web/src/components/community/members/channel-member-view-model.test.ts
+++ b/src/web/src/components/community/members/channel-member-view-model.test.ts
@@ -8,7 +8,19 @@ import { useAddableMembers, useChannelMembers } from "@/hooks/community/use-chan
 const mocks = vi.hoisted(() => ({
   serverMembers: [] as Array<Record<string, unknown>>,
   channelMembers: new Map<string, Array<Record<string, unknown>>>(),
+  channelQueryState: new Map<string, {
+    resolved?: boolean
+    isLoading?: boolean
+    isError?: boolean
+    isFetching?: boolean
+  }>(),
+  channelRefetches: new Map<string, ReturnType<typeof vi.fn>>(),
   addableMembers: [] as Array<Record<string, unknown>>,
+  addableResolved: true,
+  addableLoading: false,
+  addableError: false,
+  addableFetching: false,
+  addableRefetch: vi.fn(),
   onlineUserIds: new Set<string>(),
   userStatuses: new Map<string, { emoji: string | null; text: string }>(),
   serverSearch: vi.fn(),
@@ -36,11 +48,32 @@ vi.mock("@/hooks/community/use-server-members", () => ({
   }),
 }))
 vi.mock("@/hooks/community/use-channel-members", () => ({
-  useChannelMembers: vi.fn((channelId: string) => ({
-    members: mocks.channelMembers.get(channelId) ?? [],
-    isLoading: false,
+  useChannelMembers: vi.fn((channelId: string, enabled = true) => {
+    const members = mocks.channelMembers.get(channelId) ?? []
+    const state = mocks.channelQueryState.get(channelId)
+    const resolved = enabled && (state?.resolved ?? mocks.channelMembers.has(channelId))
+    let refetch = mocks.channelRefetches.get(channelId)
+    if (!refetch) {
+      refetch = vi.fn().mockResolvedValue({})
+      mocks.channelRefetches.set(channelId, refetch)
+    }
+    return {
+      members,
+      data: resolved ? { members } : undefined,
+      isLoading: state?.isLoading ?? (enabled && !resolved && !state?.isError),
+      isError: state?.isError ?? false,
+      isFetching: state?.isFetching ?? false,
+      refetch,
+    }
+  }),
+  useAddableMembers: vi.fn((_serverId: string, _channelId: string, enabled = true) => ({
+    members: mocks.addableMembers,
+    data: enabled && mocks.addableResolved ? { members: mocks.addableMembers } : undefined,
+    isLoading: enabled && mocks.addableLoading,
+    isError: enabled && mocks.addableError,
+    isFetching: enabled && mocks.addableFetching,
+    refetch: mocks.addableRefetch,
   })),
-  useAddableMembers: vi.fn(() => ({ members: mocks.addableMembers })),
   useAddChannelMember: () => ({ mutateAsync: mocks.addChannelMember }),
   useRemoveChannelMember: () => ({ mutateAsync: mocks.removeChannelMember }),
 }))
@@ -134,7 +167,15 @@ describe("useChannelMemberViewModel", () => {
       member("alice_1", "Alice"),
     ]
     mocks.channelMembers = new Map()
+    mocks.channelQueryState = new Map()
+    mocks.channelRefetches = new Map()
     mocks.addableMembers = []
+    mocks.addableResolved = true
+    mocks.addableLoading = false
+    mocks.addableError = false
+    mocks.addableFetching = false
+    mocks.addableRefetch.mockReset()
+    mocks.addableRefetch.mockResolvedValue({})
     mocks.onlineUserIds = new Set()
     mocks.userStatuses = new Map()
     mocks.addChannelMember.mockResolvedValue({})
@@ -294,12 +335,160 @@ describe("useChannelMemberViewModel", () => {
     expect(dialogProps.candidates).toEqual([
       expect.objectContaining({ userId: "bob_1", name: "Bob" }),
     ])
+    expect(dialogProps.queryState).toEqual(expect.objectContaining({
+      resolved: true,
+      loading: false,
+      error: false,
+      retrying: false,
+    }))
     await dialogProps.onAdd("bob_1")
     await latestModel().memberPanelProps.manageContext?.onRemove("alice_1")
     expect(mocks.addThreadParticipant).toHaveBeenCalledWith("bob_1")
     expect(mocks.removeThreadParticipant).toHaveBeenCalledWith("alice_1")
     expect(mocks.addChannelMember).not.toHaveBeenCalled()
     expect(mocks.removeChannelMember).not.toHaveBeenCalled()
+  })
+
+  it("gates thread candidates on both query sources and retries only unresolved sources", () => {
+    mocks.channelMembers.set("thread_1", [
+      member("viewer_1", "Viewer", { isCreator: true }),
+      member("alice_1", "Alice"),
+    ])
+    mocks.channelMembers.set("parent_1", [
+      member("viewer_1", "Viewer"),
+      member("alice_1", "Alice"),
+      member("bob_1", "Bob"),
+    ])
+    mocks.channelQueryState.set("thread_1", { resolved: false, isLoading: true })
+    mocks.channelQueryState.set("parent_1", { resolved: false, isLoading: true })
+    const participantRefetch = vi.fn().mockResolvedValue({})
+    const parentRefetch = vi.fn().mockResolvedValue({})
+    mocks.channelRefetches.set("thread_1", participantRefetch)
+    mocks.channelRefetches.set("parent_1", parentRefetch)
+    const modelProps = props({
+      channelId: "thread_1",
+      channelName: "topic",
+      currentServer: { categories: [{ private: true, channels: [{ id: "parent_1" }] }] },
+      channelInServer: null,
+      currentChannelMeta: { name: "topic", parentChannelId: "parent_1", creatorId: "viewer_1" },
+      isChildChannel: true,
+      isNotifyUnit: true,
+    })
+    let renderer: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(renderHarness(modelProps))
+    })
+    act(() => {
+      latestModel().memberPanelProps.onAddMember?.()
+    })
+
+    let dialogProps = mockedAddMembersDialog.mock.calls.at(-1)![0]
+    expect(dialogProps.candidates).toEqual([])
+    expect(dialogProps.queryState).toEqual(expect.objectContaining({
+      resolved: false,
+      loading: true,
+      error: false,
+    }))
+    act(() => dialogProps.queryState.retry())
+    expect(participantRefetch).toHaveBeenCalledTimes(1)
+    expect(parentRefetch).toHaveBeenCalledTimes(1)
+
+    participantRefetch.mockClear()
+    parentRefetch.mockClear()
+    mocks.channelQueryState.set("thread_1", { resolved: false, isError: true })
+    mocks.channelQueryState.set("parent_1", { resolved: true })
+    act(() => {
+      renderer!.update(renderHarness(modelProps))
+    })
+
+    dialogProps = mockedAddMembersDialog.mock.calls.at(-1)![0]
+    expect(dialogProps.candidates).toEqual([])
+    expect(dialogProps.queryState).toEqual(expect.objectContaining({
+      resolved: false,
+      loading: false,
+      error: true,
+    }))
+    act(() => dialogProps.queryState.retry())
+    expect(participantRefetch).toHaveBeenCalledTimes(1)
+    expect(parentRefetch).not.toHaveBeenCalled()
+
+    participantRefetch.mockClear()
+    parentRefetch.mockClear()
+    mocks.channelQueryState.set("thread_1", { resolved: true })
+    mocks.channelQueryState.set("parent_1", { resolved: false, isLoading: true })
+    act(() => {
+      renderer!.update(renderHarness(modelProps))
+    })
+
+    dialogProps = mockedAddMembersDialog.mock.calls.at(-1)![0]
+    expect(dialogProps.candidates).toEqual([])
+    expect(dialogProps.queryState).toEqual(expect.objectContaining({
+      resolved: false,
+      loading: true,
+      error: false,
+    }))
+    act(() => dialogProps.queryState.retry())
+    expect(participantRefetch).not.toHaveBeenCalled()
+    expect(parentRefetch).toHaveBeenCalledTimes(1)
+
+    participantRefetch.mockClear()
+    parentRefetch.mockClear()
+    mocks.channelQueryState.set("parent_1", { resolved: false, isError: true })
+    act(() => {
+      renderer!.update(renderHarness(modelProps))
+    })
+
+    dialogProps = mockedAddMembersDialog.mock.calls.at(-1)![0]
+    expect(dialogProps.candidates).toEqual([])
+    expect(dialogProps.queryState).toEqual(expect.objectContaining({
+      resolved: false,
+      loading: false,
+      error: true,
+    }))
+    act(() => dialogProps.queryState.retry())
+    expect(participantRefetch).not.toHaveBeenCalled()
+    expect(parentRefetch).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps composite candidates usable during a cached participant background error", () => {
+    mocks.channelMembers.set("thread_1", [
+      member("viewer_1", "Viewer", { isCreator: true }),
+      member("alice_1", "Alice"),
+    ])
+    mocks.channelMembers.set("parent_1", [
+      member("viewer_1", "Viewer"),
+      member("alice_1", "Alice"),
+      member("bob_1", "Bob"),
+    ])
+    mocks.channelQueryState.set("thread_1", {
+      resolved: true,
+      isError: true,
+      isFetching: true,
+    })
+    mocks.channelQueryState.set("parent_1", { resolved: true })
+    act(() => {
+      TestRenderer.create(renderHarness(props({
+        channelId: "thread_1",
+        channelName: "topic",
+        currentServer: { categories: [{ private: true, channels: [{ id: "parent_1" }] }] },
+        channelInServer: null,
+        currentChannelMeta: { name: "topic", parentChannelId: "parent_1", creatorId: "viewer_1" },
+        isChildChannel: true,
+        isNotifyUnit: true,
+      })))
+    })
+    act(() => {
+      latestModel().memberPanelProps.onAddMember?.()
+    })
+
+    const dialogProps = mockedAddMembersDialog.mock.calls.at(-1)![0]
+    expect(dialogProps.candidates.map((candidate) => candidate.userId)).toEqual(["bob_1"])
+    expect(dialogProps.queryState).toEqual(expect.objectContaining({
+      resolved: true,
+      loading: false,
+      error: false,
+      retrying: false,
+    }))
   })
 
   it("preserves server role and kick mutation wiring", async () => {

--- a/src/web/src/components/community/members/channel-member-view-model.tsx
+++ b/src/web/src/components/community/members/channel-member-view-model.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useState, type ComponentProps, type ReactNode } from "react"
+import { useCallback, useEffect, useMemo, useState, type ComponentProps, type ReactNode } from "react"
 import { toast } from "sonner"
 import { isForum, type CommunityRole as Role } from "@alook/shared"
 import { AddMembersDialog } from "@/components/community/members/add-members-dialog"
@@ -132,11 +132,46 @@ export function useChannelMemberViewModel({
   )
   const parentChannelId = isNotifyUnit ? currentChannelMeta?.parentChannelId ?? null : null
   const parentChannelMembersHook = useChannelMembers(parentChannelId ?? "", !!parentChannelId)
+  const participantMembersData = channelMembersHook.data
+  const parentMembersData = parentChannelMembersHook.data
+  const refetchParticipantMembers = channelMembersHook.refetch
+  const refetchParentMembers = parentChannelMembersHook.refetch
+  const participantCandidatesResolved =
+    participantMembersData !== undefined && parentMembersData !== undefined
+  const participantCandidatesError = !participantCandidatesResolved && (
+    (participantMembersData === undefined && channelMembersHook.isError) ||
+    (parentMembersData === undefined && parentChannelMembersHook.isError)
+  )
+  const participantCandidatesLoading =
+    !participantCandidatesResolved && !participantCandidatesError
+  const participantCandidatesRetrying = !participantCandidatesResolved && (
+    (participantMembersData === undefined && channelMembersHook.isFetching) ||
+    (parentMembersData === undefined && parentChannelMembersHook.isFetching)
+  )
+  const retryParticipantCandidates = useCallback(() => {
+    const retries: Array<Promise<unknown>> = []
+    if (participantMembersData === undefined) retries.push(refetchParticipantMembers())
+    if (parentMembersData === undefined) retries.push(refetchParentMembers())
+    void Promise.all(retries)
+  }, [
+    parentMembersData,
+    participantMembersData,
+    refetchParentMembers,
+    refetchParticipantMembers,
+  ])
   const addableChannelMembers = useAddableMembers(
     serverId,
     channelId,
     manageMembersOpen && currentChannelPrivate && !isNotifyUnit,
   )
+  const {
+    data: addableMembersData,
+    isError: addableMembersError,
+    isFetching: addableMembersFetching,
+    isLoading: addableMembersLoading,
+    members: addableMembers,
+    refetch: refetchAddableMembers,
+  } = addableChannelMembers
   const addChannelMemberMut = useAddChannelMember(channelId)
   const removeChannelMemberMut = useRemoveChannelMember(channelId)
   const parentChannel = currentChannelMeta?.parentChannelId
@@ -309,8 +344,10 @@ export function useChannelMemberViewModel({
   const manageMembersDialog = useMemo(() => {
     if (!manageMembersOpen) return null
     if (isNotifyUnit) {
-      const participantIds = new Set(channelMembersHook.members.map((member) => member.userId))
-      const candidates = parentChannelMembersHook.members
+      const participantIds = new Set(
+        participantMembersData?.members.map((member) => member.userId) ?? [],
+      )
+      const candidates = (participantMembersData && parentMembersData ? parentMembersData.members : [])
         .filter((member) => !participantIds.has(member.userId) && member.userId !== currentUser.id)
         .map((member) => ({ userId: member.userId, name: member.name ?? null, avatar: member.avatar }))
       return (
@@ -318,12 +355,19 @@ export function useChannelMemberViewModel({
           title={`Add participants to /${currentChannelMeta?.name ?? channelName}`}
           subtitle="Added people are notified of new replies. Anyone with access can already read it."
           candidates={candidates}
+          queryState={{
+            resolved: participantCandidatesResolved,
+            loading: participantCandidatesLoading,
+            error: participantCandidatesError,
+            retrying: participantCandidatesRetrying,
+            retry: retryParticipantCandidates,
+          }}
           onAdd={(userId) => addThreadParticipantMut.mutateAsync(userId)}
           onClose={() => setMemberUi({ channelId, query: memberQuery, dialogOpen: false })}
         />
       )
     }
-    const candidates = addableChannelMembers.members.map((member) => ({
+    const candidates = addableMembers.map((member) => ({
       userId: member.userId,
       name: member.name ?? null,
       avatar: member.avatar,
@@ -333,6 +377,14 @@ export function useChannelMemberViewModel({
         title={`Add members to /${channelName}`}
         subtitle="Added members can see and post here."
         candidates={candidates}
+        queryState={{
+          resolved: addableMembersData !== undefined,
+          loading: addableMembersLoading,
+          error: addableMembersError,
+          retrying:
+            addableMembersData === undefined && addableMembersFetching,
+          retry: () => { void refetchAddableMembers() },
+        }}
         onAdd={(userId) => addChannelMemberMut.mutateAsync(userId)}
         onClose={() => setMemberUi({ channelId, query: memberQuery, dialogOpen: false })}
       />
@@ -340,8 +392,11 @@ export function useChannelMemberViewModel({
   }, [
     addChannelMemberMut,
     addThreadParticipantMut,
-    addableChannelMembers.members,
-    channelMembersHook.members,
+    addableMembers,
+    addableMembersData,
+    addableMembersError,
+    addableMembersFetching,
+    addableMembersLoading,
     channelName,
     channelId,
     currentChannelMeta,
@@ -349,7 +404,14 @@ export function useChannelMemberViewModel({
     isNotifyUnit,
     manageMembersOpen,
     memberQuery,
-    parentChannelMembersHook.members,
+    parentMembersData,
+    participantMembersData,
+    participantCandidatesError,
+    participantCandidatesLoading,
+    participantCandidatesResolved,
+    participantCandidatesRetrying,
+    refetchAddableMembers,
+    retryParticipantCandidates,
   ])
 
   const resolveUserName = useMemo(

--- a/src/web/src/components/community/people-picker.test.ts
+++ b/src/web/src/components/community/people-picker.test.ts
@@ -1,0 +1,100 @@
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+import {
+  PeoplePickerBody,
+  PeoplePickerHeader,
+  resolvePeoplePickerViewState,
+} from "./people-picker"
+
+function state(overrides: Partial<Parameters<typeof resolvePeoplePickerViewState>[0]> = {}) {
+  return resolvePeoplePickerViewState({
+    resolved: false,
+    loading: true,
+    error: false,
+    sourceCount: 0,
+    visibleCount: 0,
+    query: "",
+    ...overrides,
+  })
+}
+
+describe("resolvePeoplePickerViewState", () => {
+  it("never treats an unresolved fallback array as empty", () => {
+    expect(state()).toBe("loading")
+    expect(state({ loading: false })).toBe("loading")
+  })
+
+  it("shows a first-load error before empty", () => {
+    expect(state({ loading: false, error: true })).toBe("error")
+  })
+
+  it("distinguishes resolved empty, local search-empty, and ready rows", () => {
+    expect(state({ resolved: true, loading: false })).toBe("empty")
+    expect(state({
+      resolved: true,
+      loading: false,
+      sourceCount: 2,
+      visibleCount: 0,
+      query: "nobody",
+    })).toBe("search-empty")
+    expect(state({
+      resolved: true,
+      loading: false,
+      sourceCount: 2,
+      visibleCount: 2,
+    })).toBe("ready")
+  })
+
+  it("keeps cached content usable during background fetching or error", () => {
+    expect(state({
+      resolved: true,
+      loading: true,
+      error: true,
+      sourceCount: 1,
+      visibleCount: 1,
+    })).toBe("ready")
+  })
+})
+
+describe("PeoplePickerBody", () => {
+  it("renders a retry action for a terminal first-load error", () => {
+    const html = renderToStaticMarkup(createElement(PeoplePickerBody, {
+      state: "error",
+      loading: createElement("span", null, "loading"),
+      errorMessage: "Couldn't load people.",
+      emptyMessage: "Nobody here.",
+      retrying: false,
+      onRetry: vi.fn(),
+    }, createElement("span", null, "ready")))
+    expect(html).toContain("Couldn&#x27;t load people.")
+    expect(html).toContain(">Retry<")
+    expect(html).not.toMatch(/<button[^>]*\sdisabled(?:=|>)/)
+  })
+
+  it("keeps the error frame and disables Retry while refetching", () => {
+    const html = renderToStaticMarkup(createElement(PeoplePickerBody, {
+      state: "error",
+      loading: createElement("span", null, "loading"),
+      errorMessage: "Couldn't load people.",
+      emptyMessage: "Nobody here.",
+      retrying: true,
+      onRetry: vi.fn(),
+    }, createElement("span", null, "ready")))
+    expect(html).toContain("Retrying…")
+    expect(html).toContain("disabled")
+  })
+})
+
+describe("PeoplePickerHeader", () => {
+  it("reserves the close-button column while keeping the title truncatable", () => {
+    const html = renderToStaticMarkup(createElement(PeoplePickerHeader, {
+      title: "A very long picker title",
+      subtitle: "Picker context",
+    }))
+    expect(html).toContain("min-w-0")
+    expect(html).toContain("pr-12")
+    expect(html).toContain("truncate")
+    expect(html).toContain("A very long picker title")
+  })
+})

--- a/src/web/src/components/community/people-picker.tsx
+++ b/src/web/src/components/community/people-picker.tsx
@@ -1,0 +1,120 @@
+"use client"
+
+import type { ReactNode } from "react"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { cn } from "@/lib/utils"
+
+export type PeoplePickerAsyncState = {
+  resolved: boolean
+  loading: boolean
+  error: boolean
+  retrying: boolean
+  retry: () => void
+}
+
+export type PeoplePickerViewState =
+  | "loading"
+  | "error"
+  | "empty"
+  | "search-empty"
+  | "ready"
+
+export function resolvePeoplePickerViewState({
+  resolved,
+  loading,
+  error,
+  sourceCount,
+  visibleCount,
+  query,
+}: {
+  resolved: boolean
+  loading: boolean
+  error: boolean
+  sourceCount: number
+  visibleCount: number
+  query: string
+}): PeoplePickerViewState {
+  if (!resolved) {
+    if (error) return "error"
+    if (loading) return "loading"
+    return "loading"
+  }
+  if (sourceCount === 0) return "empty"
+  if (query.trim() && visibleCount === 0) return "search-empty"
+  return "ready"
+}
+
+export function PeoplePickerHeader({
+  title,
+  subtitle,
+}: {
+  title: string
+  subtitle?: string
+}) {
+  return (
+    <header className="min-w-0 border-b border-border/50 py-3 pr-12 pl-4">
+      <h2 className="truncate text-sm font-semibold">{title}</h2>
+      {subtitle ? <p className="text-xs text-muted-foreground">{subtitle}</p> : null}
+    </header>
+  )
+}
+
+export function PeoplePickerRowsSkeleton({
+  secondaryLine = false,
+  actionClassName,
+}: {
+  secondaryLine?: boolean
+  actionClassName: string
+}) {
+  return (
+    <div data-slot="people-picker-loading">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <div key={index} className="flex items-center gap-3 rounded-md px-2 py-2">
+          <Skeleton className="size-8 shrink-0 rounded-full" />
+          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+            <Skeleton className="h-3.5 w-32 rounded" />
+            {secondaryLine ? <Skeleton className="h-3 w-24 rounded" /> : null}
+          </div>
+          <Skeleton className={cn("h-8 shrink-0 rounded-md", actionClassName)} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function PeoplePickerBody({
+  state,
+  loading,
+  errorMessage,
+  emptyMessage,
+  retrying,
+  onRetry,
+  children,
+}: {
+  state: PeoplePickerViewState
+  loading: ReactNode
+  errorMessage: string
+  emptyMessage: string
+  retrying: boolean
+  onRetry: () => void
+  children?: ReactNode
+}) {
+  if (state === "ready") return children
+  if (state === "loading") return loading
+  if (state === "error") {
+    return (
+      <div className="flex flex-col items-center gap-3 px-2 py-6 text-center">
+        <p className="text-sm text-muted-foreground">{errorMessage}</p>
+        <Button size="sm" variant="outline" disabled={retrying} onClick={onRetry}>
+          {retrying ? "Retrying…" : "Retry"}
+        </Button>
+      </div>
+    )
+  }
+  return (
+    <p className="px-2 py-6 text-center text-sm text-muted-foreground">
+      {state === "search-empty" ? "No matches." : emptyMessage}
+    </p>
+  )
+}

--- a/src/web/src/components/community/social/invite-dialog.test.ts
+++ b/src/web/src/components/community/social/invite-dialog.test.ts
@@ -91,10 +91,15 @@ describe("InviteFriendRow", () => {
   it("keeps loading rows on the real row padding and trailing action footprint", () => {
     const source = readFileSync(new URL("./invite-dialog.tsx", import.meta.url), "utf8")
     expect(source).toContain('<div data-slot="invite-friends-loading">')
-    expect(source).toContain(
-      'className="flex items-center gap-3 rounded-md px-2 py-2"',
-    )
-    expect(source).toContain('className="h-8 w-16 shrink-0 rounded-md"')
+    expect(source).toContain('<PeoplePickerRowsSkeleton secondaryLine actionClassName="w-16" />')
+  })
+
+  it("distinguishes unresolved and failed candidate data from a resolved empty list", () => {
+    const source = readFileSync(new URL("./invite-dialog.tsx", import.meta.url), "utf8")
+    expect(source).toContain("resolved: friendsQuery.data !== undefined")
+    expect(source).toContain("error: friendsQuery.isError")
+    expect(source).toContain("friendsQuery.data === undefined && friendsQuery.isFetching")
+    expect(source).toContain("void friendsQuery.refetch()")
   })
 })
 

--- a/src/web/src/components/community/social/invite-dialog.tsx
+++ b/src/web/src/components/community/social/invite-dialog.tsx
@@ -7,8 +7,13 @@ import { toast } from "sonner"
 import { Dialog, DialogContent } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
-import { Skeleton } from "@/components/ui/skeleton"
 import { Avatar } from "../avatar"
+import {
+  PeoplePickerBody,
+  PeoplePickerHeader,
+  PeoplePickerRowsSkeleton,
+  resolvePeoplePickerViewState,
+} from "../people-picker"
 import { hasStatus } from "./status-presets"
 import { useInvitableFriends } from "@/hooks/community/use-invitable-friends"
 import {
@@ -128,7 +133,8 @@ export function InviteDialog({
   const currentUser = useCurrentUser()
   // Only friends who are NOT already members of `serverId` — server-side
   // filter so a stale local members cache can't leak already-joined rows.
-  const { friends, isLoading: friendsLoading } = useInvitableFriends(serverId, open)
+  const friendsQuery = useInvitableFriends(serverId, open)
+  const { friends } = friendsQuery
   const resolveOrCreate = useResolveOrCreateInvite(serverId)
   const createOrGetDm = useCreateOrGetDm()
   const { accept: acceptDmMessage } = useDmMessageSender()
@@ -185,6 +191,15 @@ export function InviteDialog({
     })
   }, [friends, query])
 
+  const pickerState = resolvePeoplePickerViewState({
+    resolved: friendsQuery.data !== undefined,
+    loading: friendsQuery.isLoading,
+    error: friendsQuery.isError,
+    sourceCount: friends.length,
+    visibleCount: eligibleFriends.length,
+    query,
+  })
+
   const inviteFriend = async (friend: Friend) => {
     if (!token || !friend.userId) return
     const userId = friend.userId
@@ -230,9 +245,7 @@ export function InviteDialog({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="flex max-h-[80vh] w-full flex-col gap-0 p-0 sm:max-w-md">
-        <header className="border-b border-border/50 px-4 py-3">
-          <h2 className="truncate text-sm font-semibold">Invite friends to {serverName}</h2>
-        </header>
+        <PeoplePickerHeader title={`Invite friends to ${serverName}`} />
 
         <div className="px-4 pt-3">
           <label className="relative block">
@@ -250,27 +263,19 @@ export function InviteDialog({
         </div>
 
         <div className="min-h-0 flex-1 overflow-y-auto thin-scrollbar px-2 py-2">
-          {friendsLoading && friends.length === 0 ? (
-            <div data-slot="invite-friends-loading">
-              {Array.from({ length: 4 }).map((_, i) => (
-                <div key={i} className="flex items-center gap-3 rounded-md px-2 py-2">
-                  <Skeleton className="size-8 shrink-0 rounded-full" />
-                  <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-                    <Skeleton className="h-3.5 w-32 rounded" />
-                    <Skeleton className="h-3 w-24 rounded" />
-                  </div>
-                  <Skeleton className="h-8 w-16 shrink-0 rounded-md" />
-                </div>
-              ))}
-            </div>
-          ) : eligibleFriends.length === 0 ? (
-            <p className="px-2 py-6 text-center text-sm text-muted-foreground">
-              {friends.length === 0
-                ? "No friends to invite — everyone you know is already here."
-                : "No matches."}
-            </p>
-          ) : (
-            eligibleFriends.map((f) => {
+          <PeoplePickerBody
+            state={pickerState}
+            loading={(
+              <div data-slot="invite-friends-loading">
+                <PeoplePickerRowsSkeleton secondaryLine actionClassName="w-16" />
+              </div>
+            )}
+            errorMessage="Couldn't load friends."
+            emptyMessage="No friends to invite — everyone you know is already here."
+            retrying={friendsQuery.data === undefined && friendsQuery.isFetching}
+            onRetry={() => { void friendsQuery.refetch() }}
+          >
+            {eligibleFriends.map((f) => {
               const invited = f.userId ? invitedUserIds.has(f.userId) : false
               const inviting = f.userId ? invitingUserIds.has(f.userId) : false
               return (
@@ -283,8 +288,8 @@ export function InviteDialog({
                   onInvite={(candidate) => void inviteFriend(candidate)}
                 />
               )
-            })
-          )}
+            })}
+          </PeoplePickerBody>
         </div>
 
         <footer className="border-t border-border/50 px-4 py-3">

--- a/src/web/src/test/e2e-ui/33-picker-async-layout.spec.ts
+++ b/src/web/src/test/e2e-ui/33-picker-async-layout.spec.ts
@@ -1,0 +1,325 @@
+import type { Locator } from "@playwright/test"
+import { expect, test, userId } from "./_fixtures/community-fixture"
+import {
+  memberInfo,
+  renameUser,
+  seedChannel,
+  seedForumThread,
+  seedFriendship,
+  seedJoinServer,
+  seedMessage,
+  seedServer,
+} from "./_fixtures/seed"
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+async function expectTitleClearOfClose(dialog: Locator, width: 390 | 1280) {
+  const title = await dialog.getByRole("heading", { level: 2 }).boundingBox()
+  const close = await dialog.getByRole("button", { name: "Close" }).boundingBox()
+  expect(title, `title rect at ${width}px`).not.toBeNull()
+  expect(close, `Close rect at ${width}px`).not.toBeNull()
+  expect(title!.x + title!.width, `title must end before Close at ${width}px`)
+    .toBeLessThanOrEqual(close!.x)
+}
+
+test.describe.serial("invite and participant picker async states", () => {
+  test.setTimeout(180_000)
+
+  let inviteServerId: string
+  let participantServerId: string
+  let parentChannelId: string
+  let failureThreadId: string
+  let parentFailureThreadId: string
+  let emptyThreadId: string
+  let mutationThreadId: string
+  let bobName: string
+  let carolName: string
+
+  test.beforeAll(async () => {
+    const userStamp = Date.now().toString().slice(-6)
+    await renameUser("bob", `PickerBob${userStamp}`)
+    await renameUser("carol", `PickerCarol${userStamp}`)
+    inviteServerId = await seedServer(
+      "alice",
+      `Invite ${Date.now()} ${"unbroken-title-".repeat(5)}`,
+    )
+    await seedFriendship("alice", "bob", userId("bob"))
+    await seedFriendship("alice", "carol", userId("carol"))
+
+    participantServerId = await seedServer("alice", `Participants ${Date.now()}`)
+    await seedJoinServer("alice", "bob", participantServerId)
+    await seedJoinServer("alice", "carol", participantServerId)
+    parentChannelId = await seedChannel("alice", participantServerId, "picker-parent", "forum")
+    failureThreadId = await seedForumThread(
+      "alice",
+      parentChannelId,
+      `Failure ${"unbroken-thread-title-".repeat(4)}`,
+      "failure state",
+    )
+    parentFailureThreadId = await seedForumThread(
+      "alice",
+      parentChannelId,
+      `Parent failure ${"unbroken-thread-title-".repeat(4)}`,
+      "parent failure state",
+    )
+    emptyThreadId = await seedForumThread(
+      "alice",
+      parentChannelId,
+      `Empty ${Date.now()}`,
+      "resolved empty state",
+    )
+    mutationThreadId = await seedForumThread(
+      "alice",
+      parentChannelId,
+      `Mutation ${"unbroken-thread-title-".repeat(4)}`,
+      "mutation state",
+    )
+    await seedMessage("bob", failureThreadId, "existing participant")
+    await seedMessage("bob", emptyThreadId, "existing participant bob")
+    await seedMessage("carol", emptyThreadId, "existing participant carol")
+    bobName = (await memberInfo("alice", participantServerId, userId("bob"))).name
+    carolName = (await memberInfo("alice", participantServerId, userId("carol"))).name
+  })
+
+  test("Invite friends keeps cold data provisional, search local, row pending, and title clear", async ({ asUser }) => {
+    const { page } = await asUser("alice")
+    await page.setViewportSize({ width: 1280, height: 844 })
+    await page.goto(`/c/channels/${inviteServerId}`)
+    await expect(page.getByRole("button", { name: "Invite to server" })).toBeVisible({ timeout: 20_000 })
+
+    const acceptedGate = deferred()
+    let acceptedGets = 0
+    let memberGets = 0
+    await page.route("**/api/community/friends/accepted", async (route) => {
+      if (route.request().method() !== "GET") return route.continue()
+      acceptedGets += 1
+      await acceptedGate.promise
+      await route.continue()
+    })
+    await page.route(`**/api/community/servers/${inviteServerId}/members?**`, async (route) => {
+      if (route.request().method() === "GET") memberGets += 1
+      await route.continue()
+    })
+
+    await page.getByRole("button", { name: "Invite to server" }).click()
+    const dialog = page.getByRole("dialog")
+    await expect(dialog.locator('[data-slot="invite-friends-loading"]')).toBeVisible()
+    await expect(dialog.getByText(/No friends to invite|No matches/)).toHaveCount(0)
+    acceptedGate.resolve()
+    await expect(dialog.getByRole("button", { name: "Invite" }).first()).toBeVisible({ timeout: 20_000 })
+    await expectTitleClearOfClose(dialog, 1280)
+
+    const beforeSearch = { acceptedGets, memberGets }
+    await dialog.getByPlaceholder("Search for friends").fill("no-user-matches-this-query")
+    await expect(dialog.getByText("No matches.", { exact: true })).toBeVisible()
+    expect({ acceptedGets, memberGets }).toEqual(beforeSearch)
+    await dialog.getByPlaceholder("Search for friends").fill("")
+    await expect(dialog.getByRole("button", { name: "Invite" }).first()).toBeVisible()
+    await expect(dialog.getByRole("button", { name: "Copy" })).toBeEnabled({ timeout: 20_000 })
+
+    const dmGate = deferred()
+    const writes: string[] = []
+    page.on("request", (request) => {
+      if (request.method() === "POST") writes.push(new URL(request.url()).pathname)
+    })
+    await page.route("**/api/community/channels", async (route) => {
+      if (route.request().method() !== "POST") return route.continue()
+      await dmGate.promise
+      await route.continue()
+    })
+    await expect(dialog.getByRole("button", { name: "Invite" })).toHaveCount(2)
+    const selectedRow = dialog.getByText(bobName, { exact: true }).locator("..").locator("..")
+    const otherRow = dialog.getByText(carolName, { exact: true }).locator("..").locator("..")
+    await selectedRow.getByRole("button", { name: "Invite" }).click()
+    await expect.poll(() => writes.filter((path) => path === "/api/community/channels").length).toBe(1)
+    await expect(selectedRow.locator("button")).toBeDisabled()
+    await expect(selectedRow.locator("svg.animate-spin")).toBeVisible()
+    await expect(otherRow.getByRole("button", { name: "Invite" })).toBeEnabled()
+    dmGate.resolve()
+    await expect(selectedRow.getByRole("button", { name: "Invited" })).toBeVisible({ timeout: 20_000 })
+    expect(writes.filter((path) => path === "/api/community/channels")).toHaveLength(1)
+    expect(writes.filter((path) => /\/api\/community\/channels\/[^/]+\/messages$/.test(path))).toHaveLength(1)
+  })
+
+  test("Invite friends exposes one recoverable first-load error chain before resolved empty", async ({ asUser }) => {
+    const { page } = await asUser("alice")
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto(`/c/channels/${inviteServerId}`)
+    await expect(page.getByRole("button", { name: "Invite to server" })).toBeVisible({ timeout: 20_000 })
+
+    let fail = true
+    let acceptedGets = 0
+    await page.route("**/api/community/friends/accepted", async (route) => {
+      if (route.request().method() !== "GET") return route.continue()
+      acceptedGets += 1
+      if (fail) {
+        await route.fulfill({ status: 503, contentType: "application/json", body: '{"error":"failed"}' })
+        return
+      }
+      await route.fulfill({ status: 200, contentType: "application/json", body: '{"friends":[]}' })
+    })
+
+    await page.getByRole("button", { name: "Invite to server" }).click()
+    const dialog = page.getByRole("dialog")
+    await expect(dialog.getByText("Couldn't load friends.", { exact: true })).toBeVisible({ timeout: 20_000 })
+    const failedChainGets = acceptedGets
+    expect(failedChainGets).toBeGreaterThanOrEqual(2)
+    fail = false
+    await dialog.getByRole("button", { name: "Retry" }).click()
+    await expect(dialog.getByText("No friends to invite — everyone you know is already here.", { exact: true }))
+      .toBeVisible({ timeout: 20_000 })
+    expect(acceptedGets).toBeGreaterThan(failedChainGets)
+    await expectTitleClearOfClose(dialog, 390)
+  })
+
+  test("Add participants composes both sources and recovers without re-offering a participant", async ({ asUser }) => {
+    const { page } = await asUser("alice")
+    await page.setViewportSize({ width: 1280, height: 844 })
+    let failParticipants = true
+    let participantGets = 0
+    let parentGets = 0
+    await page.route(`**/api/community/channels/${failureThreadId}/members`, async (route) => {
+      if (route.request().method() !== "GET") return route.continue()
+      participantGets += 1
+      if (failParticipants) {
+        await route.fulfill({ status: 503, contentType: "application/json", body: '{"error":"failed"}' })
+        return
+      }
+      await route.continue()
+    })
+    await page.route(`**/api/community/channels/${parentChannelId}/members`, async (route) => {
+      if (route.request().method() === "GET") parentGets += 1
+      await route.continue()
+    })
+
+    await page.goto(`/c/channels/${participantServerId}/${failureThreadId}`)
+    await expect(page.getByRole("button", { name: /member/i }).first()).toBeVisible({ timeout: 20_000 })
+    await page.getByRole("button", { name: /member/i }).first().click()
+    await expect(page.getByRole("button", { name: "Add members" })).toBeVisible({ timeout: 20_000 })
+    await page.getByRole("button", { name: "Add members" }).click()
+    const dialog = page.getByRole("dialog")
+    await expect(dialog.getByText("Couldn't load people.", { exact: true })).toBeVisible({ timeout: 20_000 })
+    await expect(dialog.getByText(bobName, { exact: true })).toHaveCount(0)
+    await expectTitleClearOfClose(dialog, 1280)
+
+    const failedParticipantGets = participantGets
+    const resolvedParentGets = parentGets
+    expect(failedParticipantGets).toBeGreaterThanOrEqual(2)
+    failParticipants = false
+    await dialog.getByRole("button", { name: "Retry" }).click()
+    await expect(dialog.getByText(carolName, { exact: true })).toBeVisible({ timeout: 20_000 })
+    await expect(dialog.getByText(bobName, { exact: true })).toHaveCount(0)
+    expect(participantGets).toBeGreaterThan(failedParticipantGets)
+    expect(parentGets).toBe(resolvedParentGets)
+
+    const beforeSearch = { participantGets, parentGets }
+    await dialog.getByPlaceholder("Search members").fill("no-participant-matches-this")
+    await expect(dialog.getByText("No matches.", { exact: true })).toBeVisible()
+    expect({ participantGets, parentGets }).toEqual(beforeSearch)
+  })
+
+  test("Add participants keeps a slow first load provisional before resolved empty", async ({ asUser }) => {
+    const { page } = await asUser("alice")
+    await page.setViewportSize({ width: 1280, height: 844 })
+    const parentGate = deferred()
+    let parentGets = 0
+    await page.route(`**/api/community/channels/${parentChannelId}/members`, async (route) => {
+      if (route.request().method() !== "GET") return route.continue()
+      parentGets += 1
+      await parentGate.promise
+      await route.continue()
+    })
+
+    await page.goto(`/c/channels/${participantServerId}/${emptyThreadId}`)
+    await expect(page.getByRole("button", { name: /member/i }).first()).toBeVisible({ timeout: 20_000 })
+    await page.getByRole("button", { name: /member/i }).first().click()
+    await page.getByRole("button", { name: "Add members" }).click()
+    const dialog = page.getByRole("dialog")
+    await expect(dialog.locator('[data-slot="people-picker-loading"]')).toBeVisible()
+    await expect(dialog.getByText(/Everyone is already here|No matches/)).toHaveCount(0)
+    expect(parentGets).toBeGreaterThanOrEqual(1)
+
+    parentGate.resolve()
+    await expect(dialog.getByText("Everyone is already here.", { exact: true }))
+      .toBeVisible({ timeout: 20_000 })
+  })
+
+  test("Add participants retries an unresolved parent without refetching participants", async ({ asUser }) => {
+    const { page } = await asUser("alice")
+    await page.setViewportSize({ width: 1280, height: 844 })
+    let failParent = true
+    let participantGets = 0
+    let parentGets = 0
+    await page.route(`**/api/community/channels/${parentFailureThreadId}/members`, async (route) => {
+      if (route.request().method() === "GET") participantGets += 1
+      await route.continue()
+    })
+    await page.route(`**/api/community/channels/${parentChannelId}/members`, async (route) => {
+      if (route.request().method() !== "GET") return route.continue()
+      parentGets += 1
+      if (failParent) {
+        await route.fulfill({ status: 503, contentType: "application/json", body: '{"error":"failed"}' })
+        return
+      }
+      await route.continue()
+    })
+
+    await page.goto(`/c/channels/${participantServerId}/${parentFailureThreadId}`)
+    await expect(page.getByRole("button", { name: /member/i }).first()).toBeVisible({ timeout: 20_000 })
+    await page.getByRole("button", { name: /member/i }).first().click()
+    await page.getByRole("button", { name: "Add members" }).click()
+    const dialog = page.getByRole("dialog")
+    await expect(dialog.getByText("Couldn't load people.", { exact: true })).toBeVisible({ timeout: 20_000 })
+    await expect(dialog.getByText(bobName, { exact: true })).toHaveCount(0)
+    await expect(dialog.getByText(carolName, { exact: true })).toHaveCount(0)
+
+    const resolvedParticipantGets = participantGets
+    const failedParentGets = parentGets
+    expect(resolvedParticipantGets).toBeGreaterThanOrEqual(1)
+    expect(failedParentGets).toBeGreaterThanOrEqual(2)
+    failParent = false
+    await dialog.getByRole("button", { name: "Retry" }).click()
+    await expect(dialog.getByText(bobName, { exact: true })).toBeVisible({ timeout: 20_000 })
+    await expect(dialog.getByText(carolName, { exact: true })).toBeVisible()
+    expect(participantGets).toBe(resolvedParticipantGets)
+    expect(parentGets).toBeGreaterThan(failedParentGets)
+  })
+
+  test("Add participants keeps mutation pending local to one row", async ({ asUser }) => {
+    const { page } = await asUser("alice")
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto(`/c/channels/${participantServerId}/${mutationThreadId}`)
+    await expect(page.getByRole("button", { name: /member/i }).first()).toBeVisible({ timeout: 20_000 })
+    await page.getByRole("button", { name: /member/i }).first().click()
+    await page.getByRole("button", { name: "Add members" }).click()
+    const dialog = page.getByRole("dialog")
+    await expect(dialog.getByText(bobName, { exact: true })).toBeVisible({ timeout: 20_000 })
+    await expect(dialog.getByText(carolName, { exact: true })).toBeVisible()
+    await expectTitleClearOfClose(dialog, 390)
+
+    const mutationGate = deferred()
+    let participantPosts = 0
+    await page.route(`**/api/community/channels/${mutationThreadId}/participants`, async (route) => {
+      if (route.request().method() !== "POST") return route.continue()
+      participantPosts += 1
+      await mutationGate.promise
+      await route.continue()
+    })
+    const bobRow = dialog.getByText(bobName, { exact: true }).locator("..")
+    const carolRow = dialog.getByText(carolName, { exact: true }).locator("..")
+    await bobRow.getByRole("button", { name: "Add" }).click()
+    await expect.poll(() => participantPosts).toBe(1)
+    await expect(bobRow.locator("button")).toBeDisabled()
+    await expect(bobRow.locator("svg.animate-spin")).toBeVisible()
+    await expect(carolRow.getByRole("button", { name: "Add" })).toBeEnabled()
+    mutationGate.resolve()
+    await expect(dialog.getByText(bobName, { exact: true })).toHaveCount(0, { timeout: 20_000 })
+    expect(participantPosts).toBe(1)
+  })
+})


### PR DESCRIPTION
## Why we need this PR

Invite friends and Add participants can render a resolved empty message while their required data is still cold, slow, or retrying. The two dialogs also use titles derived from server/thread names without consistently reserving space for the Close control, so long names can collide at narrow widths.

## What changed

- Add a shared presentation-only people-picker state/header primitive for loading, first-load error + Retry, resolved empty, local search-empty, and Close-button title reservation.
- Drive Invite friends from the accepted-friends query's real `data !== undefined` state while preserving cached content during background fetch/error.
- Drive private-channel Add members from the addable-members query state.
- Gate thread Add participants candidates until both the participant roster and parent-member pool have data. A no-data failure in either source blocks candidates, and Retry refetches only unresolved sources.
- Preserve existing candidate exclusion and row-local mutation pending behavior.
- Register the measured 57-second E2E spec weight and update the deterministic five-shard snapshot.

Plan V3 scope is exactly 13 files: 5 production files, 6 feature tests, and 2 CI shard-bookkeeping files. There are no permission/member semantic, API/schema, invite accept-flow, token-flow, dependency, lockfile, or unrelated dialog changes. The adjacent observed token POST×2 behavior is explicitly out of scope.

## State invariants

- Empty renders only after every required query has `data !== undefined`.
- Cached content wins over background fetching/error.
- Thread candidates are derived only after both participant and parent-member data resolve.
- Retry refetches only sources whose data remains undefined.
- Local search issues no relevant GETs; one row mutation disables only that row.

## Validation

- Focused unit/component: 5 files / 32 tests.
- Focused CI shard test: 1 file / 7 tests.
- Fresh target Playwright: 6/6.
- Full normal hook chain: typecheck, lint, full test, WS/agent-driver boundary checks, and Knip all pass.
- Full Web suite: 643/643 files, 5616/5616 tests; root CI scripts: 11/11 files, 124/124 tests.
- `git diff --check` passes; E2E lifecycle stopped cleanly with backup absent and service/inspector ports free.

## Independent QA

- Jarvis and Madox independently passed the final 13-file freeze and commit object.
- `alook-c-qa` independently reran the final feature bytes: focused tests 32/32 and fresh Playwright 6/6.
- Coverage confirms invite and participant cold/error/retry/empty/search/pending states, independently gated participant/parent sources, existing-participant exclusion, and long-title/Close geometry at 390px and desktop.

## Residual risk

The picker state depends on React Query's distinction between missing data and cached background failures. Tests cover both source-specific no-data paths and cached-content precedence. This PR intentionally does not address the separately observed invite-token POST×2 behavior or queued items ④/⑤.

## Checklist

- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [ ] Other
