### PR TITLE
fix(web): align community sheet headers and footers

### DIFF
--- a/src/web/src/components/community/bots/bot-activity-modal.test.ts
+++ b/src/web/src/components/community/bots/bot-activity-modal.test.ts
@@ -119,6 +119,13 @@ describe("BotActivityModal CommunitySheet contract", () => {
     expect(sheet.props.resizable).toBe(true)
     expect(sheet.props.contentTestId).toBe("bot-activity-modal")
     expect(sheet.props.bodyClassName).toContain("p-0")
+    expect(sheet.props.title).toBe("Build Bot")
+    expect(sheet.props.headerLeading.props).toMatchObject({
+      name: "Build Bot",
+      seed: "bot-1",
+      size: 32,
+    })
+    expect(sheet.props.description.props.className).toBe("flex items-center gap-1.5")
     expect(sheet.props.description.props.children[1].props.children).toBe("Live")
 
     act(() => sheet.props.onOpenChange(false))
@@ -129,6 +136,8 @@ describe("BotActivityModal CommunitySheet contract", () => {
     expect(source).not.toContain("@/components/ui/dialog")
     expect(source).not.toContain("@/components/ui/sheet")
     expect(source).not.toMatch(/>\s*Close\s*</)
+    expect(source).not.toContain("truncate text-sm font-medium")
+    expect(source).not.toContain("gap-1.5 text-[11px]")
   })
 
   it("keeps loading, empty, chronological day groups, and rows in the shared body", () => {

--- a/src/web/src/components/community/bots/bot-activity-modal.tsx
+++ b/src/web/src/components/community/bots/bot-activity-modal.tsx
@@ -156,14 +156,12 @@ export function BotActivityModal({
     <CommunitySheet
       open={open}
       onOpenChange={onOpenChange}
-      title={(
-        <span className="flex min-w-0 items-center gap-3">
-          <AgentAvatar name={bot?.name ?? ""} avatarUrl={bot?.image ?? null} seed={bot?.id} size={32} />
-          <span className="truncate text-sm font-medium">{bot?.name ?? "Bot"}</span>
-        </span>
+      title={bot?.name ?? "Bot"}
+      headerLeading={(
+        <AgentAvatar name={bot?.name ?? ""} avatarUrl={bot?.image ?? null} seed={bot?.id} size={32} />
       )}
       description={(
-        <span className="flex items-center gap-1.5 text-[11px]">
+        <span className="flex items-center gap-1.5">
           <span
             className={[
               "inline-block size-1.5 rounded-full",

--- a/src/web/src/components/community/shell/community-sheet.test.ts
+++ b/src/web/src/components/community/shell/community-sheet.test.ts
@@ -119,13 +119,18 @@ describe("CommunitySheet contracts", () => {
 
     expect(renderer.root.findByType("sheet-title").children).toEqual(["Structured title"])
     expect(renderer.root.findByType("sheet-description").children).toEqual(["Structured description"])
-    expect(renderer.root.findByType("sheet-header").findAllByType("a")).toHaveLength(0)
+    const header = renderer.root.findByType("sheet-header")
+    expect(header.findAllByType("a")).toHaveLength(0)
+    expect(header.findAllByProps({ className: "flex min-w-0 items-start gap-3" })).toHaveLength(0)
     expect(renderer.root.findAllByType("button").filter((node) => node.props["aria-label"] === "Close"))
       .toHaveLength(1)
     expect(renderer.root.findByType("sheet-body").props.className).toBe("body-policy")
     expect(renderer.root.findByType("sheet-footer").props.className).toContain(
       "**:data-[slot=button]:min-h-11",
     )
+    expect(renderer.root.findByType("sheet-footer").props.className).toContain("flex-row")
+    expect(renderer.root.findByType("sheet-footer").props.className).toContain("items-center")
+    expect(renderer.root.findByType("sheet-footer").props.className).toContain("justify-end")
 
     act(() => renderer.root.findByType("sheet-root").props.onOpenChange(false))
     act(() => renderer.root.findByProps({ "aria-label": "Close" }).props.onClick())
@@ -133,5 +138,32 @@ describe("CommunitySheet contracts", () => {
     expect(onOpenChange).toHaveBeenNthCalledWith(1, false)
     expect(onOpenChange).toHaveBeenNthCalledWith(2, false)
     expect(onOpenChange).toHaveBeenNthCalledWith(3, false)
+  })
+
+  it("adds a shrink-safe leading column without replacing the standard title primitives", () => {
+    const leading = React.createElement("leading-avatar", { size: 32 })
+    const { renderer } = renderSheet({
+      title: "Bot name",
+      description: "Live · Activity log",
+      headerLeading: leading,
+      footer: React.createElement(
+        React.Fragment,
+        null,
+        React.createElement("button", { "data-action": "cancel" }, "Cancel"),
+        React.createElement("button", { "data-action": "primary" }, "Save"),
+      ),
+    })
+
+    const header = renderer.root.findByType("sheet-header")
+    expect(header.findByProps({ className: "flex min-w-0 items-start gap-3" })).toBeTruthy()
+    expect(header.findByProps({ "data-slot": "sheet-header-leading" })
+      .findByType("leading-avatar").props.size)
+      .toBe(32)
+    const textColumn = header.findByProps({ className: "flex min-w-0 flex-1 flex-col gap-1" })
+    expect(textColumn.findByType("sheet-title").children).toEqual(["Bot name"])
+    expect(textColumn.findByType("sheet-description").children).toEqual(["Live · Activity log"])
+    expect(renderer.root.findByType("sheet-footer").findAllByType("button")
+      .map((button) => button.props["data-action"]))
+      .toEqual(["cancel", "primary"])
   })
 })

--- a/src/web/src/components/community/shell/community-sheet.tsx
+++ b/src/web/src/components/community/shell/community-sheet.tsx
@@ -27,6 +27,7 @@ type CommunitySheetProps = {
   onOpenChange: (open: boolean) => void
   title: React.ReactNode
   description?: React.ReactNode
+  headerLeading?: React.ReactNode
   footer?: React.ReactNode | ((requestClose: () => void) => React.ReactNode)
   children: React.ReactNode
   bodyClassName?: string
@@ -51,6 +52,7 @@ export function CommunitySheet({
   onOpenChange,
   title,
   description,
+  headerLeading,
   footer,
   children,
   bodyClassName,
@@ -76,6 +78,7 @@ export function CommunitySheet({
         <ResizableCommunitySheetContent
           title={title}
           description={description}
+          headerLeading={headerLeading}
           footer={footer}
           bodyClassName={bodyClassName}
           bodyRef={bodyRef}
@@ -93,6 +96,7 @@ export function CommunitySheet({
           maxWidth="80vw"
           title={title}
           description={description}
+          headerLeading={headerLeading}
           footer={footer}
           bodyClassName={bodyClassName}
           bodyRef={bodyRef}
@@ -112,6 +116,7 @@ type CommunitySheetContentProps = Pick<
   CommunitySheetProps,
   | "title"
   | "description"
+  | "headerLeading"
   | "footer"
   | "children"
   | "bodyClassName"
@@ -132,6 +137,7 @@ function CommunitySheetContent({
   resize,
   title,
   description,
+  headerLeading,
   footer,
   children,
   bodyClassName,
@@ -161,14 +167,26 @@ function CommunitySheetContent({
     >
       {resize && <SheetResizeHandle {...resize} />}
       <SheetHeader className="pr-14 sm:pr-14">
-        <SheetTitle className="truncate">{title}</SheetTitle>
-        {description != null && <SheetDescription>{description}</SheetDescription>}
+        {headerLeading == null ? (
+          <>
+            <SheetTitle className="truncate">{title}</SheetTitle>
+            {description != null && <SheetDescription>{description}</SheetDescription>}
+          </>
+        ) : (
+          <div className="flex min-w-0 items-start gap-3">
+            <div data-slot="sheet-header-leading" className="shrink-0">{headerLeading}</div>
+            <div className="flex min-w-0 flex-1 flex-col gap-1">
+              <SheetTitle className="truncate">{title}</SheetTitle>
+              {description != null && <SheetDescription>{description}</SheetDescription>}
+            </div>
+          </div>
+        )}
       </SheetHeader>
       <SheetBody ref={bodyRef} data-testid={bodyTestId} className={bodyClassName}>
         {children}
       </SheetBody>
       {footerContent != null && (
-        <SheetFooter className="**:data-[slot=button]:min-h-11 sm:**:data-[slot=button]:min-h-0">
+        <SheetFooter className="flex-row items-center justify-end **:data-[slot=button]:min-h-11 sm:**:data-[slot=button]:min-h-0">
           {footerContent}
         </SheetFooter>
       )}

--- a/src/web/src/test/e2e-ui/30-bot-profile-audit-preview.spec.ts
+++ b/src/web/src/test/e2e-ui/30-bot-profile-audit-preview.spec.ts
@@ -1,13 +1,135 @@
 import { createRequire } from "module"
 import { resolve } from "path"
-import type { Page } from "@playwright/test"
+import type { Locator, Page, TestInfo } from "@playwright/test"
 import { test, expect, sessionCookie } from "./_fixtures/community-fixture"
-import { gotoAfterUserWsAuth } from "./_fixtures/actions"
+import { composerEditable, gotoAfterUserWsAuth } from "./_fixtures/actions"
 import { seedChannel, seedJoinServer, seedServer } from "./_fixtures/seed"
 import { tid } from "./_fixtures/testids"
 import { MACHINE_WS_URL, REPO_ROOT, WEB_URL } from "./_setup/paths"
 
 type UserKey = "alice" | "bob"
+type Rect = { x: number; y: number; width: number; height: number }
+
+async function rect(locator: Locator): Promise<Rect> {
+  const value = await locator.boundingBox()
+  expect(value).not.toBeNull()
+  return value!
+}
+
+async function settleSheet(sheet: Locator): Promise<void> {
+  await expect(sheet).toBeVisible()
+  await sheet.evaluate((element) => new Promise<void>((resolveStable) => {
+    const deadline = performance.now() + 1_000
+    let previous = ""
+    let stableFrames = 0
+    const sample = () => {
+      const bounds = element.getBoundingClientRect()
+      const style = getComputedStyle(element)
+      const current = [bounds.x, bounds.y, bounds.width, bounds.height, style.opacity, style.transform].join(":")
+      stableFrames = current === previous ? stableFrames + 1 : 0
+      previous = current
+      if (stableFrames >= 3 || performance.now() >= deadline) resolveStable()
+      else requestAnimationFrame(sample)
+    }
+    requestAnimationFrame(sample)
+  }))
+}
+
+async function attachPageScreenshot(testInfo: TestInfo, name: string, page: Page): Promise<void> {
+  await testInfo.attach(`${name}.png`, {
+    body: await page.screenshot(),
+    contentType: "image/png",
+  })
+}
+
+async function expectActivityHeader(
+  page: Page,
+  testInfo: TestInfo,
+  width: 390 | 1280,
+): Promise<void> {
+  await page.setViewportSize({ width, height: width === 390 ? 844 : 900 })
+  const sheet = page.getByTestId(tid.botActivityModal)
+  await settleSheet(sheet)
+  const header = sheet.locator("[data-slot='sheet-header']")
+  const avatar = header.locator("[data-slot='sheet-header-leading']")
+  const title = header.locator("[data-slot='sheet-title']")
+  const description = header.locator("[data-slot='sheet-description']")
+  const close = sheet.getByRole("button", { name: "Close", exact: true })
+  const [avatarRect, titleRect, descriptionRect, closeRect] = await Promise.all([
+    rect(avatar), rect(title), rect(description), rect(close),
+  ])
+
+  expect(avatarRect.width).toBeCloseTo(32, 0)
+  expect(avatarRect.height).toBeCloseTo(32, 0)
+  expect(titleRect.x).toBeGreaterThanOrEqual(avatarRect.x + avatarRect.width + 11.5)
+  expect(descriptionRect.x).toBeCloseTo(titleRect.x, 0)
+  expect(titleRect.x + titleRect.width).toBeLessThanOrEqual(closeRect.x + 0.5)
+  const styles = await title.evaluate((element) => {
+    const titleStyle = getComputedStyle(element)
+    const descriptionNode = element.parentElement?.querySelector<HTMLElement>("[data-slot='sheet-description']")
+    if (!descriptionNode) throw new Error("missing Activity Log description")
+    const descriptionStyle = getComputedStyle(descriptionNode)
+    return {
+      titleFontSize: titleStyle.fontSize,
+      titleFontWeight: titleStyle.fontWeight,
+      titleLineHeight: titleStyle.lineHeight,
+      descriptionFontSize: descriptionStyle.fontSize,
+      descriptionLineHeight: descriptionStyle.lineHeight,
+    }
+  })
+  expect(styles).toMatchObject({
+    titleFontSize: "18px",
+    titleFontWeight: "600",
+    descriptionFontSize: "14px",
+  })
+  expect(Number.parseFloat(styles.titleLineHeight)).toBeGreaterThan(Number.parseFloat(styles.titleFontSize))
+  expect(Number.parseFloat(styles.descriptionLineHeight)).toBeGreaterThan(Number.parseFloat(styles.descriptionFontSize))
+  await attachPageScreenshot(testInfo, `activity-log-header-${width}`, page)
+}
+
+async function expectFooterGeometry(
+  page: Page,
+  title: string,
+  actionNames: string[],
+  width: 390 | 639 | 640,
+): Promise<void> {
+  await page.setViewportSize({ width, height: 844 })
+  const sheet = page.getByRole("dialog", { name: title, exact: true })
+  await settleSheet(sheet)
+  const footer = sheet.locator("[data-slot='sheet-footer']")
+  const actions = actionNames.map((name) => footer.getByRole(
+    name === "Download" ? "link" : "button",
+    { name, exact: true },
+  ))
+  const footerRect = await rect(footer)
+  const actionRects = await Promise.all(actions.map(rect))
+  const style = await footer.evaluate((element) => {
+    const value = getComputedStyle(element)
+    return {
+      display: value.display,
+      flexDirection: value.flexDirection,
+      justifyContent: value.justifyContent,
+      alignItems: value.alignItems,
+    }
+  })
+  expect(style).toEqual({
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    alignItems: "center",
+  })
+  for (const actionRect of actionRects) {
+    expect(actionRect.width).toBeLessThan(footerRect.width * 0.75)
+    if (width < 640) expect(actionRect.height).toBeGreaterThanOrEqual(44)
+  }
+  for (let index = 1; index < actionRects.length; index++) {
+    expect(actionRects[index]!.x).toBeGreaterThan(actionRects[index - 1]!.x)
+    expect(actionRects[index]!.y).toBeCloseTo(actionRects[0]!.y, 0)
+  }
+  const finalAction = actionRects.at(-1)!
+  expect(footerRect.x + footerRect.width - (finalAction.x + finalAction.width))
+    .toBe(width < 640 ? 16 : 24)
+}
 
 function headersFor(key: UserKey, extra?: Record<string, string>) {
   return {
@@ -127,7 +249,7 @@ async function openBotProfile(page: Page, botName: string): Promise<void> {
   await expect(page.getByTestId(tid.profileCard)).toBeVisible()
 }
 
-test("owner-only bot profile preview, owner swap, and URL-owned audit modal", async ({ asUser }) => {
+test("owner-only bot profile preview, owner swap, and URL-owned audit modal", async ({ asUser }, testInfo) => {
   test.setTimeout(180_000)
   const suffix = Date.now().toString(36)
   const serverId = await seedServer("alice", `profile-preview-${suffix}`)
@@ -243,6 +365,9 @@ test("owner-only bot profile preview, owner swap, and URL-owned audit modal", as
     await alice.page.getByTestId(tid.botAuditPreview).click()
     await expect(alice.page).toHaveURL(new RegExp(`/c/me/bots\\?audit=${botId}$`))
     await expect(alice.page.getByTestId(tid.botActivityModal)).toBeVisible()
+    await expectActivityHeader(alice.page, testInfo, 1280)
+    await expectActivityHeader(alice.page, testInfo, 390)
+    await alice.page.setViewportSize({ width: 1280, height: 900 })
     await alice.page.reload()
     await expect(alice.page.getByTestId(tid.botActivityModal)).toBeVisible()
     await alice.page.goBack({ waitUntil: "commit" })
@@ -277,5 +402,65 @@ test("owner-only bot profile preview, owner swap, and URL-owned audit modal", as
     expect(bobAuditRequests).toEqual([])
   } finally {
     machine.socket.close()
+  }
+})
+
+test("CommunitySheet footers keep four consumers horizontal and intrinsic at 390/639/640", async ({ asUser }) => {
+  test.setTimeout(180_000)
+  const { machineId } = await pairMachine()
+  const botName = `Footer bot ${Date.now().toString(36)}`
+  await createBot(machineId, botName)
+  const { page } = await asUser("alice")
+  await gotoAfterUserWsAuth(page, "/c/me/bots")
+
+  await page.getByRole("button", { name: "Create a bot", exact: true }).click()
+  for (const width of [390, 639, 640] as const) {
+    await expectFooterGeometry(page, "Create a bot", ["Cancel", "Create bot"], width)
+  }
+  await page.getByRole("dialog", { name: "Create a bot", exact: true })
+    .getByRole("button", { name: "Close", exact: true }).click()
+
+  await page.getByRole("button", { name: "Bot actions", exact: true }).first().click()
+  await page.getByRole("menuitem", { name: "Edit", exact: true }).click()
+  for (const width of [390, 639, 640] as const) {
+    await expectFooterGeometry(page, `Edit ${botName}`, ["Cancel", "Save"], width)
+  }
+  await page.getByRole("dialog", { name: `Edit ${botName}`, exact: true })
+    .getByRole("button", { name: "Close", exact: true }).click()
+
+  await gotoAfterUserWsAuth(page, "/c/me/machines")
+  await page.getByTestId(tid.machinePairOpen).click()
+  for (const width of [390, 639, 640] as const) {
+    await expectFooterGeometry(page, "Connect a machine", ["Done"], width)
+  }
+  await page.getByRole("dialog", { name: "Connect a machine", exact: true })
+    .getByRole("button", { name: "Done", exact: true }).click()
+
+  const serverId = await seedServer("alice", `footer-${Date.now()}`)
+  const channelId = await seedChannel("alice", serverId, `footer-${Date.now()}`)
+  await gotoAfterUserWsAuth(page, `/c/channels/${serverId}/${channelId}`)
+  const fileName = `footer-oracle-${Date.now()}.md`
+  const uploadResponse = page.waitForResponse((response) => (
+    response.request().method() === "POST"
+    && new URL(response.url()).pathname === `/api/community/channels/${channelId}/attachments`
+  ))
+  const messageResponse = page.waitForResponse((response) => (
+    response.request().method() === "POST"
+    && new URL(response.url()).pathname === `/api/community/channels/${channelId}/messages`
+  ))
+  const editable = composerEditable(page)
+  await editable.click()
+  await editable.pressSequentially("Attachment footer oracle")
+  await page.getByTestId(tid.composerFileInput).setInputFiles({
+    name: fileName,
+    mimeType: "text/markdown",
+    buffer: Buffer.from("# Footer oracle"),
+  })
+  await page.keyboard.press("Enter")
+  expect((await uploadResponse).ok()).toBe(true)
+  expect((await messageResponse).status()).toBe(201)
+  await page.getByTestId(tid.attachmentCard(fileName)).click()
+  for (const width of [390, 639, 640] as const) {
+    await expectFooterGeometry(page, fileName, ["Download"], width)
   }
 })


### PR DESCRIPTION
# Why we need this PR?
> Closes #

Activity Log used local compact typography instead of the standard CommunitySheet title hierarchy, while CommunitySheet footers inherited the base Sheet's stacked mobile layout.

## What changed
- add an optional generic CommunitySheet header-leading slot without changing no-leading header DOM
- render Activity Log's 32px avatar through the leading slot and restore standard SheetTitle/SheetDescription typography
- keep CommunitySheet footer actions horizontal, intrinsic-width, right-aligned, and at least 44px tall below 640px
- cover Activity Log geometry and four real footer consumers at 390px, 639px, and 640px

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...
