### PR TITLE
fix(web): keep mobile server rail above user bar

### DIFF
--- a/src/web/src/components/community/shell/shell-frame-view.test.ts
+++ b/src/web/src/components/community/shell/shell-frame-view.test.ts
@@ -118,8 +118,12 @@ describe("ShellFrameView", () => {
       }, createElement("main-content")))
     })
     expect(renderer.root.findAllByType("channel-loading-frame")).toHaveLength(2)
-    expect(renderer.root.findAllByType("server-rail")).toHaveLength(1)
-    expect(renderer.root.findAllByProps({ className: "hidden sm:contents" })).toHaveLength(1)
+    const initialRailWrapper = renderer.root.find((node) =>
+      node.type === "div"
+      && typeof node.props.className === "string"
+      && node.props.className.includes("hidden sm:contents"),
+    )
+    expect(initialRailWrapper.props.className).toContain("min-h-0")
     expect(renderer.root.findAllByType("sidebar-content")).toHaveLength(1)
     expect(renderer.root.findAllByType("user-bar")).toHaveLength(1)
     expect(renderer.root.findByProps({ "data-slot": "community-user-bar-overlay" }).props.className)
@@ -170,7 +174,9 @@ describe("ShellFrameView", () => {
     expect(hostTypes.indexOf("app-surface")).toBeLessThan(hostTypes.indexOf("user-bar"))
     expect(hostTypes.indexOf("user-bar")).toBeLessThan(hostTypes.indexOf("shell-overlays"))
     expect(renderer.root.findAllByType("shell-overlays")).toHaveLength(1)
-    expect(renderer.root.findByType("server-rail").props.bottomInset).toBe(60)
+    const desktopRail = renderer.root.findByType("server-rail")
+    expect(desktopRail.props.bottomInset).toBe(60)
+    expect(renderer.root.findAllByProps({ className: "flex min-h-0" })).toHaveLength(1)
     const group = renderer.root.findByType("panel-group")
     expect(group.props.id).toBe("community-shell")
     expect(group.props.orientation).toBe("horizontal")
@@ -214,6 +220,7 @@ describe("ShellFrameView", () => {
     })
 
     expect(renderer.root.findAllByType("server-rail")).toHaveLength(1)
+    expect(renderer.root.findAllByProps({ className: "flex min-h-0" })).toHaveLength(1)
     expect(renderer.root.findAllByType("sidebar-content")).toHaveLength(1)
     expect(renderer.root.findAllByType("main-content")).toHaveLength(1)
     expect(sidebar).toHaveBeenCalledWith()

--- a/src/web/src/components/community/shell/shell-frame-view.tsx
+++ b/src/web/src/components/community/shell/shell-frame-view.tsx
@@ -84,7 +84,7 @@ export function ShellFrameView({
   return (
     <Shell onNavigationIntent={cancelPendingNavigation}>
       {!isMobileDetail && (
-        <div className={cn(isInitialDetail && "hidden sm:contents")}>
+        <div className={cn("flex min-h-0", isInitialDetail && "hidden sm:contents")}>
           <ServerRail {...rail.railProps} bottomInset={60} />
         </div>
       )}

--- a/src/web/src/test/e2e-ui/37-server-rail-pdd.spec.ts
+++ b/src/web/src/test/e2e-ui/37-server-rail-pdd.spec.ts
@@ -5,6 +5,49 @@ import { tid } from "./_fixtures/testids"
 
 const RAIL_ENDPOINT = "/api/community/users/me/server-rail"
 
+type RailGeometry = {
+  rootScrollTop: number
+  railScrollTop: number
+  railMaxScrollTop: number
+  railClientHeight: number
+  railScrollHeight: number
+  target: { top: number; bottom: number }
+  userBar: { top: number; bottom: number }
+  add: { top: number; bottom: number }
+  targetOwnsCenter: boolean
+}
+
+async function railGeometry(page: Page, serverId: string): Promise<RailGeometry> {
+  return page.getByTestId(tid.serverIcon(serverId)).evaluate((target, ids) => {
+    const nav = target.closest("nav")
+    const rail = nav?.querySelector<HTMLElement>(`[data-testid='${ids.rail}']`)
+    const userBar = document.querySelector<HTMLElement>("[data-slot='community-user-bar-overlay']")
+      ?.firstElementChild as HTMLElement | null
+    const add = nav?.querySelector<HTMLElement>(`[data-testid='${ids.add}']`)
+    let root = nav?.parentElement ?? null
+    while (root && getComputedStyle(root).position !== "fixed") root = root.parentElement
+    if (!root || !rail || !userBar || !add) throw new Error("missing server rail geometry node")
+    const targetRect = target.getBoundingClientRect()
+    const userBarRect = userBar.getBoundingClientRect()
+    const addRect = add.getBoundingClientRect()
+    const hit = document.elementFromPoint(
+      targetRect.left + targetRect.width / 2,
+      targetRect.top + targetRect.height / 2,
+    )
+    return {
+      rootScrollTop: root.scrollTop,
+      railScrollTop: rail.scrollTop,
+      railMaxScrollTop: rail.scrollHeight - rail.clientHeight,
+      railClientHeight: rail.clientHeight,
+      railScrollHeight: rail.scrollHeight,
+      target: { top: targetRect.top, bottom: targetRect.bottom },
+      userBar: { top: userBarRect.top, bottom: userBarRect.bottom },
+      add: { top: addRect.top, bottom: addRect.bottom },
+      targetOwnsCenter: target.contains(hit),
+    }
+  }, { rail: tid.serverRailScroll, add: tid.serverAdd })
+}
+
 async function openMove(page: Page, serverId: string) {
   const icon = page.getByTestId(tid.serverIcon(serverId))
   await icon.focus()
@@ -19,7 +62,11 @@ test("server rail commits one PDD drop and exposes mobile Move parity", async ({
   const stamp = Date.now()
   const first = await seedServer("alice", `Rail first ${stamp}`)
   const second = await seedServer("alice", `Rail second ${stamp}`)
-  const third = await seedServer("alice", `Rail third ${stamp}`)
+  const overflowServers: string[] = []
+  for (let index = 0; index < 12; index++) {
+    overflowServers.push(await seedServer("alice", `Rail overflow ${index} ${stamp}`))
+  }
+  const tail = overflowServers.at(-1)!
   const channel = await seedChannel("alice", first, `rail-${stamp}`)
   const { page } = await asUser("alice")
   await page.setViewportSize({ width: 1280, height: 900 })
@@ -72,7 +119,16 @@ test("server rail commits one PDD drop and exposes mobile Move parity", async ({
   await page.setViewportSize({ width: 390, height: 844 })
   await page.getByRole("button", { name: "Back" }).click()
   await expect.poll(() => new URL(page.url()).pathname).toBe(`/c/channels/${first}`)
-  await openMove(page, third)
+  const rail = page.getByTestId(tid.serverRailScroll)
+  await rail.evaluate((element) => { element.scrollTop = element.scrollHeight })
+  await expect.poll(async () => (await railGeometry(page, tail)).railScrollTop)
+    .toBeGreaterThan(0)
+  const mobileTail = await railGeometry(page, tail)
+  expect(mobileTail.rootScrollTop).toBe(0)
+  expect(mobileTail.railScrollTop).toBe(mobileTail.railMaxScrollTop)
+  expect(mobileTail.target.bottom).toBeLessThanOrEqual(mobileTail.userBar.top + 0.5)
+  expect(mobileTail.targetOwnsCenter).toBe(true)
+  await openMove(page, tail)
   await page.getByTestId(tid.serverRailMoveDestination).selectOption("new")
   await page.getByTestId(tid.serverRailMoveTarget).selectOption(first)
   const createResponsePromise = page.waitForResponse((response) =>
@@ -83,12 +139,16 @@ test("server rail commits one PDD drop and exposes mobile Move parity", async ({
   expect(createResponse.status()).toBe(200)
   expect(railRequests).toHaveLength(2)
   expect(railRequests[1]?.body).toMatchObject({
-    commands: [{ kind: "create-folder", name: "Group", serverIds: [third, first] }],
+    commands: [{ kind: "create-folder", name: "Group", serverIds: [tail, first] }],
   })
-  await expect(page.getByTestId(tid.serverIcon(third))).toBeVisible()
+  await expect(page.getByTestId(tid.serverIcon(tail))).toBeVisible()
   await expect(page.getByTestId(tid.serverIcon(first))).toBeVisible()
   await expect(page.getByTestId(tid.serverIcon(second))).toBeVisible()
-  const rail = page.getByTestId(tid.serverRailScroll)
+  await rail.evaluate((element) => { element.scrollTop = element.scrollHeight })
+  const expandedTail = await railGeometry(page, tail)
+  expect(expandedTail.rootScrollTop).toBe(0)
+  expect(expandedTail.target.bottom).toBeLessThanOrEqual(expandedTail.userBar.top + 0.5)
+  expect(expandedTail.targetOwnsCenter).toBe(true)
   const beforeSwipe = await rail.evaluate((element) => element.scrollTop)
   const box = await page.getByTestId(tid.serverIcon(second)).boundingBox()
   expect(box).not.toBeNull()
@@ -131,4 +191,27 @@ test("server rail commits one PDD drop and exposes mobile Move parity", async ({
   }
   expect((await pendingResponse).status()).toBe(200)
   await page.unroute(`**${RAIL_ENDPOINT}`)
+})
+
+test("short server rail keeps Add adjacent and desktop geometry stable", async ({ asUser }) => {
+  const stamp = Date.now()
+  const serverId = await seedServer("carol", `Rail short ${stamp}`)
+  const { page } = await asUser("carol")
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.goto(`/c/channels/${serverId}`)
+  await expect(page.getByTestId(tid.serverIcon(serverId))).toBeVisible({ timeout: 30_000 })
+
+  const mobile = await railGeometry(page, serverId)
+  expect(mobile.rootScrollTop).toBe(0)
+  expect(mobile.railScrollHeight).toBeLessThanOrEqual(mobile.railClientHeight)
+  expect(mobile.add.top - mobile.target.bottom).toBeGreaterThanOrEqual(0)
+  expect(mobile.add.top - mobile.target.bottom).toBeLessThanOrEqual(16)
+  expect(mobile.targetOwnsCenter).toBe(true)
+
+  await page.setViewportSize({ width: 1280, height: 844 })
+  const desktop = await railGeometry(page, serverId)
+  expect(desktop.rootScrollTop).toBe(0)
+  expect(desktop.target).toEqual(mobile.target)
+  expect(desktop.add).toEqual(mobile.add)
+  expect(desktop.targetOwnsCenter).toBe(true)
 })

--- a/src/web/src/test/e2e-ui/37-server-rail-pdd.spec.ts
+++ b/src/web/src/test/e2e-ui/37-server-rail-pdd.spec.ts
@@ -67,6 +67,7 @@ test("server rail commits one PDD drop and exposes mobile Move parity", async ({
     overflowServers.push(await seedServer("alice", `Rail overflow ${index} ${stamp}`))
   }
   const tail = overflowServers.at(-1)!
+  const swipeServer = overflowServers.at(-2)!
   const channel = await seedChannel("alice", first, `rail-${stamp}`)
   const { page } = await asUser("alice")
   await page.setViewportSize({ width: 1280, height: 900 })
@@ -137,6 +138,7 @@ test("server rail commits one PDD drop and exposes mobile Move parity", async ({
   await page.getByTestId(tid.serverRailMoveConfirm).click()
   const createResponse = await createResponsePromise
   expect(createResponse.status()).toBe(200)
+  await expect(page.getByRole("heading", { name: "Move server" })).toBeHidden()
   expect(railRequests).toHaveLength(2)
   expect(railRequests[1]?.body).toMatchObject({
     commands: [{ kind: "create-folder", name: "Group", serverIds: [tail, first] }],
@@ -150,7 +152,9 @@ test("server rail commits one PDD drop and exposes mobile Move parity", async ({
   expect(expandedTail.target.bottom).toBeLessThanOrEqual(expandedTail.userBar.top + 0.5)
   expect(expandedTail.targetOwnsCenter).toBe(true)
   const beforeSwipe = await rail.evaluate((element) => element.scrollTop)
-  const box = await page.getByTestId(tid.serverIcon(second)).boundingBox()
+  const swipeTarget = page.getByTestId(tid.serverIcon(swipeServer))
+  await expect(swipeTarget).toBeInViewport()
+  const box = await swipeTarget.boundingBox()
   expect(box).not.toBeNull()
   await page.mouse.move(box!.x + 20, box!.y + 20)
   await page.mouse.down()


### PR DESCRIPTION
# Why we need this PR?
> Closes N/A — fixes the mobile server rail’s final item being covered by the fixed user bar.

## What changed
- Make the existing server-rail shell wrapper a shrinkable flex container so the rail’s 60px bottom inset is honored.
- Add shell contract coverage for initial, mobile, and desktop compositions.
- Extend the existing rail browser journey for long rails, expanded folders, ordinary pointer reachability, short rails, and desktop geometry freeze.

## Checklist
- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: N/A
