### PR TITLE
fix(web): clarify reasoning effort defaults

### DIFF
--- a/src/web/src/components/community/bots/bot-runtime-fields.test.ts
+++ b/src/web/src/components/community/bots/bot-runtime-fields.test.ts
@@ -20,6 +20,15 @@ vi.mock("./model-field", () => ({
     React.createElement("div", { "data-runtime": runtime?.id, "data-model": value }),
 }))
 
+vi.mock("./reasoning-effort-field", () => ({
+  ReasoningEffortField: ({ daemonVersion }: {
+    daemonVersion?: string
+  }) => React.createElement("div", {
+    "data-testid": "reasoning-effort-field",
+    "data-daemon-version": daemonVersion,
+  }),
+}))
+
 import { BotRuntimeFields } from "./bot-runtime-fields"
 
 const OPTIONS = [
@@ -91,5 +100,14 @@ describe("BotRuntimeFields", () => {
       renderer.root.find((node) => node.props["data-motion-target"] === "model"),
     ).toBeTruthy()
     expect(radio(renderer, "codex").props.name).toBe("edit-bot-runtime")
+  })
+
+  it("forwards only the selected daemon version to reasoning effort", () => {
+    const { renderer } = renderFields({ daemonVersion: "0.1.24" })
+    expect(renderer.root.findByProps({
+      "data-testid": "reasoning-effort-field",
+    }).props).toMatchObject({
+      "data-daemon-version": "0.1.24",
+    })
   })
 })

--- a/src/web/src/components/community/bots/bot-runtime-fields.tsx
+++ b/src/web/src/components/community/bots/bot-runtime-fields.tsx
@@ -5,7 +5,10 @@ import { Label } from "@/components/ui/label"
 import { cn } from "@/lib/utils"
 import { ModelField } from "./model-field"
 import { ReasoningEffortField } from "./reasoning-effort-field"
-import type { CommunityMachineRuntime, ReasoningEffort } from "@alook/shared"
+import type {
+  CommunityMachineRuntime,
+  ReasoningEffort,
+} from "@alook/shared"
 
 export type BotRuntimeOption = Pick<CommunityMachineRuntime, "id" | "reasoning"> & {
   unhealthy: boolean
@@ -17,6 +20,7 @@ export function BotRuntimeFields({
   options,
   runtime,
   model,
+  daemonVersion,
   reasoningEffort = null,
   onRuntimeChange,
   onModelChange,
@@ -32,6 +36,7 @@ export function BotRuntimeFields({
   options: BotRuntimeOption[]
   runtime: string
   model: string | null
+  daemonVersion?: string
   reasoningEffort?: ReasoningEffort | null
   onRuntimeChange: (runtime: string) => void
   onModelChange: (model: string | null) => void
@@ -113,6 +118,7 @@ export function BotRuntimeFields({
           <ReasoningEffortField
             runtime={selectedRuntime}
             model={model}
+            daemonVersion={daemonVersion}
             value={reasoningEffort}
             onChange={onReasoningEffortChange}
           />

--- a/src/web/src/components/community/bots/create-bot-sheet.test.ts
+++ b/src/web/src/components/community/bots/create-bot-sheet.test.ts
@@ -141,6 +141,7 @@ vi.mock("./bot-form-fields", () => ({
 // Capture ModelField's incoming `value` so we can assert the create sheet
 // resets the model to null (Default) on a runtime change.
 const modelFieldRenders: Array<{ runtime: { id: string; reasoning?: unknown } | null; value: string | null }> = []
+const reasoningDaemonVersionRenders: Array<string | undefined> = []
 vi.mock("./model-field", () => ({
   ModelField: ({ runtime, value }: { runtime: { id: string; reasoning?: unknown } | null; value: string | null }) => {
     modelFieldRenders.push({ runtime, value })
@@ -149,11 +150,16 @@ vi.mock("./model-field", () => ({
 }))
 
 vi.mock("./reasoning-effort-field", () => ({
-  ReasoningEffortField: ({ onChange }: { onChange: (value: string | null) => void }) =>
-    React.createElement("button", {
+  ReasoningEffortField: ({ onChange, daemonVersion }: {
+    onChange: (value: string | null) => void
+    daemonVersion?: string
+  }) => {
+    reasoningDaemonVersionRenders.push(daemonVersion)
+    return React.createElement("button", {
       "data-testid": "set-reasoning-effort",
       onClick: () => onChange("xhigh"),
-    }),
+    })
+  },
 }))
 
 vi.mock("@/components/provider-logo", () => ({
@@ -190,6 +196,7 @@ describe("CreateBotSheet — auto-select defaults", () => {
     createMutateAsync.mockReset()
     createMutateAsync.mockResolvedValue({ bot: { id: "b1", name: "MyBot" } })
     botFormFieldsRenders.length = 0
+    reasoningDaemonVersionRenders.length = 0
   })
 
   it("uses the guide companion seed for a guided bot avatar", () => {
@@ -200,20 +207,19 @@ describe("CreateBotSheet — auto-select defaults", () => {
   })
 
   it("pre-checks the machine and runtime with one online machine + one healthy runtime", () => {
-    useMachinesMock.mockReturnValue({
-      machines: [
-        machine({
-          id: "mac",
-          status: "online",
-          availableRuntimes: [
-            { id: "claude", status: "healthy" },
-          ] as unknown as CommunityMachineSummary["availableRuntimes"],
-        }),
-      ],
+    const selectedMachine = machine({
+      id: "mac",
+      status: "online",
+      daemonVersion: "0.1.24",
+      availableRuntimes: [
+        { id: "claude", status: "healthy" },
+      ] as unknown as CommunityMachineSummary["availableRuntimes"],
     })
+    useMachinesMock.mockReturnValue({ machines: [selectedMachine] })
     const renderer = render()
     expect(checkedValue(renderer, "bot-machine")).toBe("mac")
     expect(checkedValue(renderer, "bot-runtime")).toBe("claude")
+    expect(reasoningDaemonVersionRenders).toContain("0.1.24")
   })
 
   it("resolves the [] → populated async race by auto-selecting once data arrives", () => {

--- a/src/web/src/components/community/bots/create-bot-sheet.tsx
+++ b/src/web/src/components/community/bots/create-bot-sheet.tsx
@@ -317,6 +317,7 @@ export function CreateBotSheet({
                 options={runtimeOptions}
                 runtime={runtime}
                 model={model}
+                daemonVersion={selectedMachine?.daemonVersion}
                 reasoningEffort={reasoningEffort}
                 onRuntimeChange={selectRuntime}
                 onModelChange={setModel}

--- a/src/web/src/components/community/bots/edit-bot-sheet.test.ts
+++ b/src/web/src/components/community/bots/edit-bot-sheet.test.ts
@@ -36,6 +36,7 @@ const HEALTHY_MACHINES = {
   machines: [
     {
       id: "mac1",
+      daemonVersion: "0.1.24",
       availableRuntimes: [
         { id: "claude", status: "healthy" },
         { id: "codex", status: "healthy" },
@@ -43,6 +44,11 @@ const HEALTHY_MACHINES = {
     },
   ],
 }
+
+const reasoningFieldRenders: Array<{
+  daemonVersion: string | undefined
+  value: string | null
+}> = []
 
 vi.mock("@/components/community/shell/community-sheet", () => {
   const React = require("react")
@@ -118,7 +124,11 @@ vi.mock("@/lib/utils", () => ({
 }))
 
 vi.mock("./bot-form-fields", () => ({
-  BotFormFields: () => require("react").createElement("div"),
+  BotFormFields: ({ setDescription }: { setDescription: (value: string) => void }) =>
+    require("react").createElement("button", {
+      "data-testid": "set-description",
+      onClick: () => setDescription("Updated description"),
+    }),
 }))
 const modelFieldRenders: Array<{ runtime: { id: string; reasoning?: unknown } | null }> = []
 vi.mock("./model-field", () => {
@@ -139,11 +149,17 @@ vi.mock("./model-field", () => {
 vi.mock("./reasoning-effort-field", () => {
   const React = require("react")
   return {
-    ReasoningEffortField: ({ onChange }: { onChange: (value: string | null) => void }) =>
-      React.createElement("button", {
+    ReasoningEffortField: ({ onChange, daemonVersion, value }: {
+      onChange: (value: string | null) => void
+      daemonVersion?: string
+      value: string | null
+    }) => {
+      reasoningFieldRenders.push({ daemonVersion, value })
+      return React.createElement("button", {
         "data-testid": "set-reasoning-effort",
         onClick: () => onChange("xhigh"),
-      }),
+      })
+    },
   }
 })
 vi.mock("@/components/avatar", () => ({
@@ -260,10 +276,55 @@ describe("EditBotSheet — model switch toast (online-only)", () => {
 
 describe("EditBotSheet — reasoning effort", () => {
   beforeEach(() => {
+    reasoningFieldRenders.length = 0
     toastSuccess.mockReset()
     toastApiError.mockReset()
     updateMutateAsync.mockReset()
     useMachinesMock.mockReturnValue(HEALTHY_MACHINES)
+  })
+
+  it("passes only the bot daemon version into the shared field", () => {
+    renderSheet()
+    expect(reasoningFieldRenders).toContainEqual({
+      daemonVersion: "0.1.24",
+      value: null,
+    })
+  })
+
+  it("does not PATCH reasoning effort when stored Default remains unchanged", async () => {
+    updateMutateAsync.mockResolvedValue({ bot: BOT })
+    const renderer = renderSheet({ ...BOT, reasoningEffort: null })
+    act(() => {
+      void saveButton(renderer).props.onClick()
+    })
+    await flush()
+
+    expect(updateMutateAsync).toHaveBeenCalledOnce()
+    expect(updateMutateAsync.mock.calls[0]?.[0]).not.toHaveProperty("reasoningEffort")
+  })
+
+  it("preserves stored Low on an old daemon when saving an unrelated field", async () => {
+    const bot = { ...BOT, reasoningEffort: "low" as const }
+    updateMutateAsync.mockResolvedValue({
+      bot: { ...bot, description: "Updated description" },
+    })
+    const renderer = renderSheet(bot)
+    expect(reasoningFieldRenders).toContainEqual({
+      daemonVersion: "0.1.24",
+      value: "low",
+    })
+
+    act(() => renderer.root.findByProps({ "data-testid": "set-description" }).props.onClick())
+    act(() => {
+      void saveButton(renderer).props.onClick()
+    })
+    await flush()
+
+    expect(updateMutateAsync).toHaveBeenCalledOnce()
+    expect(updateMutateAsync.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ id: "b1", description: "Updated description" }),
+    )
+    expect(updateMutateAsync.mock.calls[0]?.[0]).not.toHaveProperty("reasoningEffort")
   })
 
   it("PATCHes the explicit effort without provider confirmation and reports next-turn application", async () => {

--- a/src/web/src/components/community/bots/edit-bot-sheet.tsx
+++ b/src/web/src/components/community/bots/edit-bot-sheet.tsx
@@ -212,6 +212,7 @@ export function EditBotSheet({
               options={runtimeOptions}
               runtime={runtime}
               model={model}
+              daemonVersion={selectedMachine?.daemonVersion}
               reasoningEffort={reasoningEffort}
               onRuntimeChange={setRuntime}
               onModelChange={setModel}

--- a/src/web/src/components/community/bots/reasoning-effort-field.test.ts
+++ b/src/web/src/components/community/bots/reasoning-effort-field.test.ts
@@ -48,6 +48,7 @@ function renderField(props: Partial<React.ComponentProps<typeof ReasoningEffortF
     renderer = TestRenderer.create(React.createElement(ReasoningEffortField, {
       runtime: RUNTIME,
       model: "gpt-5",
+      daemonVersion: "0.1.25",
       value: null,
       onChange,
       ...props,
@@ -57,12 +58,12 @@ function renderField(props: Partial<React.ComponentProps<typeof ReasoningEffortF
 }
 
 describe("ReasoningEffortField", () => {
-  it("shows Default plus the exact runtime-reported options and default", () => {
-    const { renderer } = renderField()
+  it("shows exact Default without claiming the catalog default or changing storage", () => {
+    const { renderer, onChange } = renderField()
     const select = renderer.root.findByType("select")
     expect(select.props.disabled).toBe(false)
     expect(select.props.items).toEqual([
-      { value: "__default__", label: "Default (Minimal)" },
+      { value: "__default__", label: "Default" },
       { value: "minimal", label: "Minimal" },
       { value: "future_level", label: "Future_level" },
     ])
@@ -71,14 +72,47 @@ describe("ReasoningEffortField", () => {
       "minimal",
       "future_level",
     ])
+    expect(renderer.root.findAllByType("p")[0]?.children.join("")).toBe(
+      "Default sends no override. Your runtime or user configuration stays in control.",
+    )
+    expect(onChange).not.toHaveBeenCalled()
   })
 
-  it("renders disabled Default-only help when no catalog is reported", () => {
+  it("keeps genuine current-daemon unavailability distinct from upgrade guidance", () => {
     const { renderer } = renderField({ runtime: { reasoning: undefined } })
     expect(renderer.root.findByType("select").props.disabled).toBe(true)
     expect(renderer.root.findAllByType("p")[0]?.children.join("")).toBe(
       "This runtime/model does not report reasoning effort options.",
     )
+  })
+
+  it("preserves an explicit effort when an old daemon has no catalog evidence", () => {
+    const { renderer, onChange } = renderField({
+      runtime: { reasoning: undefined },
+      daemonVersion: "0.1.24",
+      value: "low",
+    })
+    expect(renderer.root.findByType("select").props.items).toEqual([
+      { value: "__default__", label: "Default" },
+      { value: "low", label: "Low" },
+    ])
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("shows only the Machines guidance when an old daemon has no catalog", () => {
+    const { renderer } = renderField({
+      runtime: { reasoning: undefined },
+      daemonVersion: "0.1.24",
+    })
+    expect(renderer.root.findAllByType("p")[0]?.children.join("")).toBe(
+      "Check the daemon version in Machines, then update and restart it there.",
+    )
+    expect(renderer.root.findAllByType("code")).toHaveLength(0)
+    expect(renderer.root.findAll(
+      (node) => node.type === "button" && node.children.join("") === "Update daemon…",
+    )).toHaveLength(0)
+    expect(renderer.root.findAllByProps({ "data-testid": "machine-update-confirm" }))
+      .toHaveLength(0)
   })
 
   it("resets an incompatible selected value to Default", () => {

--- a/src/web/src/components/community/bots/reasoning-effort-field.tsx
+++ b/src/web/src/components/community/bots/reasoning-effort-field.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo } from "react"
 import {
+  releaseVersionGte,
   resolveReasoningEffort,
   type ReasoningEffort,
   type RuntimeReasoningDescriptor,
@@ -17,6 +18,7 @@ import {
 import { tid } from "@/lib/community/testids"
 
 const DEFAULT_VALUE = "__default__"
+const REASONING_CATALOG_MIN_DAEMON_VERSION = "0.1.25"
 
 function effortLabel(value: string): string {
   return value.length === 0 ? value : value[0]!.toUpperCase() + value.slice(1)
@@ -25,12 +27,14 @@ function effortLabel(value: string): string {
 export function ReasoningEffortField({
   runtime,
   model,
+  daemonVersion,
   value,
   onChange,
   disabled,
 }: {
   runtime: RuntimeReasoningDescriptor | null
   model: string | null
+  daemonVersion?: string
   value: ReasoningEffort | null
   onChange: (value: ReasoningEffort | null) => void
   disabled?: boolean
@@ -41,15 +45,18 @@ export function ReasoningEffortField({
   )
 
   useEffect(() => {
-    if (!resolution.supported && value !== null) onChange(null)
-  }, [onChange, resolution.supported, value])
+    if (resolution.options.length > 0 && !resolution.supported && value !== null) {
+      onChange(null)
+    }
+  }, [onChange, resolution.options.length, resolution.supported, value])
 
-  const defaultLabel = resolution.defaultReasoningEffort
-    ? `Default (${effortLabel(resolution.defaultReasoningEffort)})`
-    : "Default"
+  const defaultLabel = "Default"
+  const options = value && !resolution.options.some((option) => option.value === value)
+    ? [...resolution.options, { value }]
+    : resolution.options
   const items = [
     { value: DEFAULT_VALUE, label: defaultLabel },
-    ...resolution.options.map((option) => ({
+    ...options.map((option) => ({
       value: option.value,
       label: effortLabel(option.value),
     })),
@@ -59,6 +66,16 @@ export function ReasoningEffortField({
     ? resolution.options.find((option) => option.value === value)?.description
     : undefined
   const unavailable = resolution.options.length === 0
+  const needsCatalogUpgrade = unavailable
+    && daemonVersion !== undefined
+    && !releaseVersionGte(daemonVersion, REASONING_CATALOG_MIN_DAEMON_VERSION)
+  const help = needsCatalogUpgrade
+    ? "Check the daemon version in Machines, then update and restart it there."
+    : unavailable
+      ? "This runtime/model does not report reasoning effort options."
+      : value === null
+        ? "Default sends no override. Your runtime or user configuration stays in control."
+        : selectedDescription ?? "Alook sends this reasoning effort as an explicit override."
 
   return (
     <div className="flex flex-col gap-2">
@@ -80,7 +97,7 @@ export function ReasoningEffortField({
         </SelectTrigger>
         <SelectContent>
           <SelectItem value={DEFAULT_VALUE}>{defaultLabel}</SelectItem>
-          {resolution.options.map((option) => (
+          {options.map((option) => (
             <SelectItem key={option.value} value={option.value}>
               {effortLabel(option.value)}
             </SelectItem>
@@ -88,9 +105,7 @@ export function ReasoningEffortField({
         </SelectContent>
       </Select>
       <p id="bot-reasoning-effort-help" className="text-xs text-muted-foreground">
-        {unavailable
-          ? "This runtime/model does not report reasoning effort options."
-          : selectedDescription ?? "Default lets the runtime choose for this model."}
+        {help}
       </p>
     </div>
   )


### PR DESCRIPTION
# Why we need this PR?
> Keep the reasoning-effort Default honest and distinguish old-daemon catalog absence from genuine runtime/model unavailability. No linked GitHub issue.

## What changed
- Render `Default` exactly and explain that it sends no reasoning-effort override.
- Preserve stored explicit effort when catalog evidence is missing; retain reset only for a non-empty incompatible catalog.
- Show text-only Machines update/restart guidance for pre-0.1.25 daemons, while current empty catalogs remain truthfully unavailable.
- Pass the selected daemon version through shared Create/Edit runtime fields without changing dynamic machine/model catalog discovery or Machines update behavior.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...
