### PR TITLE
fix: keep unread queries within D1 bind limit

### DIFF
--- a/src/shared/src/db/queries/community/inbox.ts
+++ b/src/shared/src/db/queries/community/inbox.ts
@@ -14,6 +14,8 @@ import { listParticipatingThreadIds } from "./thread";
 import { reachIsParticipantSet } from "../../../utils/community-roles";
 import { hasUnreadAttentionSql, notificationEligibleSql } from "./notification-eligibility";
 
+const ELIGIBLE_UNREAD_CHANNEL_CHUNK_SIZE = 80;
+
 export interface UnreadChannelRow {
   channelId: string;
   channelName: string;
@@ -223,7 +225,7 @@ export async function listEligibleUnreadChannels(
 
   const rows = (
     await Promise.all(
-      chunk(visibleChannelIds, D1_MAX_IN_PARAMS).map((ids) =>
+      chunk(visibleChannelIds, ELIGIBLE_UNREAD_CHANNEL_CHUNK_SIZE).map((ids) =>
         db
           .select({
             channelId: communityChannel.id,

--- a/src/shared/test/queries/param-limit.test.ts
+++ b/src/shared/test/queries/param-limit.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../src/db/community-schema";
 import * as mentionQueries from "../../src/db/queries/community/mention";
 import * as attachmentQueries from "../../src/db/queries/community/attachment";
+import * as inboxQueries from "../../src/db/queries/community/inbox";
 import { D1_MAX_BIND_PARAMS } from "../../src/db/queries/_chunk";
 
 const fakeDb = drizzle({} as never);
@@ -145,5 +146,40 @@ describe("listByMessageIds chunking + global re-sort", () => {
     const rows = await attachmentQueries.listByMessageIds(db, ids);
     expect(callCount()).toBe(2); // 150 ids → 2 chunks (90 + 60)
     expect(rows.map((r: any) => r.position)).toEqual([1, 2]);
+  });
+});
+
+function makeD1SelectCapture() {
+  const statements: Array<{ sql: string; params: unknown[] }> = [];
+  const client = {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          statements.push({ sql, params });
+          return { raw: async () => [] };
+        },
+      };
+    },
+  };
+  return { db: drizzle(client as never), statements };
+}
+
+describe("listEligibleUnreadChannels bound parameters", () => {
+  it("95 visible ids use 80-id chunks and keep every statement within D1's limit", async () => {
+    const { db, statements } = makeD1SelectCapture();
+    const visibleChannelIds = Array.from({ length: 95 }, (_, index) => `channel_${index}`);
+
+    await expect(
+      inboxQueries.listEligibleUnreadChannels(db as never, "user_1", visibleChannelIds),
+    ).resolves.toEqual([]);
+
+    expect(statements).toHaveLength(2);
+    expect(statements.map(({ params }) => params.filter(
+      (value) => typeof value === "string" && value.startsWith("channel_"),
+    ).length)).toEqual([80, 15]);
+    expect(statements.map(({ params }) => params.length)).toEqual([91, 26]);
+    for (const { params } of statements) {
+      expect(params.length).toBeLessThanOrEqual(D1_MAX_BIND_PARAMS);
+    }
   });
 });

--- a/src/web/src/app/api/community/servers/[id]/unreads/route.test.ts
+++ b/src/web/src/app/api/community/servers/[id]/unreads/route.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from "next/server"
 
 const mockGetMember = vi.fn()
 const mockListVisibleChannelIds = vi.fn()
+const mockListVisibleChannelIdsForUser = vi.fn()
 const mockListEligibleUnreadChannels = vi.fn()
 const mockListUnreadForumOpeners = vi.fn()
 
@@ -16,7 +17,8 @@ vi.mock("@alook/shared", async () => {
       communityMember: { getMember: (...args: unknown[]) => mockGetMember(...args) },
       communityChannel: {
         ...actual.queries.communityChannel,
-        listVisibleChannelIdsForUser: (...args: unknown[]) => mockListVisibleChannelIds(...args),
+        listVisibleChannelIds: (...args: unknown[]) => mockListVisibleChannelIds(...args),
+        listVisibleChannelIdsForUser: (...args: unknown[]) => mockListVisibleChannelIdsForUser(...args),
       },
       communityInbox: {
         ...actual.queries.communityInbox,
@@ -40,11 +42,11 @@ describe("GET /api/community/servers/[id]/unreads", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetMember.mockResolvedValue({ id: "member_1", role: "member" })
-    mockListVisibleChannelIds.mockResolvedValue(["channel_1", "channel_2", "other_1"])
+    mockListVisibleChannelIds.mockResolvedValue(["channel_1", "channel_2"])
+    mockListVisibleChannelIdsForUser.mockRejectedValue(new Error("cross-server resolver must not run"))
     mockListEligibleUnreadChannels.mockResolvedValue([
       { serverId: "server_1", channelId: "channel_1" },
       { serverId: "server_1", channelId: "channel_2", parentChannelId: "channel_1" },
-      { serverId: "server_2", channelId: "other_1" },
     ])
     mockListUnreadForumOpeners.mockResolvedValue([])
   })
@@ -61,7 +63,9 @@ describe("GET /api/community/servers/[id]/unreads", () => {
       childChannels: [{ id: "channel_2", parentChannelId: "channel_1" }],
       stale: false,
     })
-    expect(mockListEligibleUnreadChannels).toHaveBeenCalledWith(expect.anything(), "user_1", ["channel_1", "channel_2", "other_1"])
+    expect(mockListVisibleChannelIds).toHaveBeenCalledWith(expect.anything(), "server_1", "user_1")
+    expect(mockListVisibleChannelIdsForUser).not.toHaveBeenCalled()
+    expect(mockListEligibleUnreadChannels).toHaveBeenCalledWith(expect.anything(), "user_1", ["channel_1", "channel_2"])
   })
 
   it("uses the shared readable, cursor, policy, and attention projection on refetch", async () => {

--- a/src/web/src/app/api/community/servers/[id]/unreads/route.ts
+++ b/src/web/src/app/api/community/servers/[id]/unreads/route.ts
@@ -15,9 +15,8 @@ export const GET = withAuth(async (_req, ctx) => {
 
   const { value, stale } = await readOrStale(
     async () => {
-      const visibleChannelIds = await queries.communityChannel.listVisibleChannelIdsForUser(db, ctx.userId)
-      const unread = (await queries.communityInbox.listEligibleUnreadChannels(db, ctx.userId, visibleChannelIds))
-        .filter((row) => row.serverId === serverId)
+      const visibleChannelIds = await queries.communityChannel.listVisibleChannelIds(db, serverId, ctx.userId)
+      const unread = await queries.communityInbox.listEligibleUnreadChannels(db, ctx.userId, visibleChannelIds)
       const forumParentIds = unread
         .filter((row) => !row.parentChannelId && row.type === "forum")
         .map((row) => row.channelId)


### PR DESCRIPTION
## Summary

- cap only `listEligibleUnreadChannels` at 80 channel ids per statement, leaving its 11 fixed bindings under D1's 100-bound-parameter limit
- scope server unread visibility with `listVisibleChannelIds(db, serverId, userId)` before unread aggregation
- keep the cross-server Inbox resolver unchanged

Cloudflare documents a maximum of 100 bound parameters per D1 query: https://developers.cloudflare.com/d1/platform/limits/

## Regression coverage

- 95 ids compile into 80/15 chunks with actual Drizzle bind counts 91/26
- server unread calls the server-scoped resolver and never the cross-server resolver
- existing server unread response, forum projection, permission, stale fallback, and Inbox suites remain green

## Verification

- focused shared: 9 passed
- focused web: 29 passed
- normal pre-commit: full typecheck, lint, tests, boundary checks, and knip passed
- `git diff --check`: clean

Draft only. Madox owns rebase/Git review, independent QA, CI/Codecov, and merge-lock handoff.
