### PR TITLE
fix(web): unify composer accessory rail geometry

### DIFF
--- a/src/web/src/components/community/messages/composer-accessory-rail.test.ts
+++ b/src/web/src/components/community/messages/composer-accessory-rail.test.ts
@@ -23,6 +23,7 @@ vi.mock("@/components/ui/tooltip", () => ({
 }))
 
 const baseProps = {
+  typingNames: [] as string[],
   scrollCount: 4,
   scrollMode: "jump" as const,
   onScroll: vi.fn(),
@@ -65,27 +66,37 @@ describe("ComposerAccessoryRail", () => {
   }
 
   it.each([
-    [false, "empty"],
-    [true, "centered"],
+    [false, false, "empty"],
+    [true, false, "left-only"],
+    [false, true, "centered"],
+    [true, true, "centered"],
   ] as const)(
-    "renders scroll=%s as %s",
-    (center, layout) => {
+    "renders typing=%s scroll=%s as %s",
+    (typing, center, layout) => {
       const renderer = render({
+        typingNames: typing ? ["Alice"] : [],
         scrollCount: center ? 2 : 0,
       })
       const rails = renderer.root.findAllByProps({ "data-testid": tid.composerAccessoryRail })
       expect(rails).toHaveLength(layout === "empty" ? 0 : 1)
       expect(renderer.root.findAllByProps({ "data-testid": tid.scrollToPresent }))
         .toHaveLength(center ? 1 : 0)
+      expect(renderer.root.findAllByProps({ "data-testid": tid.typingIndicator }))
+        .toHaveLength(typing ? 1 : 0)
       if (layout === "empty") return
 
       expect(rails[0].props["data-layout"]).toBe(layout)
       if (center) expect(slotClassName(renderer, tid.scrollToPresent)).toContain("col-start-2")
+      if (typing) expect(slotClassName(renderer, tid.typingIndicator)).toContain("col-start-1")
     },
   )
 
-  it("keeps selection centered and wires its actions", () => {
-    const renderer = render({ selectMode: true, selectedCount: 12 })
+  it("keeps selection centered, hides typing only on mobile with CSS, and wires its actions", () => {
+    const renderer = render({
+      typingNames: ["Alice"],
+      selectMode: true,
+      selectedCount: 12,
+    })
     const rail = renderer.root.findByProps({ "data-testid": tid.composerAccessoryRail })
     expect(rail.props).toMatchObject({
       "data-layout": "centered",
@@ -93,6 +104,9 @@ describe("ComposerAccessoryRail", () => {
     })
     expect(renderer.root.findAllByProps({ "data-testid": tid.scrollToPresent })).toHaveLength(0)
     expect(slotClassName(renderer, tid.messageSelectionToolbar)).toContain("col-start-2")
+    const typingSlot = slotClassName(renderer, tid.typingIndicator)
+    expect(typingSlot).toContain("hidden")
+    expect(typingSlot).toContain("sm:block")
 
     const toolbar = renderer.root.findByProps({ "data-testid": tid.messageSelectionToolbar })
     expect(toolbar.props.className).toContain("h-10")

--- a/src/web/src/components/community/messages/composer-accessory-rail.tsx
+++ b/src/web/src/components/community/messages/composer-accessory-rail.tsx
@@ -7,8 +7,10 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { tid } from "@/lib/community/testids"
 import { cn } from "@/lib/utils"
 import { allocateComposerAccessoryRail } from "./composer-accessory-rail-layout"
+import { TypingIndicator } from "./typing-indicator"
 
 export function ComposerAccessoryRail({
+  typingNames,
   scrollCount,
   scrollMode,
   onScroll,
@@ -17,6 +19,7 @@ export function ComposerAccessoryRail({
   onCancelSelection,
   onShareSelection,
 }: {
+  typingNames: string[]
   scrollCount: number
   scrollMode: "scroll" | "jump"
   onScroll: () => void
@@ -25,10 +28,11 @@ export function ComposerAccessoryRail({
   onCancelSelection: () => void
   onShareSelection: () => void
 }) {
+  const hasTyping = typingNames.length > 0
   const hasScroll = scrollCount > 0
   const layout = allocateComposerAccessoryRail(selectMode
     ? { mode: "selection" }
-    : { mode: "normal", left: false, center: hasScroll })
+    : { mode: "normal", left: hasTyping, center: hasScroll })
 
   if (layout === "empty") return null
 
@@ -47,19 +51,33 @@ export function ComposerAccessoryRail({
         )}
       >
         {selectMode ? (
-          <div key="center" className="col-start-2 min-w-0 max-w-full justify-self-center">
-            <SelectionToolbar
-              selectedCount={selectedCount}
-              onCancel={onCancelSelection}
-              onShare={onShareSelection}
-            />
-          </div>
-        ) : (
-          hasScroll && (
+          <>
+            {hasTyping && (
+              <div key="left" className="hidden min-w-0 max-w-full sm:col-start-1 sm:block">
+                <TypingIndicator names={typingNames} className="w-fit max-w-full" />
+              </div>
+            )}
             <div key="center" className="col-start-2 min-w-0 max-w-full justify-self-center">
-              <ScrollControl count={scrollCount} mode={scrollMode} onClick={onScroll} />
+              <SelectionToolbar
+                selectedCount={selectedCount}
+                onCancel={onCancelSelection}
+                onShare={onShareSelection}
+              />
             </div>
-          )
+          </>
+        ) : (
+          <>
+            {hasTyping && (
+              <div key="left" className="col-start-1 min-w-0 max-w-full">
+                <TypingIndicator names={typingNames} className="w-fit max-w-full" />
+              </div>
+            )}
+            {hasScroll && (
+              <div key="center" className="col-start-2 min-w-0 max-w-full justify-self-center">
+                <ScrollControl count={scrollCount} mode={scrollMode} onClick={onScroll} />
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/src/web/src/components/community/messages/message-list-controller.test.ts
+++ b/src/web/src/components/community/messages/message-list-controller.test.ts
@@ -460,7 +460,7 @@ describe("useMessageListController", () => {
     act(() => renderer.unmount())
   })
 
-  it("minimally scrolls a selected row above the active accessory rail", () => {
+  it("minimally scrolls an overlapping selected row above the active accessory rail", () => {
     selectionRailTop = 692
     selectedRowBottom = 747.5
     let renderer: TestRenderer.ReactTestRenderer
@@ -474,11 +474,34 @@ describe("useMessageListController", () => {
     act(() => latest.onEnterSelectId("m1"))
     runNextFrame()
 
-    expect(scrollNode.scrollTop).toBe(55.5)
-    selectedRowBottom = 692
+    expect(scrollNode.scrollTop).toBe(63.5)
+    selectedRowBottom = 684
     runNextFrame()
     selectionRailTop = null
     runNextFrame()
+    act(() => renderer!.unmount())
+  })
+
+  it("minimally scrolls a selected row when its non-overlapping rail gap is under 8px", () => {
+    selectionRailTop = 692
+    selectedRowBottom = 688
+    let renderer: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(
+        React.createElement(Probe, { value: props() }),
+        { createNodeMock },
+      )
+    })
+
+    act(() => latest.onEnterSelectId("m1"))
+    runNextFrame()
+
+    expect(scrollNode.scrollTop).toBe(4)
+    selectedRowBottom = 684
+    runNextFrame()
+    expect(scrollNode.scrollTop).toBe(4)
+    runNextFrame()
+    expect(frameCallbacks.size).toBe(0)
     act(() => renderer!.unmount())
   })
 

--- a/src/web/src/components/community/messages/message-list-controller.ts
+++ b/src/web/src/components/community/messages/message-list-controller.ts
@@ -7,6 +7,8 @@ import { useScrollAnchor } from "@/hooks/community/use-scroll-anchor"
 import { useVirtualCursorSentinel } from "@/hooks/community/use-virtual-cursor-sentinel"
 import type { ResolvedMessageListProps } from "./message-list-types"
 
+const SELECTION_RAIL_GAP_PX = 8
+
 export function useMessageListController({
   messages,
   loading,
@@ -136,9 +138,9 @@ export function useMessageListController({
           const lowestSelectedBottom = Math.max(...selectedRows.map(
             (row) => row.getBoundingClientRect().bottom,
           ))
-          const overlap = lowestSelectedBottom - railTop
-          if (overlap > 1) {
-            element.scrollTop += overlap
+          const gapShortfall = lowestSelectedBottom + SELECTION_RAIL_GAP_PX - railTop
+          if (gapShortfall > 1) {
+            element.scrollTop += gapShortfall
             stableFrames = 0
           } else {
             stableFrames += 1

--- a/src/web/src/components/community/messages/message-list-view.test.ts
+++ b/src/web/src/components/community/messages/message-list-view.test.ts
@@ -77,17 +77,13 @@ describe("renderMessageListView", () => {
       renderer = TestRenderer.create(renderMessageListView(listProps, state, renderRows))
     })
     expect(mockedRail).toHaveBeenCalledWith(expect.objectContaining({
+      typingNames: ["Alice"],
       scrollCount: 3,
       selectMode: false,
     }), undefined)
-    const typingSpace = renderer!.root.findByProps({ "data-message-typing-space": true })
     const scrollerBoundary = renderer!.root.findByProps({ "data-message-scroller-boundary": true })
-    expect(typingSpace.props.className).toContain("shrink-0")
-    expect(typingSpace.props.className).not.toContain("absolute")
     expect(scrollerBoundary.findAllByType("accessory-rail")).toHaveLength(1)
-    expect(typingSpace.findAllByType("accessory-rail")).toHaveLength(0)
-    expect(renderer!.root.findByProps({ "data-testid": "community-typing-indicator" }).props)
-      .toMatchObject({ role: "status", "aria-live": "polite" })
+    expect(renderer!.root.findAllByProps({ "data-message-typing-space": true })).toHaveLength(0)
     expect(renderRows).toHaveBeenCalledOnce()
     expect(renderer!.root.findAllByType("virtual-rows")).toHaveLength(1)
     expect(renderer!.root.findAll((node) => node.props.className === "mb-6")).toHaveLength(1)
@@ -105,61 +101,34 @@ describe("renderMessageListView", () => {
     expect(mockedRail).not.toHaveBeenCalled()
     expect(renderRows).not.toHaveBeenCalled()
     expect(renderer!.root.findAll((node) => node.props.className === "mb-6")).toHaveLength(1)
-    const typingSpace = renderer!.root.findByProps({ "data-message-typing-space": true })
-    expect(typingSpace.props.className).toContain("h-0")
-    expect(typingSpace.props["data-occupied"]).toBe("idle")
-    expect(renderer!.root.findAllByProps({ "data-testid": "community-typing-indicator" })).toHaveLength(0)
+    expect(renderer!.root.findAllByProps({ "data-message-typing-space": true })).toHaveLength(0)
   })
 
-  it("keeps the typing-space wrapper while expanding it only for live typing", () => {
+  it("routes typing through the rail without adding a dynamic flex sibling", () => {
     let renderer!: TestRenderer.ReactTestRenderer
     act(() => {
       renderer = TestRenderer.create(renderMessageListView(
-        props({ messages: [] }),
-        controller({ isLoading: true }),
+        props({ loading: false, typingUsers: [] }),
+        controller({ isLoading: false, pillCount: 0 }),
         () => React.createElement("virtual-rows"),
       ))
     })
-    const loadingClass = renderer.root.findByProps({ "data-message-typing-space": true }).props.className
-    expect(loadingClass).toContain("h-0")
+    expect(mockedRail).toHaveBeenLastCalledWith(expect.objectContaining({ typingNames: [] }), undefined)
+    expect(renderer.root.findAllByProps({ "data-message-typing-space": true })).toHaveLength(0)
     act(() => {
       renderer.update(renderMessageListView(
         props({ loading: false, typingUsers: ["Alice"] }),
-        controller({ isLoading: false }),
+        controller({ isLoading: false, pillCount: 0 }),
         () => React.createElement("virtual-rows"),
       ))
     })
-    const loadedSpace = renderer.root.findByProps({ "data-message-typing-space": true })
-    expect(loadedSpace.props.className).toContain("h-11")
-    expect(loadedSpace.props["data-occupied"]).toBe("typing")
-    expect(renderer.root.findByProps({ "data-testid": "community-typing-indicator" })).toBeTruthy()
+    expect(mockedRail).toHaveBeenLastCalledWith(expect.objectContaining({
+      typingNames: ["Alice"],
+    }), undefined)
+    expect(renderer.root.findAllByProps({ "data-message-typing-space": true })).toHaveLength(0)
   })
 
-  it("collapses typing space when presence turns off", () => {
-    let renderer!: TestRenderer.ReactTestRenderer
-    act(() => {
-      renderer = TestRenderer.create(renderMessageListView(
-        props({ typingUsers: ["Alice"] }),
-        controller(),
-        () => React.createElement("virtual-rows"),
-      ))
-    })
-    expect(renderer.root.findByProps({ "data-message-typing-space": true }).props.className)
-      .toContain("h-11")
-    act(() => {
-      renderer.update(renderMessageListView(
-        props({ typingUsers: [] }),
-        controller(),
-        () => React.createElement("virtual-rows"),
-      ))
-    })
-    const typingSpace = renderer.root.findByProps({ "data-message-typing-space": true })
-    expect(typingSpace.props.className).toContain("h-0")
-    expect(typingSpace.props["data-occupied"]).toBe("idle")
-    expect(renderer.root.findAllByProps({ "data-testid": "community-typing-indicator" })).toHaveLength(0)
-  })
-
-  it("keeps scroll geometry stable and reserves extra clearance only for selection", () => {
+  it("keeps one fixed responsive tail safe area across every rail state", () => {
     let renderer!: TestRenderer.ReactTestRenderer
     act(() => {
       renderer = TestRenderer.create(renderMessageListView(
@@ -169,27 +138,25 @@ describe("renderMessageListView", () => {
       ))
     })
     const content = () => renderer.root.findByProps({ "data-message-list-content": true })
-    expect(content().props.className).toContain("pb-8")
-    expect(content().props.className).not.toContain("pb-14")
-
-    act(() => {
-      renderer.update(renderMessageListView(
-        props({ typingUsers: [] }),
-        controller({ pillCount: 2 }),
-        () => React.createElement("virtual-rows"),
-      ))
-    })
-    expect(content().props.className).toContain("pb-8")
-    expect(content().props.className).not.toContain("pb-14")
-
-    act(() => {
-      renderer.update(renderMessageListView(
-        props({ typingUsers: [] }),
-        controller({ pillCount: 0, selectMode: true }),
-        () => React.createElement("virtual-rows"),
-      ))
-    })
+    for (const state of [
+      { typingUsers: ["Alice"], pillCount: 0, selectMode: false },
+      { typingUsers: [], pillCount: 2, selectMode: false },
+      { typingUsers: ["Alice"], pillCount: 2, selectMode: false },
+      { typingUsers: ["Alice"], pillCount: 0, selectMode: true },
+    ]) {
+      expect(content().props.className).toContain("pb-14")
+      expect(content().props.className).toContain("sm:pb-18")
+      expect(content().props.className).not.toContain("pb-8")
+      act(() => {
+        renderer.update(renderMessageListView(
+          props({ typingUsers: state.typingUsers }),
+          controller({ pillCount: state.pillCount, selectMode: state.selectMode }),
+          () => React.createElement("virtual-rows"),
+        ))
+      })
+    }
     expect(content().props.className).toContain("pb-14")
+    expect(content().props.className).toContain("sm:pb-18")
   })
 
   it("wires selection actions and dialog close without changing overlay order", () => {
@@ -278,7 +245,8 @@ describe("renderMessageListView", () => {
       node.children.includes("Loading newer messages…"))).toBe(true)
 
     const content = renderer!.root.findByProps({ "data-message-list-content": true })
-    expect(content.props.className).toContain("pb-8")
+    expect(content.props.className).toContain("pb-14")
+    expect(content.props.className).toContain("sm:pb-18")
     const elementChildren = content.children.filter((child) => typeof child !== "string")
     expect(elementChildren).toHaveLength(3)
     expect(elementChildren[0].props.className).toBe("mb-6")

--- a/src/web/src/components/community/messages/message-list-view.tsx
+++ b/src/web/src/components/community/messages/message-list-view.tsx
@@ -1,11 +1,9 @@
 import type { ReactNode } from "react"
 import { Skeleton } from "@/components/ui/skeleton"
 import { tid } from "@/lib/community/testids"
-import { cn } from "@/lib/utils"
 import { ChannelIcon } from "../channels/channel-icon"
 import { ComposerAccessoryRail } from "./composer-accessory-rail"
 import { MessageShareDialog } from "./message-share-dialog"
-import { TypingIndicator } from "./typing-indicator"
 import type { MessageListController } from "./message-list-controller"
 import type { ResolvedMessageListProps } from "./message-list-types"
 
@@ -14,9 +12,6 @@ export function renderMessageListView(
   controller: MessageListController,
   renderRows: () => ReactNode,
 ) {
-  const showTyping = !controller.isLoading && (props.typingUsers?.length ?? 0) > 0
-  const needsSelectionClearance = !controller.isLoading && controller.selectMode
-
   return (
     <div className="relative flex min-h-0 flex-1 flex-col">
       {controller.shareOpen && controller.selectedMessages.length > 0 && (
@@ -29,6 +24,7 @@ export function renderMessageListView(
       <div data-message-scroller-boundary className="relative min-h-0 flex-1">
         {!controller.isLoading && (
           <ComposerAccessoryRail
+            typingNames={props.typingUsers ?? []}
             scrollCount={controller.pillCount}
             scrollMode={controller.pillMode}
             onScroll={controller.pillOnClick}
@@ -45,10 +41,7 @@ export function renderMessageListView(
         >
           <div
             data-message-list-content
-            className={cn(
-              "flex min-h-full flex-col justify-end px-4 pt-8",
-              needsSelectionClearance ? "pb-14" : "pb-8",
-            )}
+            className="flex min-h-full flex-col justify-end px-4 pb-14 pt-8 sm:pb-18"
           >
           {controller.isLoading ? (
             <MessageListSkeletonContent variant={props.variant} />
@@ -91,18 +84,6 @@ export function renderMessageListView(
           )}
           </div>
         </div>
-      </div>
-      <div
-        data-message-typing-space
-        data-occupied={showTyping ? "typing" : "idle"}
-        className={cn(
-          "shrink-0",
-          showTyping ? "h-11 px-4 pb-2 pt-1" : "h-0",
-        )}
-      >
-        {showTyping && (
-          <TypingIndicator names={props.typingUsers ?? []} className="w-fit max-w-full" />
-        )}
       </div>
     </div>
   )

--- a/src/web/src/test/e2e-ui/25-composer-accessory-rail-occupancy.spec.ts
+++ b/src/web/src/test/e2e-ui/25-composer-accessory-rail-occupancy.spec.ts
@@ -4,7 +4,7 @@ import { composerEditable, gotoAfterUserWsAuth, sendMessage } from "./_fixtures/
 import { renameUser, seedChannel, seedJoinServer, seedMessage, seedServer } from "./_fixtures/seed"
 import { tid } from "./_fixtures/testids"
 
-const MOBILE_WIDTHS = [390, 320] as const
+const VIEWPORT_WIDTHS = [320, 390, 639, 640, 1280] as const
 const LONG_TYPING_NAME = `Typing ${"occupancy ".repeat(8)}edge`
 
 type Rect = {
@@ -20,11 +20,12 @@ type Rect = {
 type RailMetrics = {
   layout: string | null
   rail: Rect | null
-  scroller: Rect
-  typingSpace: Rect
+  scroller: Rect & { clientHeight: number; scrollTop: number }
   composer: Rect
   typing: Rect | null
   center: Rect | null
+  finalMessage: Rect | null
+  contentPaddingBottom: number
   documentClientWidth: number
   documentScrollWidth: number
   typingText: {
@@ -36,13 +37,16 @@ type RailMetrics = {
   } | null
 }
 
-async function railMetrics(page: Page): Promise<RailMetrics> {
+async function railMetrics(page: Page, finalMessageId?: string): Promise<RailMetrics> {
   const composer = page.getByTestId(tid.channelComposerShell)
   return page.evaluate((ids) => {
     const find = (id: string) => document.querySelector<HTMLElement>(`[data-testid='${id}']`)
     const rail = find(ids.rail)
     const typing = find(ids.typing)
     const center = find(ids.scroll) ?? find(ids.selection)
+    const scroller = find(ids.scroller)!
+    const content = document.querySelector<HTMLElement>("[data-message-list-content]")!
+    const finalMessage = ids.finalMessage ? find(ids.finalMessage) : null
     const typingText = typing?.querySelector<HTMLElement>("span.min-w-0.truncate") ?? null
     const style = typingText ? getComputedStyle(typingText) : null
     const toRect = (value: DOMRect) => ({
@@ -57,11 +61,16 @@ async function railMetrics(page: Page): Promise<RailMetrics> {
     return {
       layout: rail?.dataset.layout ?? null,
       rail: rail ? toRect(rail.getBoundingClientRect()) : null,
-      scroller: toRect(find(ids.scroller)!.getBoundingClientRect()),
-      typingSpace: toRect(document.querySelector<HTMLElement>("[data-message-typing-space]")!.getBoundingClientRect()),
+      scroller: {
+        ...toRect(scroller.getBoundingClientRect()),
+        clientHeight: scroller.clientHeight,
+        scrollTop: scroller.scrollTop,
+      },
       composer: toRect(find(ids.composer)!.getBoundingClientRect()),
       typing: typing ? toRect(typing.getBoundingClientRect()) : null,
       center: center ? toRect(center.getBoundingClientRect()) : null,
+      finalMessage: finalMessage ? toRect(finalMessage.getBoundingClientRect()) : null,
+      contentPaddingBottom: Number.parseFloat(getComputedStyle(content).paddingBottom),
       documentClientWidth: document.documentElement.clientWidth,
       documentScrollWidth: document.documentElement.scrollWidth,
       typingText: typingText && style
@@ -81,10 +90,25 @@ async function railMetrics(page: Page): Promise<RailMetrics> {
     selection: tid.messageSelectionToolbar,
     scroller: tid.messageScroller,
     composer: tid.channelComposerShell,
+    finalMessage: finalMessageId ? tid.message(finalMessageId) : null,
   }).then(async (metrics) => {
     await expect(composer).toBeVisible()
     return metrics
   })
+}
+
+async function settledRailMetrics(page: Page, finalMessageId?: string): Promise<RailMetrics> {
+  let previous = ""
+  let settled: RailMetrics | null = null
+  await expect.poll(async () => {
+    const current = await railMetrics(page, finalMessageId)
+    const signature = JSON.stringify(current)
+    const stable = signature === previous
+    previous = signature
+    if (stable) settled = current
+    return stable
+  }, { timeout: 10_000 }).toBe(true)
+  return settled!
 }
 
 function expectContained(metrics: RailMetrics, state: string, width: number): void {
@@ -101,6 +125,13 @@ function expectContained(metrics: RailMetrics, state: string, width: number): vo
   }
 }
 
+function expectStableScrollerViewport(before: RailMetrics, after: RailMetrics): void {
+  for (const key of ["left", "top", "right", "bottom", "width", "height", "clientHeight"] as const) {
+    expect(after.scroller[key], `${key}: ${JSON.stringify({ before, after })}`)
+      .toBe(before.scroller[key])
+  }
+}
+
 function expectCheckpoint(
   metrics: RailMetrics,
   state: string,
@@ -110,27 +141,35 @@ function expectCheckpoint(
 ): void {
   const evidence = `${state}@${width}: ${JSON.stringify(metrics)}`
   const expectedGap = width < 640 ? 8 : 16
-  expect(metrics.typingSpace.height, evidence).toBe(typing ? 44 : 0)
-  expect(metrics.scroller.bottom, evidence).toBeLessThanOrEqual(metrics.typingSpace.top + 1)
-  expect(metrics.typingSpace.bottom, evidence).toBeLessThanOrEqual(metrics.composer.top + 1)
+  expect(metrics.contentPaddingBottom, evidence).toBe(width < 640 ? 56 : 72)
+  expect(metrics.scroller.bottom, evidence).toBeLessThanOrEqual(metrics.composer.top + 1)
   if (metrics.typing?.width) {
     expect(metrics.typing.height, `typing ${evidence}`).toBe(32)
-    expect(metrics.typing.top, evidence).toBeGreaterThanOrEqual(metrics.typingSpace.top - 1)
-    expect(metrics.typing.bottom, evidence).toBeLessThanOrEqual(metrics.typingSpace.bottom + 1)
+    expect(metrics.rail, evidence).not.toBeNull()
+    expect(metrics.typing.top, evidence).toBeGreaterThanOrEqual(metrics.rail!.top - 1)
+    expect(metrics.typing.bottom, evidence).toBeLessThanOrEqual(metrics.rail!.bottom + 1)
   }
   if (metrics.center?.width) {
     expect(metrics.rail, evidence).not.toBeNull()
     expect(Math.abs(metrics.scroller.bottom - metrics.center.bottom - expectedGap), evidence)
       .toBeLessThanOrEqual(1)
-    expect(metrics.rail!.bottom, evidence).toBeLessThanOrEqual(metrics.typingSpace.top + 1)
-    expect(metrics.center.bottom, evidence).toBeLessThanOrEqual(metrics.typingSpace.top + 1)
+    expect(metrics.rail!.bottom, evidence).toBeLessThanOrEqual(metrics.scroller.bottom + 1)
+    expect(metrics.center.bottom, evidence).toBeLessThanOrEqual(metrics.scroller.bottom + 1)
     if (!selection) {
       expect(metrics.center.height, `scroll ${evidence}`).toBe(32)
-    } else if (width === 390) {
+    } else if (width < 640) {
       expect(metrics.center.height, `selection ${evidence}`).toBe(40)
-    } else if (width === 1280) {
+    } else {
       expect(metrics.center.height, `selection ${evidence}`).toBe(38)
     }
+  }
+  const controls = [metrics.typing, metrics.center].filter(
+    (control): control is Rect => !!control && control.width > 0,
+  )
+  if (metrics.finalMessage && controls.length > 0 && (selection || (typing && !metrics.center))) {
+    const highestControlTop = Math.min(...controls.map((control) => control.top))
+    expect(highestControlTop - metrics.finalMessage.bottom, evidence)
+      .toBeGreaterThanOrEqual(expectedGap - 1)
   }
 }
 
@@ -142,7 +181,9 @@ async function captureState(args: {
   center: boolean
   typing: boolean
   selection?: boolean
+  themeEvidence?: boolean
   widths?: readonly number[]
+  finalMessageId?: string
 }): Promise<Record<number, RailMetrics>> {
   const {
     page,
@@ -152,7 +193,9 @@ async function captureState(args: {
     center,
     typing,
     selection = false,
-    widths = MOBILE_WIDTHS,
+    themeEvidence = false,
+    widths = VIEWPORT_WIDTHS,
+    finalMessageId,
   } = args
   const evidence: Record<number, RailMetrics> = {}
   for (const width of widths) {
@@ -171,16 +214,16 @@ async function captureState(args: {
         : rect.left > 1 && Math.abs(rect.right - viewportWidth) <= 1
     }, width)).toBe(true)
     const rail = page.getByTestId(tid.composerAccessoryRail)
-    await expect(rail).toHaveCount(center ? 1 : 0)
-    if (center) await expect(rail).toHaveAttribute("data-layout", layout!)
+    await expect(rail).toHaveCount(center || typing ? 1 : 0)
+    if (center || typing) await expect(rail).toHaveAttribute("data-layout", layout!)
     await expect(page.getByTestId(tid.typingIndicator)).toHaveCount(typing ? 1 : 0)
     await expect(page.getByTestId(tid.messageSelectionToolbar)).toHaveCount(selection ? 1 : 0)
-    if (selection && (width === 390 || width === 1280)) {
+    if (selection) {
       await expect.poll(() => page.getByTestId(tid.messageSelectionToolbar).evaluate(
         (element) => element.getBoundingClientRect().height,
-      )).toBe(width === 390 ? 40 : 38)
+      )).toBe(width < 640 ? 40 : 38)
     }
-    const metrics = await railMetrics(page)
+    const metrics = await settledRailMetrics(page, finalMessageId)
     expectContained(metrics, state, width)
     expectCheckpoint(metrics, state, width, selection, typing)
     if (center) {
@@ -189,16 +232,34 @@ async function captureState(args: {
         .toBeLessThanOrEqual(1)
     }
     evidence[width] = metrics
-    await testInfo.attach(`${width}-${state}.png`, {
+    if (themeEvidence) {
+      await page.emulateMedia({ colorScheme: "light" })
+      await expect(page.locator("html")).not.toHaveClass(/dark/)
+    }
+    await testInfo.attach(`${width}-${state}${themeEvidence ? "-light" : ""}.png`, {
       body: await page.screenshot(),
       contentType: "image/png",
     })
+    if (themeEvidence) {
+      await page.emulateMedia({ colorScheme: "dark" })
+      await expect(page.locator("html")).toHaveClass(/dark/)
+      await testInfo.attach(`${width}-${state}-dark.png`, {
+        body: await page.screenshot(),
+        contentType: "image/png",
+      })
+      await page.emulateMedia({ colorScheme: "light" })
+      await expect(page.locator("html")).not.toHaveClass(/dark/)
+    }
   }
   return evidence
 }
 
-async function captureEmptyState(page: Page, testInfo: TestInfo): Promise<void> {
-  for (const width of MOBILE_WIDTHS) {
+async function captureEmptyState(
+  page: Page,
+  testInfo: TestInfo,
+  finalMessageId: string,
+): Promise<void> {
+  for (const width of VIEWPORT_WIDTHS) {
     await page.setViewportSize({ width, height: 844 })
     await page.getByTestId(tid.messageScroller).evaluate((element) => {
       element.scrollTop = element.scrollHeight
@@ -207,7 +268,9 @@ async function captureEmptyState(page: Page, testInfo: TestInfo): Promise<void> 
     await expect(page.getByTestId(tid.scrollToPresent)).toHaveCount(0)
     await expect(page.getByTestId(tid.composerAccessoryRail)).toHaveCount(0)
     await expect(page.getByTestId(tid.channelComposerShell)).toBeVisible()
-    expect((await page.locator("[data-message-typing-space]").boundingBox())?.height).toBe(0)
+    const metrics = await settledRailMetrics(page, finalMessageId)
+    expect(metrics.contentPaddingBottom).toBe(width < 640 ? 56 : 72)
+    expect(metrics.scroller.bottom).toBeLessThanOrEqual(metrics.composer.top + 1)
     const documentWidths = await page.evaluate(() => ({
       client: document.documentElement.clientWidth,
       scroll: document.documentElement.scrollWidth,
@@ -247,7 +310,14 @@ test("composer accessory rail reallocates every occupied slot without overflow",
 
   const ping = `rail ws ready ${Date.now()}`
   await sendMessage(bob.page, ping)
-  await expect(alice.page.getByText(ping)).toBeVisible()
+  const finalMessage = alice.page.getByText(ping, { exact: true })
+  await expect(finalMessage).toBeVisible()
+  const finalMessageId = await finalMessage.evaluate((element, messageTestIdPrefix) => {
+    const testId = element.closest(`[data-testid^="${messageTestIdPrefix}"]`)
+      ?.getAttribute("data-testid")
+    if (!testId) throw new Error("final WS message row has no test id")
+    return testId.slice(messageTestIdPrefix.length)
+  }, tid.message(""))
 
   const scrollRoot = alice.page.getByTestId(tid.messageScroller)
   await expect.poll(() => scrollRoot.evaluate((element) => element.scrollHeight > element.clientHeight))
@@ -257,7 +327,7 @@ test("composer accessory rail reallocates every occupied slot without overflow",
     element.dispatchEvent(new Event("scroll"))
   })
   await expect(alice.page.getByTestId(tid.scrollToPresent)).toHaveCount(0)
-  await captureEmptyState(alice.page, testInfo)
+  await captureEmptyState(alice.page, testInfo, finalMessageId)
 
   let row = alice.page.getByTestId(tid.message(selectableMessageId))
   await row.hover()
@@ -271,6 +341,7 @@ test("composer accessory rail reallocates every occupied slot without overflow",
     center: true,
     typing: false,
     selection: true,
+    finalMessageId,
   })
   await alice.page.getByRole("button", { name: "Cancel message selection" }).click()
 
@@ -280,13 +351,14 @@ test("composer accessory rail reallocates every occupied slot without overflow",
   })
   await expect(alice.page.getByTestId(tid.scrollToPresent)).toBeVisible()
 
-  await captureState({
+  const centerOnly = await captureState({
     page: alice.page,
     testInfo,
     state: "c-only",
     layout: "centered",
     center: true,
     typing: false,
+    finalMessageId,
   })
 
   const bobEditor = composerEditable(bob.page)
@@ -298,14 +370,18 @@ test("composer accessory rail reallocates every occupied slot without overflow",
     await expect(alice.page.getByTestId(tid.typingIndicator)).toBeVisible({ timeout: 4_000 })
   }).toPass({ timeout: 20_000 })
 
-  await captureState({
+  const typingAndCenter = await captureState({
     page: alice.page,
     testInfo,
     state: "l-c",
     layout: "centered",
     center: true,
     typing: true,
+    finalMessageId,
   })
+  for (const width of VIEWPORT_WIDTHS) {
+    expectStableScrollerViewport(centerOnly[width], typingAndCenter[width])
+  }
 
   await alice.page.getByTestId(tid.typingIndicator).evaluate((element) => {
     element.setAttribute("data-e2e-node-identity", "typing-survived")
@@ -320,9 +396,10 @@ test("composer accessory rail reallocates every occupied slot without overflow",
     page: alice.page,
     testInfo,
     state: "l-only",
-    layout: null,
+    layout: "left-only",
     center: false,
     typing: true,
+    finalMessageId,
   })
   expect(leftOnly[320].typingText?.overflowX).toBe("hidden")
   expect(leftOnly[320].typingText?.textOverflow).toBe("ellipsis")
@@ -341,7 +418,8 @@ test("composer accessory rail reallocates every occupied slot without overflow",
     center: true,
     typing: true,
     selection: true,
-    widths: [390, 1280],
+    themeEvidence: true,
+    finalMessageId,
   })
   await alice.page.getByRole("button", { name: "Cancel message selection" }).click()
 
@@ -359,22 +437,25 @@ test("composer accessory rail reallocates every occupied slot without overflow",
     element.dispatchEvent(new Event("scroll"))
   })
   await expect(alice.page.getByTestId(tid.scrollToPresent)).toBeVisible()
-  await captureState({
+  const settledCenter = await captureState({
     page: alice.page,
     testInfo,
     state: "settled-center",
     layout: "centered",
     center: true,
     typing: false,
-    widths: [390, 320, 1280],
+    finalMessageId,
   })
+  for (const width of VIEWPORT_WIDTHS) {
+    expectStableScrollerViewport(centerOnly[width], settledCenter[width])
+  }
 
   await scrollRoot.evaluate((element) => {
     element.scrollTop = element.scrollHeight
     element.dispatchEvent(new Event("scroll"))
   })
   await expect(alice.page.getByTestId(tid.scrollToPresent)).toHaveCount(0)
-  await captureEmptyState(alice.page, testInfo)
+  await captureEmptyState(alice.page, testInfo, finalMessageId)
 
   await scrollRoot.evaluate((element) => {
     element.scrollTop = 0
@@ -387,7 +468,7 @@ test("composer accessory rail reallocates every occupied slot without overflow",
     element.dispatchEvent(new Event("scroll"))
   })
   await expect(alice.page.getByTestId(tid.scrollToPresent)).toBeVisible()
-  let metrics = await railMetrics(alice.page)
+  let metrics = await settledRailMetrics(alice.page, finalMessageId)
   expect(Math.abs(metrics.center!.center - metrics.composer.center)).toBeLessThanOrEqual(1)
   await alice.page.setViewportSize({ width: 1280, height: 900 })
   await scrollRoot.evaluate((element) => {
@@ -395,6 +476,6 @@ test("composer accessory rail reallocates every occupied slot without overflow",
     element.dispatchEvent(new Event("scroll"))
   })
   await expect(alice.page.getByTestId(tid.scrollToPresent)).toBeVisible()
-  metrics = await railMetrics(alice.page)
+  metrics = await settledRailMetrics(alice.page, finalMessageId)
   expect(Math.abs(metrics.center!.center - metrics.composer.center)).toBeLessThanOrEqual(1)
 })

--- a/src/web/src/test/e2e-ui/39-mobile-message-interactions.spec.ts
+++ b/src/web/src/test/e2e-ui/39-mobile-message-interactions.spec.ts
@@ -55,6 +55,45 @@ function frameHasMessage(
   ))
 }
 
+type ScrollerGeometry = {
+  top: number
+  bottom: number
+  height: number
+  clientHeight: number
+  scrollTop: number
+}
+
+async function settledScrollerGeometry(page: Page): Promise<ScrollerGeometry> {
+  const scroller = page.getByTestId(tid.messageScroller)
+  let previous = ""
+  let settled: ScrollerGeometry | null = null
+  await expect.poll(async () => {
+    const current = await scroller.evaluate((element) => {
+      const rect = element.getBoundingClientRect()
+      return {
+        top: rect.top,
+        bottom: rect.bottom,
+        height: rect.height,
+        clientHeight: element.clientHeight,
+        scrollTop: element.scrollTop,
+      }
+    })
+    const signature = JSON.stringify(current)
+    const stable = signature === previous
+    previous = signature
+    if (stable) settled = current
+    return stable
+  }, { timeout: 10_000 }).toBe(true)
+  return settled!
+}
+
+function expectStableScroller(before: ScrollerGeometry, after: ScrollerGeometry): void {
+  for (const key of ["top", "bottom", "height", "clientHeight", "scrollTop"] as const) {
+    expect(Math.abs(after[key] - before[key]), `${key}: ${JSON.stringify({ before, after })}`)
+      .toBeLessThanOrEqual(1)
+  }
+}
+
 async function dispatchSwipe(
   page: Page,
   messageId: string,
@@ -282,7 +321,7 @@ async function expectRetainedMountGets(
   expect(tracker.failures).toEqual([])
 }
 
-test("mobile reply, avatar mention, and typing space keep exact backend and WS identity", async ({ asUser }) => {
+test("mobile reply, avatar mention, and typing rail keep exact backend and WS identity", async ({ asUser }) => {
   test.setTimeout(240_000)
   const stamp = Date.now()
   const serverName = `Mobile-interactions-${stamp}`
@@ -415,8 +454,8 @@ test("mobile reply, avatar mention, and typing space keep exact backend and WS i
     composerId: tid.channelComposerShell,
   })
   expect(restingThreadGap).not.toBeNull()
-  expect(restingThreadGap!).toBeGreaterThanOrEqual(0)
-  expect(restingThreadGap!).toBeLessThanOrEqual(40)
+  expect(restingThreadGap!).toBeGreaterThanOrEqual(55)
+  expect(restingThreadGap!).toBeLessThanOrEqual(58)
   const threadWsReadyId = await seedMessage("alice", threadId, `thread ws ready ${stamp}`)
   await expect.poll(() => bobProxy.frames.some((frame) => (
     frameHasMessage(frame, threadId, threadWsReadyId)
@@ -502,9 +541,8 @@ test("mobile reply, avatar mention, and typing space keep exact backend and WS i
   await expect.poll(() => aliceProxy.frames.some((frame) => (
     frameHasMessage(frame, channelId, typingWsReadyId)
   )), { timeout: 20_000 }).toBe(true)
-  const typingSpace = alice.page.locator("[data-message-typing-space]")
-  const spaceBefore = await typingSpace.boundingBox()
-  expect(spaceBefore?.height).toBe(0)
+  await expect(alice.page.getByTestId(tid.message(typingWsReadyId))).toBeVisible()
+  const channelScrollerBeforeTyping = await settledScrollerGeometry(alice.page)
   const beforeTypingSeq = await latestSeq(alice.page, channelId)
   const bobEditable = composerEditable(bob.page)
   await expect(async () => {
@@ -517,9 +555,12 @@ test("mobile reply, avatar mention, and typing space keep exact backend and WS i
       event.type === "community:typing.start" && event.channelId === channelId
     ))
   )), { timeout: 20_000 }).toBe(true)
+  const channelScrollerDuringTyping = await settledScrollerGeometry(alice.page)
+  expectStableScroller(channelScrollerBeforeTyping, channelScrollerDuringTyping)
 
   const geometry = await alice.page.evaluate(({
     scrollerId,
+    railId,
     composerId,
     indicatorId,
     replyMessageTestId,
@@ -527,23 +568,28 @@ test("mobile reply, avatar mention, and typing space keep exact backend and WS i
     const rect = (element: Element | null) => element?.getBoundingClientRect() ?? null
     return {
       scroller: rect(document.querySelector(`[data-testid="${scrollerId}"]`)),
-      space: rect(document.querySelector("[data-message-typing-space]")),
+      rail: rect(document.querySelector(`[data-testid="${railId}"]`)),
       indicator: rect(document.querySelector(`[data-testid="${indicatorId}"]`)),
       composer: rect(document.querySelector(`[data-testid="${composerId}"]`)),
       finalMessage: rect(document.querySelector(`[data-testid="${replyMessageTestId}"]`)),
+      contentPaddingBottom: Number.parseFloat(getComputedStyle(
+        document.querySelector<HTMLElement>("[data-message-list-content]")!,
+      ).paddingBottom),
       horizontalOverflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
     }
   }, {
     scrollerId: tid.messageScroller,
+    railId: tid.composerAccessoryRail,
     composerId: tid.channelComposerShell,
     indicatorId: tid.typingIndicator,
-    replyMessageTestId: tid.message(replyPayload.message.id),
+    replyMessageTestId: tid.message(typingWsReadyId),
   })
-  expect(geometry.scroller!.bottom).toBeLessThanOrEqual(geometry.space!.top + 1)
-  expect(geometry.space!.height).toBe(44)
-  expect(geometry.space!.bottom).toBeLessThanOrEqual(geometry.composer!.top + 1)
-  expect(geometry.indicator!.top).toBeGreaterThanOrEqual(geometry.space!.top - 1)
-  expect(geometry.indicator!.bottom).toBeLessThanOrEqual(geometry.space!.bottom + 1)
+  expect(geometry.contentPaddingBottom).toBe(56)
+  expect(geometry.scroller!.bottom).toBeLessThanOrEqual(geometry.composer!.top + 1)
+  expect(geometry.rail!.bottom).toBeLessThanOrEqual(geometry.scroller!.bottom + 1)
+  expect(geometry.indicator!.top).toBeGreaterThanOrEqual(geometry.rail!.top - 1)
+  expect(geometry.indicator!.bottom).toBeLessThanOrEqual(geometry.rail!.bottom + 1)
+  expect(geometry.indicator!.top - geometry.finalMessage!.bottom).toBeGreaterThanOrEqual(7)
   expect(geometry.finalMessage!.bottom).toBeLessThanOrEqual(geometry.scroller!.bottom + 1)
   expect(geometry.horizontalOverflow).toBeLessThanOrEqual(0)
 
@@ -559,7 +605,6 @@ test("mobile reply, avatar mention, and typing space keep exact backend and WS i
       scroller: rect(document.querySelector(`[data-testid="${ids.scroller}"]`)),
       rail: rect(document.querySelector(`[data-testid="${ids.rail}"]`)),
       scroll: rect(document.querySelector(`[data-testid="${ids.scroll}"]`)),
-      space: rect(document.querySelector("[data-message-typing-space]")),
       indicator: rect(document.querySelector(`[data-testid="${ids.indicator}"]`)),
     }
   }, {
@@ -568,10 +613,9 @@ test("mobile reply, avatar mention, and typing space keep exact backend and WS i
     scroll: tid.scrollToPresent,
     indicator: tid.typingIndicator,
   })
-  expect(scrollTypingGeometry.rail!.bottom).toBeLessThanOrEqual(scrollTypingGeometry.space!.top + 1)
-  expect(scrollTypingGeometry.scroll!.bottom).toBeLessThanOrEqual(scrollTypingGeometry.space!.top + 1)
+  expect(scrollTypingGeometry.rail!.bottom).toBeLessThanOrEqual(scrollTypingGeometry.scroller!.bottom + 1)
   expect(scrollTypingGeometry.scroll!.bottom).toBeLessThanOrEqual(scrollTypingGeometry.scroller!.bottom + 1)
-  expect(scrollTypingGeometry.indicator!.top).toBeGreaterThanOrEqual(scrollTypingGeometry.space!.top - 1)
+  expect(scrollTypingGeometry.indicator!.top).toBeGreaterThanOrEqual(scrollTypingGeometry.rail!.top - 1)
 
   await alice.page.getByTestId(tid.scrollToPresent).click()
   await expect(alice.page.getByTestId(tid.scrollToPresent)).toHaveCount(0)
@@ -581,6 +625,7 @@ test("mobile reply, avatar mention, and typing space keep exact backend and WS i
   await finalChannelMessage.getByText(`typing ws ready ${stamp}`, { exact: true }).click()
   await alice.page.getByRole("menuitem", { name: "Share as Image" }).click()
   await expect(alice.page.getByTestId(tid.messageSelectionToolbar)).toBeVisible()
+  await expect(alice.page.getByTestId(tid.typingIndicator)).toBeHidden()
   const selectionTypingGeometry = await alice.page.evaluate((ids) => {
     const rect = (element: Element | null) => element?.getBoundingClientRect() ?? null
     return {
@@ -588,7 +633,6 @@ test("mobile reply, avatar mention, and typing space keep exact backend and WS i
       scroller: rect(document.querySelector(`[data-testid="${ids.scroller}"]`)),
       rail: rect(document.querySelector(`[data-testid="${ids.rail}"]`)),
       selection: rect(document.querySelector(`[data-testid="${ids.selection}"]`)),
-      space: rect(document.querySelector("[data-message-typing-space]")),
       indicator: rect(document.querySelector(`[data-testid="${ids.indicator}"]`)),
       composer: rect(document.querySelector(`[data-testid="${ids.composer}"]`)),
     }
@@ -600,19 +644,17 @@ test("mobile reply, avatar mention, and typing space keep exact backend and WS i
     indicator: tid.typingIndicator,
     composer: tid.channelComposerShell,
   })
-  expect(selectionTypingGeometry.finalMessage!.bottom).toBeLessThanOrEqual(selectionTypingGeometry.rail!.top + 1)
-  expect(selectionTypingGeometry.rail!.bottom).toBeLessThanOrEqual(selectionTypingGeometry.space!.top + 1)
-  expect(selectionTypingGeometry.selection!.bottom).toBeLessThanOrEqual(selectionTypingGeometry.space!.top + 1)
-  expect(selectionTypingGeometry.space!.bottom).toBeLessThanOrEqual(selectionTypingGeometry.composer!.top + 1)
+  expect(selectionTypingGeometry.selection!.top - selectionTypingGeometry.finalMessage!.bottom)
+    .toBeGreaterThanOrEqual(7)
+  expect(selectionTypingGeometry.rail!.bottom).toBeLessThanOrEqual(selectionTypingGeometry.scroller!.bottom + 1)
+  expect(selectionTypingGeometry.selection!.bottom).toBeLessThanOrEqual(selectionTypingGeometry.scroller!.bottom + 1)
+  expect(selectionTypingGeometry.scroller!.bottom).toBeLessThanOrEqual(selectionTypingGeometry.composer!.top + 1)
   expect(selectionTypingGeometry.finalMessage!.bottom).toBeLessThanOrEqual(selectionTypingGeometry.scroller!.bottom + 1)
-  expect(selectionTypingGeometry.indicator!.bottom).toBeLessThanOrEqual(selectionTypingGeometry.space!.bottom + 1)
+  expect(selectionTypingGeometry.indicator!.height).toBe(0)
   await alice.page.getByRole("button", { name: "Cancel message selection" }).click()
 
   await bobEditable.fill("")
   await expect(alice.page.getByTestId(tid.typingIndicator)).toBeHidden({ timeout: 15_000 })
-  const spaceAfter = await typingSpace.boundingBox()
-  expect(spaceAfter?.height).toBe(0)
-  expect(spaceAfter?.y).toBeCloseTo(spaceBefore!.y, 0)
   expect(await latestSeq(alice.page, channelId)).toBe(beforeTypingSeq)
 
   const dmSeqBeforeDirect = await latestSeq(alice.page, dmId)
@@ -673,31 +715,41 @@ test("mobile reply, avatar mention, and typing space keep exact backend and WS i
     ))
   )), { timeout: 20_000 }).toBe(true)
   const beforeDmTypingSeq = await latestSeq(alice.page, dmId)
-  const dmTypingSpace = alice.page.locator("[data-message-typing-space]")
-  const dmSpaceBefore = await dmTypingSpace.boundingBox()
-  expect(dmSpaceBefore?.height).toBe(0)
+  const dmScrollerBeforeTyping = await settledScrollerGeometry(alice.page)
   const bobDmEditable = composerEditable(bob.page)
   await expect(async () => {
     await bobDmEditable.fill("")
     await bobDmEditable.pressSequentially("dm typing geometry")
     await expect(alice.page.getByTestId(tid.typingIndicator)).toBeVisible({ timeout: 4_000 })
   }).toPass({ timeout: 20_000 })
-  const dmGeometry = await alice.page.evaluate(({ scrollerId, indicatorId }) => {
+  const dmScrollerDuringTyping = await settledScrollerGeometry(alice.page)
+  expectStableScroller(dmScrollerBeforeTyping, dmScrollerDuringTyping)
+  const dmGeometry = await alice.page.evaluate(({ scrollerId, railId, indicatorId }) => {
     const rect = (element: Element | null) => element?.getBoundingClientRect() ?? null
     return {
       scroller: rect(document.querySelector(`[data-testid="${scrollerId}"]`)),
-      space: rect(document.querySelector("[data-message-typing-space]")),
+      rail: rect(document.querySelector(`[data-testid="${railId}"]`)),
       indicator: rect(document.querySelector(`[data-testid="${indicatorId}"]`)),
+      composer: rect(document.querySelector('[data-onboarding-target="dm-composer"]')),
+      contentPaddingBottom: Number.parseFloat(getComputedStyle(
+        document.querySelector<HTMLElement>("[data-message-list-content]")!,
+      ).paddingBottom),
       horizontalOverflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
     }
-  }, { scrollerId: tid.messageScroller, indicatorId: tid.typingIndicator })
-  expect(dmGeometry.scroller!.bottom).toBeLessThanOrEqual(dmGeometry.space!.top + 1)
-  expect(dmGeometry.space!.height).toBe(44)
-  expect(dmGeometry.indicator!.bottom).toBeLessThanOrEqual(dmGeometry.space!.bottom + 1)
+  }, {
+    scrollerId: tid.messageScroller,
+    railId: tid.composerAccessoryRail,
+    indicatorId: tid.typingIndicator,
+  })
+  expect(dmGeometry.contentPaddingBottom).toBe(56)
+  expect(dmGeometry.scroller!.bottom).toBeLessThanOrEqual(dmGeometry.composer!.top + 1)
+  expect(dmGeometry.rail!.bottom).toBeLessThanOrEqual(dmGeometry.scroller!.bottom + 1)
+  expect(dmGeometry.indicator!.bottom).toBeLessThanOrEqual(dmGeometry.rail!.bottom + 1)
   expect(dmGeometry.horizontalOverflow).toBeLessThanOrEqual(0)
   await bobDmEditable.fill("")
   await expect(alice.page.getByTestId(tid.typingIndicator)).toBeHidden({ timeout: 15_000 })
-  expect((await dmTypingSpace.boundingBox())?.height).toBe(0)
+  const dmScrollerAfterTyping = await settledScrollerGeometry(alice.page)
+  expectStableScroller(dmScrollerBeforeTyping, dmScrollerAfterTyping)
   expect(await latestSeq(alice.page, dmId)).toBe(beforeDmTypingSeq)
 
   const dmScroller = alice.page.getByTestId(tid.messageScroller)


### PR DESCRIPTION
# Why we need this PR?

Follow-up to #607: typing was rendered as a separate 44px flex strip, so presence changes resized the message scroller, while the normal 32px tail padding could leave the last message beneath the accessory controls.

## What changed

- Put typing, jump/scroll, and selection in the existing composer accessory rail.
- Reserve a fixed responsive message-tail safe area (`56px` below 640px, `72px` from 640px).
- Keep mobile selection priority CSS-only: typing is hidden below 640px and retained on desktop.
- Add unit and browser geometry coverage for the true final row, stable typing transitions, all five target widths, and light/dark evidence.

## Validation

- Root typecheck, lint, tests, typegreps, and Knip pass through normal commit hooks.
- Web unit suite: 684 files / 6,056 tests pass.
- E2E24: 6/6; E2E25: 1/1; E2E39: 2/2.
- No deploy performed.

## Checklist

- [x] Tests added/updated as needed
- [ ] All remote CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other
