### PR TITLE
fix(web): open mobile message reaction picker

### DIFF
--- a/src/web/src/components/community/messages/message.render.test.ts
+++ b/src/web/src/components/community/messages/message.render.test.ts
@@ -11,7 +11,108 @@ import {
   shouldActivateMessageOverlays,
   shouldSuppressTouchMenuOpen,
 } from "./message"
+import { EmojiPickerPopover } from "./emoji-picker"
 import type { RenderMsg } from "@/lib/community/models/message"
+
+vi.mock("./emoji-picker", async () => {
+  const ReactModule = await import("react")
+  function MockEmojiPickerPopover({
+    children,
+    onPick,
+    ...props
+  }: {
+    children: React.ReactElement
+    onPick: (emoji: string) => void
+    side?: string
+    align?: string
+  }) {
+    const [open, setOpen] = ReactModule.useState(false)
+    return ReactModule.createElement(
+      "mock-emoji-picker-popover",
+      { ...props, onPick, open },
+      ReactModule.cloneElement(children, {
+        "data-slot": "popover-trigger",
+        onClick: () => setOpen(true),
+      } as React.HTMLAttributes<HTMLElement>),
+      open
+        ? ReactModule.createElement("mock-emoji-picker-content", { "data-slot": "popover-content" })
+        : null,
+    )
+  }
+  return { EmojiPickerPopover: MockEmojiPickerPopover }
+})
+
+vi.mock("@/components/ui/tooltip", async () => {
+  const ReactModule = await import("react")
+  return {
+    Tooltip: ({ children }: { children: React.ReactNode }) =>
+      ReactModule.createElement("mock-tooltip", null, children),
+    TooltipTrigger: ({
+      render,
+      children,
+      ...props
+    }: {
+      render: React.ReactElement
+      children?: React.ReactNode
+    }) => ReactModule.cloneElement(render, {
+      ...props,
+      "data-slot": "tooltip-trigger",
+    } as React.HTMLAttributes<HTMLElement>, children ?? render.props.children),
+    TooltipContent: ({ children }: { children: React.ReactNode }) =>
+      ReactModule.createElement("mock-tooltip-content", null, children),
+  }
+})
+
+vi.mock("@/components/ui/context-menu", async () => {
+  const ReactModule = await import("react")
+  return {
+    ContextMenu: ({ children }: { children: React.ReactNode }) =>
+      ReactModule.createElement("mock-context-menu", null, children),
+    ContextMenuTrigger: ({
+      render,
+      ...props
+    }: {
+      render: React.ReactElement
+    }) => ReactModule.cloneElement(render, {
+      ...props,
+      "data-slot": "context-menu-trigger",
+    } as React.HTMLAttributes<HTMLElement>),
+    ContextMenuContent: ({ children }: { children: React.ReactNode }) =>
+      ReactModule.createElement("mock-context-menu-content", null, children),
+    ContextMenuItem: ({
+      children,
+      ...props
+    }: {
+      children: React.ReactNode
+    }) => ReactModule.createElement("button", { ...props, "data-slot": "context-menu-item" }, children),
+  }
+})
+
+vi.mock("@/components/ui/dropdown-menu", async (importOriginal) => {
+  const ReactModule = await import("react")
+  const actual = await importOriginal<typeof import("@/components/ui/dropdown-menu")>()
+  return {
+    ...actual,
+    DropdownMenuContent: ({
+      children,
+      ...props
+    }: {
+      children: React.ReactNode
+      [key: string]: unknown
+    }) => ReactModule.createElement(
+      "mock-dropdown-menu-positioner",
+      props,
+      ReactModule.createElement("mock-dropdown-menu-content", null, children),
+    ),
+    DropdownMenuItem: ({
+      children,
+      ...props
+    }: {
+      children: React.ReactNode
+      [key: string]: unknown
+    }) => ReactModule.createElement("button", { ...props, "data-slot": "dropdown-menu-item" }, children),
+  }
+})
 
 // WS3 render-behavior tests (see plans/community-switch-perf-optimization.md):
 // - the custom memo comparator bails out despite the per-render `m` clone,
@@ -177,6 +278,123 @@ describe("Message reply content projection", () => {
       content: "@Bob\n",
       replyTo: { id: "prior", authorName: "Bob", text: "original" },
     }))).toBe(false)
+  })
+})
+
+describe("Message reaction picker", () => {
+  it("opens the shared picker from the visible non-hover Add reaction button", async () => {
+    const onReact = vi.fn()
+    let renderer: TestRenderer.ReactTestRenderer | undefined
+    await act(async () => {
+      renderer = TestRenderer.create(makeTree({
+        m: baseMsg({ reactions: [{ emoji: "👍", count: 1, me: false, userIds: ["u2"] }] }),
+        hoverCapable: false,
+        onOpenThread: vi.fn(),
+        onReact,
+      }), { createNodeMock: () => genericMock })
+    })
+
+    const addButton = renderer!.root.findAllByProps({ "aria-label": "Add reaction" })
+      .find((node) => node.type === "button" && node.props.className.includes("h-6 w-7"))
+    expect(addButton?.props["data-slot"]).toBe("popover-trigger")
+    expect(renderer!.root.findAllByProps({ "data-slot": "popover-content" })).toHaveLength(0)
+
+    await act(async () => {
+      addButton!.props.onClick({
+        button: 0,
+        defaultPrevented: false,
+        currentTarget: genericMock,
+        target: genericMock,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      })
+    })
+    expect(renderer!.root.findAllByProps({ "data-slot": "popover-content" })).toHaveLength(1)
+
+    act(() => renderer!.root.findByType(EmojiPickerPopover).props.onPick("🎉"))
+    expect(onReact).toHaveBeenCalledOnce()
+    expect(onReact).toHaveBeenCalledWith("🎉")
+    act(() => renderer!.unmount())
+  })
+
+  it("keeps desktop hover activation separate from click-to-open", async () => {
+    let renderer: TestRenderer.ReactTestRenderer | undefined
+    await act(async () => {
+      renderer = TestRenderer.create(makeTree({
+        m: baseMsg({ reactions: [{ emoji: "👍", count: 1, me: false, userIds: ["u2"] }] }),
+        hoverCapable: true,
+        onOpenThread: vi.fn(),
+        onReact: vi.fn(),
+      }), { createNodeMock: () => genericMock })
+    })
+
+    expect(renderer!.root.findAllByType(EmojiPickerPopover)).toHaveLength(0)
+    const row = renderer!.root.find(
+      (node) => typeof node.props.className === "string"
+        && node.props.className.includes("group relative -mx-2"),
+    )
+    act(() => row.props.onPointerEnter({ target: { closest: () => null } }))
+
+    expect(renderer!.root.findAllByType(EmojiPickerPopover)).toHaveLength(2)
+    expect(renderer!.root.findAllByProps({ "data-slot": "popover-content" })).toHaveLength(0)
+    const stripButton = renderer!.root.findAllByProps({ "aria-label": "Add reaction" })
+      .find((node) => node.type === "button" && node.props.className.includes("h-6 w-7"))
+    expect(stripButton?.props["data-slot"]).toBe("tooltip-trigger")
+
+    await act(async () => {
+      stripButton!.props.onClick({
+        button: 0,
+        defaultPrevented: false,
+        currentTarget: genericMock,
+        target: genericMock,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      })
+    })
+    expect(renderer!.root.findAllByProps({ "data-slot": "popover-content" })).toHaveLength(1)
+    act(() => renderer!.unmount())
+  })
+
+  it("keeps existing reaction chips on their exact toggle callback", () => {
+    const onToggleReaction = vi.fn()
+    let renderer: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(makeTree({
+        m: baseMsg({ reactions: [{ emoji: "🔥", count: 2, me: true, userIds: ["u1", "u2"] }] }),
+        hoverCapable: false,
+        onOpenThread: vi.fn(),
+        onToggleReaction,
+        onReact: vi.fn(),
+      }), { createNodeMock: () => genericMock })
+    })
+
+    const chip = renderer!.root.findAllByType("button")
+      .find((button) => textContent(button).includes("🔥"))
+    act(() => chip!.props.onClick())
+    expect(onToggleReaction).toHaveBeenCalledOnce()
+    expect(onToggleReaction).toHaveBeenCalledWith("🔥")
+    act(() => renderer!.unmount())
+  })
+
+  it("keeps the touch action menu Add Reaction item as the direct thumbs-up shortcut", () => {
+    const onReact = vi.fn()
+    let renderer: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(makeTree({
+        m: baseMsg({ reactions: [] }),
+        hoverCapable: false,
+        onOpenThread: vi.fn(),
+        onReact,
+      }), { createNodeMock: () => genericMock })
+    })
+
+    const quickReaction = renderer!.root.findAllByProps({ "data-slot": "dropdown-menu-item" })
+      .find((item) => textContent(item).includes("Add Reaction"))
+    expect(quickReaction).toBeDefined()
+    act(() => quickReaction!.props.onClick())
+    expect(onReact).toHaveBeenCalledOnce()
+    expect(onReact).toHaveBeenCalledWith("👍")
+    act(() => renderer!.unmount())
   })
 })
 

--- a/src/web/src/components/community/messages/message.render.test.ts
+++ b/src/web/src/components/community/messages/message.render.test.ts
@@ -282,7 +282,8 @@ describe("Message reply content projection", () => {
 })
 
 describe("Message reaction picker", () => {
-  it("opens the shared picker from the visible non-hover Add reaction button", async () => {
+  it("opens the non-hover picker and suppresses its Shadow DOM selection click at the row", async () => {
+    vi.stubGlobal("window", { getSelection: () => null })
     const onReact = vi.fn()
     let renderer: TestRenderer.ReactTestRenderer | undefined
     await act(async () => {
@@ -314,6 +315,31 @@ describe("Message reaction picker", () => {
     act(() => renderer!.root.findByType(EmojiPickerPopover).props.onPick("🎉"))
     expect(onReact).toHaveBeenCalledOnce()
     expect(onReact).toHaveBeenCalledWith("🎉")
+
+    const row = renderer!.root.find(
+      (node) => typeof node.props.className === "string"
+        && node.props.className.includes("group relative -mx-2"),
+    )
+    const rowElement = { contains: () => false }
+    await act(async () => {
+      row.props.onClick({
+        clientX: 271,
+        clientY: 603,
+        currentTarget: rowElement,
+        target: { closest: () => null },
+        nativeEvent: {
+          composedPath: () => [
+            { matches: (selector: string) => selector.includes("button") },
+            { matches: () => false },
+            rowElement,
+          ],
+        },
+      })
+    })
+    expect(renderer!.root.findAll(
+      (node) => node.props.positionMethod === "fixed" && node.props.anchor,
+    )).toHaveLength(0)
+    expect(onReact).toHaveBeenCalledOnce()
     act(() => renderer!.unmount())
   })
 

--- a/src/web/src/components/community/messages/message.tsx
+++ b/src/web/src/components/community/messages/message.tsx
@@ -214,6 +214,28 @@ function MessageImpl({
   // a leading checkbox overlay + a tint when picked. `canShare` rows only —
   // approval/attachment-only rows aren't selectable (nothing to put on the card).
   const selectable = selectMode && canShare
+  const reactionAddButton = (
+    <button className="grid h-6 w-7 place-items-center rounded-md bg-secondary text-muted-foreground hover:text-foreground" aria-label="Add reaction">
+      <SmilePlus className="size-4" />
+    </button>
+  )
+  const reactionAddPicker = (
+    <EmojiPickerPopover side="top" align="start" onPick={(emoji) => onReact?.(emoji)}>
+      {hoverCapable
+        ? <TooltipTrigger render={reactionAddButton} />
+        : reactionAddButton}
+    </EmojiPickerPopover>
+  )
+  const reactionAddControl = activated || !hoverCapable
+    ? hoverCapable
+      ? (
+          <Tooltip>
+            {reactionAddPicker}
+            <TooltipContent>Add reaction</TooltipContent>
+          </Tooltip>
+        )
+      : reactionAddPicker
+    : reactionAddButton
   const row = (
     <div
       className={[
@@ -517,20 +539,7 @@ function MessageImpl({
                   </Tooltip>
                 )
               })}
-              {activated ? (
-                <Tooltip>
-                  <EmojiPickerPopover side="top" align="start" onPick={(e) => onReact?.(e)}>
-                    <TooltipTrigger render={<button className="grid h-6 w-7 place-items-center rounded-md bg-secondary text-muted-foreground hover:text-foreground" aria-label="Add reaction" />}>
-                      <SmilePlus className="size-4" />
-                    </TooltipTrigger>
-                  </EmojiPickerPopover>
-                  <TooltipContent>Add reaction</TooltipContent>
-                </Tooltip>
-              ) : (
-                <button className="grid h-6 w-7 place-items-center rounded-md bg-secondary text-muted-foreground hover:text-foreground" aria-label="Add reaction">
-                  <SmilePlus className="size-4" />
-                </button>
-              )}
+              {reactionAddControl}
             </div>
           )}
 

--- a/src/web/src/components/community/messages/message.tsx
+++ b/src/web/src/components/community/messages/message.tsx
@@ -283,10 +283,14 @@ function MessageImpl({
           ? (event) => {
             const selection = window.getSelection()
             const selectionInsideRow = selectionBelongsToRow(selection, event.currentTarget)
-            const nearestControl = (event.target as Element).closest(
-              "button, a, input, textarea, select, [role=button]",
+            const controlSelector = "button, a, input, textarea, select, [role=button]"
+            const nearestControl = (event.target as Element).closest(controlSelector)
+            const composedControl = event.nativeEvent?.composedPath?.().find(
+              (target) => target !== event.currentTarget
+                && !!(target as Element).matches?.(controlSelector),
             )
-            const nestedControl = !!nearestControl && nearestControl !== event.currentTarget
+            const nestedControl = !!composedControl
+              || (!!nearestControl && nearestControl !== event.currentTarget)
             const suppress = shouldSuppressTouchMenuOpen({
               nestedControl,
               selectionInsideRow,


### PR DESCRIPTION
# Why we need this PR?
> Release blocker tracked in Alook's internal mobile reaction picker fix thread.

On non-hover devices, the Add reaction button beside existing reactions was rendered as a bare button forever because `activated` is intentionally desktop-hover-only. The control looked available but could not open the emoji picker.

## What changed
- Reuse one reaction-strip Add reaction button and one `EmojiPickerPopover` composition for mobile/non-hover and activated desktop rows.
- Keep the mobile path free of hover-only Tooltip behavior while preserving the activated desktop Tooltip and inactive desktop lazy-overlay branch.
- Keep picker opening click-only on every device: hover/focus reveals desktop controls but never controls popover open state.
- Preserve existing reaction-chip toggles, desktop hover toolbar, touch-menu quick 👍, composer picker, reaction mutation/WS code, and testids.
- Add render regressions covering mobile click-open/select, desktop hover-closed then click-open, exact existing-reaction toggle, and touch quick 👍.

Validation:
- Focused message render: 27/27 passed.
- Web typecheck and lint passed.
- Full web suite: 662 files, 5844/5844 passed.
- Root typecheck: 11/11 packages passed.
- Root test: 11/11 packages plus CI scripts 128/128 passed.
- Exact pre-commit chain passed manually, then passed again through the normal commit hook.
- Forced-fresh mobile/desktop browser QA passed all four reaction journeys with exact HTTP, WebSocket, and D1 correlation; emoji selection leaves the touch action menu closed.
- Hosted CI and UI E2E gates passed; Codecov reports all modified coverable lines covered.
- Diff is exactly `message.tsx` and `message.render.test.ts`; no third product file or release change.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [x] Other: mobile/desktop message reaction-entry behavior only
