### PR TITLE
Fix channel message load blocked by server rail refresh

### DIFF
--- a/src/web/src/hooks/community/use-servers.test.ts
+++ b/src/web/src/hooks/community/use-servers.test.ts
@@ -296,8 +296,8 @@ describe("useServer / serverQueryFn", () => {
     ], forumUnreadState: {} })
   })
 
-  it("joins the canonical servers request on cold concurrency and reuses warm caches", async () => {
-    let releaseServers!: (value: {
+  it("resolves cold server detail without joining an in-flight rail replacement", async () => {
+    let releaseRail!: (value: {
       servers: Array<{
         id: string
         name: string
@@ -307,22 +307,30 @@ describe("useServer / serverQueryFn", () => {
         ownerId: string
       }>
     }) => void
-    const pendingServers = new Promise<Parameters<typeof releaseServers>[0]>((resolve) => {
-      releaseServers = resolve
+    const pendingRail = new Promise<Parameters<typeof releaseRail>[0]>((resolve) => {
+      releaseRail = resolve
     })
+    const identity = {
+      id: "srv_1",
+      name: "Alook",
+      discriminator: "0001",
+      description: "Build together",
+      icon: null,
+      ownerId: "u_1",
+    }
     apiFetchMock.mockImplementation(async (url: string) => {
-      if (url === "/api/community/servers") return pendingServers
+      if (url === "/api/community/servers") return { servers: [identity] }
       if (url.endsWith("/categories")) return { categories: [] }
       if (url.endsWith("/channels")) return { channels: [] }
       if (url.endsWith("/unreads")) return { channelIds: [] }
       throw new Error(`unexpected ${url}`)
     })
-    const { serverQueryFn, serversQueryFn } = await import("./use-servers")
+    const { serverQueryFn } = await import("./use-servers")
     const qc = new QueryClient()
-    const list = qc.fetchQuery({
+    const railReplacement = qc.fetchQuery({
       queryKey: communityKeys.servers(),
-      queryFn: serversQueryFn,
-      staleTime: Infinity,
+      queryFn: () => pendingRail,
+      staleTime: 0,
     })
     const detail = qc.fetchQuery({
       queryKey: communityKeys.server("srv_1"),
@@ -330,41 +338,44 @@ describe("useServer / serverQueryFn", () => {
       staleTime: Infinity,
     })
 
-    await vi.waitFor(() => {
-      expect(apiFetchMock.mock.calls.filter(([url]) => url === "/api/community/servers")).toHaveLength(1)
-    })
-    releaseServers({
-      servers: [{
-        id: "srv_1",
-        name: "Alook",
-        discriminator: "0001",
-        description: "Build together",
-        icon: null,
-        ownerId: "u_1",
-      }],
-    })
-    await Promise.all([list, detail])
-    expect(apiFetchMock).toHaveBeenCalledTimes(4)
-    for (const resource of ["categories", "channels", "unreads"]) {
-      expect(apiFetchMock.mock.calls.filter(
-        ([url]) => url === `/api/community/servers/srv_1/${resource}`,
-      )).toHaveLength(1)
+    try {
+      await vi.waitFor(() => {
+        expect(apiFetchMock.mock.calls.filter(
+          ([url]) => url === "/api/community/servers",
+        )).toHaveLength(1)
+      })
+      await expect(detail).resolves.toMatchObject(identity)
+      expect(qc.getQueryState(communityKeys.servers())?.fetchStatus).toBe("fetching")
+      expect(apiFetchMock).toHaveBeenCalledWith("/api/community/servers", { signal: undefined })
+    } finally {
+      releaseRail({ servers: [identity] })
+      await Promise.allSettled([railReplacement, detail])
     }
+  })
 
-    apiFetchMock.mockClear()
-    await Promise.all([
-      qc.fetchQuery({
-        queryKey: communityKeys.servers(),
-        queryFn: serversQueryFn,
-        staleTime: Infinity,
-      }),
-      qc.fetchQuery({
-        queryKey: communityKeys.server("srv_1"),
-        queryFn: serverQueryFn(qc, "srv_1"),
-        staleTime: Infinity,
-      }),
-    ])
-    expect(apiFetchMock).not.toHaveBeenCalled()
+  it("reads warm server identity without issuing another list request", async () => {
+    const identity = {
+      id: "srv_1",
+      name: "Alook",
+      discriminator: "0001",
+      description: "Build together",
+      icon: null,
+      ownerId: "u_1",
+    }
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url.endsWith("/categories")) return { categories: [] }
+      if (url.endsWith("/channels")) return { channels: [] }
+      if (url.endsWith("/unreads")) return { channelIds: [] }
+      throw new Error(`unexpected ${url}`)
+    })
+    const { serverQueryFn } = await import("./use-servers")
+    const qc = new QueryClient()
+    qc.setQueryData(communityKeys.servers(), { servers: [identity] })
+
+    await expect(serverQueryFn(qc, "srv_1")()).resolves.toMatchObject(identity)
+
+    expect(apiFetchMock.mock.calls.filter(([url]) => url === "/api/community/servers")).toHaveLength(0)
+    expect(apiFetchMock).toHaveBeenCalledTimes(3)
   })
 
   it("cold-boots a forum fallback from a canonical unread child outside the sidebar projection", async () => {

--- a/src/web/src/hooks/community/use-servers.ts
+++ b/src/web/src/hooks/community/use-servers.ts
@@ -200,18 +200,30 @@ type UnreadResponse = {
   }>
 }
 
+async function resolveServerIdentity(
+  queryClient: QueryClient,
+  serverId: string,
+): Promise<Server | undefined> {
+  const cached = queryClient
+    .getQueryData<ServersResponse>(communityKeys.servers())
+    ?.servers.find((server) => server.id === serverId)
+  if (cached) return cached
+
+  const fetched = await serversQueryFn()
+  return fetched.servers.find((server) => server.id === serverId)
+}
+
 export const serverQueryFn = (
   queryClient: QueryClient,
   serverId: string,
 ) => async (): Promise<ServerDetail> => {
-  const [serverData, categoryData, channelData, unreadData] = await Promise.all([
-    queryClient.fetchQuery(serversQueryOptions()),
+  const [server, categoryData, channelData, unreadData] = await Promise.all([
+    resolveServerIdentity(queryClient, serverId),
     apiFetch<{ categories: Array<Omit<Category, "channels"> & { serverId?: string }> }>(`/api/community/servers/${serverId}/categories`),
     apiFetch<{ channels: RawChannel[] }>(`/api/community/servers/${serverId}/channels`),
     apiFetch<UnreadResponse>(`/api/community/servers/${serverId}/unreads`),
   ])
   if (unreadData.stale) throw new Error("stale D1 read")
-  const server = serverData.servers.find((row) => row.id === serverId)
   if (!server) throw new Error("server not found")
   const unreadIds = new Set(unreadData.channelIds)
   const forumParentIds = new Set(

--- a/src/web/src/test/e2e-ui/41-account-unread-projection.spec.ts
+++ b/src/web/src/test/e2e-ui/41-account-unread-projection.spec.ts
@@ -1,12 +1,13 @@
-import type { Page } from "@playwright/test"
+import type { Page, Request } from "@playwright/test"
 import { expect, test, userId } from "./_fixtures/community-fixture"
-import { gotoAfterUserWsAuth } from "./_fixtures/actions"
+import { composerEditable, gotoAfterUserWsAuth } from "./_fixtures/actions"
 import {
   communityFrameEvents,
   proxyCommunityWebSockets,
   type CapturedCommunityFrame,
 } from "./_fixtures/community-ws-proxy"
 import {
+  memberInfo,
   seedChannel,
   seedDm,
   seedDmMessage,
@@ -17,11 +18,11 @@ import {
 } from "./_fixtures/seed"
 import { tid } from "./_fixtures/testids"
 
-async function installReadObserverGate(page: Page) {
-  await page.addInitScript(() => {
+async function installReadObserverGate(page: Page, initiallyBlocked = false) {
+  await page.addInitScript((blockInitially) => {
     const NativeIntersectionObserver = window.IntersectionObserver
     const queued: Array<() => void> = []
-    let blocked = false
+    let blocked = blockInitially
     class GatedIntersectionObserver implements IntersectionObserver {
       readonly root: Element | Document | null
       readonly rootMargin: string
@@ -60,7 +61,7 @@ async function installReadObserverGate(page: Page) {
         for (const deliver of queued.splice(0)) deliver()
       },
     }
-  })
+  }, initiallyBlocked)
   const invoke = async (method: "block" | "pending" | "release") => page.evaluate((name) => {
     const gate = (window as unknown as Record<string, {
       block: () => void
@@ -97,6 +98,102 @@ function hasCorrelatedBundle(
 
 async function expectUnreadDot(row: ReturnType<Page["getByTestId"]>) {
   await expect(row.locator("span.rounded-full.bg-primary")).toHaveCount(1)
+}
+
+async function readSeq(page: Page, channelId: string): Promise<number> {
+  const response = await page.request.get("/api/community/users/me/read-state")
+  expect(response.ok()).toBe(true)
+  const snapshot = await response.json() as {
+    readStates: Array<{ channelId: string; lastReadSeq: number }>
+  }
+  return snapshot.readStates.find((row) => row.channelId === channelId)?.lastReadSeq ?? 0
+}
+
+async function expectRailReplacementDoesNotBlockMessages({
+  page,
+  observerGate,
+  href,
+  channelId,
+  latestText,
+  inboxRowTestId,
+  triggerUnread,
+}: {
+  page: Page
+  observerGate: Awaited<ReturnType<typeof installReadObserverGate>>
+  href: string
+  channelId: string
+  latestText: string
+  inboxRowTestId: string
+  triggerUnread: () => Promise<string>
+}) {
+  const beforeReadSeq = await readSeq(page, channelId)
+  let releaseRail!: () => void
+  const railRelease = new Promise<void>((resolve) => { releaseRail = resolve })
+  let markRailHeld!: () => void
+  const railHeld = new Promise<void>((resolve) => { markRailHeld = resolve })
+  let serverListRequests = 0
+  let messagesRequests = 0
+
+  await page.route("**/api/community/servers", async (route) => {
+    if (new URL(route.request().url()).pathname !== "/api/community/servers") {
+      await route.continue()
+      return
+    }
+    serverListRequests += 1
+    if (serverListRequests === 1) {
+      markRailHeld()
+      await railRelease
+    }
+    await route.continue()
+  })
+  const countMessagesRequest = (request: Request) => {
+    if (
+      request.method() === "GET"
+      && new URL(request.url()).pathname === `/api/community/channels/${channelId}/messages`
+    ) messagesRequests += 1
+  }
+  page.on("request", countMessagesRequest)
+
+  try {
+    const latestId = await triggerUnread()
+    await railHeld
+    await page.getByRole("button", { name: "Inbox" }).click()
+    const inboxRow = page.getByTestId(inboxRowTestId)
+    await expect(inboxRow).toBeVisible({ timeout: 30_000 })
+    const messagesResponse = page.waitForResponse((response) => (
+      response.request().method() === "GET"
+      && new URL(response.url()).pathname === `/api/community/channels/${channelId}/messages`
+      && response.status() === 200
+    ), { timeout: 30_000 })
+    await inboxRow.click()
+
+    const response = await messagesResponse
+    expect(serverListRequests).toBeGreaterThanOrEqual(1)
+    expect(messagesRequests).toBeGreaterThanOrEqual(1)
+    expect(await readSeq(page, channelId)).toBe(beforeReadSeq)
+    releaseRail()
+
+    const body = await response.json() as { messages: Array<{ id: string; seq: number }> }
+    expect(body.messages.at(-1)?.id).toBe(latestId)
+    await expect(page).toHaveURL(href)
+    await expect(page.getByText(latestText, { exact: true })).toBeVisible({ timeout: 30_000 })
+    await expect(page.getByText(latestText, { exact: true })).toHaveCount(1)
+    await expect.poll(observerGate.pending, { timeout: 20_000 }).toBeGreaterThan(0)
+    expect(await readSeq(page, channelId)).toBe(beforeReadSeq)
+
+    const readResponse = page.waitForResponse((candidate) => (
+      candidate.request().method() === "PUT"
+      && new URL(candidate.url()).pathname === `/api/community/channels/${channelId}/read`
+    ))
+    await observerGate.release()
+    expect((await readResponse).status()).toBe(200)
+    await expect.poll(() => readSeq(page, channelId), { timeout: 20_000 })
+      .toBeGreaterThan(beforeReadSeq)
+  } finally {
+    releaseRail()
+    page.off("request", countMessagesRequest)
+    await page.unroute("**/api/community/servers")
+  }
 }
 
 test.describe.serial("account unread projection", () => {
@@ -217,6 +314,102 @@ test.describe.serial("account unread projection", () => {
     expect(cursor(unreadChannel)).toBeGreaterThan(beforeCursor(unreadChannel))
     expect(cursor(forumChild)).toBe(beforeCursor(forumChild))
     expect(cursor(dmId)).toBe(beforeCursor(dmId))
+  })
+
+  test("a held rail server-list request does not block channel or child messages", async ({ asUser }) => {
+    const stamp = Date.now()
+    const foregroundServer = await seedServer("alice", `Rail foreground ${stamp}`)
+    const foregroundChannel = await seedChannel("alice", foregroundServer, `foreground-${stamp}`)
+    await seedJoinServer("alice", "bob", foregroundServer)
+
+    const channelServer = await seedServer("alice", `Rail channel target ${stamp}`)
+    const channelId = await seedChannel("alice", channelServer, `channel-${stamp}`)
+    await seedJoinServer("alice", "bob", channelServer)
+    const childServer = await seedServer("alice", `Rail child target ${stamp}`)
+    const forumId = await seedChannel("alice", childServer, `forum-${stamp}`, "forum")
+    await seedJoinServer("alice", "bob", childServer)
+    const childId = await seedForumThread(
+      "bob",
+      forumId,
+      `Child ${stamp}`,
+      `Child participation ${stamp}`,
+    )
+    const railTriggerServer = await seedServer("alice", `Rail mention trigger ${stamp}`)
+    const railTriggerChannel = await seedChannel(
+      "alice",
+      railTriggerServer,
+      `mention-trigger-${stamp}`,
+    )
+    await seedJoinServer("alice", "bob", railTriggerServer)
+    const bobInfo = await memberInfo("alice", railTriggerServer, userId("bob"))
+    const channelText = `Rail-independent channel ${stamp}`
+    const childText = `Rail-independent child ${stamp}`
+
+    const { context, page } = await asUser("bob")
+    await page.setViewportSize({ width: 1280, height: 900 })
+    const channelObserverGate = await installReadObserverGate(page, true)
+    const childPage = await context.newPage()
+    await childPage.setViewportSize({ width: 390, height: 844 })
+    const childObserverGate = await installReadObserverGate(childPage, true)
+    await Promise.all([
+      gotoAfterUserWsAuth(page, `/c/channels/${foregroundServer}/${foregroundChannel}`),
+      gotoAfterUserWsAuth(childPage, `/c/channels/${foregroundServer}/${foregroundChannel}`),
+    ])
+    await Promise.all([
+      expect(page.getByTestId(tid.serverIcon(channelServer))).toBeVisible({ timeout: 30_000 }),
+      expect(page.getByTestId(tid.serverIcon(childServer))).toBeVisible({ timeout: 30_000 }),
+      expect(page.getByTestId(tid.channelComposerShell)).toBeVisible({ timeout: 30_000 }),
+      expect(childPage.getByTestId(tid.channelComposerShell)).toBeVisible({ timeout: 30_000 }),
+    ])
+
+    const alice = await asUser("alice")
+    await gotoAfterUserWsAuth(
+      alice.page,
+      `/c/channels/${railTriggerServer}/${railTriggerChannel}`,
+    )
+    const triggerComposer = composerEditable(alice.page)
+    await expect(triggerComposer).toBeVisible({ timeout: 30_000 })
+    const sendRailMention = async (label: string) => {
+      const response = alice.page.waitForResponse((candidate) => (
+        candidate.request().method() === "POST"
+        && new URL(candidate.url()).pathname
+          === `/api/community/channels/${railTriggerChannel}/messages`
+      ))
+      await triggerComposer.click()
+      await triggerComposer.pressSequentially(`@${bobInfo.name.slice(0, 3)}`)
+      await alice.page.getByTestId(tid.mentionOption(bobInfo.id)).click()
+      await triggerComposer.pressSequentially(` ${label}`)
+      await alice.page.keyboard.press("Enter")
+      expect((await response).status()).toBe(201)
+    }
+
+    await expectRailReplacementDoesNotBlockMessages({
+      page,
+      observerGate: channelObserverGate,
+      href: `/c/channels/${channelServer}/${channelId}`,
+      channelId,
+      latestText: channelText,
+      inboxRowTestId: tid.inboxUnreadChannel(channelId),
+      triggerUnread: async () => {
+        await sendRailMention(`channel rail ${stamp}`)
+        return seedMessage("alice", channelId, channelText)
+      },
+    })
+
+    await gotoAfterUserWsAuth(childPage, "/c/me")
+    await expectRailReplacementDoesNotBlockMessages({
+      page: childPage,
+      observerGate: childObserverGate,
+      href: `/c/channels/${childServer}/${childId}`,
+      channelId: childId,
+      latestText: childText,
+      inboxRowTestId: tid.inboxUnreadChild(childId),
+      triggerUnread: async () => {
+        await sendRailMention(`child rail ${stamp}`)
+        return seedMessage("alice", childId, childText)
+      },
+    })
+    await childPage.close()
   })
 
   test("mark all settles three domains and rolls back only the failed domain", async ({ asUser }) => {


### PR DESCRIPTION
## Summary

- decouple server-detail identity resolution from the shared server-list query's in-flight/cancel lane
- reuse warm server identity; on cache miss, fetch the list independently while categories, channels, and unreads stay parallel
- add deterministic unit and force-fresh browser coverage for desktop text-channel and mobile child-thread navigation

## Root cause

A server-rail unread refresh could hold the shared `communityKeys.servers()` replacement. `serverQueryFn` joined that same promise, so route hydration—and therefore the canonical messages query—waited behind the rail request.

## Verification

- independent `/c` QA PASS
- force-fresh Chromium unread-projection file: 3/3
- Web Vitest: 683 files / 6,038 tests
- agent-driver: 588 pass / 4 skip; CI scripts: 128/128
- repository typecheck, lint, tests, Knip, and boundary checks PASS

No new dependencies. No production deployment.
