### PR TITLE
fix(web): anchor suggestion popups to mobile caret

### DIFF
--- a/src/web/src/components/community/messages/composer-suggestion-popups.test.ts
+++ b/src/web/src/components/community/messages/composer-suggestion-popups.test.ts
@@ -120,6 +120,61 @@ describe("Composer suggestion popups", () => {
 
   })
 
+  it("projects mention and channel popups through the same add-once viewport geometry", async () => {
+    Object.assign(window, {
+      visualViewport: {
+        offsetTop: 100,
+        offsetLeft: 20,
+        width: 320,
+        height: 500,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+    })
+    const mentionState: MentionPopupState = {
+      items: [{ kind: "everyone", id: "everyone", label: "everyone" }],
+      query: "",
+      selectedIndex: 0,
+      command: vi.fn(),
+      getRect: () => rect(400),
+    }
+    const channelState: ChannelRefPopupState = {
+      items: [{
+        id: "channel-1",
+        name: "general",
+        serverId: "server-1",
+        serverName: "One",
+        serverDiscriminator: "0001",
+      }],
+      selectedIndex: 0,
+      command: vi.fn(),
+      getRect: () => rect(400),
+    }
+    let mention!: TestRenderer.ReactTestRenderer
+    let channel!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      mention = TestRenderer.create(createElement(CommunityMentionList, {
+        state: mentionState,
+        presentation: { status: "ready" },
+      }))
+      channel = TestRenderer.create(createElement(ChannelRefList, {
+        state: channelState,
+      }))
+    })
+
+    const expectedProjection = expect.objectContaining({
+      left: 60,
+      top: 496,
+      transform: "translateY(-100%)",
+    })
+    expect(mention.root.findByProps({
+      "data-testid": "community-mention-popup",
+    }).props.style).toEqual(expectedProjection)
+    expect(channel.root.findByProps({
+      "data-testid": "community-channel-ref-popup",
+    }).props.style).toEqual(expectedProjection)
+  })
+
   it("renders virtual/member rows in order and selects on mousedown", async () => {
     const command = vi.fn()
     const state: MentionPopupState = {

--- a/src/web/src/hooks/use-anchored-popover.test.ts
+++ b/src/web/src/hooks/use-anchored-popover.test.ts
@@ -14,16 +14,18 @@ function rect(top: number, left: number, height = 16): AnchorRect {
 }
 
 describe("anchoredPopoverStyle", () => {
-  it("keeps layout coordinates unchanged inside a non-zero visual viewport", () => {
+  it("projects visual-local coordinates into fixed layout coordinates exactly once", () => {
     const style = anchoredPopoverStyle(rect(400, 40), VIEWPORT, 256, 240)
-    expect(style.top).toBe(396)
-    expect(style.left).toBe(40)
+    expect(style.top).toBe(496)
+    expect(style.left).toBe(60)
+    expect(Number(style.top) - VIEWPORT.top).toBe(396)
+    expect(Number(style.left) - VIEWPORT.left).toBe(40)
     expect(style.transform).toBe("translateY(-100%)")
     expect(style["--anchored-popover-max-height"]).toBe("240px")
   })
 
   it("flips below a caret near the visual viewport top", () => {
-    const style = anchoredPopoverStyle(rect(120, 40), VIEWPORT, 256, 240)
+    const style = anchoredPopoverStyle(rect(20, 40), VIEWPORT, 256, 240)
     expect(style.top).toBe(140)
     expect(Number(style.top) - VIEWPORT.top).toBe(40)
     expect(style.transform).toBeUndefined()
@@ -36,24 +38,57 @@ describe("anchoredPopoverStyle", () => {
 
   it("uses the roomier side and reduces list height when neither side fully fits", () => {
     const shortViewport = { top: 100, left: 0, width: 320, height: 220 }
-    const style = anchoredPopoverStyle(rect(180, 20), shortViewport, 256, 240)
+    const style = anchoredPopoverStyle(rect(80, 20), shortViewport, 256, 240)
     expect(style.transform).toBeUndefined()
     expect(style["--anchored-popover-max-height"]).toBe("102px")
   })
 
-  it("does not add the keyboard-panned viewport offset to the fixed anchor", () => {
+  it("keeps the visible caret gap stable when the keyboard pans the viewport", () => {
     const keyboardViewport = { top: 364, left: 0, width: 390, height: 480 }
-    const style = anchoredPopoverStyle(rect(797, 76, 21), keyboardViewport, 256, 240)
+    const style = anchoredPopoverStyle(rect(433, 76, 21), keyboardViewport, 256, 240)
     expect(style.top).toBe(793)
     expect(style.left).toBe(76)
+    expect(Number(style.top) - keyboardViewport.top).toBe(429)
+    expect(433 - (Number(style.top) - keyboardViewport.top)).toBe(4)
     expect(style.transform).toBe("translateY(-100%)")
   })
 
   it("keeps the left margin when the visible viewport is narrower than the popup", () => {
     const narrowViewport = { top: 100, left: 50, width: 200, height: 300 }
-    const style = anchoredPopoverStyle(rect(220, 200), narrowViewport, 256, 240)
+    const style = anchoredPopoverStyle(rect(120, 200), narrowViewport, 256, 240)
     expect(style.left).toBe(58)
+    expect(Number(style.left) - narrowViewport.left).toBe(8)
     expect(style.maxWidth).toBe(184)
+  })
+
+  it("reprojects current offsets after hide and reopen without retaining or doubling them", () => {
+    const anchor = rect(400, 70)
+    const hidden = anchoredPopoverStyle(
+      anchor,
+      { top: 0, left: 0, width: 390, height: 844 },
+      256,
+      240,
+    )
+    const open = anchoredPopoverStyle(
+      anchor,
+      { top: 300, left: 12, width: 390, height: 480 },
+      256,
+      240,
+    )
+    const reopened = anchoredPopoverStyle(
+      anchor,
+      { top: 364, left: 20, width: 390, height: 480 },
+      256,
+      240,
+    )
+
+    expect(Number(hidden.top)).toBe(396)
+    expect(Number(open.top)).toBe(696)
+    expect(Number(reopened.top)).toBe(760)
+    expect(Number(open.top) - 300).toBe(Number(hidden.top))
+    expect(Number(reopened.top) - 364).toBe(Number(hidden.top))
+    expect(Number(open.left) - 12).toBe(Number(hidden.left))
+    expect(Number(reopened.left) - 20).toBe(Number(hidden.left))
   })
 
   it("keeps zero-offset desktop geometry unchanged", () => {

--- a/src/web/src/hooks/use-anchored-popover.ts
+++ b/src/web/src/hooks/use-anchored-popover.ts
@@ -144,20 +144,23 @@ export function anchoredPopoverStyle(
   popupWidth: number,
   popupMaxHeight: number,
 ): AnchoredPopoverStyle {
-  const viewportRight = viewport.left + viewport.width
-  const viewportBottom = viewport.top + viewport.height
-  const minVisibleLeft = viewport.left + VIEWPORT_MARGIN
+  // Caret rectangles are visual-viewport-local, while iOS Safari positions
+  // fixed descendants in layout-viewport coordinates while the keyboard pans
+  // the visual viewport. Keep fit/flip/clamp local, then project the final CSS
+  // coordinates into layout space exactly once.
+  const minVisibleLeft = VIEWPORT_MARGIN
   const maxVisibleLeft = Math.max(
     minVisibleLeft,
-    viewportRight - popupWidth - VIEWPORT_MARGIN,
+    viewport.width - popupWidth - VIEWPORT_MARGIN,
   )
-  const left = Math.min(
+  const visibleLeft = Math.min(
     Math.max(rect.left, minVisibleLeft),
     maxVisibleLeft,
   )
+  const left = viewport.left + visibleLeft
 
-  const spaceAbove = rect.top - viewport.top
-  const spaceBelow = viewportBottom - rect.bottom
+  const spaceAbove = rect.top
+  const spaceBelow = viewport.height - rect.bottom
   const fullHeight = popupMaxHeight + POPOVER_CHROME_HEIGHT + POPOVER_GAP + VIEWPORT_MARGIN
   const placeBelow = spaceAbove < fullHeight
     && (spaceBelow >= fullHeight || spaceBelow > spaceAbove)
@@ -173,10 +176,10 @@ export function anchoredPopoverStyle(
   }
 
   return placeBelow
-    ? { ...common, top: rect.bottom + POPOVER_GAP }
+    ? { ...common, top: viewport.top + rect.bottom + POPOVER_GAP }
     : {
         ...common,
-        top: rect.top - POPOVER_GAP,
+        top: viewport.top + rect.top - POPOVER_GAP,
         transform: "translateY(-100%)",
       }
 }

--- a/src/web/src/test/e2e-ui/31-mention-candidate-pagination.spec.ts
+++ b/src/web/src/test/e2e-ui/31-mention-candidate-pagination.spec.ts
@@ -28,7 +28,7 @@ function candidate(prefix: string, index: number): Candidate {
   }
 }
 
-test("@ candidates page to completion, expose first search page, and keep status anchored on mobile", async ({ asUser }) => {
+test("@ candidates page to completion and shared popups stay anchored through viewport resize signals", async ({ asUser }) => {
   const serverId = await seedServer("alice", `Mention pages ${Date.now()}`)
   const channelId = await seedChannel("alice", serverId, "mention-pages")
   const { page } = await asUser("alice")
@@ -52,7 +52,7 @@ test("@ candidates page to completion, expose first search page, and keep status
       configurable: true,
       value: viewport,
     })
-    Object.defineProperty(window, "__setMentionTestVisualViewport", {
+    Object.defineProperty(window, "__setSuggestionTestViewportSize", {
       configurable: true,
       value: (next: Partial<typeof geometry>) => {
         Object.assign(geometry, next)
@@ -186,11 +186,16 @@ test("@ candidates page to completion, expose first search page, and keep status
 
   expectAnchoredToCaret(await readBounds(tid.mentionPopup))
   await page.evaluate(() => {
-    const setViewport = Reflect.get(window, "__setMentionTestVisualViewport") as
-      | ((geometry: { offsetTop: number; height: number }) => void)
+    const setViewport = Reflect.get(window, "__setSuggestionTestViewportSize") as
+      | ((geometry: { height: number }) => void)
       | undefined
     if (!setViewport) throw new Error("Missing controlled visual viewport")
-    setViewport({ offsetTop: 364, height: 480 })
+    // Chromium does not reproduce iOS Safari's fixed/layout viewport split.
+    // Keep this automated journey to resize/scroll refresh and containment,
+    // using a height that still contains Chromium's unpanned caret. Non-zero
+    // offset projection is locked by the geometry unit contract and verified
+    // with the real software keyboard in device QA.
+    setViewport({ height: 820 })
   })
   await page.evaluate(() => new Promise<void>((resolve) => {
     requestAnimationFrame(() => requestAnimationFrame(() => resolve()))


### PR DESCRIPTION
# Why we need this PR?

On iPhone Safari, opening the software keyboard can pan the visual viewport. The mention and channel-reference suggestion popups were using visual-local caret rectangles as fixed layout coordinates, so they drifted farther upward than the composer.

## What changed

- Keep fit, flip, clamp, and max-height calculations in visual-viewport-local space.
- Add visualViewport.offsetTop and offsetLeft exactly once when projecting the final fixed top and left.
- Keep the shared mention/channel-reference hook and existing selection behavior.
- Replace misleading mocked-offset assertions with add-once, keyboard settle, hide/reopen, horizontal-offset, and zero-offset contracts.
- Keep Chromium E2E focused on deterministic resize/scroll containment; real iPhone Safari remains the device gate.

## Verification

- Full commit hook: typecheck, lint, web 684 files / 6,043 tests, agent-driver 36 passed / 1 skipped (588 tests), CI scripts 12 files / 128 tests, typegreps, Knip — PASS.
- Focused viewport/wiring: 16/16 PASS.
- Force-fresh E2E31: 1/1 PASS.
- Trace: pre-send message POST = 0; message.create WS = 0.
- Independent alook-c-qa: PASS.

## Merge hold

This PR must remain Draft. Physical iPhone Safari evidence is still required with the real software keyboard visible, including a non-zero visualViewport.offsetTop, mention and channel-reference journeys, exact commit/build URL, numeric geometry, continuous recording, and zero pre-send Network/D1/WS writes. Do not merge or deploy until that gate, final review, hosted CI, and Codecov pass.

## Checklist

- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (@alook/shared)
- [x] Web app (@alook/web)
- [ ] CLI (@alook/cli)
- [ ] Email Worker (@alook/email-worker)
- [ ] WebSocket DO (@alook/ws-do)
- [ ] CI/CD
- [ ] Other
