### PR TITLE
fix: bound mark-all-read revision guard under D1 limit

### DIFF
--- a/src/shared/src/db/queries/community/read-state.ts
+++ b/src/shared/src/db/queries/community/read-state.ts
@@ -64,6 +64,55 @@ export function readStateAdvancesCondition(
   return guard ? and(guard, advances)! : advances;
 }
 
+export type ReadStateAdvanceTarget = {
+  channelId: string;
+  targetSeq: number;
+};
+
+/**
+ * Set-based sibling for mass read-state mutations.
+ *
+ * D1 limits one SQL statement to 100 bound variables. Building one
+ * `readStateAdvancesCondition` per channel and joining them with `OR` makes
+ * the revision statement grow by three binds per target, even though the
+ * sibling read-state upserts are separate statements in the same batch.
+ * Encode the target set in one JSON bind instead, then correlate each JSON
+ * row against the durable read state. The explicit INTEGER cast is
+ * load-bearing: JSON extraction must compare seq numerically, never by its
+ * textual representation.
+ */
+export function readStateAdvancesAnyTargetCondition(
+  db: Database,
+  userId: string,
+  targets: readonly ReadStateAdvanceTarget[],
+): SQL<unknown> {
+  const encodedTargets = JSON.stringify(
+    targets.map(({ channelId, targetSeq }) => [channelId, targetSeq]),
+  );
+  const targetChannelId = sql<string>`CAST(json_extract(read_target.value, '$[0]') AS TEXT)`;
+  const targetSeq = sql<number>`CAST(json_extract(read_target.value, '$[1]') AS INTEGER)`;
+
+  return exists(
+    db
+      .select({ one: sql<number>`1` })
+      .from(sql`json_each(${encodedTargets}) AS read_target`)
+      .where(
+        notExists(
+          db
+            .select({ one: sql<number>`1` })
+            .from(communityReadState)
+            .where(
+              and(
+                eq(communityReadState.userId, userId),
+                eq(communityReadState.channelId, targetChannelId),
+                gte(communityReadState.lastReadSeq, targetSeq),
+              ),
+            ),
+        ),
+      ),
+  );
+}
+
 export type CanonicalReadTarget = {
   id: string;
   channelId: string;
@@ -406,16 +455,13 @@ export async function markAllServerChannelsRead(
     channelId: message.channelId,
     message,
   }));
-  const effectConditions = latest.map((message) =>
-    readStateAdvancesCondition(db, {
-      userId,
+  const effectCondition = readStateAdvancesAnyTargetCondition(
+    db,
+    userId,
+    latest.map((message) => ({
       channelId: message.channelId,
       targetSeq: message.seq,
-    })
-  );
-  const effectCondition = effectConditions.slice(1).reduce(
-    (combined, condition) => or(combined, condition)!,
-    effectConditions[0]!
+    })),
   );
   const results = await db.batch([
     advanceReadStateRevisionWhenBuilder(db, userId, effectCondition),

--- a/src/shared/test/queries/param-limit.test.ts
+++ b/src/shared/test/queries/param-limit.test.ts
@@ -9,6 +9,7 @@ import {
 import * as mentionQueries from "../../src/db/queries/community/mention";
 import * as attachmentQueries from "../../src/db/queries/community/attachment";
 import * as inboxQueries from "../../src/db/queries/community/inbox";
+import * as readStateQueries from "../../src/db/queries/community/read-state";
 import { D1_MAX_BIND_PARAMS } from "../../src/db/queries/_chunk";
 
 const fakeDb = drizzle({} as never);
@@ -181,5 +182,39 @@ describe("listEligibleUnreadChannels bound parameters", () => {
     for (const { params } of statements) {
       expect(params.length).toBeLessThanOrEqual(D1_MAX_BIND_PARAMS);
     }
+  });
+});
+
+describe("mark-all-read revision guard bound parameters", () => {
+  function buildGuard(targetCount: number) {
+    const targets = Array.from({ length: targetCount }, (_, index) => ({
+      channelId: `channel_${index}`,
+      targetSeq: index + 1,
+    }));
+    const condition = readStateQueries.readStateAdvancesAnyTargetCondition(
+      fakeDb as never,
+      "user_1",
+      targets,
+    );
+    return readStateQueries
+      .advanceReadStateRevisionWhenBuilder(fakeDb as never, "user_1", condition)
+      .toSQL();
+  }
+
+  it("33 and 95 targets keep one constant-size JSON guard below D1's limit", () => {
+    const thirtyThree = buildGuard(33);
+    const ninetyFive = buildGuard(95);
+
+    expect(thirtyThree.params).toHaveLength(4);
+    expect(ninetyFive.params).toHaveLength(4);
+    expect(ninetyFive.params.length).toBeLessThanOrEqual(D1_MAX_BIND_PARAMS);
+    expect(ninetyFive.sql).toContain("json_each");
+    expect(ninetyFive.sql).toMatch(
+      /cast\(json_extract\(read_target\.value, '\$\[1\]'\) as integer\)/i,
+    );
+    const encodedTargets = ninetyFive.params.find(
+      (param) => typeof param === "string" && param.startsWith('[["channel_0",'),
+    );
+    expect(JSON.parse(encodedTargets as string)).toHaveLength(95);
   });
 });

--- a/src/web/src/hooks/community/mutations/messages.test.ts
+++ b/src/web/src/hooks/community/mutations/messages.test.ts
@@ -942,6 +942,30 @@ describe("useMarkAllInboxRead", () => {
     await runMutation<void>(undefined as unknown as void).catch(() => { })
     expect(toastMock).toHaveBeenCalledWith("boom")
   })
+
+  it("retries all three idempotent routes after mentions and DMs commit before unreads fails", async () => {
+    let unreadAttempts = 0
+    apiFetchMock.mockImplementation(async (path: string) => {
+      if (path === "/api/community/users/me/inbox/unreads/read-all" && unreadAttempts++ === 0) {
+        throw new Error("channel read-all failed")
+      }
+      return undefined
+    })
+    const mod = await loadMod()
+    mod.useMarkAllInboxRead()
+
+    await runMutation<void>(undefined as unknown as void).catch(() => { })
+    await runMutation<void>(undefined as unknown as void)
+
+    for (const path of [
+      "/api/community/users/me/inbox/mentions/read-all",
+      "/api/community/users/me/inbox/unreads/read-all",
+      "/api/community/users/me/inbox/dms/read-all",
+    ]) {
+      expect(apiFetchMock.mock.calls.filter((call) => call[0] === path)).toHaveLength(2)
+    }
+    expect(toastMock).toHaveBeenCalledWith("channel read-all failed")
+  })
 })
 
 // ── useDeleteMention — rollback ──────────────────────────────────────────

--- a/src/web/test-runtime/community-read-all-bind-limit.runtime.test.ts
+++ b/src/web/test-runtime/community-read-all-bind-limit.runtime.test.ts
@@ -1,0 +1,200 @@
+/// <reference types="@cloudflare/vitest-plugin/types" />
+
+import { env } from "cloudflare:workers"
+import { afterEach, describe, expect, it } from "vitest"
+import { createDb, queries } from "@alook/shared"
+
+const runtimeEnv = env as unknown as CloudflareEnv
+const createdServers: string[] = []
+const createdUsers: string[] = []
+const createdTriggers: string[] = []
+const createdCounterTables: string[] = []
+
+async function run(statement: string, ...bindings: unknown[]): Promise<void> {
+  await runtimeEnv.DB.prepare(statement).bind(...bindings).run()
+}
+
+async function first<T>(statement: string, ...bindings: unknown[]): Promise<T | null> {
+  return runtimeEnv.DB.prepare(statement).bind(...bindings).first<T>()
+}
+
+function stamp4(value: string): string {
+  let hash = 0
+  for (const char of value) hash = (hash * 31 + char.charCodeAt(0)) % 10_000
+  return String(hash).padStart(4, "0")
+}
+
+type Fixture = {
+  userId: string
+  serverId: string
+  prefix: string
+  channelIds: string[]
+  messageIds: string[]
+}
+
+async function seedNonEmptyChannels(count: number): Promise<Fixture> {
+  const suffix = crypto.randomUUID().replaceAll("-", "")
+  const prefix = `readall_${suffix}`
+  const userId = `${prefix}_user`
+  const serverId = `${prefix}_server`
+  const createdAt = "2026-08-28T01:00:00.000Z"
+  const channelIds = Array.from({ length: count }, (_, index) =>
+    `${prefix}_channel_${String(index).padStart(3, "0")}`,
+  )
+  const messageIds = channelIds.map((_, index) =>
+    `${prefix}_message_${String(index).padStart(3, "0")}`,
+  )
+
+  createdUsers.push(userId)
+  createdServers.push(serverId)
+  await run(
+    "INSERT INTO user (id, email, name, discriminator) VALUES (?, ?, 'Reader', ?)",
+    userId,
+    `${userId}@example.com`,
+    stamp4(userId),
+  )
+  await run(
+    `INSERT INTO community_server
+      (id, name, description, owner_id, created_at, discriminator)
+     VALUES (?, ?, '', ?, ?, ?)`,
+    serverId,
+    serverId,
+    userId,
+    createdAt,
+    stamp4(serverId),
+  )
+
+  const statements = channelIds.flatMap((channelId, index) => [
+    runtimeEnv.DB.prepare(
+      `INSERT INTO community_channel
+        (id, server_id, name, type, message_count, last_message_at, created_at)
+       VALUES (?, ?, ?, 'text', 1, ?, ?)`,
+    ).bind(channelId, serverId, `channel-${index}`, createdAt, createdAt),
+    runtimeEnv.DB.prepare(
+      `INSERT INTO community_message
+        (id, author_id, content, created_at, channel_id, seq)
+       VALUES (?, ?, 'latest', ?, ?, ?)`,
+    ).bind(messageIds[index]!, userId, createdAt, channelId, index + 1),
+  ])
+  for (let offset = 0; offset < statements.length; offset += 60) {
+    await runtimeEnv.DB.batch(statements.slice(offset, offset + 60))
+  }
+
+  return { userId, serverId, prefix, channelIds, messageIds }
+}
+
+async function readRevision(userId: string): Promise<number> {
+  return (await first<{ revision: number }>(
+    "SELECT revision FROM community_read_state_revision WHERE user_id = ?",
+    userId,
+  ))?.revision ?? 0
+}
+
+async function readStateSummary(fixture: Fixture) {
+  return first<{ total: number; aligned: number }>(
+    `SELECT COUNT(*) AS total,
+            SUM(CASE WHEN rs.last_read_message_id = m.id
+                       AND rs.last_read_at = m.created_at
+                       AND rs.last_read_seq = m.seq
+                     THEN 1 ELSE 0 END) AS aligned
+       FROM community_read_state rs
+       JOIN community_message m ON m.id = rs.last_read_message_id
+      WHERE rs.user_id = ? AND rs.channel_id LIKE ?`,
+    fixture.userId,
+    `${fixture.prefix}_channel_%`,
+  )
+}
+
+afterEach(async () => {
+  for (const trigger of createdTriggers.splice(0)) {
+    await runtimeEnv.DB.prepare(`DROP TRIGGER IF EXISTS ${trigger}`).run()
+  }
+  for (const table of createdCounterTables.splice(0)) {
+    await runtimeEnv.DB.prepare(`DROP TABLE IF EXISTS ${table}`).run()
+  }
+  for (const serverId of createdServers.splice(0)) {
+    await runtimeEnv.DB.prepare("DELETE FROM community_server WHERE id = ?").bind(serverId).run()
+  }
+  for (const userId of createdUsers.splice(0)) {
+    await runtimeEnv.DB.prepare("DELETE FROM user WHERE id = ?").bind(userId).run()
+  }
+})
+
+describe("markAllServerChannelsRead real D1 bind limit", () => {
+  it.each([33, 95])("marks %i non-empty channels and makes retry a revision no-op", async (count) => {
+    const fixture = await seedNonEmptyChannels(count)
+    const db = createDb(runtimeEnv.DB)
+
+    await expect(
+      queries.communityReadState.markAllServerChannelsRead(db, fixture.userId, fixture.channelIds),
+    ).resolves.toEqual({ count, changed: true, revision: 1 })
+    expect(await readStateSummary(fixture)).toEqual({ total: count, aligned: count })
+
+    await expect(
+      queries.communityReadState.markAllServerChannelsRead(db, fixture.userId, fixture.channelIds),
+    ).resolves.toEqual({ count, changed: false, revision: 1 })
+    expect(await readRevision(fixture.userId)).toBe(1)
+    expect(await readStateSummary(fixture)).toEqual({ total: count, aligned: count })
+  })
+
+  it("bumps once for a mixed 95-target advance, then stays stable on retry", async () => {
+    const fixture = await seedNonEmptyChannels(95)
+    const db = createDb(runtimeEnv.DB)
+    await queries.communityReadState.markAllServerChannelsRead(db, fixture.userId, fixture.channelIds)
+
+    const advancedAt = "2026-08-28T02:00:00.000Z"
+    for (const index of [0, 9, 94]) {
+      const messageId = `${fixture.prefix}_advanced_${index}`
+      await run(
+        `INSERT INTO community_message
+          (id, author_id, content, created_at, channel_id, seq)
+         VALUES (?, ?, 'advanced', ?, ?, ?)`,
+        messageId,
+        fixture.userId,
+        advancedAt,
+        fixture.channelIds[index],
+        1_000 + index,
+      )
+    }
+
+    await expect(
+      queries.communityReadState.markAllServerChannelsRead(db, fixture.userId, fixture.channelIds),
+    ).resolves.toEqual({ count: 95, changed: true, revision: 2 })
+    expect(await readRevision(fixture.userId)).toBe(2)
+    expect(await readStateSummary(fixture)).toEqual({ total: 95, aligned: 95 })
+
+    await expect(
+      queries.communityReadState.markAllServerChannelsRead(db, fixture.userId, fixture.channelIds),
+    ).resolves.toEqual({ count: 95, changed: false, revision: 2 })
+    expect(await readRevision(fixture.userId)).toBe(2)
+  })
+
+  it("rolls back the revision and earlier rows when a later upsert fails", async () => {
+    const fixture = await seedNonEmptyChannels(5)
+    const db = createDb(runtimeEnv.DB)
+    const suffix = crypto.randomUUID().replaceAll("-", "")
+    const counterTable = `readall_counter_${suffix}`
+    const trigger = `readall_abort_${suffix}`
+    createdCounterTables.push(counterTable)
+    createdTriggers.push(trigger)
+    await runtimeEnv.DB.prepare(`CREATE TABLE ${counterTable} (attempts INTEGER NOT NULL)`).run()
+    await runtimeEnv.DB.prepare(`INSERT INTO ${counterTable} (attempts) VALUES (0)`).run()
+    await runtimeEnv.DB.prepare(`
+      CREATE TRIGGER ${trigger}
+      BEFORE INSERT ON community_read_state
+      BEGIN
+        UPDATE ${counterTable} SET attempts = attempts + 1;
+        SELECT CASE WHEN (SELECT attempts FROM ${counterTable}) = 3
+          THEN RAISE(ABORT, 'forced read-state failure') END;
+      END
+    `).run()
+
+    await expect(
+      queries.communityReadState.markAllServerChannelsRead(db, fixture.userId, fixture.channelIds),
+    ).rejects.toThrow(/forced read-state failure/)
+
+    expect(await readRevision(fixture.userId)).toBe(0)
+    expect(await readStateSummary(fixture)).toEqual({ total: 0, aligned: null })
+    expect(await first<{ attempts: number }>(`SELECT attempts FROM ${counterTable}`)).toEqual({ attempts: 0 })
+  })
+})


### PR DESCRIPTION
## Summary
- replace the per-channel OR revision guard with one JSON-backed `json_each` target set
- cast JSON seq values to SQLite INTEGER and keep the guard at 4 binds for both 33 and 95 targets
- preserve one atomic D1 batch for the single revision bump plus all monotone read-state upserts
- cover partial-success frontend retry without assuming the three read-all routes are atomic together

## Regression coverage
- real workerd/D1: 33 and 95 non-empty channels
- fresh, mixed advance, all-no-op, and retry revision semantics
- forced third-upsert failure rolls revision and earlier rows back together
- mentions, unreads, and DMs retry all three idempotent endpoints after partial success

## Validation
- full pre-commit gate passed: typecheck, lint, all tests, typegrep, knip
- web: 659 files / 5807 tests
- shared: 146 files / 2055 tests

## Release hold
Do not version, release, or deploy this PR independently. Merge is allowed; release waits for #12 per owner instruction.
