### PR TITLE
feat(web): badge supported platform links

### DIFF
--- a/src/web/src/app/globals.css
+++ b/src/web/src/app/globals.css
@@ -634,6 +634,7 @@ body.community-onboarding-active.driver-active :is(
   --muted-foreground: oklch(0.44 0.03 230);
   --accent: oklch(0.94 0.008 80);
   --accent-foreground: oklch(0.22 0.03 230);
+  --link: oklch(0.5 0.18 270);
   --destructive: oklch(0.577 0.245 27.325);
   --warning: oklch(0.62 0.11 75);
   --border: oklch(0.86 0.01 80);
@@ -688,6 +689,7 @@ body.community-onboarding-active.driver-active :is(
   --muted-foreground: oklch(0.65 0.01 70);
   --accent: oklch(0.27 0.008 60);
   --accent-foreground: oklch(0.93 0.006 80);
+  --link: oklch(0.75 0.14 270);
   --destructive: oklch(0.704 0.191 22.216);
   --warning: oklch(0.76 0.1 75);
   --border: oklch(1 0.005 80 / 10%);
@@ -1933,6 +1935,85 @@ body.community-onboarding-active.driver-active :is(
   text-decoration: underline;
   text-underline-offset: 2px;
   text-decoration-color: currentColor;
+}
+
+/* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V5
+ * component: platform link badge · genre: playful · theme: studied-DNA (supplied reference)
+ * macrostructure: platform glyph + Alook inline-reference pill
+ * states: default · hover · focus · active · disabled · loading · error · success
+ * slop: pass (1–58) · contrast: pass (40–41) · mobile: pass (34, 49, 50–57)
+ */
+.markdown a.platform-link-badge {
+  display: inline-flex;
+  max-inline-size: min(24rem, 100%);
+  min-inline-size: 0;
+  align-items: center;
+  gap: 0.25em;
+  padding-inline: 0.3em;
+  border: 0;
+  border-radius: var(--radius-lg);
+  color: var(--link);
+  background-color: var(--accent);
+  font-weight: 500;
+  line-height: inherit;
+  text-decoration: none;
+  vertical-align: bottom;
+  transition:
+    background-color 120ms var(--ease-out),
+    color 120ms var(--ease-out);
+}
+
+.platform-link-badge-icon {
+  inline-size: 0.9em;
+  block-size: 0.9em;
+  flex: none;
+}
+
+.platform-link-badge-label {
+  min-inline-size: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.platform-link-badge:focus-visible {
+  outline: 2px solid var(--link);
+  outline-offset: 2px;
+}
+
+.platform-link-badge:active {
+  background-color: color-mix(in oklch, var(--link) 22%, var(--accent));
+}
+
+.platform-link-badge[aria-disabled="true"] {
+  pointer-events: none;
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.platform-link-badge[aria-busy="true"] .platform-link-badge-icon {
+  opacity: 0.55;
+}
+
+.platform-link-badge[data-state="error"] {
+  text-decoration: underline;
+  text-decoration-style: wavy;
+}
+
+.platform-link-badge[data-state="success"] {
+  box-shadow: inset 0 0 0 1px var(--link);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .platform-link-badge:hover {
+    background-color: color-mix(in oklch, var(--link) 14%, var(--accent));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .platform-link-badge {
+    transition-duration: 0ms;
+  }
 }
 
 .markdown hr {

--- a/src/web/src/components/community/messages/message-body.test.ts
+++ b/src/web/src/components/community/messages/message-body.test.ts
@@ -4,7 +4,7 @@ import TestRenderer, { act } from "react-test-renderer"
 import { MessageBody } from "./message-body"
 
 describe("MessageBody — plain URL rendering", () => {
-  it("keeps an HTTPS URL as a normal clickable link", () => {
+  it("renders an unsupported HTTPS URL as a generic clickable link badge", () => {
     let renderer: TestRenderer.ReactTestRenderer
     act(() => {
       renderer = TestRenderer.create(
@@ -14,7 +14,26 @@ describe("MessageBody — plain URL rendering", () => {
 
     const link = renderer!.root.findByType("a")
     expect(link.props.href).toBe("https://example.com/story")
-    expect(link.children.join("")).toBe("https://example.com/story")
+    expect(link.props["data-platform-link"]).toBe("generic")
+    expect(renderer!.root.findAllByType("svg")).toHaveLength(1)
+  })
+
+  it("badges supported platform URLs without changing their href", () => {
+    let renderer: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(
+        React.createElement(MessageBody, {
+          text: "Review https://github.com/alookai/alook/pull/598 then https://example.com/story",
+        }),
+      )
+    })
+
+    const links = renderer!.root.findAllByType("a")
+    expect(links).toHaveLength(2)
+    expect(links[0].props.href).toBe("https://github.com/alookai/alook/pull/598")
+    expect(links[0].props["data-platform-link"]).toBe("github")
+    expect(links[1].props.href).toBe("https://example.com/story")
+    expect(links[1].props["data-platform-link"]).toBe("generic")
   })
 })
 

--- a/src/web/src/components/community/messages/message-markdown.tsx
+++ b/src/web/src/components/community/messages/message-markdown.tsx
@@ -2,6 +2,7 @@ import type React from "react"
 import { Spoiler, MentionPill } from "./inline-marks"
 import { ChannelRefPill } from "./channel-ref-pill"
 import { ServerRefPill } from "./server-ref-pill"
+import { PlatformLinkBadge } from "./platform-link-badge"
 
 // Match `/c/invite/<token>` — with or without an origin.
 // - token allows [A-Za-z0-9_-] (nanoid alphabet) and length 6..64 (short + old
@@ -63,6 +64,7 @@ export function mentionNameFromText(text: string): string {
 }
 
 export const MD_COMPONENTS = {
+  a: PlatformLinkBadge,
   spoiler: ({ children }: { children?: React.ReactNode }) => <Spoiler>{children}</Spoiler>,
   mention: ({ children, ...rest }: Record<string, unknown> & { children?: React.ReactNode }) => (
     <MentionPill everyone={rest["data-everyone"] === "1"}>{children}</MentionPill>

--- a/src/web/src/components/community/messages/platform-link-badge.test.ts
+++ b/src/web/src/components/community/messages/platform-link-badge.test.ts
@@ -1,0 +1,49 @@
+import React from "react"
+import TestRenderer, { act } from "react-test-renderer"
+import { describe, expect, it } from "vitest"
+import { PlatformLinkBadge } from "./platform-link-badge"
+
+describe("PlatformLinkBadge", () => {
+  it("adds a platform icon and accessible label to a supported URL", () => {
+    let renderer: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(
+        React.createElement(
+          PlatformLinkBadge,
+          { href: "https://github.com/alookai/alook/pull/598", target: "_blank" },
+          "https://github.com/alookai/alook/pull/598",
+        ),
+      )
+    })
+
+    const link = renderer!.root.findByType("a")
+    expect(link.props["data-platform-link"]).toBe("github")
+    expect(link.props["aria-label"]).toBe("GitHub: https://github.com/alookai/alook/pull/598")
+    expect(link.props.target).toBe("_blank")
+    expect(renderer!.root.findAllByType("svg")).toHaveLength(1)
+    expect(renderer!.root.findByType("span").children.join("")).toBe(
+      "https://github.com/alookai/alook/pull/598",
+    )
+  })
+
+  it("gives an unsupported URL the generic link icon and the same badge treatment", () => {
+    let renderer: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(
+        React.createElement(
+          PlatformLinkBadge,
+          { href: "https://example.com/story", className: "existing-link" },
+          "Example story",
+        ),
+      )
+    })
+
+    const link = renderer!.root.findByType("a")
+    expect(link.props.className).toContain("platform-link-badge")
+    expect(link.props.className).toContain("existing-link")
+    expect(link.props["data-platform-link"]).toBe("generic")
+    expect(link.props["aria-label"]).toBe("Link: https://example.com/story")
+    expect(renderer!.root.findAllByType("svg")).toHaveLength(1)
+    expect(renderer!.root.findByType("span").children.join("")).toBe("Example story")
+  })
+})

--- a/src/web/src/components/community/messages/platform-link-badge.tsx
+++ b/src/web/src/components/community/messages/platform-link-badge.tsx
@@ -1,0 +1,67 @@
+import type { ComponentPropsWithoutRef } from "react"
+import { Link2 } from "lucide-react"
+import {
+  SiDiscord,
+  SiFigma,
+  SiGithub,
+  SiNotion,
+  SiReddit,
+  SiX,
+  SiYoutube,
+} from "@icons-pack/react-simple-icons"
+import type { PlatformLinkKind } from "@/lib/community/platform-link"
+import { matchPlatformLink } from "@/lib/community/platform-link"
+import { cn } from "@/lib/utils"
+
+const ICONS = {
+  github: SiGithub,
+  x: SiX,
+  reddit: SiReddit,
+  youtube: SiYoutube,
+  figma: SiFigma,
+  notion: SiNotion,
+  discord: SiDiscord,
+} satisfies Record<PlatformLinkKind, typeof SiGithub>
+
+type PlatformLinkBadgeProps = ComponentPropsWithoutRef<"a"> & {
+  node?: unknown
+}
+
+/** Streamdown anchor renderer: every link becomes an inline badge. */
+export function PlatformLinkBadge({
+  children,
+  className,
+  href,
+  node: _node,
+  ...props
+}: PlatformLinkBadgeProps) {
+  const platform = matchPlatformLink(href)
+  if (!platform) {
+    return (
+      <a
+        {...props}
+        href={href}
+        className={cn("platform-link-badge", className)}
+        data-platform-link="generic"
+        aria-label={props["aria-label"] ?? `Link: ${href}`}
+      >
+        <Link2 className="platform-link-badge-icon" aria-hidden="true" />
+        <span className="platform-link-badge-label">{children}</span>
+      </a>
+    )
+  }
+
+  const Icon = ICONS[platform.kind]
+  return (
+    <a
+      {...props}
+      href={href}
+      className={cn("platform-link-badge", className)}
+      data-platform-link={platform.kind}
+      aria-label={props["aria-label"] ?? `${platform.label}: ${href}`}
+    >
+      <Icon className="platform-link-badge-icon" aria-hidden="true" />
+      <span className="platform-link-badge-label">{children}</span>
+    </a>
+  )
+}

--- a/src/web/src/lib/community/platform-link.test.ts
+++ b/src/web/src/lib/community/platform-link.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import { matchPlatformLink } from "./platform-link"
+
+describe("matchPlatformLink", () => {
+  it.each([
+    ["https://github.com/alookai/alook/pull/598", "github", "GitHub"],
+    ["https://gist.github.com/alookai/abc", "github", "GitHub"],
+    ["https://x.com/alookai/status/1", "x", "X"],
+    ["https://mobile.twitter.com/alookai/status/1", "x", "X"],
+    ["https://old.reddit.com/r/LocalLLaMA/comments/abc", "reddit", "Reddit"],
+    ["https://redd.it/abc", "reddit", "Reddit"],
+    ["https://youtu.be/abc", "youtube", "YouTube"],
+    ["https://www.youtube.com/watch?v=abc", "youtube", "YouTube"],
+    ["https://www.figma.com/design/abc", "figma", "Figma"],
+    ["https://workspace.notion.site/Page-abc", "notion", "Notion"],
+    ["https://discord.gg/abc", "discord", "Discord"],
+  ])("recognizes %s", (href, kind, label) => {
+    expect(matchPlatformLink(href)).toEqual({ kind, label })
+  })
+
+  it.each([
+    "https://github.com.evil.example/alookai/alook",
+    "https://notgithub.com/alookai/alook",
+    "https://example.com/story",
+    "ftp://github.com/alookai/alook",
+    "/c/invite/abcdef",
+    "not a URL",
+    undefined,
+  ])("does not badge unsupported or unsafe input: %s", (href) => {
+    expect(matchPlatformLink(href)).toBeNull()
+  })
+})

--- a/src/web/src/lib/community/platform-link.ts
+++ b/src/web/src/lib/community/platform-link.ts
@@ -1,0 +1,55 @@
+export type PlatformLinkKind =
+  | "github"
+  | "x"
+  | "reddit"
+  | "youtube"
+  | "figma"
+  | "notion"
+  | "discord"
+
+export type PlatformLinkMatch = {
+  kind: PlatformLinkKind
+  label: string
+}
+
+type PlatformDefinition = PlatformLinkMatch & {
+  domains: readonly string[]
+}
+
+const PLATFORM_DEFINITIONS: readonly PlatformDefinition[] = [
+  { kind: "github", label: "GitHub", domains: ["github.com"] },
+  { kind: "x", label: "X", domains: ["x.com", "twitter.com"] },
+  { kind: "reddit", label: "Reddit", domains: ["reddit.com", "redd.it"] },
+  { kind: "youtube", label: "YouTube", domains: ["youtube.com", "youtu.be"] },
+  { kind: "figma", label: "Figma", domains: ["figma.com"] },
+  { kind: "notion", label: "Notion", domains: ["notion.so", "notion.site"] },
+  { kind: "discord", label: "Discord", domains: ["discord.com", "discord.gg"] },
+]
+
+function hostMatchesDomain(host: string, domain: string): boolean {
+  return host === domain || host.endsWith(`.${domain}`)
+}
+
+/**
+ * Classifies a fully-qualified HTTP(S) URL using hostname boundaries only.
+ * No request, metadata lookup, redirect resolution, or storage is involved.
+ */
+export function matchPlatformLink(href: string | undefined): PlatformLinkMatch | null {
+  if (!href) return null
+
+  let url: URL
+  try {
+    url = new URL(href)
+  } catch {
+    return null
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null
+
+  const host = url.hostname.toLowerCase().replace(/\.$/, "")
+  const definition = PLATFORM_DEFINITIONS.find(({ domains }) =>
+    domains.some((domain) => hostMatchesDomain(host, domain)),
+  )
+
+  return definition ? { kind: definition.kind, label: definition.label } : null
+}


### PR DESCRIPTION
## Summary

- recognize seven supported platform URL families entirely in the browser
- render every link as an Alook-style rounded inline badge
- use brand icons for GitHub, X/Twitter, Reddit, YouTube, Figma, Notion, and Discord
- use a generic link icon for unknown platforms so all links stay visually consistent
- preserve the exact destination and anchor props

## Scope

Web frontend only. No metadata fetch, preview card, API, cache, database, Worker, or backend changes.

## Validation

- full repository pre-commit hook passed: typecheck, lint, tests, typegrep, and knip
- web suite: 656 files / 5,687 tests
- post-rebase focused suite: 3 files / 29 tests
- post-rebase web typecheck passed
- PC/mobile light/dark browser QA passed
- 390px viewport: no horizontal overflow
- Gus visual QA passed in /Alook#5620/gus-issues/#40#30
