### PR TITLE
ci(config): require full patch coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -23,7 +23,8 @@ coverage:
           - src/web/**
     patch:
       default:
-        target: 60%
+        target: 100%
+        threshold: 0%
 
 ignore:
   - "src/web/src/components/home/**"


### PR DESCRIPTION
# Why we need this PR?
> Closes N/A

The required patch status currently permits uncovered changed lines. This tightens the repository policy so every changed coverable line must be exercised.

## What changed
- Set `coverage.status.patch.default.target` to `100%`.
- Set the patch threshold explicitly to `0%`.
- Leave project targets, ignored paths, coverage uploads, and report behavior unchanged.
- Validate the exact file with Codecov's official validator (HTTP 200) and the repository's full local gates.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [ ] Other: ...

