### PR TITLE
fix(web): preserve reply author in message content

### DIFF
--- a/src/web/src/app/c/me/[dmId]/page.tsx
+++ b/src/web/src/app/c/me/[dmId]/page.tsx
@@ -53,6 +53,7 @@ import { useNotificationSettings } from "@/hooks/community/use-notification-sett
 import { useSetChannelNotif } from "@/hooks/community/mutations"
 import { toastApiError } from "@/lib/api/client"
 import { communityKeys } from "@/lib/query-keys"
+import { displayReplyContent } from "@/lib/community/reply-content"
 
 const EMPTY_DMS: DmsResponse["conversations"] = []
 
@@ -358,11 +359,18 @@ function DmView() {
       toggleReaction({ dmId, messageId: id, emoji, userId: currentUser.id }),
     onReply: (id: string) => {
       const m = messages.find((x) => x.id === id)
-      if (m) setReplyTo({ id: m.id, authorName: m.authorName ?? "", text: m.content ?? "" })
+      if (m) {
+        setReplyTo({
+          id: m.id,
+          authorName: m.authorName ?? "",
+          text: displayReplyContent(m.content ?? "", m.replyTo),
+        })
+      }
     },
     onCopy: (id: string) => {
       const m = messages.find((x) => x.id === id)
-      if (m?.content) { navigator.clipboard?.writeText(m.content); toast("Copied to clipboard") }
+      const content = m ? displayReplyContent(m.content ?? "", m.replyTo) : ""
+      if (content) { navigator.clipboard?.writeText(content); toast("Copied to clipboard") }
     },
     // A DM is a channel (type='dm'), so its id IS the mark route's channelId.
     onMark: (id: string) => toggleMark(dmId, id),

--- a/src/web/src/components/community/messages/message-channel-controller-actions.test.ts
+++ b/src/web/src/components/community/messages/message-channel-controller-actions.test.ts
@@ -241,4 +241,36 @@ describe("createMessageActions", () => {
     expect(harness.setReplyTo).toHaveBeenCalledWith({ id: "m2", authorName: "Latest", text: "new" })
     expect("onDelete" in harness.actions).toBe(false)
   })
+
+  it("uses projected reply text for actions and restores one canonical prefix on edit", async () => {
+    const harness = setup()
+    harness.actionContext.current.messages = [{
+      ...harness.actionContext.current.messages[0],
+      content: "@Alice Smith\n> quote\n\nbody",
+      replyTo: { id: "prior", authorName: "Alice Smith", text: "original" },
+    }]
+
+    harness.actions.onReply("m1")
+    expect(harness.setReplyTo).toHaveBeenCalledWith({
+      id: "m1",
+      authorName: "Viewer",
+      text: "> quote\n\nbody",
+    })
+
+    harness.actions.onCopy("m1")
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("> quote\n\nbody")
+
+    await harness.actions.onCreateThread("m1")
+    expect(mocks.deriveThreadName).toHaveBeenCalledWith("> quote\n\nbody", "general")
+
+    vi.stubGlobal("window", { prompt: vi.fn(() => "edited") })
+    harness.actions.onEdit("m1")
+    expect(window.prompt).toHaveBeenCalledWith("Edit message", "> quote\n\nbody")
+    expect(harness.editMessage).toHaveBeenCalledWith({
+      serverId: "server_1",
+      channelId: "channel_1",
+      messageId: "m1",
+      content: "@Alice Smith\nedited",
+    }, expect.objectContaining({ onError: expect.any(Function) }))
+  })
 })

--- a/src/web/src/components/community/messages/message-channel-controller-actions.ts
+++ b/src/web/src/components/community/messages/message-channel-controller-actions.ts
@@ -4,6 +4,7 @@ import { toast } from "sonner"
 import { toastApiError } from "@/lib/api/client"
 import type { FileAttachment, ImagePreview, Msg } from "@/lib/community/models/message"
 import { useMessageStreamStore } from "@/stores/community/message-stream"
+import { canonicalizeReplyContent, displayReplyContent } from "@/lib/community/reply-content"
 import type {
   MessageActions,
   MessageUiHandlers,
@@ -90,7 +91,7 @@ export function createMessageActions({
         setReplyTo({
           id: message.id,
           authorName: message.authorName ?? "",
-          text: message.content ?? "",
+          text: displayReplyContent(message.content ?? "", message.replyTo),
         })
       }
     },
@@ -111,7 +112,10 @@ export function createMessageActions({
     onMark: (id) => toggleMark(channelId, id),
     onCreateThread: async (id) => {
       const message = actionContext.current.messages.find((item) => item.id === id)
-      const name = deriveThreadName(message?.content, actionContext.current.channelName)
+      const content = message
+        ? displayReplyContent(message.content ?? "", message.replyTo)
+        : undefined
+      const name = deriveThreadName(content, actionContext.current.channelName)
       try {
         const data = await createThreadAsync({ serverId, channelId, messageId: id, name })
         actionContext.current.onOpenThread(data.id)
@@ -121,15 +125,20 @@ export function createMessageActions({
     },
     onCopy: (id) => {
       const message = actionContext.current.messages.find((item) => item.id === id)
-      if (!message?.content) return
-      void navigator.clipboard?.writeText(message.content)
+      if (!message) return
+      const content = displayReplyContent(message.content ?? "", message.replyTo)
+      if (!content) return
+      void navigator.clipboard?.writeText(content)
       toast("Copied to clipboard")
     },
     onEdit: (id) => {
       const message = actionContext.current.messages.find((item) => item.id === id)
-      if (!message?.content || message.authorId !== viewerUserId || message.seq === undefined) return
-      const content = window.prompt("Edit message", message.content)
-      if (!content || content === message.content) return
+      if (!message || message.authorId !== viewerUserId || message.seq === undefined) return
+      const visibleContent = displayReplyContent(message.content ?? "", message.replyTo)
+      if (!visibleContent) return
+      const editedContent = window.prompt("Edit message", visibleContent)
+      if (!editedContent || editedContent === visibleContent) return
+      const content = canonicalizeReplyContent(editedContent, message.replyTo)
       editMessage({ serverId, channelId, messageId: id, content }, {
         onError: (error) => toastApiError(error, "Failed to edit message"),
       })

--- a/src/web/src/components/community/messages/message-channel-controller-send.test.ts
+++ b/src/web/src/components/community/messages/message-channel-controller-send.test.ts
@@ -97,7 +97,7 @@ describe("message channel send helpers", () => {
           authorId: "viewer_1",
           authorName: "Viewer",
           authorAvatar: "V",
-          content: "hello",
+          content: "@Alice\nhello",
           createdAt: "2026-01-02T03:04:05.000Z",
           replyTo: { id: "reply_1", authorName: "Alice", text: "prior" },
         },
@@ -171,6 +171,29 @@ describe("message channel send helpers", () => {
     expect(runner).toHaveBeenCalledWith("nonce_1")
     expect(mocks.resetTyping).toHaveBeenCalledWith({ channelId: "channel_1" })
     expect(clearReply).toHaveBeenCalledOnce()
+  })
+
+  it("stores the canonical author prefix for an attachment-only reply", () => {
+    const file = new File(["abc"], "only.txt", { type: "text/plain" })
+    mocks.accept.mockReturnValue(true)
+
+    expect(acceptChannelMessage({
+      markdown: "",
+      attachments: [{ file, previewObjectUrl: "blob:provided" }],
+      messageScope: scope,
+      viewer,
+      replyTo: { id: "reply_1", authorName: "Alice Smith", text: "prior" },
+      runAcceptedIntent: vi.fn(async () => {}),
+      channelId: "channel_1",
+      clearReply: vi.fn(),
+    })).toBe(true)
+
+    expect(mocks.accept).toHaveBeenCalledWith(scope, expect.objectContaining({
+      message: expect.objectContaining({
+        content: "@Alice Smith\n",
+        replyTo: { id: "reply_1", authorName: "Alice Smith", text: "prior" },
+      }),
+    }))
   })
 
   it("reuses settled projections and dispatches all-or-nothing upload failure without sending", async () => {
@@ -351,5 +374,40 @@ describe("message channel send helpers", () => {
     }))
     expect(mocks.dispatch).not.toHaveBeenCalled()
     expect(mocks.toastApiError).not.toHaveBeenCalled()
+  })
+
+  it("sends the accepted canonical reply bytes unchanged on every retry", async () => {
+    const canonicalContent = "@Alice Smith\n> quoted\n\nbody"
+    mocks.getRetryPayload.mockReturnValue({
+      localUploads: [],
+      uploadStatus: "settled",
+      message: {
+        content: canonicalContent,
+        replyTo: { id: "reply_1", authorName: "Alice Smith", text: "prior" },
+      },
+    })
+    const sendMessageAsync = vi.fn(async () => ({}))
+    const args = {
+      messageScope: scope,
+      nonce: "nonce_retry",
+      uploadFileAsync: vi.fn(),
+      sendMessageAsync,
+      channelId: "channel_1",
+      serverId: "server_1",
+      viewer,
+    }
+
+    await runAcceptedMessageIntent(args)
+    await runAcceptedMessageIntent(args)
+
+    expect(sendMessageAsync).toHaveBeenCalledTimes(2)
+    expect(sendMessageAsync).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      content: canonicalContent,
+      replyToId: "reply_1",
+    }))
+    expect(sendMessageAsync).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      content: canonicalContent,
+      replyToId: "reply_1",
+    }))
   })
 })

--- a/src/web/src/components/community/messages/message-channel-controller-send.ts
+++ b/src/web/src/components/community/messages/message-channel-controller-send.ts
@@ -12,6 +12,7 @@ import {
 import { toastApiError } from "@/lib/api/client"
 import { useMessageStreamStore } from "@/stores/community/message-stream"
 import { communityWsResetTypingThrottle } from "@/hooks/community/use-community-ws"
+import { canonicalizeReplyContent } from "@/lib/community/reply-content"
 
 type ChannelMessageScope = {
   kind: "channel"
@@ -149,6 +150,7 @@ export function acceptChannelMessage({
   clearReply: () => void
 }): boolean {
   if (!markdown && !attachments?.length) return false
+  const content = canonicalizeReplyContent(markdown, replyTo)
   const nonce = sendNonce()
   const createdPreviewUrls: string[] = []
   const accepted = useMessageStreamStore.getState().accept(messageScope, {
@@ -159,7 +161,7 @@ export function acceptChannelMessage({
       authorId: viewer.id,
       authorName: viewer.name,
       authorAvatar: viewer.avatar,
-      content: markdown,
+      content,
       createdAt: new Date().toISOString(),
       ...(replyTo ? { replyTo: toOptimisticReplyPreview(replyTo) } : {}),
     },

--- a/src/web/src/components/community/messages/message-context-sheet.tsx
+++ b/src/web/src/components/community/messages/message-context-sheet.tsx
@@ -8,6 +8,7 @@ import { deriveThreadName } from "@alook/shared"
 import { CommunitySheet } from "@/components/community/shell/community-sheet"
 import { MessageRow } from "./message-row"
 import { MessageShareDialog } from "./message-share-dialog"
+import { displayReplyContent } from "@/lib/community/reply-content"
 import { ChannelIcon } from "../channels/channel-icon"
 import { Skeleton } from "@/components/ui/skeleton"
 import { apiFetch, toastApiError } from "@/lib/api/client"
@@ -251,8 +252,9 @@ export function MessageContextSheet({
 
   const onCopyId = useCallback((id: string) => {
     const m = findMessage(id)
-    if (m?.content) {
-      navigator.clipboard?.writeText(m.content)
+    const content = m ? displayReplyContent(m.content ?? "", m.replyTo) : ""
+    if (content) {
+      navigator.clipboard?.writeText(content)
       toast("Copied to clipboard")
     }
   }, [findMessage])
@@ -261,7 +263,11 @@ export function MessageContextSheet({
     if (!onReply) return
     const m = findMessage(id)
     if (!m) return
-    onReply({ id: m.id, authorName: m.authorName ?? "", text: m.content ?? "" })
+    onReply({
+      id: m.id,
+      authorName: m.authorName ?? "",
+      text: displayReplyContent(m.content ?? "", m.replyTo),
+    })
   }, [findMessage, onReply])
 
   // Mark works for both channel and DM (unlike pin) — the sheet's channelId is
@@ -292,7 +298,8 @@ export function MessageContextSheet({
     const serverId = routeParams?.serverId
     if (!serverId) return
     const m = findMessage(id)
-    const name = deriveThreadName(m?.content, "channel")
+    const content = m ? displayReplyContent(m.content ?? "", m.replyTo) : undefined
+    const name = deriveThreadName(content, "channel")
     try {
       const data = await createThreadMut.mutateAsync({ serverId, channelId, messageId: id, name })
       // Match the main-channel UX: after creating a thread the row shows

--- a/src/web/src/components/community/messages/message-share-dialog.test.ts
+++ b/src/web/src/components/community/messages/message-share-dialog.test.ts
@@ -80,6 +80,35 @@ describe("MessageShareDialog message context", () => {
     ])
   })
 
+  it("keeps the reply header while sharing only projected message content", () => {
+    const renderer = renderMessage(message({
+      content: "@Bob Smith\n**visible** body",
+      replyTo: {
+        id: "original",
+        authorName: "Bob Smith",
+        text: "Original body",
+      },
+    }))
+
+    expect(renderer.root.findByType("mock-message-body").props.text).toBe("**visible** body")
+    const reply = renderer.root.findByProps({ "data-testid": "message-share-reply-m1" })
+    expect(reply.findAllByType("span").map((span) => span.children.join(""))).toEqual([
+      "@Bob Smith",
+      "Original body",
+    ])
+  })
+
+  it("omits a standalone body for an attachment-only canonical reply", () => {
+    const renderer = renderMessage(message({
+      content: "@Bob\n",
+      replyTo: { id: "original", authorName: "Bob", text: "Original body" },
+      attachments: [{ kind: "image", name: "photo.png", url: "/photo.png" }],
+    }))
+
+    expect(renderer.root.findAllByType("mock-message-body")).toHaveLength(0)
+    expect(renderer.root.findByProps({ "data-testid": "message-share-image-m1-0" })).toBeDefined()
+  })
+
   it("renders the deleted-original state without stale reply details", () => {
     const renderer = renderMessage(message({
       replyTo: {

--- a/src/web/src/components/community/messages/message-share-dialog.tsx
+++ b/src/web/src/components/community/messages/message-share-dialog.tsx
@@ -14,6 +14,7 @@ import { attachmentAspectRatio } from "./attachment-layout"
 import { tid } from "@/lib/community/testids"
 import { applyHighlightToRange, clearHighlights, hasHighlights } from "@/lib/community/highlight-range"
 import type { RenderMsg } from "@/lib/community/models/message"
+import { displayReplyContent } from "@/lib/community/reply-content"
 
 const SHARE_IMAGE_READY_TIMEOUT_MS = 5_000
 
@@ -250,8 +251,10 @@ export function MessageShareDialog({ m, open, onClose }: {
             ref={cardRef}
             className="rounded-xl bg-card p-5 shadow-(--e1)"
           >
-            {messages.map((msg) => (
-              <div key={msg.id} className={msg.grouped ? "mt-0.5" : "mt-3 first:mt-0"}>
+            {messages.map((msg) => {
+              const visibleContent = displayReplyContent(msg.content ?? "", msg.replyTo)
+              return (
+                <div key={msg.id} className={msg.grouped ? "mt-0.5" : "mt-3 first:mt-0"}>
                 {msg.replyTo && (
                   <div
                     data-testid={`message-share-reply-${msg.id}`}
@@ -292,14 +295,14 @@ export function MessageShareDialog({ m, open, onClose }: {
                         (rasterises cleanly under html-to-image — plain bg +
                         box-decoration-break, no mask). max-h ≈ 32 lines at the
                         body's 15px/leading-snug. */}
-                    {msg.content && (
+                    {visibleContent && (
                       <div
                         ref={(el) => { bodyRefs.current.set(msg.id, el) }}
                         onMouseUp={() => onBodyMouseUp(msg.id)}
                         className="max-h-164 overflow-hidden line-clamp-32 [&_mark[data-hl]]:rounded-xs [&_mark[data-hl]]:bg-[rgba(255,208,92,0.5)] [&_mark[data-hl]]:p-[0_1px] [&_mark[data-hl]]:[box-decoration-break:clone] [&_mark[data-hl]]:[-webkit-box-decoration-break:clone] [&_mark[data-hl]]:text-inherit"
                       >
                         <MessageBody
-                          text={msg.content}
+                          text={visibleContent}
                           perspective="neutral"
                           enableLinkPreview={!msg.embeds?.length}
                         />
@@ -352,8 +355,9 @@ export function MessageShareDialog({ m, open, onClose }: {
                     )}
                   </div>
                 </div>
-              </div>
-            ))}
+                </div>
+              )
+            })}
 
             {/* Brand footer — Alook logo + brand font, mirrors the marketing
                 footer treatment. One footer for the whole card, single or multi. */}

--- a/src/web/src/components/community/messages/message.render.test.ts
+++ b/src/web/src/components/community/messages/message.render.test.ts
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import {
   createMessageMenuPointAnchor,
   Message,
+  messageCanShare,
   selectionBelongsToRow,
   shouldActivateMessageOverlays,
   shouldSuppressTouchMenuOpen,
@@ -52,6 +53,12 @@ function makeTree(props: Parameters<typeof Message>[0]) {
     { client: queryClient },
     React.createElement(Message, props),
   )
+}
+
+function textContent(node: TestRenderer.ReactTestInstance): string {
+  return node.children.map((child) => (
+    typeof child === "string" ? child : textContent(child)
+  )).join("")
 }
 
 beforeEach(() => {
@@ -127,6 +134,49 @@ describe("Message memo comparator", () => {
       }))
     })
     expect(resolveUserName.mock.calls.length).toBeGreaterThan(before)
+  })
+})
+
+describe("Message reply content projection", () => {
+  it("keeps the reply header and renders only the projected Markdown body", () => {
+    let renderer: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(makeTree({
+        m: baseMsg({
+          content: "@Bob Smith\n**visible** body",
+          replyTo: { id: "prior", authorName: "Bob Smith", text: "original" },
+        }),
+        onOpenThread: vi.fn(),
+      }), { createNodeMock: () => genericMock })
+    })
+
+    const body = renderer!.root.findByProps({ "data-community-message-body": true })
+    expect(textContent(body)).not.toContain("@Bob Smith")
+    expect(textContent(body)).toContain("visible")
+    expect(renderer!.root.findAllByType("button").some((button) => (
+      textContent(button).includes("@Bob Smith")
+      && textContent(button).includes("original")
+    ))).toBe(true)
+  })
+
+  it("keeps a different leading mention visible and hides prefix-only reply text", () => {
+    let different: TestRenderer.ReactTestRenderer
+    act(() => {
+      different = TestRenderer.create(makeTree({
+        m: baseMsg({
+          content: "@Carol\nhello",
+          replyTo: { id: "prior", authorName: "Bob", text: "original" },
+        }),
+        onOpenThread: vi.fn(),
+      }), { createNodeMock: () => genericMock })
+    })
+    const body = different!.root.findByProps({ "data-community-message-body": true })
+    expect(textContent(body)).toContain("@Carol")
+
+    expect(messageCanShare(baseMsg({
+      content: "@Bob\n",
+      replyTo: { id: "prior", authorName: "Bob", text: "original" },
+    }))).toBe(false)
   })
 })
 

--- a/src/web/src/components/community/messages/message.tsx
+++ b/src/web/src/components/community/messages/message.tsx
@@ -25,6 +25,7 @@ import type { FileAttachment, ImagePreview, RenderMsg } from "@/lib/community/mo
 import type { OpenProfile } from "@/components/community/social/profile-types"
 import { attachmentAspectRatio } from "./attachment-layout"
 import { AttachmentCard } from "./attachment-card"
+import { displayReplyContent } from "@/lib/community/reply-content"
 
 // Whether the "Share as Image" action is offered for a message. Share is
 // computed inside `Message` from the message alone (no handler is threaded in),
@@ -38,7 +39,10 @@ import { AttachmentCard } from "./attachment-card"
 export function messageCanShare(m: RenderMsg, compact?: boolean): boolean {
   return !compact
     && !m.approval
-    && (!!m.content || !!m.attachments?.some((attachment) => attachment.kind === "image"))
+    && (
+      !!displayReplyContent(m.content ?? "", m.replyTo)
+      || !!m.attachments?.some((attachment) => attachment.kind === "image")
+    )
 }
 
 export function shouldActivateMessageOverlays(target: EventTarget | null): boolean {
@@ -147,6 +151,7 @@ function MessageImpl({
   // default without subscribing at all.
   hoverCapable?: boolean
 }) {
+  const visibleContent = displayReplyContent(m.content ?? "", m.replyTo)
   // keep the hover toolbar pinned open while its ⋯ dropdown is open
   const [toolbarOpen, setToolbarOpen] = useState(false)
   // Right-click context-menu open state — tracked so the Mark/Unmark label's
@@ -369,9 +374,9 @@ function MessageImpl({
           {m.approval ? (
             <BotApprovalCard approval={m.approval} />
           ) : (
-            m.content && (
+            visibleContent && (
               <MessageBody
-                text={m.content}
+                text={visibleContent}
                 onOpenProfile={onOpenProfile}
                 enableLinkPreview={!m.embeds?.length}
                 perspective={

--- a/src/web/src/components/community/messages/thread-opener.test.ts
+++ b/src/web/src/components/community/messages/thread-opener.test.ts
@@ -15,7 +15,44 @@ const genericMock = {
   getBoundingClientRect: () => ({ top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 }),
 }
 
+function textContent(node: TestRenderer.ReactTestInstance): string {
+  return node.children.map((child) => (
+    typeof child === "string" ? child : textContent(child)
+  )).join("")
+}
+
 describe("ThreadOpener image attachment layout", () => {
+  it("renders projected reply content in the opener", () => {
+    useMessageMock.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      message: {
+        id: "opener_1",
+        type: "chat",
+        authorId: "user_1",
+        authorName: "Alice",
+        content: "@Bob Smith\n**visible** body",
+        replyTo: { id: "prior", authorName: "Bob Smith", text: "original" },
+        createdAt: "2026-08-08T00:00:00.000Z",
+      },
+    })
+
+    let renderer: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(
+        React.createElement(ThreadOpener, {
+          parentMessageId: "opener_1",
+          viewerUserId: "viewer_1",
+        }),
+        { createNodeMock: () => genericMock },
+      )
+    })
+
+    const body = renderer!.root.findByProps({ "data-community-message-body": true })
+    expect(textContent(body)).not.toContain("@Bob Smith")
+    expect(textContent(body)).toContain("visible")
+  })
+
   it("keeps a known portrait image intrinsic and constrains it by message width + max height", () => {
     useMessageMock.mockReturnValue({
       isLoading: false,

--- a/src/web/src/components/community/messages/thread-opener.tsx
+++ b/src/web/src/components/community/messages/thread-opener.tsx
@@ -13,6 +13,7 @@ import { tid } from "@/lib/community/testids"
 import type { FileAttachment, ImagePreview } from "@/lib/community/models/message"
 import type { OpenProfile } from "@/components/community/social/profile-types"
 import { AttachmentCard } from "./attachment-card"
+import { displayReplyContent } from "@/lib/community/reply-content"
 
 // Thread opener — the parent message the thread was created from, pinned at
 // the top of the thread's message list. Deliberately styled like a REGULAR
@@ -67,6 +68,7 @@ export function ThreadOpener({
   }
 
   const avatarLabel = msg.authorAvatar || avatarInitial(msg.authorName)
+  const visibleContent = displayReplyContent(msg.content ?? "", msg.replyTo)
 
   return (
     <div className="group relative">
@@ -108,9 +110,9 @@ export function ThreadOpener({
             </span>
           </div>
 
-          {msg.content && (
+          {visibleContent && (
             <MessageBody
-              text={msg.content}
+              text={visibleContent}
               onOpenProfile={onOpenProfile}
               perspective={msg.authorId === viewerUserId ? "sender" : "recipient"}
             />

--- a/src/web/src/hooks/community/use-dm-message-sender.test.ts
+++ b/src/web/src/hooks/community/use-dm-message-sender.test.ts
@@ -44,7 +44,7 @@ describe("useDmMessageSender", () => {
 
     const receipt = sender.accept({
       dmId: "dm_1",
-      content: "hello",
+      content: "@Peer\nhello",
       replyTo: { id: "prior", authorName: "Peer", text: "quoted" },
       author: { id: "u_me", name: "Me", avatar: "M" },
     })
@@ -54,12 +54,12 @@ describe("useDmMessageSender", () => {
     expect(intent?.message).toEqual(expect.objectContaining({
       authorId: "u_me",
       authorName: "Me",
-      content: "hello",
+      content: "@Peer\nhello",
       replyTo: { id: "prior", authorName: "Peer", text: "quoted" },
     }))
     expect(postMock).toHaveBeenCalledWith({
       dmId: "dm_1",
-      content: "hello",
+      content: "@Peer\nhello",
       replyToId: "prior",
       attachments: undefined,
       nonce: "fresh_nonce",
@@ -181,11 +181,49 @@ describe("useDmMessageSender", () => {
     if (!receipt.accepted) throw new Error("expected accepted receipt")
     await expect(receipt.committed).resolves.toEqual({ ok: false, error: expect.any(Error) })
     const expected = `${"x".repeat(MESSAGE_PREVIEW_LENGTH - 1)}…`
-    expect(getMessageOverlay({ kind: "dm", id: "dm_1" }).outboxByNonce.get("fresh_nonce")?.message.replyTo?.text).toBe(expected)
+    const intent = getMessageOverlay({ kind: "dm", id: "dm_1" }).outboxByNonce.get("fresh_nonce")
+    expect(intent?.message.replyTo?.text).toBe(expected)
+    expect(intent?.message.content).toBe("@Peer\nreplying")
 
     await expect(sender.retry("dm_1", "fresh_nonce")).resolves.toEqual({ ok: false, error: expect.any(Error) })
     expect(getMessageOverlay({ kind: "dm", id: "dm_1" }).outboxByNonce.get("fresh_nonce")?.message.replyTo?.text).toBe(expected)
-    expect(postMock).toHaveBeenNthCalledWith(2, expect.objectContaining({ replyToId: "prior", nonce: "fresh_nonce" }))
+    expect(postMock).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      content: "@Peer\nreplying", replyToId: "prior", nonce: "fresh_nonce",
+    }))
+    expect(postMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      content: "@Peer\nreplying", replyToId: "prior", nonce: "fresh_nonce",
+    }))
+  })
+
+  it("sends a canonical prefix for an attachment-only DM reply", async () => {
+    uploadMock.mockResolvedValueOnce({
+      id: "att_x",
+      filename: "x.txt",
+      contentType: "text/plain",
+      size: 1,
+    })
+    postMock.mockResolvedValueOnce({ message: { id: "server_file", seq: 9 } })
+    const { useDmMessageSender } = await import("./use-dm-message-sender")
+    const file = new File(["x"], "x.txt", { type: "text/plain" })
+    const receipt = useDmMessageSender().accept({
+      dmId: "dm_1",
+      content: "",
+      replyTo: { id: "prior", authorName: "Peer Name", text: "quoted" },
+      attachments: [{ file, previewObjectUrl: "blob:x" }],
+      author: { id: "u_me", name: "Me", avatar: "M" },
+    })
+
+    if (!receipt.accepted) throw new Error("expected accepted receipt")
+    await expect(receipt.committed).resolves.toEqual({
+      ok: true,
+      message: { id: "server_file", seq: 9 },
+    })
+    expect(getMessageOverlay({ kind: "dm", id: "dm_1" }).outboxByNonce.get("fresh_nonce")?.message.content)
+      .toBe("@Peer Name\n")
+    expect(postMock).toHaveBeenCalledWith(expect.objectContaining({
+      content: "@Peer Name\n",
+      replyToId: "prior",
+    }))
   })
 
   it("reuses settled remote attachments on retry without uploading twice", async () => {

--- a/src/web/src/hooks/community/use-dm-message-sender.ts
+++ b/src/web/src/hooks/community/use-dm-message-sender.ts
@@ -6,6 +6,7 @@ import type { SendAttachment } from "@/lib/community/models/message"
 import { toastApiError } from "@/lib/api/client"
 import { toOptimisticReplyPreview } from "@/lib/community/reply-preview"
 import { useMessageStreamStore } from "@/stores/community/message-stream"
+import { canonicalizeReplyContent } from "@/lib/community/reply-content"
 import {
   sendNonce,
   tempMessageId,
@@ -117,6 +118,7 @@ export function useDmMessageSender() {
 
   const accept = useCallback((args: AcceptDmMessageArgs): DmSendReceipt => {
     if (!args.content && !args.attachments?.length) return { accepted: false }
+    const content = canonicalizeReplyContent(args.content, args.replyTo)
     const nonce = args.nonce ?? sendNonce()
     const createdPreviewUrls: string[] = []
     const accepted = useMessageStreamStore.getState().accept(
@@ -129,7 +131,7 @@ export function useDmMessageSender() {
           authorId: args.author.id,
           authorName: args.author.name,
           authorAvatar: args.author.avatar,
-          content: args.content,
+          content,
           createdAt: new Date().toISOString(),
           ...(args.replyTo ? { replyTo: toOptimisticReplyPreview(args.replyTo) } : {}),
         },

--- a/src/web/src/hooks/community/use-message.ts
+++ b/src/web/src/hooks/community/use-message.ts
@@ -28,6 +28,7 @@ export type OpenerPayload = {
   // shape (this payload is fed by that same endpoint, `GET /api/community/messages/:id`).
   type: "chat" | "system"
   createdAt: string
+  replyTo?: Msg["replyTo"]
   attachments?: Msg["attachments"]
   embeds?: Msg["embeds"]
   reactions?: Msg["reactions"]

--- a/src/web/src/lib/community/reply-content.test.ts
+++ b/src/web/src/lib/community/reply-content.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+import { canonicalizeReplyContent, displayReplyContent } from "./reply-content"
+
+describe("reply content", () => {
+  const alice = { authorName: "Alice Smith" }
+
+  it("adds one exact author prefix to plain text and Markdown blocks", () => {
+    expect(canonicalizeReplyContent("hello", alice)).toBe("@Alice Smith\nhello")
+    expect(canonicalizeReplyContent("> quote\n\n- one", alice)).toBe(
+      "@Alice Smith\n> quote\n\n- one",
+    )
+  })
+
+  it("keeps an existing same-author mention only at an exact boundary", () => {
+    expect(canonicalizeReplyContent("@Alice Smith\nhello", alice)).toBe(
+      "@Alice Smith\nhello",
+    )
+    expect(canonicalizeReplyContent("@Alice Smith hello", alice)).toBe(
+      "@Alice Smith hello",
+    )
+    expect(canonicalizeReplyContent("@Alice Smith", alice)).toBe("@Alice Smith")
+    expect(canonicalizeReplyContent("@Alice Smithers hello", alice)).toBe(
+      "@Alice Smith\n@Alice Smithers hello",
+    )
+    expect(canonicalizeReplyContent("@Bob hello", alice)).toBe(
+      "@Alice Smith\n@Bob hello",
+    )
+  })
+
+  it("canonicalizes attachment-only reply content", () => {
+    expect(canonicalizeReplyContent("", alice)).toBe("@Alice Smith\n")
+  })
+
+  it("strips one matching prefix and one logical boundary", () => {
+    expect(displayReplyContent("@Alice Smith\nhello", alice)).toBe("hello")
+    expect(displayReplyContent("@Alice Smith\r\nhello", alice)).toBe("hello")
+    expect(displayReplyContent("@Alice Smith  hello", alice)).toBe(" hello")
+    expect(displayReplyContent("@Alice Smith\thello", alice)).toBe("hello")
+    expect(displayReplyContent("@Alice Smith", alice)).toBe("")
+  })
+
+  it("leaves legacy, different-author, longer-name, and non-reply content unchanged", () => {
+    expect(displayReplyContent("legacy", alice)).toBe("legacy")
+    expect(displayReplyContent("@Bob\nhello", alice)).toBe("@Bob\nhello")
+    expect(displayReplyContent("@Alice Smithers\nhello", alice)).toBe(
+      "@Alice Smithers\nhello",
+    )
+    expect(displayReplyContent("@Alice Smith\nhello", undefined)).toBe(
+      "@Alice Smith\nhello",
+    )
+  })
+
+  it("does not manufacture a bare mention for a missing author name", () => {
+    expect(canonicalizeReplyContent("hello", { authorName: "" })).toBe("hello")
+    expect(displayReplyContent("@\nhello", { authorName: "" })).toBe("@\nhello")
+  })
+})

--- a/src/web/src/lib/community/reply-content.ts
+++ b/src/web/src/lib/community/reply-content.ts
@@ -1,0 +1,36 @@
+type ReplyAuthor = { authorName: string } | null | undefined
+
+function replyAuthorPrefix(replyTo: ReplyAuthor): string | null {
+  if (!replyTo?.authorName) return null
+  return `@${replyTo.authorName}`
+}
+
+function matchingReplyPrefixLength(content: string, replyTo: ReplyAuthor): number {
+  const prefix = replyAuthorPrefix(replyTo)
+  if (!prefix || !content.startsWith(prefix)) return 0
+  const boundary = content.slice(prefix.length, prefix.length + 1)
+  return boundary === "" || /\s/u.test(boundary) ? prefix.length : 0
+}
+
+/**
+ * Canonical raw content for a reply. This runs once when a send/edit intent is
+ * accepted; optimistic state, POST, and retry all reuse the returned string.
+ */
+export function canonicalizeReplyContent(content: string, replyTo: ReplyAuthor): string {
+  const prefix = replyAuthorPrefix(replyTo)
+  if (!prefix || matchingReplyPrefixLength(content, replyTo) > 0) return content
+  return `${prefix}\n${content}`
+}
+
+/**
+ * User-facing projection of canonical reply content. Only a prefix matching
+ * the actual replied-to author is hidden. One following whitespace boundary
+ * is removed as well; CRLF is treated as one line-break boundary.
+ */
+export function displayReplyContent(content: string, replyTo: ReplyAuthor): string {
+  const prefixLength = matchingReplyPrefixLength(content, replyTo)
+  if (prefixLength === 0) return content
+  const remainder = content.slice(prefixLength)
+  if (remainder.startsWith("\r\n")) return remainder.slice(2)
+  return /^\s/u.test(remainder) ? remainder.slice(1) : remainder
+}


### PR DESCRIPTION
# Why we need this PR?
> Closes #

Replies already persist `replyToId`, but their raw content does not identify the replied-to author. That leaves agent context without the conversational addressee, while naively exposing an added mention would duplicate information already shown by the Reply header.

## What changed

- Added a frontend-only reply-content helper that canonicalizes raw reply content as `@{reply author}\n{original}` with exact same-author boundary detection, including attachment-only replies.
- Canonicalized channel and DM content once when accepting the optimistic intent, so optimistic rows, initial POSTs, and retries reuse byte-identical raw content.
- Projected one matching author prefix out of visible message bodies, thread openers, share cards, copy/reply targets, and derived thread names while preserving Reply headers and legacy/different-author content.
- Kept the existing uiux #14 Edit menu contract unchanged; the internal channel edit handler now prompts with projected content and restores one canonical prefix before PATCH.
- Added boundary, sender/retry, action, render, share, and opener coverage. Independent forced-fresh channel and DM QA verified browser, POST, WS, and D1 parity at desktop and mobile widths.
- No API, schema, backend notification, participant, or mention-extraction changes.

## Checklist
- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [x] Other: forced-fresh channel/DM browser, WS, and D1 evidence
