### PR TITLE
fix(web): avoid picker keyboard focus flash

### DIFF
--- a/src/web/src/components/community/messages/use-composer-controller.test.ts
+++ b/src/web/src/components/community/messages/use-composer-controller.test.ts
@@ -1025,11 +1025,8 @@ describe("useComposerController", () => {
 
     focus.mockClear()
     view.onUploadFile()
-    expect(filePickerClick).toHaveBeenCalled()
-    expect(focus).toHaveBeenCalledWith()
-    expect(filePickerClick.mock.invocationCallOrder.at(-1)).toBeLessThan(
-      focus.mock.invocationCallOrder.at(-1),
-    )
+    expect(filePickerClick).toHaveBeenCalledOnce()
+    expect(focus).not.toHaveBeenCalled()
 
     view.onEmojiPick("🌱")
     expect(editor.chain).toHaveBeenCalled()

--- a/src/web/src/components/community/messages/use-composer-controller.ts
+++ b/src/web/src/components/community/messages/use-composer-controller.ts
@@ -389,7 +389,6 @@ export function useComposerController(
     onSend: send,
     onUploadFile: () => {
       fileInputRef.current?.click()
-      editor?.commands.focus()
     },
     onEmojiPick: (emoji) => {
       editor?.chain().focus().insertContent(emoji).run()

--- a/src/web/src/test/e2e-ui/24-composer-overflow.spec.ts
+++ b/src/web/src/test/e2e-ui/24-composer-overflow.spec.ts
@@ -232,6 +232,13 @@ test.describe.serial("community composer text containment", () => {
 
   test("default channel placeholder stays in the editable width and leaves controls clickable", async ({ asUser }) => {
     const { page } = await asUser("alice")
+    let messagePosts = 0
+    page.on("request", (request) => {
+      if (
+        request.method() === "POST"
+        && new URL(request.url()).pathname === `/api/community/channels/${longChannelId}/messages`
+      ) messagePosts += 1
+    })
     await page.goto(`/c/channels/${serverId}/${longChannelId}`)
     await page.waitForURL(new RegExp(longChannelId), { timeout: 20_000, waitUntil: "commit" })
     await ignoreNextDevToolsPointerCapture(page)
@@ -241,12 +248,26 @@ test.describe.serial("community composer text containment", () => {
     await page.setViewportSize({ width: 375, height: 800 })
     const attach = page.getByTestId(tid.composerAttach)
     const editable = composerEditable(page)
+    await editable.evaluate((element) => {
+      const editor = element as HTMLElement
+      editor.blur()
+      editor.dataset.e2eFocusEvents = "0"
+      editor.addEventListener("focus", () => {
+        editor.dataset.e2eFocusEvents = String(
+          Number(editor.dataset.e2eFocusEvents ?? "0") + 1,
+        )
+      })
+    })
+    await expect(editable).not.toBeFocused()
     const beforeCancel = await editable.textContent()
     const cancelledChooser = page.waitForEvent("filechooser")
     await attach.click()
     expect((await cancelledChooser).isMultiple()).toBe(true)
     await expect(page.getByRole("menuitem", { name: "Upload a File" })).toHaveCount(0)
+    await expect(editable).not.toBeFocused()
+    await expect(editable).toHaveAttribute("data-e2e-focus-events", "0")
     expect(await editable.textContent()).toBe(beforeCancel)
+    expect(messagePosts).toBe(0)
 
     const selectedChooser = page.waitForEvent("filechooser")
     await attach.click()
@@ -256,8 +277,16 @@ test.describe.serial("community composer text containment", () => {
       buffer: Buffer.from("direct native picker"),
     })
     await expect(page.getByText("direct-picker.txt", { exact: true })).toBeVisible()
+    await expect(editable).not.toBeFocused()
+    await expect(editable).toHaveAttribute("data-e2e-focus-events", "0")
+    expect(messagePosts).toBe(0)
     await page.getByRole("button", { name: "Remove file" }).click()
     await expect(page.getByText("direct-picker.txt", { exact: true })).toHaveCount(0)
+
+    await editable.click()
+    await expect(editable).toBeFocused()
+    await expect(editable).toHaveAttribute("data-e2e-focus-events", "1")
+    expect(messagePosts).toBe(0)
 
     const emoji = page.getByRole("button", { name: "Emoji picker" })
     await emoji.click()


### PR DESCRIPTION
## Summary

- stop the attachment picker action from synchronously refocusing the TipTap editor
- preserve direct native file-input activation and all attachment/upload/send behavior
- cover cancel, selection, zero intermediate focus, zero message writes, and explicit user refocus

## Root cause

`onUploadFile` called the hidden file input and then immediately focused the editor. On iOS, the native picker is presented after the click handler yields, so the intermediate contenteditable focus could open the software keyboard before the picker closed it again.

## Verification

- focused controller unit: 19/19
- edited mobile Playwright journey: 1/1; independent full E2E24: 6/6
- independent QA: focus events 0 across cancel/select, then exactly 1 after explicit editor tap; message POST 0, message.create WS 0, D1 delta 0
- full repository `pnpm test`
- full repository `pnpm typecheck`
- commit hook: typecheck, lint, test, typegreps, Knip all PASS

Alook task: `/Alook#5620/gus-issues/#63`
