### PR TITLE
fix(web): move attachment download to sheet footer

### DIFF
--- a/src/web/src/components/community/messages/attachment-preview-sheet.test.ts
+++ b/src/web/src/components/community/messages/attachment-preview-sheet.test.ts
@@ -8,14 +8,14 @@ vi.mock("@/components/community/shell/community-sheet", () => ({
   CommunitySheet: ({
     title,
     description,
-    headerActions,
+    footer,
     children,
     bodyTestId,
     bodyClassName,
   }: {
     title: React.ReactNode
     description?: React.ReactNode
-    headerActions?: React.ReactNode
+    footer?: React.ReactNode
     children: React.ReactNode
     bodyTestId?: string
     bodyClassName?: string
@@ -24,8 +24,8 @@ vi.mock("@/components/community/shell/community-sheet", () => ({
     null,
     React.createElement("h2", null, title),
     description != null && React.createElement("p", null, description),
-    headerActions,
     React.createElement("main", { "data-testid": bodyTestId, className: bodyClassName }, children),
+    React.createElement("footer", null, footer),
   ),
 }))
 
@@ -106,6 +106,9 @@ describe("AttachmentPreviewSheet", () => {
     const download = renderer!.root.findByProps({ "data-testid": "community-attachment-preview-download" })
     expect(download.props.href).toBe("/attachments/a1")
     expect(download.props.download).toBe("notes.md")
+    expect(download.props.className).toContain("h-11")
+    expect(download.props.className).toContain("sm:h-7")
+    expect(download.parent?.type).toBe("footer")
     expect(renderer!.root.findByType("p").children.join("")).toContain("text/markdown · 128 B")
   })
 

--- a/src/web/src/components/community/messages/attachment-preview-sheet.tsx
+++ b/src/web/src/components/community/messages/attachment-preview-sheet.tsx
@@ -125,7 +125,7 @@ export function AttachmentPreviewSheet({
       onOpenChange={onOpenChange}
       title={selected?.name ?? "Attachment"}
       description={[selected?.contentType || presentation?.category, size].filter(Boolean).join(" · ")}
-      headerActions={selected && (
+      footer={selected && (
         <a
           data-testid={tid.attachmentPreviewDownload}
           href={selected.url}

--- a/src/web/src/components/community/shell/community-sheet-migrations.test.ts
+++ b/src/web/src/components/community/shell/community-sheet-migrations.test.ts
@@ -22,6 +22,7 @@ describe("CommunitySheet migrations", () => {
     expect(source).not.toContain("@/components/ui/sheet-resize-handle")
     expect(source).not.toMatch(/mode="(?:sidecar|task|preview)"/)
     expect(source).not.toContain("initialWidth=")
+    expect(source).not.toContain("headerActions")
     expect(source).not.toMatch(/CommunitySheet(?:Header|Body|Footer|Title|Description|Close)/)
   })
 

--- a/src/web/src/components/community/shell/community-sheet.test.ts
+++ b/src/web/src/components/community/shell/community-sheet.test.ts
@@ -103,13 +103,12 @@ describe("CommunitySheet contracts", () => {
     expect(renderer.root.findByProps({ "aria-label": "Close" }).props.className).toContain("size-11")
   })
 
-  it("owns header, body, footer, and routes every close entry through one request", () => {
+  it("keeps the header to title and description, and routes every close entry through one request", () => {
     const onOpenChange = vi.fn()
     const { renderer } = renderSheet({
       onOpenChange,
       title: "Structured title",
       description: "Structured description",
-      headerActions: React.createElement("a", { "data-action": true }, "Download"),
       bodyClassName: "body-policy",
       footer: (requestClose) => React.createElement(
         "button",
@@ -120,7 +119,9 @@ describe("CommunitySheet contracts", () => {
 
     expect(renderer.root.findByType("sheet-title").children).toEqual(["Structured title"])
     expect(renderer.root.findByType("sheet-description").children).toEqual(["Structured description"])
-    expect(renderer.root.findByProps({ "data-action": true })).toBeTruthy()
+    expect(renderer.root.findByType("sheet-header").findAllByType("a")).toHaveLength(0)
+    expect(renderer.root.findAllByType("button").filter((node) => node.props["aria-label"] === "Close"))
+      .toHaveLength(1)
     expect(renderer.root.findByType("sheet-body").props.className).toBe("body-policy")
     expect(renderer.root.findByType("sheet-footer").props.className).toContain(
       "**:data-[slot=button]:min-h-11",

--- a/src/web/src/components/community/shell/community-sheet.tsx
+++ b/src/web/src/components/community/shell/community-sheet.tsx
@@ -27,7 +27,6 @@ type CommunitySheetProps = {
   onOpenChange: (open: boolean) => void
   title: React.ReactNode
   description?: React.ReactNode
-  headerActions?: React.ReactNode
   footer?: React.ReactNode | ((requestClose: () => void) => React.ReactNode)
   children: React.ReactNode
   bodyClassName?: string
@@ -43,16 +42,15 @@ type CommunitySheetProps = {
  * Controlled modal shell for every community right-hand surface.
  *
  * The shell owns structure, dismissal, width, and the CSS-only 640px
- * checkpoint. Callers supply business content through the title, actions,
- * body, and optional footer slots. Attachment preview is the only caller that
- * opts into the fixed internal resize policy.
+ * checkpoint. Callers supply business content through the title, body, and
+ * optional footer slots. Callers may opt into the fixed internal resize
+ * policy when their content benefits from more horizontal space.
  */
 export function CommunitySheet({
   open,
   onOpenChange,
   title,
   description,
-  headerActions,
   footer,
   children,
   bodyClassName,
@@ -78,7 +76,6 @@ export function CommunitySheet({
         <ResizableCommunitySheetContent
           title={title}
           description={description}
-          headerActions={headerActions}
           footer={footer}
           bodyClassName={bodyClassName}
           bodyRef={bodyRef}
@@ -96,7 +93,6 @@ export function CommunitySheet({
           maxWidth="80vw"
           title={title}
           description={description}
-          headerActions={headerActions}
           footer={footer}
           bodyClassName={bodyClassName}
           bodyRef={bodyRef}
@@ -116,7 +112,6 @@ type CommunitySheetContentProps = Pick<
   CommunitySheetProps,
   | "title"
   | "description"
-  | "headerActions"
   | "footer"
   | "children"
   | "bodyClassName"
@@ -137,7 +132,6 @@ function CommunitySheetContent({
   resize,
   title,
   description,
-  headerActions,
   footer,
   children,
   bodyClassName,
@@ -167,13 +161,8 @@ function CommunitySheetContent({
     >
       {resize && <SheetResizeHandle {...resize} />}
       <SheetHeader className="pr-14 sm:pr-14">
-        <div className="flex min-w-0 items-start gap-2">
-          <div className="min-w-0 flex-1">
-            <SheetTitle className="truncate">{title}</SheetTitle>
-            {description != null && <SheetDescription>{description}</SheetDescription>}
-          </div>
-          {headerActions != null && <div className="shrink-0">{headerActions}</div>}
-        </div>
+        <SheetTitle className="truncate">{title}</SheetTitle>
+        {description != null && <SheetDescription>{description}</SheetDescription>}
       </SheetHeader>
       <SheetBody ref={bodyRef} data-testid={bodyTestId} className={bodyClassName}>
         {children}


### PR DESCRIPTION
# Why we need this PR?
Attachment Preview was the only `/c` CommunitySheet caller placing a business action in the title area. Keeping Download there made the shared shell API permit non-Close header actions and broke the one-header-action contract.

## What changed
- move the native Attachment Preview Download link into the CommunitySheet footer
- remove the `headerActions` prop and render slot from CommunitySheet
- lock the header-only-Close, footer placement, native URL/filename, and 44px mobile action contracts in tests

## Checklist
- [x] Tests added/updated as needed
- [x] All local checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...

## Verification
- focused: 3 files, 24 tests
- root typecheck: 11/11 packages
- root lint: 5/5 packages
- root test: 11/11 packages; Web 649 files / 5720 tests; CI scripts 11 files / 124 tests
- normal pre-commit hook: typecheck, lint, test, WS typegrep, agent-driver boundary, and knip all passed
