### PR TITLE
fix(web): migrate bot activity to CommunitySheet

### DIFF
--- a/src/web/src/components/community/bots/bot-activity-modal.test.ts
+++ b/src/web/src/components/community/bots/bot-activity-modal.test.ts
@@ -1,0 +1,198 @@
+import { readFileSync } from "node:fs"
+import React from "react"
+import TestRenderer, { act } from "react-test-renderer"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { auditState, fetchNextPage, scrollNode, bottomAnchor } = vi.hoisted(() => ({
+  auditState: {
+    events: [] as Array<{
+      id: string
+      kind: "tool_call"
+      payload: unknown
+      sessionId: string | null
+      launchId: string | null
+      createdAt: string
+    }>,
+    isLoading: false,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  },
+  fetchNextPage: vi.fn(),
+  scrollNode: { scrollHeight: 600, scrollTop: 0, clientHeight: 300 },
+  bottomAnchor: { scrollIntoView: vi.fn() },
+}))
+
+vi.mock("@/components/community/shell/community-sheet", () => ({
+  CommunitySheet: ({
+    children,
+    bodyRef,
+    ...props
+  }: React.PropsWithChildren<Record<string, unknown>>) => {
+    if (bodyRef && typeof bodyRef === "object" && "current" in bodyRef) {
+      bodyRef.current = scrollNode
+    }
+    return React.createElement("community-sheet", props, children)
+  },
+}))
+
+vi.mock("@/components/avatar", () => ({
+  AgentAvatar: (props: Record<string, unknown>) => React.createElement("agent-avatar", props),
+}))
+
+vi.mock("@/stores/community/ws", () => ({
+  useOnlineUserIds: () => new Set(["bot-1"]),
+}))
+
+vi.mock("@/hooks/community/use-bot-audit-log", () => ({
+  useBotAuditLog: () => ({ ...auditState, fetchNextPage }),
+}))
+
+vi.mock("./bot-activity-row", () => ({
+  BotActivityRow: ({ event }: { event: { id: string } }) =>
+    React.createElement("activity-row", { eventId: event.id }),
+}))
+
+import { BotActivityModal } from "./bot-activity-modal"
+
+const bot = {
+  id: "bot-1",
+  name: "Build Bot",
+  description: "",
+  image: null,
+  machineId: "machine-1",
+  runtime: "codex",
+  modelName: null,
+  lastRefreshContextAt: null,
+  dailyActivity: [],
+}
+
+function event(id: string, createdAt: string) {
+  return {
+    id,
+    kind: "tool_call" as const,
+    payload: { name: "Read" },
+    sessionId: null,
+    launchId: null,
+    createdAt,
+  }
+}
+
+function renderModal(onOpenChange = vi.fn()) {
+  let renderer!: TestRenderer.ReactTestRenderer
+  act(() => {
+    renderer = TestRenderer.create(
+      React.createElement(BotActivityModal, { bot, open: true, onOpenChange }),
+      { createNodeMock: () => bottomAnchor },
+    )
+  })
+  return { renderer, onOpenChange }
+}
+
+function updateModal(renderer: TestRenderer.ReactTestRenderer, onOpenChange: (open: boolean) => void) {
+  act(() => renderer.update(
+    React.createElement(BotActivityModal, { bot, open: true, onOpenChange }),
+  ))
+}
+
+describe("BotActivityModal CommunitySheet contract", () => {
+  beforeEach(() => {
+    auditState.events = []
+    auditState.isLoading = false
+    auditState.hasNextPage = false
+    auditState.isFetchingNextPage = false
+    fetchNextPage.mockReset()
+    bottomAnchor.scrollIntoView.mockReset()
+    scrollNode.scrollHeight = 600
+    scrollNode.scrollTop = 0
+    scrollNode.clientHeight = 300
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0)
+      return 1
+    })
+  })
+
+  it("uses the resizable 672px shared shell and its one dismissal callback", () => {
+    const { renderer, onOpenChange } = renderModal()
+    const sheet = renderer.root.findByType("community-sheet")
+
+    expect(sheet.props.desktopWidth).toBe(672)
+    expect(sheet.props.resizable).toBe(true)
+    expect(sheet.props.contentTestId).toBe("bot-activity-modal")
+    expect(sheet.props.bodyClassName).toContain("p-0")
+    expect(sheet.props.description.props.children[1].props.children).toBe("Live")
+
+    act(() => sheet.props.onOpenChange(false))
+    expect(onOpenChange).toHaveBeenCalledOnce()
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+
+    const source = readFileSync(new URL("./bot-activity-modal.tsx", import.meta.url), "utf8")
+    expect(source).not.toContain("@/components/ui/dialog")
+    expect(source).not.toContain("@/components/ui/sheet")
+    expect(source).not.toMatch(/>\s*Close\s*</)
+  })
+
+  it("keeps loading, empty, chronological day groups, and rows in the shared body", () => {
+    auditState.isLoading = true
+    const loading = renderModal().renderer
+    expect(loading.root.findAllByProps({ className: "h-3 w-16 animate-pulse rounded bg-muted/40" }))
+      .toHaveLength(8)
+    loading.unmount()
+
+    auditState.isLoading = false
+    const empty = renderModal().renderer
+    expect(empty.root.findByProps({ children: "No activity yet" })).toBeTruthy()
+    empty.unmount()
+
+    auditState.events = [
+      event("new", "2026-08-27T12:00:00.000Z"),
+      event("old", "2026-08-26T12:00:00.000Z"),
+    ]
+    const populated = renderModal().renderer
+    expect(populated.root.findAllByType("section")).toHaveLength(2)
+    expect(populated.root.findAllByType("activity-row").map((row) => row.props.eventId))
+      .toEqual(["old", "new"])
+  })
+
+  it("preserves the visible row when an older page prepends", () => {
+    auditState.events = [event("new", "2026-08-27T12:00:00.000Z")]
+    auditState.hasNextPage = true
+    const { renderer, onOpenChange } = renderModal()
+
+    scrollNode.scrollHeight = 600
+    scrollNode.scrollTop = 120
+    act(() => renderer.root.findByProps({ children: "Load older" }).props.onClick())
+    expect(fetchNextPage).toHaveBeenCalledOnce()
+
+    auditState.events = [
+      event("new", "2026-08-27T12:00:00.000Z"),
+      event("old", "2026-08-26T12:00:00.000Z"),
+    ]
+    scrollNode.scrollHeight = 850
+    updateModal(renderer, onOpenChange)
+    expect(scrollNode.scrollTop).toBe(370)
+  })
+
+  it("pins a new live row only while the reader is near the tail", () => {
+    auditState.events = [event("one", "2026-08-27T12:00:00.000Z")]
+    const { renderer, onOpenChange } = renderModal()
+
+    scrollNode.scrollHeight = 1_100
+    scrollNode.scrollTop = 800
+    scrollNode.clientHeight = 250
+    auditState.events = [
+      event("one", "2026-08-27T12:00:00.000Z"),
+      event("two", "2026-08-27T12:01:00.000Z"),
+    ]
+    updateModal(renderer, onOpenChange)
+    expect(scrollNode.scrollTop).toBe(1_100)
+
+    scrollNode.scrollHeight = 1_300
+    scrollNode.scrollTop = 100
+    auditState.events = [
+      ...auditState.events,
+      event("three", "2026-08-27T12:02:00.000Z"),
+    ]
+    updateModal(renderer, onOpenChange)
+    expect(scrollNode.scrollTop).toBe(100)
+  })
+})

--- a/src/web/src/components/community/bots/bot-activity-modal.tsx
+++ b/src/web/src/components/community/bots/bot-activity-modal.tsx
@@ -2,12 +2,7 @@
 
 import { useLayoutEffect, useMemo, useRef, useEffect } from "react"
 import { AgentAvatar } from "@/components/avatar"
-import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-  DialogDescription,
-} from "@/components/ui/dialog"
+import { CommunitySheet } from "@/components/community/shell/community-sheet"
 import { useOnlineUserIds } from "@/stores/community/ws"
 import {
   useBotAuditLog,
@@ -96,9 +91,9 @@ export function BotActivityModal({
     }
   }, [open, bot?.id])
 
-  // Snap to the newest event on first paint of an open cycle. The Radix
-  // Dialog mounts DialogContent inside a portal with an entrance animation,
-  // so relying on a `useLayoutEffect` that only fires when
+  // Snap to the newest event on first paint of an open cycle. CommunitySheet
+  // mounts its content inside a portal with an entrance animation, so relying
+  // on a `useLayoutEffect` that only fires when
   // `chronological.length` changes can race the portal's first layout — the
   // scroll fires before the container has its final height. Anchor + rAF
   // guarantees the browser has laid out at least once before we jump.
@@ -158,77 +153,69 @@ export function BotActivityModal({
   }, [chronological.length])
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        data-testid={tid.botActivityModal}
-        showCloseButton={false}
-        className="flex h-[72vh] max-h-170 w-full max-w-2xl flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl"
-      >
-        <header className="flex shrink-0 items-center gap-3 border-b border-border/40 px-4 py-3">
+    <CommunitySheet
+      open={open}
+      onOpenChange={onOpenChange}
+      title={(
+        <span className="flex min-w-0 items-center gap-3">
           <AgentAvatar name={bot?.name ?? ""} avatarUrl={bot?.image ?? null} seed={bot?.id} size={32} />
-          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-            <DialogTitle className="truncate text-sm font-medium">
-              {bot?.name ?? "Bot"}
-            </DialogTitle>
-            <DialogDescription className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-              <span
-                className={[
-                  "inline-block size-1.5 rounded-full",
-                  online ? "bg-status-online" : "bg-muted-foreground/60",
-                ].join(" ")}
-                aria-hidden
-              />
-              <span>{online ? "Live" : "Offline"}</span>
-              <span aria-hidden className="text-muted-foreground/40">·</span>
-              <span>Activity log</span>
-            </DialogDescription>
-          </div>
-          <button
-            type="button"
-            onClick={() => onOpenChange(false)}
-            className="rounded-md px-2 py-1 text-[11px] text-muted-foreground hover:bg-accent hover:text-foreground"
-          >
-            Close
-          </button>
-        </header>
-
-        <div ref={scrollRef} className="flex-1 overflow-y-auto thin-scrollbar bg-background">
-          {isLoading && chronological.length === 0 ? (
-            <SkeletonRows />
-          ) : chronological.length === 0 ? (
-            <EmptyState />
+          <span className="truncate text-sm font-medium">{bot?.name ?? "Bot"}</span>
+        </span>
+      )}
+      description={(
+        <span className="flex items-center gap-1.5 text-[11px]">
+          <span
+            className={[
+              "inline-block size-1.5 rounded-full",
+              online ? "bg-status-online" : "bg-muted-foreground/60",
+            ].join(" ")}
+            aria-hidden
+          />
+          <span>{online ? "Live" : "Offline"}</span>
+          <span aria-hidden className="text-muted-foreground/40">·</span>
+          <span>Activity log</span>
+        </span>
+      )}
+      desktopWidth={672}
+      resizable
+      contentTestId={tid.botActivityModal}
+      bodyRef={scrollRef}
+      bodyClassName="bg-background p-0"
+    >
+      {isLoading && chronological.length === 0 ? (
+        <SkeletonRows />
+      ) : chronological.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <div className="pb-3">
+          {hasNextPage ? (
+            <div className="flex justify-center py-2">
+              <button
+                type="button"
+                onClick={onLoadOlder}
+                disabled={isFetchingNextPage}
+                className="rounded-md px-3 py-1 font-mono text-[10px] uppercase tracking-wider text-muted-foreground/70 hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isFetchingNextPage ? "Loading older" : "Load older"}
+              </button>
+            </div>
           ) : (
-            <div className="pb-3">
-              {hasNextPage ? (
-                <div className="flex justify-center py-2">
-                  <button
-                    type="button"
-                    onClick={onLoadOlder}
-                    disabled={isFetchingNextPage}
-                    className="rounded-md px-3 py-1 font-mono text-[10px] uppercase tracking-wider text-muted-foreground/70 hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    {isFetchingNextPage ? "Loading older" : "Load older"}
-                  </button>
-                </div>
-              ) : (
-                <div className="py-2 text-center font-mono text-[10px] uppercase tracking-wider text-muted-foreground/40">
-                  Beginning of log
-                </div>
-              )}
-              {grouped.map((group) => (
-                <section key={group.dayKey}>
-                  <DayDivider label={group.label} />
-                  {group.events.map((event) => (
-                    <BotActivityRow key={event.id} event={event} />
-                  ))}
-                </section>
-              ))}
-              <div ref={bottomAnchorRef} aria-hidden />
+            <div className="py-2 text-center font-mono text-[10px] uppercase tracking-wider text-muted-foreground/40">
+              Beginning of log
             </div>
           )}
+          {grouped.map((group) => (
+            <section key={group.dayKey}>
+              <DayDivider label={group.label} />
+              {group.events.map((event) => (
+                <BotActivityRow key={event.id} event={event} />
+              ))}
+            </section>
+          ))}
+          <div ref={bottomAnchorRef} aria-hidden />
         </div>
-      </DialogContent>
-    </Dialog>
+      )}
+    </CommunitySheet>
   )
 }
 

--- a/src/web/src/components/community/shell/community-sheet-migrations.test.ts
+++ b/src/web/src/components/community/shell/community-sheet-migrations.test.ts
@@ -7,6 +7,7 @@ const migrations = [
   "../messages/attachment-preview-sheet.tsx",
   "../bots/create-bot-sheet.tsx",
   "../bots/edit-bot-sheet.tsx",
+  "../bots/bot-activity-modal.tsx",
   "../machines/pair-machine-sheet.tsx",
 ] as const
 
@@ -24,19 +25,23 @@ describe("CommunitySheet migrations", () => {
     expect(source).not.toMatch(/CommunitySheet(?:Header|Body|Footer|Title|Description|Close)/)
   })
 
-  it("allows only Attachment Preview to opt into the fixed resize policy", () => {
+  it("allows only Attachment Preview and Activity Log to opt into resize", () => {
     for (const path of migrations) {
       const source = readFileSync(new URL(path, import.meta.url), "utf8")
-      if (path.includes("attachment-preview")) expect(source).toContain("resizable")
+      if (path.includes("attachment-preview") || path.includes("bot-activity")) {
+        expect(source).toContain("resizable")
+      }
       else expect(source).not.toContain("resizable")
     }
   })
 
-  it("keeps only Members on the compact desktop width", () => {
+  it("reserves explicit desktop widths for Members and Activity Log", () => {
     for (const path of migrations) {
       const source = readFileSync(new URL(path, import.meta.url), "utf8")
       if (path === "./community-panel.tsx") {
         expect(source).toContain('desktopWidth={kind === "members" ? 380 : undefined}')
+      } else if (path.includes("bot-activity")) {
+        expect(source).toContain("desktopWidth={672}")
       } else {
         expect(source).not.toContain("desktopWidth=")
       }

--- a/src/web/src/components/community/shell/community-sheet.test.ts
+++ b/src/web/src/components/community/shell/community-sheet.test.ts
@@ -74,12 +74,12 @@ describe("CommunitySheet contracts", () => {
     expect(resizeHandle).not.toHaveBeenCalled()
   })
 
-  it("uses the primitive resize policy only when Attachment opts in", () => {
-    const { renderer } = renderSheet({ resizable: true })
+  it("uses the primitive resize policy at the caller's desktop width", () => {
+    const { renderer } = renderSheet({ resizable: true, desktopWidth: 672 })
     const content = renderer.root.findByType("sheet-content")
     expect(content.props.style["--community-sheet-width"]).toBe("480px")
     expect(content.props.style["--community-sheet-max-width"]).toBe("80vw")
-    expect(resizeHook).toHaveBeenCalledWith({ defaultWidth: 480 })
+    expect(resizeHook).toHaveBeenCalledWith({ defaultWidth: 672 })
     expect(resizeHandle).toHaveBeenCalledOnce()
   })
 


### PR DESCRIPTION
## Summary

- migrate Bot Activity Log from its independent Dialog to the shared `CommunitySheet`
- keep the existing owner-only audit hook, loading/empty states, chronological groups, pagination anchor, initial tail, and live-tail behavior
- start the desktop sheet at 672px with the shared resize handle and standard sole close control
- add focused shell, migration, pagination-anchor, and live-tail contract coverage

## Verification

- focused Vitest — 4 files, 25 tests passed
- raw V8 focused coverage — 100% functions, 91.13% lines for `bot-activity-modal.tsx`
- root typecheck — 11/11 packages passed
- root lint — 5/5 packages passed
- root test — 11/11 tasks; Web 648 files / 5716 tests; CI scripts 11 files / 124 tests
- typegrep WS and agent-driver boundaries passed; knip 8/8 passed
- normal commit hook passed all required checks
- independent forced-fresh `/c` Playwright QA — 1 passed (45.0s)

## Browser QA

- desktop: exact 672px initial width, real resize to 799px with fixed right edge, one overlay/content, sole standard Close
- pagination: 50 to 56 rows; anchor moved only 0.44px; cursor GET correlated; no mutation, WS, or D1 change
- live tail: near-tail event stayed pinned; historical reader retained scrollTop; each expected event correlated to one audit WS frame and one D1 row
- outside press, Escape, and Close each dismissed and reopened with zero writes/additional WS and exact D1 equality
- owner audit GET returned 200; non-owner returned 404 and did not open the modal
- mobile: full-width loading/content/empty plus Escape/Close passed; a physical outside click is structurally unavailable because the full-width sheet covers the 375px viewport
- teardown restored the exact raw D1 hash; backups absent and service/debug ports free

## Scope

- `src/web/src/components/community/bots/bot-activity-modal.tsx`
- `src/web/src/components/community/bots/bot-activity-modal.test.ts`
- `src/web/src/components/community/shell/community-sheet.test.ts`
- `src/web/src/components/community/shell/community-sheet-migrations.test.ts`

No API, schema, backend notification, query, or WebSocket contract changes.
