### PR TITLE
test(web): cover forum archive race branches

### DIFF
--- a/src/shared/test/queries/community-thread.test.ts
+++ b/src/shared/test/queries/community-thread.test.ts
@@ -174,6 +174,26 @@ describe("listForumThreadsByCreatedAt against real SQLite", () => {
     expect(rows.map((row) => row.userId)).toEqual(["A", "a"]);
   });
 
+  it("keeps retained disposition explicit when the participating query is disabled", async () => {
+    for (const params of [
+      { parentChannelIds: [] as string[], limitPerParent: 5 },
+      { parentChannelIds: ["forum_1"], limitPerParent: 0 },
+    ]) {
+      const result = await threadQueries.listParticipatingForumThreads(db as never, {
+        ...params,
+        userId: "viewer",
+        activeAfter: "2026-08-08T03:00:00.000Z",
+        retainId: "t_created",
+      });
+
+      expect(result).toEqual({
+        canonical: [],
+        retained: null,
+        retainedDisposition: "genuine-negative",
+      });
+    }
+  });
+
   it("returns per-forum recent notify rows and retains an older open post", async () => {
     sqlite.prepare("INSERT INTO user (id, name) VALUES (?, ?)").run("viewer", "Viewer");
     const insertMember = sqlite.prepare(`

--- a/src/web/src/hooks/community/use-forum-sidebar-threads.test.ts
+++ b/src/web/src/hooks/community/use-forum-sidebar-threads.test.ts
@@ -987,6 +987,63 @@ describe("forum sidebar Stage B resources", () => {
     renderer!.unmount()
   })
 
+  it("does not let a stale eligible retained response override an in-flight archive", async () => {
+    let resolveStale: ((value: SidebarThreadEnvelope) => void) | undefined
+    apiFetchMock
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveStale = resolve }))
+      .mockResolvedValueOnce({
+        ...envelope([]),
+        canonicalChannels: [],
+        retainedChannel: null,
+        retainedDisposition: "opener-archived",
+      })
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    let renderer: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(Capture, { retainId: "post-1", onRender: () => undefined }),
+        ),
+      )
+    })
+    await waitFor(() => apiFetchMock.mock.calls.length === 1)
+
+    await act(async () => {
+      await reconcileForumSidebarArchiveTag(queryClient, "server-1", "post-1", true)
+    })
+    await waitFor(() => queryClient.getQueryState(
+      communityKeys.forumSidebarThreads("server-1"),
+    )?.status === "success")
+
+    const canonical = envelope(["post-2"])
+    const retained = envelope(["post-1"])
+    await act(async () => {
+      resolveStale?.({
+        ...canonical,
+        canonicalChannels: canonical.channels,
+        retainedChannel: retained.channels[0],
+        retainedDisposition: "eligible",
+        included: {
+          parentMessages: [
+            ...canonical.included.parentMessages,
+            ...retained.included.parentMessages,
+          ],
+        },
+      })
+      await Promise.resolve()
+    })
+
+    expect(queryClient.getQueryData<ForumSidebarQueryData>(
+      communityKeys.forumSidebarThreads("server-1"),
+    )?.threads).toEqual([])
+    expect(queryClient.getQueryData(
+      communityKeys.forumSidebarRetained("server-1", "post-1"),
+    )).toBeNull()
+    renderer!.unmount()
+  })
+
   it("allows a failed optimistic removal to accept the restored server row", async () => {
     let resolveRequest: ((value: SidebarThreadEnvelope) => void) | undefined
     apiFetchMock.mockImplementation(() => new Promise((resolve) => { resolveRequest = resolve }))


### PR DESCRIPTION
## Summary

- add a hook regression proving a delayed eligible retained response cannot resurrect an opener after an in-flight archive reconciliation
- add shared-query coverage for retained candidates with an empty parent scope or non-positive limit
- keep product code and behavior unchanged

## Coverage audit

The original PR #606 Codecov report identified 12 uncovered changed lines. This follow-up executes the 9 reachable lines. The remaining 3 are structurally unreachable:

- the private removal helper's default `cause` argument is bypassed by every call site, which always passes an explicit cause
- the same-generation unarchive cleanup branch cannot observe the archive-owned in-flight entry because the archive path synchronously aborts and deletes that entry before returning

## Verification

- focused web hook: 39/39
- focused shared query: 20/20
- root typecheck, lint, full tests, both typegrep checks, and knip
- full tests: web 5711; shared 2076; daemon 1260 + packed 6; agent-driver 530 pass / 4 skip; CI scripts 128
- independent forced-fresh `/c` QA: `17-forum-sidebar-stage-b.spec.ts` 7/7, with HTTP/D1/WS/direct-route/Archived-feed correlation and clean state/listener teardown

Follow-up to #606.
