### PR TITLE
feat(web): add mobile composer send control

### DIFF
--- a/scripts/ci/e2e-shards.mjs
+++ b/scripts/ci/e2e-shards.mjs
@@ -49,6 +49,7 @@ export const SPEC_SECONDS = {
   "36-server-switch-pending-checkpoint.spec.ts": 60,
   "37-server-rail-pdd.spec.ts": 10,
   "38-community-navigation-checkpoint-matrix.spec.ts": 60,
+  "39-mobile-composer-send.spec.ts": 45,
 }
 
 function walk(directory) {

--- a/scripts/ci/e2e-shards.test.ts
+++ b/scripts/ci/e2e-shards.test.ts
@@ -70,7 +70,7 @@ describe("planE2eShards", () => {
     expect(first).toHaveLength(E2E_SHARD_COUNT)
     expect([...assigned].sort()).toEqual(specs)
     expect(new Set(assigned).size).toBe(specs.length)
-    expect(totals.sort((left, right) => left - right)).toEqual([314, 314, 318, 318, 318])
+    expect(totals.sort((left, right) => left - right)).toEqual([323, 324, 324, 328, 328])
     expect(Math.max(...totals) / Math.min(...totals)).toBeLessThanOrEqual(1.15)
   })
 

--- a/src/web/src/components/community/messages/composer-keydown.ts
+++ b/src/web/src/components/community/messages/composer-keydown.ts
@@ -1,0 +1,32 @@
+import type { Breakpoint } from "@/hooks/use-mobile"
+
+type ComposerKeyDownOptions = {
+  breakpoint: Breakpoint
+  channelRefOpen: boolean
+  isForumThreadBody: boolean
+  mentionOpen: boolean
+  send: () => void
+}
+
+export function handleComposerKeyDown(
+  event: KeyboardEvent,
+  options: ComposerKeyDownOptions,
+): boolean {
+  if (options.mentionOpen || options.channelRefOpen) return false
+  if (options.isForumThreadBody) {
+    if (event.key !== "Enter" || !event.shiftKey || event.isComposing) {
+      return false
+    }
+  } else if (
+    event.key !== "Enter" ||
+    event.shiftKey ||
+    event.isComposing ||
+    options.breakpoint !== "desktop"
+  ) {
+    return false
+  }
+
+  event.preventDefault()
+  options.send()
+  return true
+}

--- a/src/web/src/components/community/messages/composer-view.test.ts
+++ b/src/web/src/components/community/messages/composer-view.test.ts
@@ -13,6 +13,8 @@ vi.mock("lucide-react", () => ({
     createElement("image-icon", props),
   PlusCircle: (props: Record<string, unknown>) =>
     createElement("plus-icon", props),
+  SendHorizontal: (props: Record<string, unknown>) =>
+    createElement("send-icon", props),
   Smile: (props: Record<string, unknown>) => createElement("smile-icon", props),
   Upload: (props: Record<string, unknown>) =>
     createElement("upload-icon", props),
@@ -79,6 +81,9 @@ function baseProps(
     editor: null,
     hideAttach: false,
     hideEmoji: false,
+    showSend: false,
+    sendDisabled: true,
+    onSend: vi.fn(),
     onAttachOpenChange: vi.fn(),
     onUploadFile: vi.fn(),
     onEmojiPick: vi.fn(),
@@ -341,24 +346,92 @@ describe("ComposerView", () => {
     )
   })
 
+  it("renders the mobile send control after emoji with exact eligibility and padding", async () => {
+    const onSend = vi.fn()
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(
+        createElement(
+          ComposerView,
+          baseProps({ showSend: true, sendDisabled: true, onSend }),
+        ),
+      )
+    })
+    const input = renderer.root.find(
+      (node) => node.props["data-testid"] === tid.composerInput,
+    )
+    expect(input.props.className).toContain("pl-12 pr-24")
+    expect(input.props.className).not.toContain("px-12")
+    expect(
+      renderer.root.findByType("emoji-picker").findByType("button").props
+        .className,
+    ).toContain("right-12")
+    const send = renderer.root.find(
+      (node) => node.props["data-testid"] === tid.composerSend,
+    )
+    expect(send.props).toMatchObject({
+      type: "button",
+      "aria-label": "Send message",
+      disabled: true,
+    })
+    expect(send.props.className).toContain("right-2")
+    expect(renderer.root.findAllByType("send-icon")).toHaveLength(1)
+    expect(
+      renderer.root
+        .findAllByType("button")
+        .map((node) => node.props["aria-label"])
+        .filter(Boolean),
+    ).toEqual(["Add", "Emoji picker", "Send message"])
+
+    await act(async () => {
+      renderer.update(
+        createElement(
+          ComposerView,
+          baseProps({ showSend: true, sendDisabled: false, onSend }),
+        ),
+      )
+    })
+    await act(async () => {
+      renderer.root.find(
+        (node) => node.props["data-testid"] === tid.composerSend,
+      ).props.onClick()
+    })
+    expect(onSend).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      renderer.update(createElement(ComposerView, baseProps()))
+    })
+    expect(
+      renderer.root.findAll(
+        (node) => node.props["data-testid"] === tid.composerSend,
+      ),
+    ).toHaveLength(0)
+    expect(
+      renderer.root.find(
+        (node) => node.props["data-testid"] === tid.composerInput,
+      ).props.className,
+    ).toContain("px-12")
+  })
+
   it("keeps the exact ComposerSkeleton footprint", async () => {
     let renderer!: TestRenderer.ReactTestRenderer
     await act(async () => {
       renderer = TestRenderer.create(createElement(ComposerSkeleton))
     })
     const skeletons = renderer.root.findAllByType("skeleton")
-    expect(skeletons).toHaveLength(3)
+    expect(skeletons).toHaveLength(4)
     expect(skeletons.map((node) => node.props.className)).toEqual([
       "h-5 w-2/5 rounded",
       "absolute left-2 bottom-2 size-8 rounded-full",
-      "absolute right-2 bottom-2 size-8 rounded-full",
+      "absolute right-12 bottom-2 size-8 rounded-full sm:right-2",
+      "absolute right-2 bottom-2 size-8 rounded-full sm:hidden",
     ])
     expect(renderer.toJSON()).toMatchObject({
       type: "div",
       props: { className: "relative px-3 pb-3 pt-0" },
     })
     expect(JSON.stringify(renderer.toJSON())).toContain(
-      "relative rounded-xl bg-muted px-12 py-3 shadow-(--e1) ring-1 ring-border/40",
+      "relative rounded-xl bg-muted py-3 pl-12 pr-24 shadow-(--e1) ring-1 ring-border/40 sm:px-12",
     )
   })
 })

--- a/src/web/src/components/community/messages/composer-view.tsx
+++ b/src/web/src/components/community/messages/composer-view.tsx
@@ -4,7 +4,15 @@ import type {
   RefObject,
 } from "react"
 import { EditorContent, type Editor } from "@tiptap/react"
-import { FileIcon, ImageIcon, PlusCircle, Smile, Upload, X } from "lucide-react"
+import {
+  FileIcon,
+  ImageIcon,
+  PlusCircle,
+  SendHorizontal,
+  Smile,
+  Upload,
+  X,
+} from "lucide-react"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -48,6 +56,9 @@ export type ComposerViewProps = {
   editor: Editor | null
   hideAttach: boolean
   hideEmoji: boolean
+  showSend: boolean
+  sendDisabled: boolean
+  onSend: () => void
   onAttachOpenChange: (open: boolean) => void
   onUploadFile: () => void
   onEmojiPick: (emoji: string) => void
@@ -73,6 +84,9 @@ export function ComposerView({
   editor,
   hideAttach,
   hideEmoji,
+  showSend,
+  sendDisabled,
+  onSend,
   onAttachOpenChange,
   onUploadFile,
   onEmojiPick,
@@ -169,7 +183,13 @@ export function ComposerView({
           className="hidden"
         />
         <div
-          className={`chat-composer relative py-3 ${isForumThreadBody ? "px-2" : "px-12"}`}
+          className={`chat-composer relative py-3 ${
+            isForumThreadBody
+              ? "px-2"
+              : showSend
+                ? "pl-12 pr-24"
+                : "px-12"
+          }`}
           data-testid={tid.composerInput}
         >
           <EditorContent
@@ -200,12 +220,24 @@ export function ComposerView({
         {!hideEmoji && (
           <EmojiPickerPopover side="top" align="end" onPick={onEmojiPick}>
             <button
-              className="absolute right-2 bottom-2 grid size-8 place-items-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground aria-expanded:bg-accent aria-expanded:text-foreground"
+              className={`absolute bottom-2 grid size-8 place-items-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground aria-expanded:bg-accent aria-expanded:text-foreground ${showSend ? "right-12" : "right-2"}`}
               aria-label="Emoji picker"
             >
               <Smile className="size-5" />
             </button>
           </EmojiPickerPopover>
+        )}
+        {showSend && (
+          <button
+            type="button"
+            data-testid={tid.composerSend}
+            className="absolute right-2 bottom-2 grid size-8 place-items-center rounded-full bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:bg-transparent disabled:text-muted-foreground"
+            aria-label="Send message"
+            disabled={sendDisabled}
+            onClick={onSend}
+          >
+            <SendHorizontal className="size-5" />
+          </button>
         )}
       </div>
     </div>
@@ -215,10 +247,11 @@ export function ComposerView({
 export function ComposerSkeleton() {
   return (
     <div className="relative px-3 pb-3 pt-0">
-      <div className="relative rounded-xl bg-muted px-12 py-3 shadow-(--e1) ring-1 ring-border/40">
+      <div className="relative rounded-xl bg-muted py-3 pl-12 pr-24 shadow-(--e1) ring-1 ring-border/40 sm:px-12">
         <Skeleton className="h-5 w-2/5 rounded" />
         <Skeleton className="absolute left-2 bottom-2 size-8 rounded-full" />
-        <Skeleton className="absolute right-2 bottom-2 size-8 rounded-full" />
+        <Skeleton className="absolute right-12 bottom-2 size-8 rounded-full sm:right-2" />
+        <Skeleton className="absolute right-2 bottom-2 size-8 rounded-full sm:hidden" />
       </div>
     </div>
   )

--- a/src/web/src/components/community/messages/composer.send-lifecycle.test.ts
+++ b/src/web/src/components/community/messages/composer.send-lifecycle.test.ts
@@ -42,6 +42,10 @@ vi.mock("@/hooks/use-file-attachments", () => ({
   useFileAttachments: (...args: unknown[]) => mocks.useFileAttachments(...args),
 }))
 
+vi.mock("@/hooks/use-mobile", () => ({
+  useBreakpoint: () => "desktop",
+}))
+
 import { Composer, type ComposerProps } from "./composer"
 import type { PendingFile } from "@/hooks/use-file-attachments"
 

--- a/src/web/src/components/community/messages/use-composer-controller.test.ts
+++ b/src/web/src/components/community/messages/use-composer-controller.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   buildPasteDom: vi.fn(),
   fromSchema: vi.fn(),
   parseSlice: vi.fn(),
+  breakpoint: "desktop" as "unknown" | "desktop" | "mobile",
 }))
 
 vi.mock("@tiptap/react", () => ({
@@ -41,6 +42,9 @@ vi.mock("@/hooks/use-file-attachments", () => ({
   useFileAttachments: (...args: unknown[]) =>
     mocks.useFileAttachments(...args),
 }))
+vi.mock("@/hooks/use-mobile", () => ({
+  useBreakpoint: () => mocks.breakpoint,
+}))
 vi.mock("@/lib/community/composer-draft", () => ({
   clearComposerDraft: (...args: unknown[]) => mocks.clearDraft(...args),
   readComposerDraft: (...args: unknown[]) => mocks.readDraft(...args),
@@ -63,6 +67,7 @@ import type { PendingFile } from "@/hooks/use-file-attachments"
 
 type EditorOptions = {
   editorProps: {
+    attributes: Record<string, string>
     handleKeyDown: (_view: unknown, event: KeyboardEvent) => boolean
     handlePaste: (_view: unknown, event: ClipboardEvent) => boolean
     clipboardTextParser: (text: string, context: never) => unknown
@@ -79,6 +84,9 @@ type TestEditor = {
   }
   view: {
     dispatch: ReturnType<typeof vi.fn>
+    dom: {
+      setAttribute: ReturnType<typeof vi.fn>
+    }
   }
   commands: {
     clearContent: ReturnType<typeof vi.fn>
@@ -103,6 +111,7 @@ describe("useComposerController", () => {
   let focus: ReturnType<typeof vi.fn>
   let setContent: ReturnType<typeof vi.fn>
   let dispatch: ReturnType<typeof vi.fn>
+  let setDomAttribute: ReturnType<typeof vi.fn>
   let transaction: object
   let chainFocus: ReturnType<typeof vi.fn>
   let insertContent: ReturnType<typeof vi.fn>
@@ -123,6 +132,7 @@ describe("useComposerController", () => {
     focus = vi.fn()
     setContent = vi.fn()
     dispatch = vi.fn()
+    setDomAttribute = vi.fn()
     transaction = {}
     run = vi.fn()
     insertContent = vi.fn(() => ({ run }))
@@ -140,7 +150,7 @@ describe("useComposerController", () => {
       getText: vi.fn(() => "  hello @everyone  "),
       getJSON: vi.fn(() => ({ type: "doc" })),
       state: { tr: transaction },
-      view: { dispatch },
+      view: { dispatch, dom: { setAttribute: setDomAttribute } },
       commands: {
         clearContent,
         focus,
@@ -183,6 +193,7 @@ describe("useComposerController", () => {
     }))
     mocks.detectMentionType.mockReturnValue("everyone")
     mocks.readDraft.mockReturnValue(null)
+    mocks.breakpoint = "desktop"
   })
 
   afterEach(() => {
@@ -508,6 +519,127 @@ describe("useComposerController", () => {
     expect(mocks.useEditor).toHaveBeenCalledTimes(2)
     expect(mocks.starterConfigure).toHaveBeenCalledTimes(2)
     expect(mocks.placeholderConfigure).toHaveBeenCalledTimes(2)
+  })
+
+  it("keeps one live breakpoint contract across unknown, mobile, and desktop", async () => {
+    mocks.breakpoint = "unknown"
+    const accept = vi.fn(() => true)
+    const props = acceptedProps(accept)
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(Harness, props))
+    })
+    const stableHandleKeyDown = editorOptions.editorProps.handleKeyDown
+    const key = (overrides: Partial<KeyboardEvent> = {}) => ({
+      key: "Enter",
+      shiftKey: false,
+      isComposing: false,
+      preventDefault: vi.fn(),
+      ...overrides,
+    }) as unknown as KeyboardEvent
+
+    const unknownEnter = key()
+    expect(stableHandleKeyDown({} as never, unknownEnter)).toBe(false)
+    expect(unknownEnter.preventDefault).not.toHaveBeenCalled()
+    expect(accept).not.toHaveBeenCalled()
+    expect(setDomAttribute).toHaveBeenLastCalledWith("enterkeyhint", "enter")
+    expect(renderer.root.findByType("controller-probe").props.view.showSend).toBe(false)
+
+    mocks.breakpoint = "mobile"
+    await act(async () => {
+      renderer.update(createElement(Harness, props))
+    })
+    const mobileEnter = key()
+    expect(stableHandleKeyDown({} as never, mobileEnter)).toBe(false)
+    expect(mobileEnter.preventDefault).not.toHaveBeenCalled()
+    expect(accept).not.toHaveBeenCalled()
+    expect(setDomAttribute).toHaveBeenLastCalledWith("enterkeyhint", "enter")
+    expect(renderer.root.findByType("controller-probe").props.view.showSend).toBe(true)
+
+    mocks.breakpoint = "desktop"
+    await act(async () => {
+      renderer.update(createElement(Harness, props))
+    })
+    const desktopShiftEnter = key({ shiftKey: true })
+    expect(stableHandleKeyDown({} as never, desktopShiftEnter)).toBe(false)
+    expect(desktopShiftEnter.preventDefault).not.toHaveBeenCalled()
+    const desktopEnter = key()
+    expect(stableHandleKeyDown({} as never, desktopEnter)).toBe(true)
+    expect(desktopEnter.preventDefault).toHaveBeenCalledOnce()
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(accept).toHaveBeenCalledOnce()
+    expect(setDomAttribute).toHaveBeenLastCalledWith("enterkeyhint", "send")
+    expect(renderer.root.findByType("controller-probe").props.view.showSend).toBe(false)
+
+    mocks.breakpoint = "mobile"
+    await act(async () => {
+      renderer.update(createElement(Harness, props))
+    })
+    mentionPopupRef.current = { items: [{}], command: vi.fn() }
+    const suggestionEnter = key()
+    expect(stableHandleKeyDown({} as never, suggestionEnter)).toBe(false)
+    expect(suggestionEnter.preventDefault).not.toHaveBeenCalled()
+    mentionPopupRef.current = { items: [], command: null }
+    const composingEnter = key({ isComposing: true })
+    expect(stableHandleKeyDown({} as never, composingEnter)).toBe(false)
+    expect(composingEnter.preventDefault).not.toHaveBeenCalled()
+    expect(accept).toHaveBeenCalledOnce()
+    expect(setDomAttribute).toHaveBeenLastCalledWith("enterkeyhint", "enter")
+  })
+
+  it("projects mobile send eligibility from text, pending files, and single-flight", async () => {
+    mocks.breakpoint = "mobile"
+    editor.isEmpty = true
+    let releaseFiles!: () => void
+    const fileGate = new Promise<void>((resolve) => {
+      releaseFiles = resolve
+    })
+    awaitPendingFiles.mockImplementation(async () => {
+      await fileGate
+      return pendingFiles
+    })
+    const accept = vi.fn(() => true)
+    const props = acceptedProps(accept)
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(Harness, props))
+    })
+    const view = () => renderer.root.findByType("controller-probe").props.view
+    expect(view()).toMatchObject({ showSend: true, sendDisabled: true })
+
+    editor.isEmpty = false
+    await act(async () => {
+      editorOptions.onUpdate({ editor })
+    })
+    expect(view().sendDisabled).toBe(false)
+    await act(async () => {
+      view().onSend()
+      view().onSend()
+    })
+    expect(awaitPendingFiles).toHaveBeenCalledOnce()
+    expect(view().sendDisabled).toBe(true)
+    expect(accept).not.toHaveBeenCalled()
+    await act(async () => {
+      releaseFiles()
+      await fileGate
+      await Promise.resolve()
+    })
+    expect(accept).toHaveBeenCalledOnce()
+    expect(view().sendDisabled).toBe(true)
+
+    editor.isEmpty = true
+    pendingFiles = [{
+      file: new File(["x"], "pending.txt", { type: "text/plain" }),
+      thumbnailUrl: null,
+      thumbnailBlob: null,
+    }]
+    await act(async () => {
+      renderer.update(createElement(Harness, props))
+    })
+    expect(view().sendDisabled).toBe(false)
   })
 
   it("updates the live placeholder without replacing or resetting the editor", async () => {

--- a/src/web/src/components/community/messages/use-composer-controller.ts
+++ b/src/web/src/components/community/messages/use-composer-controller.ts
@@ -4,6 +4,7 @@ import {
   useImperativeHandle,
   useLayoutEffect,
   useRef,
+  useState,
   type DragEvent,
   type ForwardedRef,
 } from "react"
@@ -13,6 +14,7 @@ import Placeholder from "@tiptap/extension-placeholder"
 import { DOMParser as PMDOMParser } from "@tiptap/pm/model"
 import { MAX_ATTACHMENT_SIZE_BYTES } from "@alook/shared"
 import { useFileAttachments } from "@/hooks/use-file-attachments"
+import { useBreakpoint } from "@/hooks/use-mobile"
 import {
   clearComposerDraft,
   readComposerDraft,
@@ -25,6 +27,7 @@ import {
   createLongPasteAttachment,
   pendingFilesToSendAttachments,
 } from "./composer-file-utils"
+import { handleComposerKeyDown } from "./composer-keydown"
 import type { ComposerHandle, ComposerProps } from "./composer-types"
 import type { ComposerViewProps } from "./composer-view"
 import { useComposerSuggestions } from "./use-composer-suggestions"
@@ -55,6 +58,13 @@ export function useComposerController(
   ref: ForwardedRef<ComposerHandle>,
 ): ComposerViewProps {
   const isForumThreadBody = mode === "forumThreadBody"
+  const breakpoint = useBreakpoint()
+  const breakpointRef = useRef(breakpoint)
+  const [editorHasContent, setEditorHasContent] = useState(false)
+  const [sendInFlight, setSendInFlight] = useState(false)
+  useLayoutEffect(() => {
+    breakpointRef.current = breakpoint
+  }, [breakpoint])
   const attachments = useFileAttachments({
     maxFileSize: MAX_ATTACHMENT_SIZE_BYTES,
   })
@@ -151,39 +161,21 @@ export function useComposerController(
     editorProps: {
       attributes: {
         class: "outline-none",
-        enterkeyhint: isForumThreadBody ? "enter" : "send",
+        enterkeyhint:
+          isForumThreadBody || breakpoint !== "desktop" ? "enter" : "send",
       },
-      handleKeyDown: (_view, event) => {
-        const mentionOpen =
-          suggestions.mentionPopupRef.current.items.length > 0 &&
-          suggestions.mentionPopupRef.current.command !== null
-        const channelRefOpen =
-          suggestions.channelRefPopupRef.current.items.length > 0 &&
-          suggestions.channelRefPopupRef.current.command !== null
-        if (mentionOpen || channelRefOpen) return false
-        if (isForumThreadBody) {
-          if (
-            event.key === "Enter" &&
-            event.shiftKey &&
-            !event.isComposing
-          ) {
-            event.preventDefault()
-            sendRef.current()
-            return true
-          }
-          return false
-        }
-        if (
-          event.key === "Enter" &&
-          !event.shiftKey &&
-          !event.isComposing
-        ) {
-          event.preventDefault()
-          sendRef.current()
-          return true
-        }
-        return false
-      },
+      handleKeyDown: (_view, event) =>
+        handleComposerKeyDown(event, {
+          breakpoint: breakpointRef.current,
+          channelRefOpen:
+            suggestions.channelRefPopupRef.current.items.length > 0 &&
+            suggestions.channelRefPopupRef.current.command !== null,
+          isForumThreadBody,
+          mentionOpen:
+            suggestions.mentionPopupRef.current.items.length > 0 &&
+            suggestions.mentionPopupRef.current.command !== null,
+          send: () => sendRef.current(),
+        }),
       handlePaste: (_view, event) => {
         const files = clipboardFiles(event.clipboardData?.items)
         if (files.length > 0) {
@@ -213,6 +205,7 @@ export function useComposerController(
       },
     },
     onUpdate: ({ editor: updatedEditor }) => {
+      setEditorHasContent(!updatedEditor.isEmpty)
       if (restoringDraftRef.current) return
       fireTyping()
       emitDirtyTransition()
@@ -225,6 +218,12 @@ export function useComposerController(
       }
     },
   })
+
+  const enterKeyHint =
+    isForumThreadBody || breakpoint !== "desktop" ? "enter" : "send"
+  useLayoutEffect(() => {
+    editor?.view?.dom?.setAttribute("enterkeyhint", enterKeyHint)
+  }, [editor, enterKeyHint])
 
   useLayoutEffect(() => {
     if (placeholderRef.current === resolvedPlaceholder) return
@@ -243,6 +242,7 @@ export function useComposerController(
         emitUpdate: false,
         errorOnInvalidContent: true,
       })
+      setEditorHasContent(!editor.isEmpty)
     } catch {
       clearComposerDraft(draftKey)
     } finally {
@@ -272,6 +272,8 @@ export function useComposerController(
     if (!editor || sendInFlightRef.current) return
     const attemptScopeVersion = sendScopeVersionRef.current
     const attemptLifecycle = lifecycleVersionRef.current
+    sendInFlightRef.current = Promise.resolve()
+    setSendInFlight(true)
     const attempt = (async () => {
       const preparedFiles = await awaitPendingFiles()
       if (
@@ -291,6 +293,7 @@ export function useComposerController(
       }
       if (isForumThreadBody) return
       editor.commands.clearContent()
+      setEditorHasContent(false)
       if (draftKeyRef.current) clearComposerDraft(draftKeyRef.current)
       transferPendingFiles()
       nextLongPasteIndexRef.current = 1
@@ -301,11 +304,13 @@ export function useComposerController(
       () => {
         if (sendInFlightRef.current === attempt) {
           sendInFlightRef.current = null
+          setSendInFlight(false)
         }
       },
       () => {
         if (sendInFlightRef.current === attempt) {
           sendInFlightRef.current = null
+          setSendInFlight(false)
         }
       },
     )
@@ -325,6 +330,7 @@ export function useComposerController(
     resetAfterSubmit: () => {
       if (!editor) return
       editor.commands.clearContent()
+      setEditorHasContent(false)
       setPendingFiles([])
       nextLongPasteIndexRef.current = 1
       suggestions.resetPopups()
@@ -374,6 +380,10 @@ export function useComposerController(
     editor,
     hideAttach,
     hideEmoji,
+    showSend: !isForumThreadBody && breakpoint === "mobile",
+    sendDisabled:
+      sendInFlight || (!editorHasContent && pendingFiles.length === 0),
+    onSend: send,
     onAttachOpenChange: (open) => {
       if (!open) editor?.commands.focus()
     },

--- a/src/web/src/test/e2e-ui/24-composer-overflow.spec.ts
+++ b/src/web/src/test/e2e-ui/24-composer-overflow.spec.ts
@@ -1,6 +1,6 @@
 import { type Locator, type Page } from "@playwright/test"
 import { test, expect, userId } from "./_fixtures/community-fixture"
-import { composerEditable } from "./_fixtures/actions"
+import { composerEditable, ignoreNextDevToolsPointerCapture } from "./_fixtures/actions"
 import { tid } from "./_fixtures/testids"
 import {
   memberInfo,
@@ -122,15 +122,6 @@ async function expectChatPlaceholderAtWidths(
     expectContainedPlaceholder(metrics, expected, width)
   }
   expect(sawOverflowingSource).toBe(true)
-}
-
-async function ignoreNextDevToolsPointerCapture(page: Page): Promise<void> {
-  await page.addStyleTag({
-    content: [
-      "nextjs-portal { pointer-events: none !important; }",
-      ".tsqd-parent-container { pointer-events: none !important; }",
-    ].join("\n"),
-  })
 }
 
 async function suggestionMetrics(option: Locator): Promise<{

--- a/src/web/src/test/e2e-ui/39-mobile-composer-send.spec.ts
+++ b/src/web/src/test/e2e-ui/39-mobile-composer-send.spec.ts
@@ -1,0 +1,151 @@
+import type { Page } from "@playwright/test"
+import { test, expect, userId } from "./_fixtures/community-fixture"
+import { composerEditable } from "./_fixtures/actions"
+import {
+  seedChannel,
+  seedDm,
+  seedMessage,
+  seedServer,
+  seedThread,
+} from "./_fixtures/seed"
+import { tid } from "./_fixtures/testids"
+
+test.use({ viewport: { width: 390, height: 844 } })
+
+async function expectExplicitMobileSend({
+  page,
+  route,
+  channelId,
+  label,
+  exerciseResize = false,
+}: {
+  page: Page
+  route: string
+  channelId: string
+  label: string
+  exerciseResize?: boolean
+}) {
+  let messagePosts = 0
+  page.on("request", (request) => {
+    if (
+      request.method() === "POST"
+      && new URL(request.url()).pathname === `/api/community/channels/${channelId}/messages`
+    ) messagePosts += 1
+  })
+  await page.goto(route, { waitUntil: "commit" })
+  await page.addStyleTag({
+    content: [
+      "nextjs-portal { pointer-events: none !important; }",
+      ".tsqd-parent-container { pointer-events: none !important; }",
+    ].join("\n"),
+  })
+
+  const editable = composerEditable(page)
+  const send = page.getByTestId(tid.composerSend)
+  await expect(editable).toBeVisible({ timeout: 20_000 })
+  await expect(editable).toHaveAttribute("enterkeyhint", "enter")
+  await expect(send).toBeVisible()
+  await expect(send).toBeDisabled()
+
+  if (exerciseResize) {
+    await editable.evaluate((element) => {
+      ;(element as HTMLElement).dataset.e2eEditorIdentity = "stable"
+    })
+    await page.setViewportSize({ width: 640, height: 844 })
+    await expect(editable).toHaveAttribute("data-e2e-editor-identity", "stable")
+    await expect(editable).toHaveAttribute("enterkeyhint", "send")
+    await expect(send).toBeHidden()
+    await page.setViewportSize({ width: 639, height: 844 })
+    await expect(editable).toHaveAttribute("data-e2e-editor-identity", "stable")
+    await expect(editable).toHaveAttribute("enterkeyhint", "enter")
+    await expect(send).toBeVisible()
+  }
+
+  await page.getByTestId(tid.composerFileInput).setInputFiles({
+    name: `${label}.txt`,
+    mimeType: "text/plain",
+    buffer: Buffer.from("pending attachment eligibility"),
+  })
+  await expect(page.getByRole("button", { name: "Remove file" })).toBeVisible()
+  await expect(send).toBeEnabled()
+  await page.getByRole("button", { name: "Remove file" }).click()
+  await expect(send).toBeDisabled()
+
+  const firstLine = `${label} first ${Date.now()}`
+  const secondLine = `${label} second`
+  await editable.click()
+  await editable.pressSequentially(firstLine)
+  await page.keyboard.press("Enter")
+  await editable.pressSequentially(secondLine)
+  await expect(editable.locator("p")).toHaveCount(2)
+  await expect(editable).toContainText(firstLine)
+  await expect(editable).toContainText(secondLine)
+  await expect(send).toBeEnabled()
+  expect(messagePosts).toBe(0)
+  await expect(page.locator("[data-msg-id]").filter({ hasText: firstLine })).toHaveCount(0)
+
+  const responsePromise = page.waitForResponse((response) => (
+    response.request().method() === "POST"
+    && new URL(response.url()).pathname === `/api/community/channels/${channelId}/messages`
+  ))
+  await send.evaluate((button) => {
+    const sendButton = button as HTMLButtonElement
+    sendButton.click()
+    sendButton.click()
+  })
+  const response = await responsePromise
+  expect(response.status()).toBe(201)
+  const payload = await response.json() as { message: { id: string } }
+  await expect(page.getByTestId(tid.message(payload.message.id))).toHaveCount(1)
+  await expect(page.getByTestId(tid.message(payload.message.id))).toContainText(firstLine)
+  await expect(page.getByTestId(tid.message(payload.message.id))).toContainText(secondLine)
+  await expect(editable).toHaveText("")
+  await expect(send).toBeDisabled()
+  expect(messagePosts).toBe(1)
+}
+
+test.describe.serial("mobile composer explicit send", () => {
+  let serverId: string
+  let channelId: string
+  let threadId: string
+  let dmId: string
+
+  test.beforeAll(async () => {
+    serverId = await seedServer("alice", `mobile-send-${Date.now()}`)
+    channelId = await seedChannel("alice", serverId, "mobile-send")
+    const openerId = await seedMessage("alice", channelId, "mobile send thread opener")
+    threadId = await seedThread("alice", openerId, "mobile-send-thread")
+    dmId = await seedDm("alice", userId("bob"))
+  })
+
+  test("text channel Enter stays multiline and the button sends once", async ({ asUser }) => {
+    const { page } = await asUser("alice")
+    await expectExplicitMobileSend({
+      page,
+      route: `/c/channels/${serverId}/${channelId}`,
+      channelId,
+      label: "channel",
+      exerciseResize: true,
+    })
+  })
+
+  test("child thread Enter stays multiline and the button targets the child", async ({ asUser }) => {
+    const { page } = await asUser("alice")
+    await expectExplicitMobileSend({
+      page,
+      route: `/c/channels/${serverId}/${threadId}`,
+      channelId: threadId,
+      label: "thread",
+    })
+  })
+
+  test("DM Enter stays multiline and the button targets the DM channel", async ({ asUser }) => {
+    const { page } = await asUser("alice")
+    await expectExplicitMobileSend({
+      page,
+      route: `/c/me/${dmId}`,
+      channelId: dmId,
+      label: "dm",
+    })
+  })
+})

--- a/src/web/src/test/e2e-ui/39-mobile-composer-send.spec.ts
+++ b/src/web/src/test/e2e-ui/39-mobile-composer-send.spec.ts
@@ -1,6 +1,6 @@
 import type { Page } from "@playwright/test"
 import { test, expect, userId } from "./_fixtures/community-fixture"
-import { composerEditable } from "./_fixtures/actions"
+import { composerEditable, ignoreNextDevToolsPointerCapture } from "./_fixtures/actions"
 import {
   seedChannel,
   seedDm,
@@ -33,12 +33,7 @@ async function expectExplicitMobileSend({
     ) messagePosts += 1
   })
   await page.goto(route, { waitUntil: "commit" })
-  await page.addStyleTag({
-    content: [
-      "nextjs-portal { pointer-events: none !important; }",
-      ".tsqd-parent-container { pointer-events: none !important; }",
-    ].join("\n"),
-  })
+  await ignoreNextDevToolsPointerCapture(page)
 
   const editable = composerEditable(page)
   const send = page.getByTestId(tid.composerSend)

--- a/src/web/src/test/e2e-ui/_fixtures/actions.ts
+++ b/src/web/src/test/e2e-ui/_fixtures/actions.ts
@@ -33,6 +33,17 @@ export async function gotoAfterUserWsAuth(page: Page, url: string): Promise<void
   }
 }
 
+// Keep Next's development-only portals from capturing pointer input intended
+// for the product UI. Production builds do not mount either overlay.
+export async function ignoreNextDevToolsPointerCapture(page: Page): Promise<void> {
+  await page.addStyleTag({
+    content: [
+      "nextjs-portal { pointer-events: none !important; }",
+      ".tsqd-parent-container { pointer-events: none !important; }",
+    ].join("\n"),
+  })
+}
+
 // Reusable UI action helpers built on the canonical testids. Journeys compose
 // these so the real user path (click → type → assert) stays readable and the
 // selectors live in one place.
@@ -112,6 +123,7 @@ export async function sendMessage(page: Page, text: string): Promise<void> {
     const sendButton = page.getByTestId(tid.composerSend)
     await expect(sendButton).toBeVisible()
     await expect(sendButton).toBeEnabled()
+    await ignoreNextDevToolsPointerCapture(page)
     await sendButton.click()
     return
   }

--- a/src/web/src/test/e2e-ui/_fixtures/actions.ts
+++ b/src/web/src/test/e2e-ui/_fixtures/actions.ts
@@ -102,12 +102,19 @@ export function composerEditable(page: Page) {
   return page.getByTestId(tid.composerInput).locator("[contenteditable='true']")
 }
 
-// Type into the TipTap composer and send with Enter. Returns after the input
-// clears (the send round-trip's observable completion).
+// Type into the TipTap composer and submit through the control for the current
+// breakpoint: the explicit send button below 640px, or Enter on desktop.
 export async function sendMessage(page: Page, text: string): Promise<void> {
   const editable = composerEditable(page)
   await editable.click()
   await editable.pressSequentially(text)
+  if ((page.viewportSize()?.width ?? 640) < 640) {
+    const sendButton = page.getByTestId(tid.composerSend)
+    await expect(sendButton).toBeVisible()
+    await expect(sendButton).toBeEnabled()
+    await sendButton.click()
+    return
+  }
   await page.keyboard.press("Enter")
 }
 


### PR DESCRIPTION
# Why we need this PR?
> Closes #

Mobile chat keyboards should keep Enter available for multiline writing while preserving the existing desktop shortcut.

## What changed
- add a mobile-only explicit Send control to shared channel, thread, and DM composers
- keep TipTap key handling and `enterkeyhint` synchronized with the live breakpoint
- preserve existing send eligibility/single-flight behavior and cover it with unit and Playwright tests

## Checklist
- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...
