### PR TITLE
fix(web): fit selection toolbar typing

### DIFF
--- a/src/web/src/components/community/messages/composer-accessory-rail.test.ts
+++ b/src/web/src/components/community/messages/composer-accessory-rail.test.ts
@@ -1,10 +1,11 @@
 import React from "react"
 import { readFileSync } from "node:fs"
+import { X } from "lucide-react"
 import TestRenderer, { act } from "react-test-renderer"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { tid } from "@/lib/community/testids"
 import { useCommunityWsStore } from "@/stores/community/ws"
-import { ComposerAccessoryRail } from "./composer-accessory-rail"
+import { ComposerAccessoryRail, selectionTypingFits } from "./composer-accessory-rail"
 
 vi.mock("@/components/ui/number-ticker", () => ({
   NumberTicker: ({ value }: { value: number }) => React.createElement("ticker", { value }),
@@ -91,7 +92,7 @@ describe("ComposerAccessoryRail", () => {
     },
   )
 
-  it("keeps selection centered, hides typing only on mobile with CSS, and wires its actions", () => {
+  it("keeps selection centered, starts typing hidden pending measurement, and wires its actions", () => {
     const renderer = render({
       typingNames: ["Alice"],
       selectMode: true,
@@ -105,8 +106,9 @@ describe("ComposerAccessoryRail", () => {
     expect(renderer.root.findAllByProps({ "data-testid": tid.scrollToPresent })).toHaveLength(0)
     expect(slotClassName(renderer, tid.messageSelectionToolbar)).toContain("col-start-2")
     const typingSlot = slotClassName(renderer, tid.typingIndicator)
-    expect(typingSlot).toContain("hidden")
-    expect(typingSlot).toContain("sm:block")
+    expect(typingSlot).toContain("col-start-1")
+    expect(typingSlot).not.toContain("sm:block")
+    expect(renderer.root.findByProps({ "data-selection-typing-fit": "pending" })).toBeDefined()
 
     const toolbar = renderer.root.findByProps({ "data-testid": tid.messageSelectionToolbar })
     expect(toolbar.props.className).toContain("h-10")
@@ -116,11 +118,22 @@ describe("ComposerAccessoryRail", () => {
       "aria-label": "Share 12 selected messages as image",
     })
     expect(cancel.props.className).toContain("w-11")
+    expect(cancel.props.className).toContain("text-foreground")
+    expect(cancel.findByType(X).props.className).toBe("text-foreground")
+    expect(cancel.findAllByType("span").find((node) => node.children.includes("Cancel"))?.props.className)
+      .toContain("text-foreground")
     expect(share.props.className).toContain("after:-inset-y-1.5")
     act(() => cancel.props.onClick())
     act(() => share.props.onClick())
     expect(baseProps.onCancelSelection).toHaveBeenCalledOnce()
     expect(baseProps.onShareSelection).toHaveBeenCalledOnce()
+  })
+
+  it("shows selection typing only when the complete intrinsic pill fits", () => {
+    expect(selectionTypingFits(160, 160)).toBe(true)
+    expect(selectionTypingFits(160, 159.5)).toBe(true)
+    expect(selectionTypingFits(160, 160.5)).toBe(false)
+    expect(selectionTypingFits(0, 0)).toBe(false)
   })
 
   it("centers the scroll control, preserves the floating boundary, and wires scroll", () => {
@@ -157,5 +170,6 @@ describe("ComposerAccessoryRail", () => {
     expect(source).not.toContain("@/stores/community/ws")
     expect(source).not.toContain("WsStatusControl")
     expect(source).not.toMatch(/max-w-\[calc\([^\]]*vw/)
+    expect(source).not.toContain('className="hidden min-w-0 max-w-full sm:col-start-1 sm:block"')
   })
 })

--- a/src/web/src/components/community/messages/composer-accessory-rail.tsx
+++ b/src/web/src/components/community/messages/composer-accessory-rail.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useLayoutEffect, useMemo, useRef, useState } from "react"
 import { ArrowDown, ImageIcon, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { NumberTicker } from "@/components/ui/number-ticker"
@@ -53,9 +54,7 @@ export function ComposerAccessoryRail({
         {selectMode ? (
           <>
             {hasTyping && (
-              <div key="left" className="hidden min-w-0 max-w-full sm:col-start-1 sm:block">
-                <TypingIndicator names={typingNames} className="w-fit max-w-full" />
-              </div>
+              <SelectionTypingIndicator key="left" names={typingNames} />
             )}
             <div key="center" className="col-start-2 min-w-0 max-w-full justify-self-center">
               <SelectionToolbar
@@ -79,6 +78,63 @@ export function ComposerAccessoryRail({
             )}
           </>
         )}
+      </div>
+    </div>
+  )
+}
+
+export function selectionTypingFits(slotWidth: number, pillWidth: number): boolean {
+  return slotWidth > 0 && pillWidth > 0 && pillWidth <= slotWidth
+}
+
+function SelectionTypingIndicator({ names }: { names: string[] }) {
+  const slotRef = useRef<HTMLDivElement>(null)
+  const pillRef = useRef<HTMLDivElement>(null)
+  const measurementKey = useMemo(() => JSON.stringify(names), [names])
+  const [measurement, setMeasurement] = useState({ key: "", fits: false })
+  const isMeasured = measurement.key === measurementKey
+  const isVisible = isMeasured && measurement.fits
+
+  useLayoutEffect(() => {
+    const slot = slotRef.current
+    const pill = pillRef.current
+    if (!slot || !pill) return
+
+    const measure = () => {
+      const fits = selectionTypingFits(
+        slot.getBoundingClientRect().width,
+        pill.getBoundingClientRect().width,
+      )
+      setMeasurement((current) => (
+        current.key === measurementKey && current.fits === fits
+          ? current
+          : { key: measurementKey, fits }
+      ))
+    }
+
+    measure()
+    if (typeof ResizeObserver === "undefined") return
+    const observer = new ResizeObserver(measure)
+    observer.observe(slot)
+    observer.observe(pill)
+    return () => observer.disconnect()
+  }, [measurementKey])
+
+  return (
+    <div
+      ref={slotRef}
+      data-selection-typing-fit={isMeasured ? (isVisible ? "visible" : "hidden") : "pending"}
+      className="relative col-start-1 min-w-0 max-w-full"
+    >
+      <div
+        ref={pillRef}
+        aria-hidden={!isVisible}
+        className={cn(
+          "w-max max-w-none",
+          isVisible ? "relative" : "invisible absolute bottom-0 left-0",
+        )}
+      >
+        <TypingIndicator names={names} />
       </div>
     </div>
   )
@@ -109,11 +165,11 @@ function SelectionToolbar({
               variant="ghost"
               onClick={onCancel}
               aria-label="Cancel message selection"
-              className="relative h-8 w-11 shrink-0 rounded-lg px-0 after:absolute after:-inset-y-1.5 after:inset-x-0 after:content-[''] sm:h-7 sm:w-auto sm:px-2 sm:after:hidden"
+              className="relative h-8 w-11 shrink-0 rounded-lg px-0 text-foreground after:absolute after:-inset-y-1.5 after:inset-x-0 after:content-[''] sm:h-7 sm:w-auto sm:px-2 sm:after:hidden"
             />
           }
         >
-          <X /> <span className="hidden sm:inline">Cancel</span>
+          <X className="text-foreground" /> <span className="hidden text-foreground sm:inline">Cancel</span>
         </TooltipTrigger>
         <TooltipContent>Cancel selection</TooltipContent>
       </Tooltip>

--- a/src/web/src/test/e2e-ui/25-composer-accessory-rail-occupancy.spec.ts
+++ b/src/web/src/test/e2e-ui/25-composer-accessory-rail-occupancy.spec.ts
@@ -246,6 +246,12 @@ async function captureState(args: {
         (element) => element.getBoundingClientRect().height,
       )).toBe(width < 640 ? 40 : 38)
     }
+    if (!center || selection) {
+      await scrollRoot.evaluate((element) => {
+        element.scrollTop = element.scrollHeight
+        element.dispatchEvent(new Event("scroll"))
+      })
+    }
     const metrics = await settledRailMetrics(page, finalMessageId)
     expectContained(metrics, state, width)
     expectCheckpoint(metrics, state, width, selection, metrics.typing !== null)

--- a/src/web/src/test/e2e-ui/25-composer-accessory-rail-occupancy.spec.ts
+++ b/src/web/src/test/e2e-ui/25-composer-accessory-rail-occupancy.spec.ts
@@ -35,6 +35,12 @@ type RailMetrics = {
     textOverflow: string
     whiteSpace: string
   } | null
+  selectionTypingFit: {
+    state: string | null
+    slotWidth: number
+    pillWidth: number
+    visibility: string
+  } | null
 }
 
 async function railMetrics(page: Page, finalMessageId?: string): Promise<RailMetrics> {
@@ -43,12 +49,16 @@ async function railMetrics(page: Page, finalMessageId?: string): Promise<RailMet
     const find = (id: string) => document.querySelector<HTMLElement>(`[data-testid='${id}']`)
     const rail = find(ids.rail)
     const typing = find(ids.typing)
+    const selectionTypingSlot = document.querySelector<HTMLElement>("[data-selection-typing-fit]")
+    const selectionTypingPill = selectionTypingSlot?.firstElementChild as HTMLElement | null
     const center = find(ids.scroll) ?? find(ids.selection)
     const scroller = find(ids.scroller)!
     const content = document.querySelector<HTMLElement>("[data-message-list-content]")!
     const finalMessage = ids.finalMessage ? find(ids.finalMessage) : null
     const typingText = typing?.querySelector<HTMLElement>("span.min-w-0.truncate") ?? null
     const style = typingText ? getComputedStyle(typingText) : null
+    const typingStyle = typing ? getComputedStyle(typing) : null
+    const typingVisible = !!typing && typingStyle?.visibility !== "hidden"
     const toRect = (value: DOMRect) => ({
       left: value.left,
       top: value.top,
@@ -67,7 +77,7 @@ async function railMetrics(page: Page, finalMessageId?: string): Promise<RailMet
         scrollTop: scroller.scrollTop,
       },
       composer: toRect(find(ids.composer)!.getBoundingClientRect()),
-      typing: typing ? toRect(typing.getBoundingClientRect()) : null,
+      typing: typingVisible ? toRect(typing.getBoundingClientRect()) : null,
       center: center ? toRect(center.getBoundingClientRect()) : null,
       finalMessage: finalMessage ? toRect(finalMessage.getBoundingClientRect()) : null,
       contentPaddingBottom: Number.parseFloat(getComputedStyle(content).paddingBottom),
@@ -80,6 +90,14 @@ async function railMetrics(page: Page, finalMessageId?: string): Promise<RailMet
           overflowX: style.overflowX,
           textOverflow: style.textOverflow,
           whiteSpace: style.whiteSpace,
+        }
+        : null,
+      selectionTypingFit: selectionTypingSlot && selectionTypingPill
+        ? {
+          state: selectionTypingSlot.dataset.selectionTypingFit ?? null,
+          slotWidth: selectionTypingSlot.getBoundingClientRect().width,
+          pillWidth: selectionTypingPill.getBoundingClientRect().width,
+          visibility: getComputedStyle(selectionTypingPill).visibility,
         }
         : null,
     }
@@ -217,6 +235,11 @@ async function captureState(args: {
     await expect(rail).toHaveCount(center || typing ? 1 : 0)
     if (center || typing) await expect(rail).toHaveAttribute("data-layout", layout!)
     await expect(page.getByTestId(tid.typingIndicator)).toHaveCount(typing ? 1 : 0)
+    if (typing && !selection) await expect(page.getByTestId(tid.typingIndicator)).toBeVisible()
+    if (typing && selection) {
+      await expect(page.locator("[data-selection-typing-fit]"))
+        .toHaveAttribute("data-selection-typing-fit", /^(visible|hidden)$/)
+    }
     await expect(page.getByTestId(tid.messageSelectionToolbar)).toHaveCount(selection ? 1 : 0)
     if (selection) {
       await expect.poll(() => page.getByTestId(tid.messageSelectionToolbar).evaluate(
@@ -225,7 +248,22 @@ async function captureState(args: {
     }
     const metrics = await settledRailMetrics(page, finalMessageId)
     expectContained(metrics, state, width)
-    expectCheckpoint(metrics, state, width, selection, typing)
+    expectCheckpoint(metrics, state, width, selection, metrics.typing !== null)
+    if (selection && typing) {
+      const fit = metrics.selectionTypingFit
+      expect(fit, `${state}@${width}`).not.toBeNull()
+      const shouldFit = fit!.pillWidth <= fit!.slotWidth
+      expect(fit!.state, `${state}@${width}: ${JSON.stringify(fit)}`)
+        .toBe(shouldFit ? "visible" : "hidden")
+      expect(fit!.visibility, `${state}@${width}: ${JSON.stringify(fit)}`)
+        .toBe(shouldFit ? "visible" : "hidden")
+      expect(metrics.typing === null, `${state}@${width}: ${JSON.stringify(fit)}`)
+        .toBe(!shouldFit)
+      if (shouldFit) {
+        expect(metrics.typingText!.scrollWidth, `${state}@${width}: ${JSON.stringify(metrics)}`)
+          .toBeLessThanOrEqual(metrics.typingText!.clientWidth)
+      }
+    }
     if (center) {
       expect(metrics.center, `${state}@${width}`).not.toBeNull()
       expect(Math.abs(metrics.center!.center - metrics.composer.center), `${state}@${width}`)
@@ -235,6 +273,7 @@ async function captureState(args: {
     if (themeEvidence) {
       await page.emulateMedia({ colorScheme: "light" })
       await expect(page.locator("html")).not.toHaveClass(/dark/)
+      await expectCancelForeground(page, "light")
     }
     await testInfo.attach(`${width}-${state}${themeEvidence ? "-light" : ""}.png`, {
       body: await page.screenshot(),
@@ -243,6 +282,7 @@ async function captureState(args: {
     if (themeEvidence) {
       await page.emulateMedia({ colorScheme: "dark" })
       await expect(page.locator("html")).toHaveClass(/dark/)
+      await expectCancelForeground(page, "dark")
       await testInfo.attach(`${width}-${state}-dark.png`, {
         body: await page.screenshot(),
         contentType: "image/png",
@@ -252,6 +292,22 @@ async function captureState(args: {
     }
   }
   return evidence
+}
+
+async function expectCancelForeground(page: Page, theme: "light" | "dark"): Promise<void> {
+  const colors = await page.getByRole("button", { name: "Cancel message selection" }).evaluate((button) => {
+    const icon = button.querySelector("svg")!
+    const label = button.querySelector("span")!
+    return {
+      button: getComputedStyle(button).color,
+      icon: getComputedStyle(icon).color,
+      label: getComputedStyle(label).color,
+      body: getComputedStyle(document.body).color,
+    }
+  })
+  expect(colors.icon, `${theme}: ${JSON.stringify(colors)}`).toBe(colors.body)
+  expect(colors.label, `${theme}: ${JSON.stringify(colors)}`).toBe(colors.body)
+  if (theme === "dark") expect(colors.label).not.toBe("rgb(0, 0, 0)")
 }
 
 async function captureEmptyState(
@@ -288,7 +344,9 @@ test("composer accessory rail reallocates every occupied slot without overflow",
   const serverId = await seedServer("alice", `Rail occupancy ${Date.now()}`)
   const channelId = await seedChannel("alice", serverId, "rail-occupancy")
   await seedJoinServer("alice", "bob", serverId)
+  await seedJoinServer("alice", "carol", serverId)
   await renameUser("bob", LONG_TYPING_NAME)
+  await renameUser("carol", "Cy")
   let selectableMessageId = ""
   for (let index = 0; index < 28; index++) {
     selectableMessageId = await seedMessage(
@@ -300,13 +358,17 @@ test("composer accessory rail reallocates every occupied slot without overflow",
 
   const alice = await asUser("alice")
   const bob = await asUser("bob")
+  const carol = await asUser("carol")
   await alice.page.setViewportSize({ width: 390, height: 844 })
   await bob.page.setViewportSize({ width: 390, height: 844 })
+  await carol.page.setViewportSize({ width: 390, height: 844 })
   const route = `/c/channels/${serverId}/${channelId}`
   await gotoAfterUserWsAuth(alice.page, route)
   await gotoAfterUserWsAuth(bob.page, route)
+  await gotoAfterUserWsAuth(carol.page, route)
   await expect(composerEditable(alice.page)).toBeVisible()
   await expect(composerEditable(bob.page)).toBeVisible()
+  await expect(composerEditable(carol.page)).toBeVisible()
 
   const ping = `rail ws ready ${Date.now()}`
   await sendMessage(bob.page, ping)
@@ -333,7 +395,7 @@ test("composer accessory rail reallocates every occupied slot without overflow",
   await row.hover()
   await alice.page.getByTestId(tid.messageShare(selectableMessageId)).click()
   await expect(alice.page.getByTestId(tid.messageSelectionToolbar)).toBeVisible()
-  await captureState({
+  const selectionNone = await captureState({
     page: alice.page,
     testInfo,
     state: "selection-none",
@@ -406,32 +468,106 @@ test("composer accessory rail reallocates every occupied slot without overflow",
   expect(leftOnly[320].typingText?.whiteSpace).toBe("nowrap")
   expect(leftOnly[320].typingText!.scrollWidth).toBeGreaterThan(leftOnly[320].typingText!.clientWidth)
 
+  await sendMessage(bob.page, `long typing clear ${Date.now()}`)
+  await expect(alice.page.getByTestId(tid.typingIndicator)).toHaveCount(0)
+  const carolEditor = composerEditable(carol.page)
+  await expect(async () => {
+    await carolEditor.click()
+    await carol.page.keyboard.press("ControlOrMeta+A")
+    await carol.page.keyboard.press("Backspace")
+    await carol.page.keyboard.type("short selection typing")
+    await expect(alice.page.getByTestId(tid.typingIndicator)).toBeVisible({ timeout: 4_000 })
+  }).toPass({ timeout: 20_000 })
+
   row = alice.page.getByTestId(tid.message(selectableMessageId))
   await row.hover()
   await alice.page.getByTestId(tid.messageShare(selectableMessageId)).click()
   await expect(alice.page.getByTestId(tid.messageSelectionToolbar)).toBeVisible()
-  await captureState({
+  const selectionShort = await captureState({
     page: alice.page,
     testInfo,
-    state: "selection-l",
+    state: "selection-short",
     layout: "centered",
     center: true,
     typing: true,
     selection: true,
-    themeEvidence: true,
     finalMessageId,
   })
-  await alice.page.getByRole("button", { name: "Cancel message selection" }).click()
+  const shortFitStates = VIEWPORT_WIDTHS.map(
+    (width) => selectionShort[width].selectionTypingFit?.state,
+  )
+  expect(shortFitStates).toContain("visible")
+  expect(shortFitStates).toContain("hidden")
+  for (const width of VIEWPORT_WIDTHS) {
+    expect(selectionShort[width].center!.center).toBe(selectionNone[width].center!.center)
+  }
 
   await expect(async () => {
     await bobEditor.click()
     await bob.page.keyboard.press("ControlOrMeta+A")
     await bob.page.keyboard.press("Backspace")
-    await bob.page.keyboard.type("typing occupancy settle")
-    await expect(alice.page.getByTestId(tid.typingIndicator)).toBeVisible({ timeout: 4_000 })
+    await bob.page.keyboard.type("multiple selection typing")
+    await expect(alice.page.getByTestId(tid.typingIndicator)).toContainText(" and ", {
+      timeout: 4_000,
+    })
   }).toPass({ timeout: 20_000 })
+  const selectionMultiple = await captureState({
+    page: alice.page,
+    testInfo,
+    state: "selection-multiple",
+    layout: "centered",
+    center: true,
+    typing: true,
+    selection: true,
+    widths: [390, 639, 1280],
+    finalMessageId,
+  })
+  for (const width of [390, 639, 1280] as const) {
+    expect(selectionMultiple[width].center!.center).toBe(selectionNone[width].center!.center)
+  }
 
-  await expect(alice.page.getByTestId(tid.typingIndicator)).toHaveCount(0, { timeout: 15_000 })
+  await sendMessage(bob.page, `multiple typing clear ${Date.now()}`)
+  await sendMessage(carol.page, `short typing clear ${Date.now()}`)
+  await expect(alice.page.getByTestId(tid.typingIndicator)).toHaveCount(0)
+  await expect(async () => {
+    await bobEditor.click()
+    await bob.page.keyboard.press("ControlOrMeta+A")
+    await bob.page.keyboard.press("Backspace")
+    await bob.page.keyboard.type("long selection typing")
+    await expect(alice.page.getByTestId(tid.typingIndicator)).toHaveCount(1, { timeout: 4_000 })
+  }).toPass({ timeout: 20_000 })
+  const selectionLong = await captureState({
+    page: alice.page,
+    testInfo,
+    state: "selection-long",
+    layout: "centered",
+    center: true,
+    typing: true,
+    selection: true,
+    widths: [390, 639, 640, 1280],
+    finalMessageId,
+  })
+  for (const width of [390, 639, 640, 1280] as const) {
+    expect(selectionLong[width].selectionTypingFit?.state).toBe("hidden")
+    expect(selectionLong[width].typing).toBeNull()
+  }
+
+  await sendMessage(bob.page, `theme typing clear ${Date.now()}`)
+  await expect(alice.page.getByTestId(tid.typingIndicator)).toHaveCount(0)
+  await captureState({
+    page: alice.page,
+    testInfo,
+    state: "selection-theme",
+    layout: "centered",
+    center: true,
+    typing: false,
+    selection: true,
+    themeEvidence: true,
+    widths: [1280],
+    finalMessageId,
+  })
+  await alice.page.getByRole("button", { name: "Cancel message selection" }).click()
+
   await scrollRoot.evaluate((element) => {
     element.scrollTop = 0
     element.dispatchEvent(new Event("scroll"))

--- a/src/web/src/test/e2e-ui/39-mobile-message-interactions.spec.ts
+++ b/src/web/src/test/e2e-ui/39-mobile-message-interactions.spec.ts
@@ -609,16 +609,31 @@ test("mobile reply, avatar mention, and typing rail keep exact backend and WS id
   await finalChannelMessage.getByText(`typing ws ready ${stamp}`, { exact: true }).click()
   await alice.page.getByRole("menuitem", { name: "Share as Image" }).click()
   await expect(alice.page.getByTestId(tid.messageSelectionToolbar)).toBeVisible()
-  await expect(alice.page.getByTestId(tid.typingIndicator)).toBeHidden()
+  await expect(alice.page.locator("[data-selection-typing-fit]"))
+    .toHaveAttribute("data-selection-typing-fit", /^(visible|hidden)$/)
   const selectionTypingGeometry = await alice.page.evaluate((ids) => {
     const rect = (element: Element | null) => element?.getBoundingClientRect() ?? null
+    const typingSlot = document.querySelector<HTMLElement>("[data-selection-typing-fit]")
+    const typingPill = typingSlot?.firstElementChild as HTMLElement | null
+    const typingIndicator = document.querySelector<HTMLElement>(`[data-testid="${ids.indicator}"]`)
+    const typingText = typingIndicator?.querySelector<HTMLElement>("span.min-w-0.truncate")
     return {
       finalMessage: rect(document.querySelector(`[data-testid="${ids.finalMessage}"]`)),
       scroller: rect(document.querySelector(`[data-testid="${ids.scroller}"]`)),
       rail: rect(document.querySelector(`[data-testid="${ids.rail}"]`)),
       selection: rect(document.querySelector(`[data-testid="${ids.selection}"]`)),
-      indicator: rect(document.querySelector(`[data-testid="${ids.indicator}"]`)),
+      indicator: rect(typingIndicator),
       composer: rect(document.querySelector(`[data-testid="${ids.composer}"]`)),
+      typingFit: typingSlot && typingPill && typingIndicator && typingText
+        ? {
+          state: typingSlot.dataset.selectionTypingFit,
+          slotWidth: typingSlot.getBoundingClientRect().width,
+          pillWidth: typingPill.getBoundingClientRect().width,
+          visibility: getComputedStyle(typingIndicator).visibility,
+          textClientWidth: typingText.clientWidth,
+          textScrollWidth: typingText.scrollWidth,
+        }
+        : null,
     }
   }, {
     finalMessage: tid.message(typingWsReadyId),
@@ -634,7 +649,17 @@ test("mobile reply, avatar mention, and typing rail keep exact backend and WS id
   expect(selectionTypingGeometry.selection!.bottom).toBeLessThanOrEqual(selectionTypingGeometry.scroller!.bottom + 1)
   expect(selectionTypingGeometry.scroller!.bottom).toBeLessThanOrEqual(selectionTypingGeometry.composer!.top + 1)
   expect(selectionTypingGeometry.finalMessage!.bottom).toBeLessThanOrEqual(selectionTypingGeometry.scroller!.bottom + 1)
-  expect(selectionTypingGeometry.indicator!.height).toBe(0)
+  expect(selectionTypingGeometry.typingFit).not.toBeNull()
+  const selectionTypingFits = selectionTypingGeometry.typingFit!.pillWidth
+    <= selectionTypingGeometry.typingFit!.slotWidth
+  expect(selectionTypingGeometry.typingFit!.state)
+    .toBe(selectionTypingFits ? "visible" : "hidden")
+  expect(selectionTypingGeometry.typingFit!.visibility)
+    .toBe(selectionTypingFits ? "visible" : "hidden")
+  if (selectionTypingFits) {
+    expect(selectionTypingGeometry.typingFit!.textScrollWidth)
+      .toBeLessThanOrEqual(selectionTypingGeometry.typingFit!.textClientWidth)
+  }
   await alice.page.getByRole("button", { name: "Cancel message selection" }).click()
 
   await bobEditable.fill("")


### PR DESCRIPTION
# Why we need this PR?
Selection-mode typing presence was gated by the desktop breakpoint instead of the accessory rail’s available space. Long names could therefore collapse into a partial icon-only pill beside the centered toolbar. The Cancel label also inherited an unreadable dark color in dark mode.

## What changed
- measure the real selection rail left slot and intrinsic typing-pill width
- keep the typing pill hidden until measured, then render it only when the complete pill fits
- recompute on container, sidebar, and typing-name size changes without moving the centered toolbar
- apply the semantic foreground token locally to the Cancel label and X icon
- expand unit and Playwright coverage for short, long, and multiple typers; 320/390/639/640/1280 widths; resize transitions; and light/dark computed colors
- align existing mobile geometry coverage with the measured full-pill/hidden contract and anchor rail capture at the true message-list bottom

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm typegrep:ws`
- `pnpm typegrep:agent-driver`
- `pnpm knip`
- exact-head independent real-stack QA: channel, DM, and thread PASS with bidirectional viewport/sidebar resize, exact WebSocket correlation, zero selection-mode message mutations, and light/dark screenshots
- hosted CI and all five UI E2E shards PASS
- Codecov patch PASS: all modified and coverable lines covered

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...
