### PR TITLE
fix(web): prevent composer double-height caret

### DIFF
--- a/src/web/src/components/community/messages/composer-keydown.ts
+++ b/src/web/src/components/community/messages/composer-keydown.ts
@@ -1,4 +1,6 @@
 import type { Breakpoint } from "@/hooks/use-mobile"
+import type { EditorView } from "@tiptap/pm/view"
+import { normalizeConsecutiveTerminalHardBreak } from "./consecutive-hard-break"
 
 type ComposerKeyDownOptions = {
   breakpoint: Breakpoint
@@ -8,7 +10,7 @@ type ComposerKeyDownOptions = {
   send: () => void
 }
 
-export function handleComposerKeyDown(
+function submitComposerForKeyDown(
   event: KeyboardEvent,
   options: ComposerKeyDownOptions,
 ): boolean {
@@ -29,4 +31,21 @@ export function handleComposerKeyDown(
   event.preventDefault()
   options.send()
   return true
+}
+
+export function handleComposerEditorKeyDown(
+  view: EditorView,
+  event: KeyboardEvent,
+  options: ComposerKeyDownOptions,
+): boolean {
+  const submitted = submitComposerForKeyDown(event, options)
+  if (
+    submitted
+    || options.mentionOpen
+    || options.channelRefOpen
+    || event.isComposing
+  ) {
+    return submitted
+  }
+  return normalizeConsecutiveTerminalHardBreak(view, event)
 }

--- a/src/web/src/components/community/messages/consecutive-hard-break.test.ts
+++ b/src/web/src/components/community/messages/consecutive-hard-break.test.ts
@@ -1,0 +1,146 @@
+import { Editor } from "@tiptap/react"
+import StarterKit from "@tiptap/starter-kit"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { EditorView } from "@tiptap/pm/view"
+import { normalizeConsecutiveTerminalHardBreak } from "./consecutive-hard-break"
+
+const editors: Editor[] = []
+
+function createEditor(content: Parameters<typeof Editor>[0]["content"]): Editor {
+  const editor = new Editor({
+    element: null,
+    extensions: [
+      StarterKit.configure({
+        heading: false,
+        horizontalRule: false,
+        codeBlock: false,
+        code: false,
+        blockquote: false,
+        bold: false,
+        italic: false,
+        strike: false,
+        bulletList: false,
+        orderedList: false,
+        listItem: false,
+        listKeymap: false,
+      }),
+    ],
+    content,
+  })
+  editors.push(editor)
+  return editor
+}
+
+function keyEvent(overrides: Partial<KeyboardEvent> = {}): KeyboardEvent {
+  return {
+    key: "Enter",
+    shiftKey: true,
+    isComposing: false,
+    preventDefault: vi.fn(),
+    ...overrides,
+  } as unknown as KeyboardEvent
+}
+
+function viewFor(editor: Editor): EditorView {
+  return {
+    state: editor.state,
+    dispatch: (transaction) => editor.view.updateState(editor.state.apply(transaction)),
+  } as EditorView
+}
+
+afterEach(() => {
+  editors.splice(0).forEach((editor) => editor.destroy())
+})
+
+describe("consecutive terminal hard breaks", () => {
+  it("normalizes the second soft break into a paragraph boundary without changing plaintext", () => {
+    const editor = createEditor({
+      type: "doc",
+      content: [{
+        type: "paragraph",
+        content: [
+          { type: "text", text: "2." },
+          { type: "hardBreak" },
+        ],
+      }],
+    })
+    editor.commands.setTextSelection(editor.state.doc.content.size)
+    const before = `${editor.getText({ blockSeparator: "\n\n" })}\n`
+    const event = keyEvent()
+
+    expect(normalizeConsecutiveTerminalHardBreak(viewFor(editor), event)).toBe(true)
+
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+    expect(editor.getJSON()).toEqual({
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "2." }] },
+        { type: "paragraph" },
+      ],
+    })
+    expect(editor.getText({ blockSeparator: "\n\n" })).toBe(before)
+    expect(editor.state.selection.empty).toBe(true)
+    expect(editor.state.selection.$from.parent.type.name).toBe("paragraph")
+    expect(editor.state.selection.$from.parentOffset).toBe(0)
+  })
+
+  it("leaves the first soft break and non-terminal selections to TipTap", () => {
+    const editor = createEditor({
+      type: "doc",
+      content: [{
+        type: "paragraph",
+        content: [{ type: "text", text: "line" }],
+      }],
+    })
+    editor.commands.setTextSelection(editor.state.doc.content.size)
+    const event = keyEvent()
+
+    expect(normalizeConsecutiveTerminalHardBreak(viewFor(editor), event)).toBe(false)
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(editor.getText()).toBe("line")
+  })
+
+  it("preserves every newline across a longer run without consecutive hard breaks", () => {
+    const editor = createEditor({
+      type: "doc",
+      content: [{
+        type: "paragraph",
+        content: [{ type: "text", text: "2." }],
+      }],
+    })
+    editor.commands.setTextSelection(editor.state.doc.content.size)
+
+    for (let newlineCount = 1; newlineCount <= 4; newlineCount += 1) {
+      const event = keyEvent()
+      if (!normalizeConsecutiveTerminalHardBreak(viewFor(editor), event)) {
+        expect(editor.commands.setHardBreak()).toBe(true)
+      }
+      expect(editor.getText({ blockSeparator: "\n\n" })).toBe(
+        `2.${"\n".repeat(newlineCount)}`,
+      )
+    }
+
+    const json = JSON.stringify(editor.getJSON())
+    expect(json).not.toContain('"type":"hardBreak"},{"type":"hardBreak"')
+    expect(editor.state.selection.empty).toBe(true)
+  })
+
+  it.each([
+    { key: "Escape" },
+    { shiftKey: false },
+    { isComposing: true },
+  ])("ignores non-soft-break key paths: %o", (overrides) => {
+    const editor = createEditor({
+      type: "doc",
+      content: [{
+        type: "paragraph",
+        content: [{ type: "hardBreak" }],
+      }],
+    })
+    editor.commands.setTextSelection(editor.state.doc.content.size)
+    const event = keyEvent(overrides)
+
+    expect(normalizeConsecutiveTerminalHardBreak(viewFor(editor), event)).toBe(false)
+    expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+})

--- a/src/web/src/components/community/messages/consecutive-hard-break.ts
+++ b/src/web/src/components/community/messages/consecutive-hard-break.ts
@@ -1,0 +1,45 @@
+import { Selection } from "@tiptap/pm/state"
+import { canSplit } from "@tiptap/pm/transform"
+import type { EditorView } from "@tiptap/pm/view"
+
+/**
+ * Keep blank lines semantically lossless while avoiding the consecutive
+ * terminal `<br>` structure associated with the reported multi-line caret
+ * paint.
+ *
+ * One Shift+Enter remains a hard break (`\n`). On the second consecutive
+ * Shift+Enter, replace the existing hard break with a paragraph split
+ * (`\n\n`). The community send serializer already uses `\n\n` between
+ * paragraphs, so the outgoing plain text is unchanged.
+ */
+export function normalizeConsecutiveTerminalHardBreak(
+  view: EditorView,
+  event: KeyboardEvent,
+): boolean {
+  if (event.key !== "Enter" || !event.shiftKey || event.isComposing) {
+    return false
+  }
+
+  const { state } = view
+  const { selection } = state
+  if (!selection.empty) return false
+
+  const { $from } = selection
+  if (
+    !$from.parent.isTextblock
+    || $from.parentOffset !== $from.parent.content.size
+    || $from.nodeBefore?.type.name !== "hardBreak"
+  ) {
+    return false
+  }
+
+  const splitPos = $from.pos - 1
+  let transaction = state.tr.delete(splitPos, $from.pos)
+  if (!canSplit(transaction.doc, splitPos)) return false
+
+  transaction = transaction.split(splitPos)
+  transaction.setSelection(Selection.near(transaction.doc.resolve(splitPos + 1), 1))
+  event.preventDefault()
+  view.dispatch(transaction.scrollIntoView())
+  return true
+}

--- a/src/web/src/components/community/messages/use-composer-controller.test.ts
+++ b/src/web/src/components/community/messages/use-composer-controller.test.ts
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   buildPasteDom: vi.fn(),
   fromSchema: vi.fn(),
   parseSlice: vi.fn(),
+  normalizeHardBreak: vi.fn(),
   breakpoint: "desktop" as "unknown" | "desktop" | "mobile",
 }))
 
@@ -80,6 +81,10 @@ vi.mock("@/lib/community/paste-plain-text", () => ({
 vi.mock("./use-composer-suggestions", () => ({
   useComposerSuggestions: (...args: unknown[]) =>
     mocks.useSuggestions(...args),
+}))
+vi.mock("./consecutive-hard-break", () => ({
+  normalizeConsecutiveTerminalHardBreak: (...args: unknown[]) =>
+    mocks.normalizeHardBreak(...args),
 }))
 
 import { useComposerController } from "./use-composer-controller"
@@ -226,6 +231,7 @@ describe("useComposerController", () => {
       resetPopups,
     }))
     mocks.detectMentionType.mockReturnValue("everyone")
+    mocks.normalizeHardBreak.mockReturnValue(false)
     mocks.readDraft.mockReturnValue(null)
     mocks.readAttachmentSession.mockReturnValue([])
     mocks.appendAttachmentSession.mockReturnValue({ accepted: true, evictedScopes: 0 })
@@ -1127,24 +1133,40 @@ describe("useComposerController", () => {
         ...overrides,
       }) as unknown as KeyboardEvent
 
+    const editorView = { identity: "real-view" }
     channelRefPopupRef.current = { items: [{}], command: vi.fn() }
-    expect(editorOptions.editorProps.handleKeyDown({} as never, key())).toBe(
+    expect(editorOptions.editorProps.handleKeyDown(editorView, key())).toBe(
       false,
     )
+    expect(mocks.normalizeHardBreak).not.toHaveBeenCalled()
     expect(accept).not.toHaveBeenCalled()
     channelRefPopupRef.current = { items: [], command: vi.fn() }
+
+    mentionPopupRef.current = { items: [{}], command: vi.fn() }
+    expect(editorOptions.editorProps.handleKeyDown(editorView, key())).toBe(
+      false,
+    )
+    expect(mocks.normalizeHardBreak).not.toHaveBeenCalled()
+    mentionPopupRef.current = { items: [], command: vi.fn() }
+
+    mocks.normalizeHardBreak.mockReturnValueOnce(true)
+    const softBreak = key({ shiftKey: true })
     expect(
       editorOptions.editorProps.handleKeyDown(
-        {} as never,
-        key({ shiftKey: true }),
+        editorView,
+        softBreak,
       ),
-    ).toBe(false)
+    ).toBe(true)
+    expect(mocks.normalizeHardBreak).toHaveBeenCalledWith(editorView, softBreak)
+    mocks.normalizeHardBreak.mockClear()
+
     expect(
       editorOptions.editorProps.handleKeyDown(
-        {} as never,
+        editorView,
         key({ isComposing: true }),
       ),
     ).toBe(false)
+    expect(mocks.normalizeHardBreak).not.toHaveBeenCalled()
     expect(accept).not.toHaveBeenCalled()
 
     const forumProps: ComposerProps = {

--- a/src/web/src/components/community/messages/use-composer-controller.ts
+++ b/src/web/src/components/community/messages/use-composer-controller.ts
@@ -27,7 +27,7 @@ import {
   createLongPasteAttachment,
   pendingFilesToSendAttachments,
 } from "./composer-file-utils"
-import { handleComposerKeyDown } from "./composer-keydown"
+import { handleComposerEditorKeyDown } from "./composer-keydown"
 import type { ComposerHandle, ComposerProps } from "./composer-types"
 import { mentionNodesForCaretInsertion, textNodeForCaretInsertion } from "./caret-text-insertion"
 import type { ComposerViewProps } from "./composer-view"
@@ -162,8 +162,8 @@ export function useComposerController(
         enterkeyhint:
           isForumThreadBody || breakpoint !== "desktop" ? "enter" : "send",
       },
-      handleKeyDown: (_view, event) =>
-        handleComposerKeyDown(event, {
+      handleKeyDown: (view, event) =>
+        handleComposerEditorKeyDown(view, event, {
           breakpoint: breakpointRef.current,
           channelRefOpen:
             suggestions.channelRefPopupRef.current.items.length > 0 &&


### PR DESCRIPTION
## Summary

- preserve first `Shift+Enter` as a hard break
- normalize a second consecutive terminal hard break into a paragraph boundary without changing outgoing plain text
- keep Enter send/mobile paragraph behavior, IME handling, mentions, and attachment-draft wiring intact

## Verification

- focused composer and attachment-draft regressions: 61 passed
- final focused suite: 39 passed
- workspace typecheck and lint passed
- Web: 684 files / 6,034 tests passed
- agent-driver: 588 passed / 4 skipped
- CI scripts: 128 passed
- boundary checks and Knip passed
- independent desktop/mobile channel, DM, thread, D1/WS, and 375/639/640 placeholder QA passed

## Evidence boundary

The exact editor JSON and collapsed Selection are proven. The reported WebKit paint causality remains an inference; the fix avoids the consecutive terminal `<br>` structure associated with the reported multi-line caret paint.
