### PR TITLE
fix(web): unify reply composer previews

### DIFF
--- a/src/web/src/app/c/me/[dmId]/page.tsx
+++ b/src/web/src/app/c/me/[dmId]/page.tsx
@@ -540,7 +540,7 @@ function DmView() {
             onChannelRefIntent={handleChannelRefIntent}
             onAcceptSend={acceptDmSend}
             onTyping={handleTyping}
-            replyingTo={replyTo?.authorName}
+            replyingTo={replyTo ?? undefined}
             onCancelReply={() => setReplyTo(null)}
             autoFocus={bp === "desktop"}
               draftKey={`dm/${dmId}`}

--- a/src/web/src/components/community/messages/composer-facade.contract.test.ts
+++ b/src/web/src/components/community/messages/composer-facade.contract.test.ts
@@ -16,6 +16,10 @@ describe("Composer public facade", () => {
     expectTypeOf<ComponentProps<typeof Composer>>().toEqualTypeOf<ComposerProps>()
     expectTypeOf<ComponentRef<typeof Composer>>().toEqualTypeOf<ComposerHandle>()
     expectTypeOf<ComposerMention>().toEqualTypeOf<{ id: string; label: string }>()
+    expectTypeOf<NonNullable<ComposerProps["replyingTo"]>>().toEqualTypeOf<{
+      authorName: string
+      text: string
+    }>()
     expectTypeOf<keyof ComposerHandle>().toEqualTypeOf<
       | "focusEditor"
       | "insertTextAtCaret"
@@ -25,6 +29,17 @@ describe("Composer public facade", () => {
       | "isEmpty"
       | "openFilePicker"
     >()
+  })
+
+  it("keeps DM, channel, and thread on the structured reply-target contract", () => {
+    const dm = readWeb("src/app/c/me/[dmId]/page.tsx")
+    const channel = readWeb("src/components/community/channels/text-channel-surface.tsx")
+    const thread = readWeb("src/components/community/channels/thread-channel-surface.tsx")
+
+    expect(dm).toContain("replyingTo={replyTo ?? undefined}")
+    expect(dm).not.toContain("replyingTo={replyTo?.authorName}")
+    expect(channel).toContain("replyingTo={controller.replyTo ?? undefined}")
+    expect(thread).toContain("replyingTo={controller.replyTo ?? undefined}")
   })
 
   it("retains the original-path eight-export facade", () => {

--- a/src/web/src/components/community/messages/composer-types.ts
+++ b/src/web/src/components/community/messages/composer-types.ts
@@ -57,7 +57,7 @@ type ComposerBaseProps = {
   channelRefCandidateSource?: ChannelRefCandidateSource
   onChannelRefIntent?: () => void
   onTyping?: () => void
-  replyingTo?: ComposerReplyTarget | string
+  replyingTo?: ComposerReplyTarget
   onCancelReply?: () => void
   autoFocus?: boolean
   mode?: ComposerMode

--- a/src/web/src/components/community/messages/composer-view.test.ts
+++ b/src/web/src/components/community/messages/composer-view.test.ts
@@ -44,6 +44,12 @@ import {
 import { EMPTY_MENTION_STATE } from "@/lib/community/mention-extension"
 import { tid } from "@/lib/community/testids"
 
+function textContent(node: TestRenderer.ReactTestInstance): string {
+  return node.children
+    .map((child) => typeof child === "string" ? child : textContent(child))
+    .join("")
+}
+
 function baseProps(
   overrides: Partial<ComposerViewProps> = {},
 ): ComposerViewProps {
@@ -326,7 +332,7 @@ describe("ComposerView", () => {
     )
   })
 
-  it("shows the exact same-author reply target as one stripped, truncated line", async () => {
+  it("shows the exact same-author reply target as one stripped, whole-row-truncated line", async () => {
     const first = {
       authorName: "Ada",
       text: "**First** target with [docs](https://example.test) " + "x".repeat(320),
@@ -345,11 +351,12 @@ describe("ComposerView", () => {
     let preview = renderer.root.findByProps({
       "data-slot": "composer-reply-preview",
     })
-    expect(preview.children.join("")).toBe(
-      "First target with docs " + "x".repeat(320),
+    expect(textContent(preview)).toBe(
+      "Replying to Ada · First target with docs " + "x".repeat(320),
     )
     expect(preview.props.className).toContain("truncate")
-    expect(preview.parent?.props.className).toContain("min-w-0")
+    expect(preview.props.className).toContain("min-w-0")
+    expect(preview.parent?.props.className).toContain("items-center")
 
     await act(async () => {
       renderer.update(
@@ -359,16 +366,7 @@ describe("ComposerView", () => {
     preview = renderer.root.findByProps({
       "data-slot": "composer-reply-preview",
     })
-    expect(preview.children.join("")).toBe("Second target")
-
-    await act(async () => {
-      renderer.update(
-        createElement(ComposerView, baseProps({ replyingTo: "Legacy DM" })),
-      )
-    })
-    expect(renderer.root.findAllByProps({
-      "data-slot": "composer-reply-preview",
-    })).toHaveLength(0)
+    expect(textContent(preview)).toBe("Replying to Ada · Second target")
   })
 
   it("renders the mobile send control after emoji with exact eligibility and padding", async () => {

--- a/src/web/src/components/community/messages/composer-view.tsx
+++ b/src/web/src/components/community/messages/composer-view.tsx
@@ -42,7 +42,7 @@ export type ComposerViewProps = {
   mentionPresentation: MentionCandidatePresentation
   channelRefPopup: ChannelRefPopupState
   channelRefPresentation?: ChannelRefCandidatePresentation
-  replyingTo?: ComposerReplyTarget | string
+  replyingTo?: ComposerReplyTarget
   onCancelReply?: () => void
   pendingFiles: PendingFile[]
   removePendingFile: (index: number) => void
@@ -84,14 +84,9 @@ export function ComposerView({
   onUploadFile,
   onEmojiPick,
 }: ComposerViewProps) {
-  const replyAuthorName = typeof replyingTo === "string"
-    ? replyingTo
-    : replyingTo?.authorName
-  const replyPreview = typeof replyingTo === "string"
-    ? null
-    : replyingTo
-      ? stripInlineMarkup(replyingTo.text)
-      : null
+  const replyPreview = replyingTo
+    ? stripInlineMarkup(replyingTo.text).replace(/\s+/g, " ").trim()
+    : null
 
   return (
     <div
@@ -113,20 +108,17 @@ export function ComposerView({
       />
 
       {replyingTo && (
-        <div className="flex items-start gap-2 rounded-t-xl border border-b-0 border-border/40 bg-muted/60 px-4 py-2 text-xs text-muted-foreground">
-          <div className="min-w-0 flex-1">
-            <div className="truncate">
-              Replying to{" "}
-              <span className="font-medium text-foreground">{replyAuthorName}</span>
-            </div>
-            {replyPreview !== null && (
-              <div
-                data-slot="composer-reply-preview"
-                className="mt-0.5 truncate text-foreground/70"
-              >
-                {replyPreview}
-              </div>
-            )}
+        <div className="flex items-center gap-2 rounded-t-xl border border-b-0 border-border/40 bg-muted/60 px-4 py-2 text-xs text-muted-foreground">
+          <div
+            data-slot="composer-reply-preview"
+            className="min-w-0 flex-1 truncate"
+          >
+            Replying to{" "}
+            <span className="font-medium text-foreground">
+              {replyingTo.authorName}
+            </span>
+            <span aria-hidden="true"> · </span>
+            <span className="text-foreground/70">{replyPreview}</span>
           </div>
           <button
             onClick={onCancelReply}

--- a/src/web/src/components/community/messages/use-composer-controller.test.ts
+++ b/src/web/src/components/community/messages/use-composer-controller.test.ts
@@ -1001,7 +1001,8 @@ describe("useComposerController", () => {
         }),
       )
     })
-    expect(focus).toHaveBeenCalledTimes(1)
+    expect(focus).toHaveBeenCalledTimes(2)
+    expect(focus).toHaveBeenLastCalledWith("end")
     await act(async () => {
       renderer.update(
         createElement(Harness, {
@@ -1021,7 +1022,7 @@ describe("useComposerController", () => {
         }),
       )
     })
-    expect(focus).toHaveBeenCalledTimes(2)
+    expect(focus).toHaveBeenCalledTimes(3)
 
     const view = renderer.root.findByType("controller-probe").props.view
     focus.mockClear()

--- a/src/web/src/components/community/messages/use-composer-controller.ts
+++ b/src/web/src/components/community/messages/use-composer-controller.ts
@@ -351,9 +351,9 @@ export function useComposerController(
 
   const previousReplyingToRef = useRef(replyingTo)
   useEffect(() => {
-    const opened = !previousReplyingToRef.current && !!replyingTo
+    const targetChanged = previousReplyingToRef.current !== replyingTo
     previousReplyingToRef.current = replyingTo
-    if (opened && editor && !isForumThreadBody) {
+    if (targetChanged && replyingTo && editor && !isForumThreadBody) {
       editor.commands.focus("end")
     }
   }, [replyingTo, editor, isForumThreadBody])

--- a/src/web/src/test/e2e-ui/39-mobile-message-interactions.spec.ts
+++ b/src/web/src/test/e2e-ui/39-mobile-message-interactions.spec.ts
@@ -165,14 +165,15 @@ test("mobile reply, avatar mention, and typing space keep exact backend and WS i
   const serverId = await seedServer("alice", serverName)
   const channelId = await seedChannel("alice", serverId, "mobile-interactions")
   await seedJoinServer("alice", "bob", serverId)
-  const channelBobMessageId = await seedMessage("bob", channelId, `channel target ${stamp}`)
+  const channelBobMessageId = await seedMessage("bob", channelId, `channel **target** ${stamp}`)
+  const channelBobSecondMessageId = await seedMessage("bob", channelId, `channel _alternate_ ${stamp}`)
   await seedMessage("alice", channelId, Array.from(
     { length: 80 },
     (_, index) => `scroll restoration line ${index} ${stamp}`,
   ).join("\n\n"))
   const openerId = await seedMessage("alice", channelId, `thread opener ${stamp}`)
   const threadId = await seedThread("alice", openerId, `mobile-thread-${stamp}`)
-  const threadBobMessageId = await seedMessage("bob", threadId, `thread target ${stamp}`)
+  const threadBobMessageId = await seedMessage("bob", threadId, `thread **target** ${stamp}`)
   const dmId = await seedDm("alice", userId("bob"))
   const bobInfo = await memberInfo("alice", serverId, userId("bob"))
   const aliceInfo = await memberInfo("alice", serverId, userId("alice"))
@@ -236,7 +237,14 @@ test("mobile reply, avatar mention, and typing space keep exact backend and WS i
   expect(bobProxy.frames).toHaveLength(beforeRejectedSwipeFrames)
 
   await dispatchSwipe(alice.page, channelBobMessageId, { x: 72, y: 2 })
-  await expect(alice.page.getByText(`Replying to ${bobInfo.name}`, { exact: false })).toBeVisible()
+  const replyPreview = alice.page.locator('[data-slot="composer-reply-preview"]')
+  await expect(replyPreview).toHaveText(`Replying to ${bobInfo.name} · channel target ${stamp}`)
+  await alice.page.getByRole("button", { name: "Cancel reply" }).click()
+  await expect(replyPreview).toHaveCount(0)
+  expect(await latestSeq(alice.page, channelId)).toBe(beforeRejectedSwipeSeq)
+
+  await dispatchSwipe(alice.page, channelBobSecondMessageId, { x: 72, y: 2 })
+  await expect(replyPreview).toHaveText(`Replying to ${bobInfo.name} · channel alternate ${stamp}`)
   const replyBody = `swipe reply ${stamp}`
   const replyResponsePromise = alice.page.waitForResponse((response) => (
     response.request().method() === "POST"
@@ -249,12 +257,12 @@ test("mobile reply, avatar mention, and typing space keep exact backend and WS i
   const replyPayload = await replyResponse.json() as {
     message: { id: string; content: string; replyToId: string | null }
   }
-  expect(replyPayload.message.replyToId).toBe(channelBobMessageId)
+  expect(replyPayload.message.replyToId).toBe(channelBobSecondMessageId)
   expect(replyPayload.message.content).toContain(replyBody)
   await expect.poll(() => bobProxy.frames.some((frame) => (
     frameHasMessage(frame, channelId, replyPayload.message.id)
     && communityFrameEvents(frame).some((event) => (
-      (event.message as { replyTo?: { id: string } } | undefined)?.replyTo?.id === channelBobMessageId
+      (event.message as { replyTo?: { id: string } } | undefined)?.replyTo?.id === channelBobSecondMessageId
     ))
   )), { timeout: 20_000 }).toBe(true)
   await expectMessageVisible(bob.page, replyBody)
@@ -330,7 +338,7 @@ test("mobile reply, avatar mention, and typing space keep exact backend and WS i
   await expect(bob.page.getByTestId(tid.message(mentionPayload.message.id))).toBeVisible()
 
   await dispatchSwipe(alice.page, threadBobMessageId, { x: 72, y: 1 })
-  await expect(alice.page.getByText(`Replying to ${bobInfo.name}`, { exact: false })).toBeVisible()
+  await expect(replyPreview).toHaveText(`Replying to ${bobInfo.name} · thread target ${stamp}`)
   const threadReplyBody = `thread swipe reply ${stamp}`
   const threadReplyResponsePromise = alice.page.waitForResponse((response) => (
     response.request().method() === "POST"
@@ -482,9 +490,32 @@ test("mobile reply, avatar mention, and typing space keep exact backend and WS i
   await ignoreNextDevToolsPointerCapture(bob.page)
   await expect(composerEditable(alice.page)).toBeVisible()
   await expect(composerEditable(bob.page)).toBeVisible()
-  const dmWsReadyId = await seedMessage("bob", dmId, `dm typing ws ready ${stamp}`)
+  const dmWsReadyId = await seedMessage("bob", dmId, `dm **reply target** ${stamp}`)
   await expect.poll(() => aliceProxy.frames.some((frame) => (
     frameHasMessage(frame, dmId, dmWsReadyId)
+  )), { timeout: 20_000 }).toBe(true)
+  await expect(alice.page.getByTestId(tid.message(dmWsReadyId))).toBeVisible()
+  await dispatchSwipe(alice.page, dmWsReadyId, { x: 72, y: 1 })
+  await expect(replyPreview).toHaveText(`Replying to ${bobInfo.name} · dm reply target ${stamp}`)
+  await expect(composerEditable(alice.page)).toBeFocused()
+  const dmReplyBody = `dm swipe reply ${stamp}`
+  const dmReplyResponsePromise = alice.page.waitForResponse((response) => (
+    response.request().method() === "POST"
+    && new URL(response.url()).pathname === `/api/community/channels/${dmId}/messages`
+  ))
+  await composerEditable(alice.page).fill(dmReplyBody)
+  await alice.page.getByTestId(tid.composerSend).click()
+  const dmReplyResponse = await dmReplyResponsePromise
+  expect(dmReplyResponse.status()).toBe(201)
+  const dmReplyPayload = await dmReplyResponse.json() as {
+    message: { id: string; content: string; replyToId: string | null }
+  }
+  expect(dmReplyPayload.message.replyToId).toBe(dmWsReadyId)
+  await expect.poll(() => bobProxy.frames.some((frame) => (
+    frameHasMessage(frame, dmId, dmReplyPayload.message.id)
+    && communityFrameEvents(frame).some((event) => (
+      (event.message as { replyTo?: { id: string } } | undefined)?.replyTo?.id === dmWsReadyId
+    ))
   )), { timeout: 20_000 }).toBe(true)
   const beforeDmTypingSeq = await latestSeq(alice.page, dmId)
   const dmTypingSpace = alice.page.locator("[data-message-typing-space]")


### PR DESCRIPTION
# Why we need this PR?
> Follow-up corrective for #607

DM reply state already retains the same structured target as channel and thread replies, but its composer prop discarded the target text. The shared composer also rendered structured targets on two rows, so reply selection diverged by surface and same-author targets were harder to distinguish before send.

## What changed

- Require a structured `{ authorName, text }` reply target across DM, channel, and thread composers.
- Render `Replying to author · stripped original summary` as one whole-row-truncated label.
- Refocus the composer when reply target identity changes, including adjacent A→B replacement; preserve the forum-body exemption.
- Preserve cancel, exact `replyToId`, accepted-send cleanup, and mention/quote semantics.
- Extend focused contracts and the existing mobile browser journey for same-author selection plus DM/channel/thread request and WS identity.
- Rebase onto #627 while preserving its `handleComposerEditorKeyDown` path and consecutive terminal hard-break/caret normalization.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (web: 684 files / 6041 tests; agent-driver: 36 passed + 1 skipped; CI scripts: 12 files / 128 tests)
- Focused composer/controller/hard-break: 5 files / 50 tests
- Independent focused overlap QA: 4 files / 36 tests
- Focused coverage: `composer-view.tsx` 100% lines; `use-composer-controller.ts` 99.36% lines
- Codecov patch: all modified and coverable lines covered
- Forced-fresh real-stack QA: channel/thread/DM at 1280×900 and 390×844; target replacement focus, cancel/POST, D1, WS, canonical content, truncation, and cleanup all passed
- Fresh hosted CI and UI E2E: all required checks passed

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other
