### PR TITLE
fix(web): reuse overflow rail in reaction details

### DIFF
--- a/src/web/src/components/community/channels/forum-view.tsx
+++ b/src/web/src/components/community/channels/forum-view.tsx
@@ -25,6 +25,11 @@ import { cn } from "@/lib/utils"
 import { FORUM_ARCHIVE_TAG } from "@alook/shared"
 import { useProfilesByUserId } from "@/stores/community/ws"
 import { readCommunityProfile } from "@/lib/community/profile-read"
+import {
+  HorizontalOverflowFadeOverlays,
+  horizontalOverflowFades,
+  useHorizontalOverflowRail,
+} from "../horizontal-overflow-rail"
 
 const MAX_AVATARS = 5
 const MAX_VISIBLE_TAGS = 2
@@ -37,22 +42,7 @@ export function shouldActivateForumRow(event: {
   return event.target === event.currentTarget && (event.key === "Enter" || event.key === " ")
 }
 
-export function forumTagScrollFades({
-  scrollLeft,
-  scrollWidth,
-  clientWidth,
-}: {
-  scrollLeft: number
-  scrollWidth: number
-  clientWidth: number
-}) {
-  const maxScrollLeft = Math.max(0, scrollWidth - clientWidth)
-  if (maxScrollLeft <= 1) return { left: false, right: false }
-  return {
-    left: scrollLeft > 1,
-    right: scrollLeft < maxScrollLeft - 1,
-  }
-}
+export const forumTagScrollFades = horizontalOverflowFades
 
 function ForumTagSummary({ tags }: { tags: string[] }) {
   const shown = tags.slice(0, MAX_VISIBLE_TAGS)
@@ -226,10 +216,7 @@ export function ForumView({
   const profilesByUserId = useProfilesByUserId()
   const [composing, setComposing] = useState(false)
   const [deletingFor, setDeletingFor] = useState<ForumThread | null>(null)
-  const [tagFades, setTagFades] = useState({ left: false, right: false })
   const newPostTriggerRef = useRef<HTMLButtonElement>(null)
-  const activeFilterRef = useRef<HTMLButtonElement>(null)
-  const tagScrollerRef = useRef<HTMLDivElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const bindScrollRoot = useCallback((node: HTMLDivElement | null) => {
     scrollRef.current = node
@@ -255,39 +242,21 @@ export function ForumView({
     ...(hasArchivedPosts ? [FORUM_ARCHIVE_TAG] : []),
   ]
   const filterTagKey = filterTags.join("\0")
-  const syncTagFades = useCallback(() => {
-    const scroller = tagScrollerRef.current
-    if (!scroller) return
-    const next = forumTagScrollFades(scroller)
-    setTagFades((current) => current.left === next.left && current.right === next.right ? current : next)
-  }, [])
+  const {
+    fades: tagFades,
+    onKeyDown: onTagRailKeyDown,
+    onScroll: onTagRailScroll,
+    scrollerRef: tagScrollerRef,
+    selectedRef: activeFilterRef,
+  } = useHorizontalOverflowRail<HTMLDivElement, HTMLButtonElement>({
+    contentKey: filterTagKey,
+    selectedKey: tag,
+  })
   useLayoutEffect(() => {
     if (posts.length === 0 || alignedTagRef.current === tag) return
     alignedTagRef.current = tag
     virtualizer.scrollToIndex(0, { align: "start" })
   }, [posts.length, tag, virtualizer])
-  useLayoutEffect(() => {
-    const scroller = tagScrollerRef.current
-    const active = activeFilterRef.current
-    if (!scroller || !active) return
-    const scrollerRect = scroller.getBoundingClientRect()
-    const activeRect = active.getBoundingClientRect()
-    if (activeRect.left < scrollerRect.left) {
-      scroller.scrollLeft -= scrollerRect.left - activeRect.left
-    } else if (activeRect.right > scrollerRect.right) {
-      scroller.scrollLeft += activeRect.right - scrollerRect.right
-    }
-    syncTagFades()
-  }, [filterTagKey, syncTagFades, tag])
-  useLayoutEffect(() => {
-    const scroller = tagScrollerRef.current
-    if (!scroller) return
-    syncTagFades()
-    if (typeof ResizeObserver === "undefined") return
-    const observer = new ResizeObserver(syncTagFades)
-    observer.observe(scroller)
-    return () => observer.disconnect()
-  }, [filterTagKey, syncTagFades])
   const olderSentinelRef = useVirtualCursorSentinel({
     scrollRef,
     hasMore,
@@ -332,20 +301,8 @@ export function ForumView({
               role="region"
               aria-label="Forum tag filters"
               tabIndex={0}
-              onScroll={syncTagFades}
-              onKeyDown={(event) => {
-                if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
-                  event.preventDefault()
-                  event.currentTarget.scrollLeft += event.key === "ArrowLeft" ? -48 : 48
-                  syncTagFades()
-                } else if (event.key === "Home" || event.key === "End") {
-                  event.preventDefault()
-                  event.currentTarget.scrollLeft = event.key === "Home"
-                    ? 0
-                    : event.currentTarget.scrollWidth - event.currentTarget.clientWidth
-                  syncTagFades()
-                }
-              }}
+              onScroll={onTagRailScroll}
+              onKeyDown={onTagRailKeyDown}
               className="flex w-full min-w-0 flex-nowrap items-center gap-2 overflow-x-auto overscroll-x-contain thin-scrollbar scrollbar-none"
             >
               {filterTags.length > 0 && (
@@ -382,20 +339,11 @@ export function ForumView({
                 </>
               )}
             </div>
-            {tagFades.left && (
-              <span
-                aria-hidden
-                data-testid={tid.forumTagFadeLeft}
-                className="pointer-events-none absolute inset-y-0 left-0 z-10 w-3.5 bg-linear-to-r from-background to-transparent"
-              />
-            )}
-            {tagFades.right && (
-              <span
-                aria-hidden
-                data-testid={tid.forumTagFadeRight}
-                className="pointer-events-none absolute inset-y-0 right-0 z-10 w-3.5 bg-linear-to-l from-background to-transparent"
-              />
-            )}
+            <HorizontalOverflowFadeOverlays
+              fades={tagFades}
+              leftTestId={tid.forumTagFadeLeft}
+              rightTestId={tid.forumTagFadeRight}
+            />
           </div>
           <div className="flex shrink-0 items-center gap-1">
             <Button data-testid={tid.forumNewPost} size="sm" ref={newPostTriggerRef} onClick={() => setComposing(true)}><Plus className="size-4" /> New Post</Button>

--- a/src/web/src/components/community/horizontal-overflow-rail.test.ts
+++ b/src/web/src/components/community/horizontal-overflow-rail.test.ts
@@ -2,6 +2,7 @@ import { act, create, type ReactTestRenderer } from "react-test-renderer"
 import { createElement } from "react"
 import { describe, expect, it, vi } from "vitest"
 import {
+  HorizontalOverflowFadeOverlays,
   horizontalOverflowFades,
   useHorizontalOverflowRail,
 } from "./horizontal-overflow-rail"
@@ -16,6 +17,25 @@ describe("horizontalOverflowFades", () => {
       .toEqual({ left: true, right: true })
     expect(horizontalOverflowFades({ scrollLeft: 140, scrollWidth: 240, clientWidth: 100 }))
       .toEqual({ left: true, right: false })
+  })
+})
+
+describe("HorizontalOverflowFadeOverlays", () => {
+  it("matches the caller's surface token", () => {
+    let renderer: ReactTestRenderer
+    act(() => {
+      renderer = create(createElement(HorizontalOverflowFadeOverlays, {
+        fades: { left: true, right: true },
+        leftTestId: "left-fade",
+        rightTestId: "right-fade",
+        surface: "popover",
+      }))
+    })
+
+    expect(renderer!.root.findByProps({ "data-testid": "left-fade" }).props.className)
+      .toContain("from-popover")
+    expect(renderer!.root.findByProps({ "data-testid": "right-fade" }).props.className)
+      .toContain("from-popover")
   })
 })
 

--- a/src/web/src/components/community/horizontal-overflow-rail.test.ts
+++ b/src/web/src/components/community/horizontal-overflow-rail.test.ts
@@ -1,0 +1,70 @@
+import { act, create, type ReactTestRenderer } from "react-test-renderer"
+import { createElement } from "react"
+import { describe, expect, it, vi } from "vitest"
+import {
+  horizontalOverflowFades,
+  useHorizontalOverflowRail,
+} from "./horizontal-overflow-rail"
+
+describe("horizontalOverflowFades", () => {
+  it("only enables fades for directions that still scroll", () => {
+    expect(horizontalOverflowFades({ scrollLeft: 0, scrollWidth: 100, clientWidth: 100 }))
+      .toEqual({ left: false, right: false })
+    expect(horizontalOverflowFades({ scrollLeft: 0, scrollWidth: 240, clientWidth: 100 }))
+      .toEqual({ left: false, right: true })
+    expect(horizontalOverflowFades({ scrollLeft: 60, scrollWidth: 240, clientWidth: 100 }))
+      .toEqual({ left: true, right: true })
+    expect(horizontalOverflowFades({ scrollLeft: 140, scrollWidth: 240, clientWidth: 100 }))
+      .toEqual({ left: true, right: false })
+  })
+})
+
+describe("useHorizontalOverflowRail", () => {
+  const scroller = {
+    scrollLeft: 0,
+    scrollWidth: 240,
+    clientWidth: 100,
+    getBoundingClientRect: () => ({ left: 0, right: 100 }),
+  }
+  const selected = {
+    getBoundingClientRect: () => ({ left: 120, right: 164 }),
+  }
+
+  function Fixture() {
+    const rail = useHorizontalOverflowRail<HTMLDivElement, HTMLButtonElement>({
+      contentKey: "one\0two\0three",
+      selectedKey: "three",
+    })
+    return createElement("div", {
+      ref: rail.scrollerRef,
+      "data-testid": "rail",
+      "data-fade-left": rail.fades.left,
+      "data-fade-right": rail.fades.right,
+      onKeyDown: rail.onKeyDown,
+      onScroll: rail.onScroll,
+    }, createElement("button", { ref: rail.selectedRef }, "three"))
+  }
+
+  it("reveals the selected item and supports Arrow/Home/End scrolling", () => {
+    scroller.scrollLeft = 0
+    let renderer: ReactTestRenderer
+    act(() => {
+      renderer = create(createElement(Fixture), {
+        createNodeMock: (element) => element.props["data-testid"] === "rail" ? scroller : selected,
+      })
+    })
+    expect(scroller.scrollLeft).toBe(64)
+    const rail = renderer!.root.findByProps({ "data-testid": "rail" })
+    expect(rail.props["data-fade-left"]).toBe(true)
+    expect(rail.props["data-fade-right"]).toBe(true)
+
+    const preventDefault = vi.fn()
+    act(() => rail.props.onKeyDown({ key: "Home", currentTarget: scroller, preventDefault }))
+    expect(scroller.scrollLeft).toBe(0)
+    act(() => rail.props.onKeyDown({ key: "ArrowRight", currentTarget: scroller, preventDefault }))
+    expect(scroller.scrollLeft).toBe(48)
+    act(() => rail.props.onKeyDown({ key: "End", currentTarget: scroller, preventDefault }))
+    expect(scroller.scrollLeft).toBe(140)
+    expect(preventDefault).toHaveBeenCalledTimes(3)
+  })
+})

--- a/src/web/src/components/community/horizontal-overflow-rail.tsx
+++ b/src/web/src/components/community/horizontal-overflow-rail.tsx
@@ -1,0 +1,119 @@
+"use client"
+
+import { useCallback, useLayoutEffect, useRef, useState } from "react"
+import type React from "react"
+
+export type HorizontalOverflowFades = { left: boolean; right: boolean }
+
+export function horizontalOverflowFades({
+  scrollLeft,
+  scrollWidth,
+  clientWidth,
+}: {
+  scrollLeft: number
+  scrollWidth: number
+  clientWidth: number
+}): HorizontalOverflowFades {
+  const maxScrollLeft = Math.max(0, scrollWidth - clientWidth)
+  if (maxScrollLeft <= 1) return { left: false, right: false }
+  return {
+    left: scrollLeft > 1,
+    right: scrollLeft < maxScrollLeft - 1,
+  }
+}
+
+export function useHorizontalOverflowRail<
+  TScroller extends HTMLElement,
+  TSelected extends HTMLElement,
+>({
+  contentKey,
+  selectedKey,
+  scrollStep = 48,
+  preserveChildKeyboard = false,
+}: {
+  contentKey: string
+  selectedKey: string | null
+  scrollStep?: number
+  preserveChildKeyboard?: boolean
+}) {
+  const scrollerRef = useRef<TScroller>(null)
+  const selectedRef = useRef<TSelected>(null)
+  const [fades, setFades] = useState<HorizontalOverflowFades>({ left: false, right: false })
+
+  const syncFades = useCallback(() => {
+    const scroller = scrollerRef.current
+    if (!scroller) return
+    const next = horizontalOverflowFades(scroller)
+    setFades((current) => current.left === next.left && current.right === next.right ? current : next)
+  }, [])
+
+  useLayoutEffect(() => {
+    const scroller = scrollerRef.current
+    const selected = selectedRef.current
+    if (!scroller || !selected) return
+    const scrollerRect = scroller.getBoundingClientRect()
+    const selectedRect = selected.getBoundingClientRect()
+    if (selectedRect.left < scrollerRect.left) {
+      scroller.scrollLeft -= scrollerRect.left - selectedRect.left
+    } else if (selectedRect.right > scrollerRect.right) {
+      scroller.scrollLeft += selectedRect.right - scrollerRect.right
+    }
+    syncFades()
+  }, [contentKey, selectedKey, syncFades])
+
+  useLayoutEffect(() => {
+    const scroller = scrollerRef.current
+    if (!scroller) return
+    syncFades()
+    if (typeof ResizeObserver === "undefined") return
+    const observer = new ResizeObserver(syncFades)
+    observer.observe(scroller)
+    return () => observer.disconnect()
+  }, [contentKey, syncFades])
+
+  const onKeyDown = useCallback((event: React.KeyboardEvent<TScroller>) => {
+    const childOwnsKeyboard = preserveChildKeyboard && event.target !== event.currentTarget
+    if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
+      if (!childOwnsKeyboard) event.preventDefault()
+      event.currentTarget.scrollLeft += event.key === "ArrowLeft" ? -scrollStep : scrollStep
+      syncFades()
+    } else if (event.key === "Home" || event.key === "End") {
+      if (!childOwnsKeyboard) event.preventDefault()
+      event.currentTarget.scrollLeft = event.key === "Home"
+        ? 0
+        : event.currentTarget.scrollWidth - event.currentTarget.clientWidth
+      syncFades()
+    }
+  }, [preserveChildKeyboard, scrollStep, syncFades])
+
+  return { fades, onKeyDown, onScroll: syncFades, scrollerRef, selectedRef }
+}
+
+export function HorizontalOverflowFadeOverlays({
+  fades,
+  leftTestId,
+  rightTestId,
+}: {
+  fades: HorizontalOverflowFades
+  leftTestId?: string
+  rightTestId?: string
+}) {
+  return (
+    <>
+      {fades.left && (
+        <span
+          aria-hidden
+          data-testid={leftTestId}
+          className="pointer-events-none absolute inset-y-0 left-0 z-10 w-3.5 bg-linear-to-r from-background to-transparent"
+        />
+      )}
+      {fades.right && (
+        <span
+          aria-hidden
+          data-testid={rightTestId}
+          className="pointer-events-none absolute inset-y-0 right-0 z-10 w-3.5 bg-linear-to-l from-background to-transparent"
+        />
+      )}
+    </>
+  )
+}

--- a/src/web/src/components/community/horizontal-overflow-rail.tsx
+++ b/src/web/src/components/community/horizontal-overflow-rail.tsx
@@ -93,25 +93,28 @@ export function HorizontalOverflowFadeOverlays({
   fades,
   leftTestId,
   rightTestId,
+  surface = "background",
 }: {
   fades: HorizontalOverflowFades
   leftTestId?: string
   rightTestId?: string
+  surface?: "background" | "popover"
 }) {
+  const fromSurface = surface === "popover" ? "from-popover" : "from-background"
   return (
     <>
       {fades.left && (
         <span
           aria-hidden
           data-testid={leftTestId}
-          className="pointer-events-none absolute inset-y-0 left-0 z-10 w-3.5 bg-linear-to-r from-background to-transparent"
+          className={`pointer-events-none absolute inset-y-0 left-0 z-10 w-3.5 bg-linear-to-r to-transparent ${fromSurface}`}
         />
       )}
       {fades.right && (
         <span
           aria-hidden
           data-testid={rightTestId}
-          className="pointer-events-none absolute inset-y-0 right-0 z-10 w-3.5 bg-linear-to-l from-background to-transparent"
+          className={`pointer-events-none absolute inset-y-0 right-0 z-10 w-3.5 bg-linear-to-l to-transparent ${fromSurface}`}
         />
       )}
     </>

--- a/src/web/src/components/community/members/member-identity-row.tsx
+++ b/src/web/src/components/community/members/member-identity-row.tsx
@@ -1,0 +1,51 @@
+import type React from "react"
+import { Avatar } from "../avatar"
+import type { Presence } from "@/lib/community/models/people"
+import { cn } from "@/lib/utils"
+
+export function MemberIdentityRow({
+  name,
+  discriminator,
+  avatarLabel,
+  avatarSeed,
+  avatarSrc,
+  presence,
+  dim = false,
+  ringColor,
+  secondary,
+  className,
+}: {
+  name: string
+  discriminator?: string | null
+  avatarLabel: string
+  avatarSeed?: string
+  avatarSrc?: string | null
+  presence?: Presence
+  dim?: boolean
+  ringColor?: string
+  secondary?: React.ReactNode
+  className?: string
+}) {
+  return (
+    <div className={cn("flex min-w-0 flex-1 items-center gap-3", className)}>
+      <Avatar
+        label={avatarLabel}
+        seed={avatarSeed}
+        src={avatarSrc}
+        size={32}
+        presence={presence}
+        dim={dim}
+        ringColor={ringColor}
+      />
+      <div className="min-w-0 flex-1 space-y-0.5 text-left">
+        <div className={cn("truncate text-sm leading-tight", dim && "text-muted-foreground")}>
+          {name}
+          {discriminator && (
+            <span className="ml-1 text-xs font-normal tracking-wide text-muted-foreground">#{discriminator}</span>
+          )}
+        </div>
+        {secondary && <div className="truncate text-xs leading-tight text-muted-foreground">{secondary}</div>}
+      </div>
+    </div>
+  )
+}

--- a/src/web/src/components/community/members/member-list.tsx
+++ b/src/web/src/components/community/members/member-list.tsx
@@ -9,7 +9,6 @@ import {
 } from "@/components/ui/context-menu"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Input } from "@/components/ui/input"
-import { Avatar } from "../avatar"
 import { ConfirmDialog } from "@/components/ui/confirm-dialog"
 import { toastApiError } from "@/lib/api/client"
 import { COMMUNITY_VIRTUALIZER_REACT_OPTIONS } from "@/hooks/community/virtualizer-react-options"
@@ -26,6 +25,7 @@ import {
   ROLES,
   type CommunityRole as Role,
 } from "@alook/shared"
+import { MemberIdentityRow } from "./member-identity-row"
 
 // The Leave/Remove confirm flow the row menu opens (private channel/post/thread).
 type ManageConfirm = { kind: "leave" | "remove"; member: Member }
@@ -366,18 +366,15 @@ function MemberRow({
       onClick={(e) => onOpenProfile?.(mem.name, e, undefined, mem.userId)}
       className="flex w-full items-center gap-3 rounded-md px-2 py-2 select-none hover:bg-accent"
     >
-      <Avatar label={mem.avatar} seed={mem.userId} size={32} presence={mem.status} dim={isPresenceOffline(mem.status)} />
-      <div className="min-w-0 flex-1 space-y-0.5 text-left">
-        <div className={`truncate text-sm leading-tight ${isPresenceOffline(mem.status) ? "text-muted-foreground" : ""}`}>
-          {mem.name}
-          {showDiscriminator && mem.discriminator && (
-            <span className="ml-1 text-xs font-normal tracking-wide text-muted-foreground">#{mem.discriminator}</span>
-          )}
-        </div>
-        {hasStatus(mem.statusEmoji, mem.statusText) && (
-          <div className="truncate text-xs leading-tight text-muted-foreground">{mem.statusEmoji} {mem.statusText}</div>
-        )}
-      </div>
+      <MemberIdentityRow
+        name={mem.name}
+        discriminator={showDiscriminator ? mem.discriminator : undefined}
+        avatarLabel={mem.avatar}
+        avatarSeed={mem.userId}
+        presence={mem.status}
+        dim={isPresenceOffline(mem.status)}
+        secondary={hasStatus(mem.statusEmoji, mem.statusText) ? `${mem.statusEmoji} ${mem.statusText}` : undefined}
+      />
     </button>
   )
 

--- a/src/web/src/components/community/messages/message-reactions.test.ts
+++ b/src/web/src/components/community/messages/message-reactions.test.ts
@@ -24,8 +24,8 @@ vi.mock("@/components/ui/dialog", () => ({
   DialogContent: ({ children, ...props }: React.ComponentProps<"div">) =>
     React.createElement("mock-dialog-content", props, children),
   DialogHeader: ({ children }: { children: React.ReactNode }) => React.createElement("div", null, children),
-  DialogTitle: ({ children }: { children: React.ReactNode }) => React.createElement("div", null, children),
-  DialogDescription: ({ children }: { children: React.ReactNode }) => React.createElement("div", null, children),
+  DialogTitle: ({ children, ...props }: { children: React.ReactNode }) => React.createElement("mock-dialog-title", props, children),
+  DialogDescription: ({ children, ...props }: { children: React.ReactNode }) => React.createElement("mock-dialog-description", props, children),
 }))
 vi.mock("@/components/ui/tabs", () => ({
   Tabs: ({ children, value }: { children: React.ReactNode; value: string }) =>
@@ -70,6 +70,8 @@ function renderReactions(
     renderer = TestRenderer.create(
       React.createElement(MessageReactions, {
         messageId: "message_1",
+        authorName: "Alice",
+        messagePreview: "A deliberately long message preview",
         reactions: reactionItems,
         hoverCapable: false,
         tooltipActive: false,
@@ -175,6 +177,20 @@ describe("MessageReactions", () => {
     expect(rail.props.className).toContain("bg-transparent!")
   })
 
+  it("uses the message author and one-line message preview as its header", () => {
+    vi.useFakeTimers()
+    const { renderer } = renderReactions()
+    const chip = renderer.root.findByProps({ "data-testid": tid.reactionChip("message_1", "👍") })
+    act(() => chip.props.onPointerDown({ pointerType: "touch", clientX: 10, clientY: 10, stopPropagation: vi.fn() }))
+    act(() => vi.advanceTimersByTime(450))
+    const title = renderer.root.findByType("mock-dialog-title")
+    const description = renderer.root.findByType("mock-dialog-description")
+    expect(title.children).toEqual(["Alice"])
+    expect(title.props.className).toContain("truncate")
+    expect(description.children).toEqual(["A deliberately long message preview"])
+    expect(description.props.className).toContain("truncate")
+  })
+
   it("uses the shared 32px identity row for authorized reactors", () => {
     vi.useFakeTimers()
     const { renderer } = renderReactions()
@@ -225,6 +241,8 @@ describe("MessageReactions", () => {
     act(() => vi.advanceTimersByTime(450))
     act(() => renderer.update(React.createElement(MessageReactions, {
       messageId: "message_1",
+      authorName: "Alice",
+      messagePreview: "A deliberately long message preview",
       reactions: [],
       hoverCapable: false,
       tooltipActive: false,

--- a/src/web/src/components/community/messages/message-reactions.test.ts
+++ b/src/web/src/components/community/messages/message-reactions.test.ts
@@ -152,6 +152,16 @@ describe("MessageReactions", () => {
       .toContain("flex-auto")
   })
 
+  it("switches the dialog surface with its overflow fades without a color transition", () => {
+    vi.useFakeTimers()
+    const { renderer } = renderReactions()
+    const chip = renderer.root.findByProps({ "data-testid": tid.reactionChip("message_1", "👍") })
+    act(() => chip.props.onPointerDown({ pointerType: "touch", clientX: 10, clientY: 10, stopPropagation: vi.fn() }))
+    act(() => vi.advanceTimersByTime(450))
+    expect(renderer.root.findByType("mock-dialog-content").props.className)
+      .toContain("transition-none")
+  })
+
   it("renders a transparent single-line horizontal tab rail with an accessible label", () => {
     vi.useFakeTimers()
     const { renderer } = renderReactions()

--- a/src/web/src/components/community/messages/message-reactions.test.ts
+++ b/src/web/src/components/community/messages/message-reactions.test.ts
@@ -30,7 +30,8 @@ vi.mock("@/components/ui/dialog", () => ({
 vi.mock("@/components/ui/tabs", () => ({
   Tabs: ({ children, value }: { children: React.ReactNode; value: string }) =>
     React.createElement("mock-tabs", { value }, children),
-  TabsList: ({ children }: { children: React.ReactNode }) => React.createElement("div", null, children),
+  TabsList: ({ children, variant: _variant, ...props }: { children: React.ReactNode; variant?: string }) =>
+    React.createElement("div", props, children),
   TabsTrigger: ({ children, ...props }: React.ComponentProps<"button">) =>
     React.createElement("button", props, children),
 }))
@@ -43,26 +44,41 @@ vi.mock("@/components/ui/tooltip", () => ({
 import { MessageReactions, reconcileReactionSelection } from "./message-reactions"
 import { tid } from "@/lib/community/testids"
 
-const buttonNode = { focus: vi.fn(), isConnected: true }
+const buttonNode = {
+  focus: vi.fn(),
+  isConnected: true,
+  getBoundingClientRect: () => ({ left: 0, right: 52 }),
+}
 const reactionGroupNode = { focus: vi.fn() }
+const reactionScrollerNode = {
+  scrollLeft: 0,
+  scrollWidth: 180,
+  clientWidth: 120,
+  getBoundingClientRect: () => ({ left: 0, right: 120 }),
+}
 const reactions = [
   { emoji: "👍", count: 1, me: false, userIds: ["user_1"] },
   { emoji: "🔥", count: 1, me: true, userIds: ["user_2"] },
 ]
 
-function renderReactions(onToggleReaction = vi.fn()) {
+function renderReactions(
+  onToggleReaction = vi.fn(),
+  reactionItems = reactions,
+) {
   let renderer: TestRenderer.ReactTestRenderer
   act(() => {
     renderer = TestRenderer.create(
       React.createElement(MessageReactions, {
         messageId: "message_1",
-        reactions,
+        reactions: reactionItems,
         hoverCapable: false,
         tooltipActive: false,
         onToggleReaction,
       }),
       {
-        createNodeMock: (node) => node.type === "button"
+        createNodeMock: (node) => node.props?.["data-testid"] === tid.reactionScroller("message_1")
+          ? reactionScrollerNode
+          : node.type === "button"
           ? buttonNode
           : node.props?.["data-testid"] === tid.reactionGroup("message_1")
             ? reactionGroupNode
@@ -122,6 +138,48 @@ describe("MessageReactions", () => {
     act(() => vi.advanceTimersByTime(450))
     expect(renderer.root.findByType("mock-dialog-content").props.className)
       .toContain("**:data-[slot=dialog-close]:size-11")
+  })
+
+  it("renders a transparent single-line horizontal tab rail with an accessible label", () => {
+    vi.useFakeTimers()
+    const { renderer } = renderReactions()
+    const chip = renderer.root.findByProps({ "data-testid": tid.reactionChip("message_1", "👍") })
+    act(() => chip.props.onPointerDown({ pointerType: "touch", clientX: 10, clientY: 10, stopPropagation: vi.fn() }))
+    act(() => vi.advanceTimersByTime(450))
+    const rail = renderer.root.findByProps({ "data-testid": tid.reactionScroller("message_1") })
+    expect(rail.props["aria-label"]).toBe("Reaction types")
+    expect(rail.props.className).toContain("flex-nowrap")
+    expect(rail.props.className).toContain("overflow-x-auto")
+    expect(rail.props.className).toContain("bg-transparent!")
+  })
+
+  it("uses the shared 32px identity row for authorized reactors", () => {
+    vi.useFakeTimers()
+    const { renderer } = renderReactions()
+    const chip = renderer.root.findByProps({ "data-testid": tid.reactionChip("message_1", "👍") })
+    act(() => chip.props.onPointerDown({ pointerType: "touch", clientX: 10, clientY: 10, stopPropagation: vi.fn() }))
+    act(() => vi.advanceTimersByTime(450))
+    const member = renderer.root.findByProps({ "data-testid": tid.reactionMember("user_1") })
+    const text = member.findAll((node) => node.children.some((child) => typeof child === "string"))
+      .flatMap((node) => node.children.filter((child): child is string => typeof child === "string"))
+      .join("")
+    expect(text).toContain("Alice")
+    expect(text).toContain("#0001")
+  })
+
+  it("keeps an unauthorized actor on the Unknown member fallback", () => {
+    vi.useFakeTimers()
+    const unknownReactions = [{ emoji: "👀", count: 1, me: false, userIds: ["user_3"] }]
+    const { renderer } = renderReactions(vi.fn(), unknownReactions)
+    const chip = renderer.root.findByProps({ "data-testid": tid.reactionChip("message_1", "👀") })
+    act(() => chip.props.onPointerDown({ pointerType: "touch", clientX: 10, clientY: 10, stopPropagation: vi.fn() }))
+    act(() => vi.advanceTimersByTime(450))
+    const member = renderer.root.findByProps({ "data-testid": tid.reactionMember("user_3") })
+    const text = member.findAll((node) => node.children.some((child) => typeof child === "string"))
+      .flatMap((node) => node.children.filter((child): child is string => typeof child === "string"))
+      .join("")
+    expect(text).toContain("Unknown member")
+    expect(text).not.toContain("#000")
   })
 
   it("restores focus after the dialog close focus handoff", () => {

--- a/src/web/src/components/community/messages/message-reactions.test.ts
+++ b/src/web/src/components/community/messages/message-reactions.test.ts
@@ -140,6 +140,18 @@ describe("MessageReactions", () => {
       .toContain("**:data-[slot=dialog-close]:size-11")
   })
 
+  it("constrains long reactor lists to the dialog scroll region", () => {
+    vi.useFakeTimers()
+    const { renderer } = renderReactions()
+    const chip = renderer.root.findByProps({ "data-testid": tid.reactionChip("message_1", "👍") })
+    act(() => chip.props.onPointerDown({ pointerType: "touch", clientX: 10, clientY: 10, stopPropagation: vi.fn() }))
+    act(() => vi.advanceTimersByTime(450))
+    expect(renderer.root.findByType("mock-dialog-content").props.className)
+      .toContain("flex-col")
+    expect(renderer.root.findByProps({ role: "tabpanel" }).props.className)
+      .toContain("flex-auto")
+  })
+
   it("renders a transparent single-line horizontal tab rail with an accessible label", () => {
     vi.useFakeTimers()
     const { renderer } = renderReactions()

--- a/src/web/src/components/community/messages/message-reactions.test.ts
+++ b/src/web/src/components/community/messages/message-reactions.test.ts
@@ -162,6 +162,8 @@ describe("MessageReactions", () => {
     act(() => vi.advanceTimersByTime(450))
     expect(renderer.root.findByType("mock-dialog-content").props.className)
       .toContain("transition-none")
+    expect(renderer.root.findByType("mock-dialog-content").props.className)
+      .toContain("**:data-[slot=dialog-close]:transition-none")
   })
 
   it("renders a transparent single-line horizontal tab rail with an accessible label", () => {

--- a/src/web/src/components/community/messages/message-reactions.tsx
+++ b/src/web/src/components/community/messages/message-reactions.tsx
@@ -253,6 +253,7 @@ function ReactionDetailsDialog({
               fades={reactionFades}
               leftTestId={tid.reactionFadeLeft(messageId)}
               rightTestId={tid.reactionFadeRight(messageId)}
+              surface="popover"
             />
           </div>
         </Tabs>

--- a/src/web/src/components/community/messages/message-reactions.tsx
+++ b/src/web/src/components/community/messages/message-reactions.tsx
@@ -218,7 +218,7 @@ function ReactionDetailsDialog({
   return (
     <DialogContent
       data-testid={tid.reactionDialog(messageId)}
-      className="flex max-h-[calc(100dvh-2rem-env(safe-area-inset-top)-env(safe-area-inset-bottom))] flex-col gap-3 overflow-hidden transition-none sm:max-w-sm **:data-[slot=dialog-close]:size-11 sm:**:data-[slot=dialog-close]:size-7"
+      className="flex max-h-[calc(100dvh-2rem-env(safe-area-inset-top)-env(safe-area-inset-bottom))] flex-col gap-3 overflow-hidden transition-none sm:max-w-sm **:data-[slot=dialog-close]:size-11 **:data-[slot=dialog-close]:transition-none sm:**:data-[slot=dialog-close]:size-7"
     >
       <DialogHeader className="min-w-0 shrink-0">
         <DialogTitle className="truncate pr-8">{authorName}</DialogTitle>

--- a/src/web/src/components/community/messages/message-reactions.tsx
+++ b/src/web/src/components/community/messages/message-reactions.tsx
@@ -182,11 +182,15 @@ function ReactionChip({
 
 function ReactionDetailsDialog({
   messageId,
+  authorName,
+  messagePreview,
   reactions,
   selectedEmoji,
   onSelectedEmojiChange,
 }: {
   messageId: string
+  authorName: string
+  messagePreview: string
   reactions: readonly Reaction[]
   selectedEmoji: string | null
   onSelectedEmojiChange: (emoji: string) => void
@@ -216,9 +220,9 @@ function ReactionDetailsDialog({
       data-testid={tid.reactionDialog(messageId)}
       className="flex max-h-[calc(100dvh-2rem-env(safe-area-inset-top)-env(safe-area-inset-bottom))] flex-col gap-3 overflow-hidden transition-none sm:max-w-sm **:data-[slot=dialog-close]:size-11 sm:**:data-[slot=dialog-close]:size-7"
     >
-      <DialogHeader className="shrink-0">
-        <DialogTitle>Reactions</DialogTitle>
-        <DialogDescription>People who reacted to this message</DialogDescription>
+      <DialogHeader className="min-w-0 shrink-0">
+        <DialogTitle className="truncate pr-8">{authorName}</DialogTitle>
+        <DialogDescription className="truncate" title={messagePreview}>{messagePreview}</DialogDescription>
       </DialogHeader>
 
       {reactions.length > 0 && selectedEmoji && (
@@ -292,6 +296,8 @@ function ReactionDetailsDialog({
 
 export function MessageReactions({
   messageId,
+  authorName,
+  messagePreview,
   reactions,
   hoverCapable,
   tooltipActive,
@@ -300,6 +306,8 @@ export function MessageReactions({
   trailingControl,
 }: {
   messageId: string
+  authorName: string
+  messagePreview: string
   reactions: readonly Reaction[]
   hoverCapable: boolean
   tooltipActive: boolean
@@ -368,6 +376,8 @@ export function MessageReactions({
         {open && (
           <ReactionDetailsDialog
             messageId={messageId}
+            authorName={authorName}
+            messagePreview={messagePreview || "Message"}
             reactions={reactions}
             selectedEmoji={selectedEmoji}
             onSelectedEmojiChange={setSelectedEmoji}

--- a/src/web/src/components/community/messages/message-reactions.tsx
+++ b/src/web/src/components/community/messages/message-reactions.tsx
@@ -214,7 +214,7 @@ function ReactionDetailsDialog({
   return (
     <DialogContent
       data-testid={tid.reactionDialog(messageId)}
-      className="flex max-h-[calc(100dvh-2rem-env(safe-area-inset-top)-env(safe-area-inset-bottom))] flex-col gap-3 overflow-hidden sm:max-w-sm **:data-[slot=dialog-close]:size-11 sm:**:data-[slot=dialog-close]:size-7"
+      className="flex max-h-[calc(100dvh-2rem-env(safe-area-inset-top)-env(safe-area-inset-bottom))] flex-col gap-3 overflow-hidden transition-none sm:max-w-sm **:data-[slot=dialog-close]:size-11 sm:**:data-[slot=dialog-close]:size-7"
     >
       <DialogHeader className="shrink-0">
         <DialogTitle>Reactions</DialogTitle>

--- a/src/web/src/components/community/messages/message-reactions.tsx
+++ b/src/web/src/components/community/messages/message-reactions.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useRef, useState } from "react"
 import type React from "react"
-import { Avatar } from "../avatar"
 import { NumberTicker } from "@/components/ui/number-ticker"
 import {
   Dialog,
@@ -13,7 +12,6 @@ import {
 } from "@/components/ui/dialog"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
-import { avatarInitial } from "@/lib/community/avatar"
 import { displayName } from "@/lib/community/display-name"
 import type { Reaction } from "@/lib/community/models/message"
 import { tid } from "@/lib/community/testids"
@@ -22,6 +20,11 @@ import {
   useReactionDetails,
 } from "@/hooks/community/use-reaction-details"
 import { useCommunityProfile } from "@/stores/community/ws"
+import {
+  HorizontalOverflowFadeOverlays,
+  useHorizontalOverflowRail,
+} from "../horizontal-overflow-rail"
+import { MemberIdentityRow } from "../members/member-identity-row"
 
 const HOLD_MS = 450
 const MOVE_TOLERANCE_PX = 10
@@ -47,20 +50,16 @@ function ReactionMemberRow({
 }) {
   const liveProfile = useCommunityProfile(authorizedProfile ? userId : null)
   const name = authorizedProfile ? (liveProfile?.name ?? authorizedProfile.name) : "Unknown member"
-  const avatar = authorizedProfile
-    ? (liveProfile?.avatar ?? authorizedProfile.avatar ?? avatarInitial(name))
-    : avatarInitial(name)
   return (
     <li data-testid={tid.reactionMember(userId)} className="flex min-h-11 items-center gap-3 rounded-lg px-2 py-2">
-      <Avatar label={name} seed={authorizedProfile ? userId : undefined} src={authorizedProfile ? avatar : undefined} size={32} ringColor="var(--popover)" />
-      <div className="min-w-0">
-        <div className="truncate text-sm font-medium">{name}</div>
-        {authorizedProfile && (
-          <div className="truncate text-xs text-muted-foreground">
-            @{liveProfile?.name ?? authorizedProfile.name}#{liveProfile?.discriminator ?? authorizedProfile.discriminator}
-          </div>
-        )}
-      </div>
+      <MemberIdentityRow
+        name={name}
+        discriminator={authorizedProfile ? (liveProfile?.discriminator ?? authorizedProfile.discriminator) : undefined}
+        avatarLabel={name}
+        avatarSeed={authorizedProfile ? userId : undefined}
+        avatarSrc={authorizedProfile ? (liveProfile?.avatar ?? authorizedProfile.avatar) : undefined}
+        ringColor="var(--popover)"
+      />
     </li>
   )
 }
@@ -199,6 +198,18 @@ function ReactionDetailsDialog({
   const details = useReactionDetails({ messageId, open: true, userIds })
   const selectedReaction = reactions.find((reaction) => reaction.emoji === selectedEmoji)
   const actors = new Map(details.data?.actors.map((actor) => [actor.userId, actor]))
+  const reactionRailKey = reactions.map((reaction) => `${reaction.emoji}\0${reaction.count}`).join("\0")
+  const {
+    fades: reactionFades,
+    onKeyDown: onReactionRailKeyDown,
+    onScroll: onReactionRailScroll,
+    scrollerRef: reactionScrollerRef,
+    selectedRef: selectedReactionRef,
+  } = useHorizontalOverflowRail<HTMLDivElement, HTMLButtonElement>({
+    contentKey: reactionRailKey,
+    selectedKey: selectedEmoji,
+    preserveChildKeyboard: true,
+  })
 
   return (
     <DialogContent
@@ -212,22 +223,38 @@ function ReactionDetailsDialog({
 
       {reactions.length > 0 && selectedEmoji && (
         <Tabs value={selectedEmoji} onValueChange={onSelectedEmojiChange}>
-          <TabsList variant="default" className="h-11! min-h-11 thin-scrollbar">
-            {reactions.map((reaction) => (
-              <TabsTrigger
-                key={reaction.emoji}
-                value={reaction.emoji}
-                id={tid.reactionTab(reaction.emoji)}
-                data-testid={tid.reactionTab(reaction.emoji)}
-                aria-label={`${reaction.emoji}, ${reaction.count}`}
-                aria-controls={`${tid.reactionDialog(messageId)}-panel`}
-                className="h-11! min-h-11 min-w-11"
-              >
-                <span aria-hidden="true">{reaction.emoji}</span>
-                <span>{reaction.count}</span>
-              </TabsTrigger>
-            ))}
-          </TabsList>
+          <div className="relative min-w-0">
+            <TabsList
+              ref={reactionScrollerRef}
+              variant="line"
+              data-testid={tid.reactionScroller(messageId)}
+              aria-label="Reaction types"
+              onScroll={onReactionRailScroll}
+              onKeyDown={onReactionRailKeyDown}
+              className="h-11! min-h-11 w-full max-w-full flex-nowrap gap-1 overflow-x-auto overflow-y-hidden rounded-none bg-transparent! p-0! overscroll-x-contain thin-scrollbar scrollbar-none"
+            >
+              {reactions.map((reaction) => (
+                <TabsTrigger
+                  key={reaction.emoji}
+                  ref={selectedEmoji === reaction.emoji ? selectedReactionRef : undefined}
+                  value={reaction.emoji}
+                  id={tid.reactionTab(reaction.emoji)}
+                  data-testid={tid.reactionTab(reaction.emoji)}
+                  aria-label={`${reaction.emoji}, ${reaction.count}`}
+                  aria-controls={`${tid.reactionDialog(messageId)}-panel`}
+                  className="h-11! min-h-11 min-w-11"
+                >
+                  <span aria-hidden="true">{reaction.emoji}</span>
+                  <span>{reaction.count}</span>
+                </TabsTrigger>
+              ))}
+            </TabsList>
+            <HorizontalOverflowFadeOverlays
+              fades={reactionFades}
+              leftTestId={tid.reactionFadeLeft(messageId)}
+              rightTestId={tid.reactionFadeRight(messageId)}
+            />
+          </div>
         </Tabs>
       )}
 

--- a/src/web/src/components/community/messages/message-reactions.tsx
+++ b/src/web/src/components/community/messages/message-reactions.tsx
@@ -214,15 +214,15 @@ function ReactionDetailsDialog({
   return (
     <DialogContent
       data-testid={tid.reactionDialog(messageId)}
-      className="max-h-[calc(100dvh-2rem-env(safe-area-inset-top)-env(safe-area-inset-bottom))] gap-3 overflow-hidden sm:max-w-sm **:data-[slot=dialog-close]:size-11 sm:**:data-[slot=dialog-close]:size-7"
+      className="flex max-h-[calc(100dvh-2rem-env(safe-area-inset-top)-env(safe-area-inset-bottom))] flex-col gap-3 overflow-hidden sm:max-w-sm **:data-[slot=dialog-close]:size-11 sm:**:data-[slot=dialog-close]:size-7"
     >
-      <DialogHeader>
+      <DialogHeader className="shrink-0">
         <DialogTitle>Reactions</DialogTitle>
         <DialogDescription>People who reacted to this message</DialogDescription>
       </DialogHeader>
 
       {reactions.length > 0 && selectedEmoji && (
-        <Tabs value={selectedEmoji} onValueChange={onSelectedEmojiChange}>
+        <Tabs className="shrink-0" value={selectedEmoji} onValueChange={onSelectedEmojiChange}>
           <div className="relative min-w-0">
             <TabsList
               ref={reactionScrollerRef}
@@ -263,7 +263,7 @@ function ReactionDetailsDialog({
         id={`${tid.reactionDialog(messageId)}-panel`}
         role="tabpanel"
         aria-labelledby={selectedEmoji ? tid.reactionTab(selectedEmoji) : undefined}
-        className="min-h-28 overflow-y-auto thin-scrollbar"
+        className="min-h-28 flex-auto overflow-y-auto thin-scrollbar"
         aria-live="polite"
       >
         {details.isLoading ? (

--- a/src/web/src/components/community/messages/message.tsx
+++ b/src/web/src/components/community/messages/message.tsx
@@ -615,6 +615,8 @@ function MessageImpl({
             <div className="mt-2">
               <MessageReactions
                 messageId={m.id}
+                authorName={authorName}
+                messagePreview={visibleContent}
                 reactions={m.reactions}
                 hoverCapable={hoverCapable}
                 tooltipActive={activated}

--- a/src/web/src/components/community/messages/thread-opener.tsx
+++ b/src/web/src/components/community/messages/thread-opener.tsx
@@ -189,6 +189,8 @@ export function ThreadOpener({
             <div className="mt-2">
               <MessageReactions
                 messageId={msg.id}
+                authorName={authorName}
+                messagePreview={visibleContent}
                 reactions={msg.reactions}
                 hoverCapable={hoverCapable}
                 tooltipActive

--- a/src/web/src/lib/community/testids.test.ts
+++ b/src/web/src/lib/community/testids.test.ts
@@ -48,6 +48,9 @@ describe("community QA selectors", () => {
     expect(tid.reactionDialog("message_1")).toBe("community-reaction-dialog-message_1")
     expect(tid.reactionTab("👍")).toBe("community-reaction-tab-%F0%9F%91%8D")
     expect(tid.reactionMember("user_1")).toBe("community-reaction-member-user_1")
+    expect(tid.reactionScroller("message_1")).toBe("community-reaction-scroller-message_1")
+    expect(tid.reactionFadeLeft("message_1")).toBe("community-reaction-fade-left-message_1")
+    expect(tid.reactionFadeRight("message_1")).toBe("community-reaction-fade-right-message_1")
     expect(tid.reactionEmpty("message_1")).toBe("community-reaction-empty-message_1")
   })
 

--- a/src/web/src/lib/community/testids.ts
+++ b/src/web/src/lib/community/testids.ts
@@ -130,6 +130,9 @@ export const tid = {
   reactionChip: (msgId: string, emoji: string) =>
     `community-reaction-chip-${msgId}-${encodeURIComponent(emoji)}`,
   reactionDialog: (msgId: string) => `community-reaction-dialog-${msgId}`,
+  reactionScroller: (msgId: string) => `community-reaction-scroller-${msgId}`,
+  reactionFadeLeft: (msgId: string) => `community-reaction-fade-left-${msgId}`,
+  reactionFadeRight: (msgId: string) => `community-reaction-fade-right-${msgId}`,
   reactionTab: (emoji: string) => `community-reaction-tab-${encodeURIComponent(emoji)}`,
   reactionMember: (userId: string) => `community-reaction-member-${userId}`,
   reactionEmpty: (msgId: string) => `community-reaction-empty-${msgId}`,

--- a/src/web/src/test/e2e-ui/44-mobile-reaction-details.spec.ts
+++ b/src/web/src/test/e2e-ui/44-mobile-reaction-details.spec.ts
@@ -3,6 +3,8 @@ import { expect, test, userId } from "./_fixtures/community-fixture"
 import { gotoAfterUserWsAuth } from "./_fixtures/actions"
 import {
   seedChannel,
+  seedDm,
+  seedDmMessage,
   seedJoinServer,
   seedMessage,
   seedReaction,
@@ -12,6 +14,7 @@ import {
 import { tid } from "./_fixtures/testids"
 
 const HOVER_QUERY = "(hover: hover) and (pointer: fine)"
+const OVERFLOW_EMOJIS = ["👍", "🔥", "🎉", "✅", "🚀", "👀", "❤️", "😂", "🤔"] as const
 
 async function installInputCapability(page: Page, hoverCapable: boolean) {
   await page.addInitScript(({ query, matches }) => {
@@ -69,6 +72,8 @@ test.describe.serial("mobile reaction details", () => {
   let emptyMessageId: string
   let threadId: string
   let threadOpenerId: string
+  let dmId: string
+  let dmMessageId: string
 
   test.beforeAll(async () => {
     const stamp = Date.now()
@@ -81,11 +86,15 @@ test.describe.serial("mobile reaction details", () => {
     await seedReaction("bob", messageId, "👍")
     await seedReaction("bob", messageId, "🔥")
     await seedReaction("carol", messageId, "🎉")
+    for (const emoji of OVERFLOW_EMOJIS.slice(3)) await seedReaction("alice", messageId, emoji)
     emptyMessageId = await seedMessage("alice", channelId, `Empty reactions ${stamp}`)
     await seedReaction("alice", emptyMessageId, "✅")
     threadOpenerId = await seedMessage("alice", channelId, `Thread opener reactions ${stamp}`)
     await seedReaction("bob", threadOpenerId, "👍")
     threadId = await seedThread("alice", threadOpenerId, `Reaction thread ${stamp}`)
+    dmId = await seedDm("alice", userId("bob"))
+    dmMessageId = await seedDmMessage("alice", dmId, `DM reactions ${stamp}`)
+    await seedReaction("bob", dmMessageId, "👍")
   })
 
   test("hold opens one authorized batch dialog while tap keeps the canonical toggle", async ({ asUser }, testInfo) => {
@@ -139,8 +148,8 @@ test.describe.serial("mobile reaction details", () => {
     expect(detailsRequests).toHaveLength(1)
   })
 
-  test("coarse input follows the 320, 639, and 640 cross-capability geometry", async ({ asUser }) => {
-    for (const width of [320, 639, 640]) {
+  test("coarse input follows the 320, 639, 640, and 1280 cross-capability geometry", async ({ asUser }) => {
+    for (const width of [320, 639, 640, 1280]) {
       const session = await asUser("alice")
       await session.page.setViewportSize({ width, height: width === 320 ? 568 : 844 })
       await installInputCapability(session.page, false)
@@ -154,6 +163,85 @@ test.describe.serial("mobile reaction details", () => {
       ))).toBeGreaterThanOrEqual(44)
       await session.context.close()
     }
+  })
+
+  test("the emoji rail stays transparent and one-line with directional fades and tab keyboard semantics", async ({ asUser }, testInfo) => {
+    const alice = await asUser("alice")
+    await alice.page.setViewportSize({ width: 320, height: 568 })
+    await alice.page.emulateMedia({ colorScheme: "light" })
+    await installInputCapability(alice.page, false)
+    await gotoAfterUserWsAuth(alice.page, `/c/channels/${serverId}/${channelId}`)
+    await holdReaction(alice.page, alice.page.getByTestId(tid.reactionChip(messageId, OVERFLOW_EMOJIS[0])))
+    await expectDialogInsideViewport(alice.page, messageId)
+
+    const rail = alice.page.getByTestId(tid.reactionScroller(messageId))
+    const panel = alice.page.getByRole("tabpanel")
+    await expect(rail).toHaveRole("tablist")
+    await expect(rail).toHaveAttribute("aria-label", "Reaction types")
+    await expect(panel).toHaveAttribute("aria-labelledby", tid.reactionTab(OVERFLOW_EMOJIS[0]))
+    const initial = await rail.evaluate((element) => {
+      const style = getComputedStyle(element)
+      element.scrollLeft = 0
+      element.dispatchEvent(new Event("scroll"))
+      return {
+        backgroundColor: style.backgroundColor,
+        flexWrap: style.flexWrap,
+        overflowX: style.overflowX,
+        clientWidth: element.clientWidth,
+        scrollWidth: element.scrollWidth,
+      }
+    })
+    expect(initial.backgroundColor).toBe("rgba(0, 0, 0, 0)")
+    expect(initial.flexWrap).toBe("nowrap")
+    expect(initial.overflowX).toBe("auto")
+    expect(initial.scrollWidth).toBeGreaterThan(initial.clientWidth)
+    await expect(alice.page.getByTestId(tid.reactionFadeLeft(messageId))).toHaveCount(0)
+    await expect(alice.page.getByTestId(tid.reactionFadeRight(messageId))).toBeVisible()
+
+    const first = alice.page.getByTestId(tid.reactionTab(OVERFLOW_EMOJIS[0]))
+    const last = alice.page.getByTestId(tid.reactionTab(OVERFLOW_EMOJIS.at(-1)!))
+    await first.focus()
+    await first.press("End")
+    await expect.poll(() => rail.evaluate((element) => ({
+      left: element.scrollLeft,
+      max: element.scrollWidth - element.clientWidth,
+    }))).toEqual(expect.objectContaining({ left: initial.scrollWidth - initial.clientWidth }))
+    await expect(alice.page.getByTestId(tid.reactionFadeLeft(messageId))).toBeVisible()
+    await expect(alice.page.getByTestId(tid.reactionFadeRight(messageId))).toHaveCount(0)
+
+    await rail.evaluate((element) => {
+      element.scrollLeft = 0
+      element.dispatchEvent(new Event("scroll"))
+    })
+    await last.evaluate((element) => (element as HTMLElement).click())
+    await expect(last).toHaveAttribute("data-active", "")
+    await expect.poll(() => rail.evaluate((element) => element.scrollLeft)).toBeGreaterThan(0)
+
+    await rail.evaluate((element) => {
+      element.scrollLeft = (element.scrollWidth - element.clientWidth) / 2
+      element.dispatchEvent(new Event("scroll"))
+    })
+    await expect(alice.page.getByTestId(tid.reactionFadeLeft(messageId))).toBeVisible()
+    await expect(alice.page.getByTestId(tid.reactionFadeRight(messageId))).toBeVisible()
+
+    await last.focus()
+    await last.press("Home")
+    await expect.poll(() => rail.evaluate((element) => element.scrollLeft)).toBe(0)
+    await expect(alice.page.getByTestId(tid.reactionFadeLeft(messageId))).toHaveCount(0)
+    await expect(alice.page.getByTestId(tid.reactionFadeRight(messageId))).toBeVisible()
+    await first.evaluate((element) => (element as HTMLElement).click())
+    await expect(first).toHaveAttribute("data-active", "")
+    await expect(alice.page.getByTestId(tid.reactionMember(userId("alice")))).toBeVisible()
+    await testInfo.attach("320-reaction-rail-overflow-light.png", {
+      body: await alice.page.screenshot(),
+      contentType: "image/png",
+    })
+    await alice.page.emulateMedia({ colorScheme: "dark" })
+    await expect(alice.page.locator("html")).toHaveClass(/dark/)
+    await testInfo.attach("320-reaction-rail-overflow-dark.png", {
+      body: await alice.page.screenshot(),
+      contentType: "image/png",
+    })
   })
 
   test("hover-capable desktop keeps compact click and tooltip behavior", async ({ asUser }, testInfo) => {
@@ -190,6 +278,27 @@ test.describe.serial("mobile reaction details", () => {
       body: await alice.page.screenshot(),
       contentType: "image/png",
     })
+  })
+
+  test("DM and message-context rows open the same authorized reaction dialog", async ({ asUser }) => {
+    const dm = await asUser("alice")
+    await dm.page.setViewportSize({ width: 390, height: 844 })
+    await installInputCapability(dm.page, false)
+    await gotoAfterUserWsAuth(dm.page, `/c/me/${dmId}`)
+    await holdReaction(dm.page, dm.page.getByTestId(tid.reactionChip(dmMessageId, "👍")))
+    await expectDialogInsideViewport(dm.page, dmMessageId)
+    await expect(dm.page.getByTestId(tid.reactionMember(userId("bob")))).toBeVisible()
+    await dm.page.getByRole("button", { name: "Close" }).click()
+    await dm.context.close()
+
+    const context = await asUser("alice")
+    await context.page.setViewportSize({ width: 390, height: 844 })
+    await installInputCapability(context.page, false)
+    await gotoAfterUserWsAuth(context.page, `/c/channels/${serverId}/${channelId}?seq=1`)
+    const sheet = context.page.locator('[data-slot="sheet-content"]')
+    await expect(sheet).toBeVisible()
+    await holdReaction(context.page, sheet.getByTestId(tid.reactionChip(messageId, OVERFLOW_EMOJIS[0])))
+    await expectDialogInsideViewport(context.page, messageId)
   })
 
   test("removing the last reaction keeps the dialog open on its empty state", async ({ asUser }, testInfo) => {

--- a/src/web/src/test/e2e-ui/44-mobile-reaction-details.spec.ts
+++ b/src/web/src/test/e2e-ui/44-mobile-reaction-details.spec.ts
@@ -69,6 +69,7 @@ test.describe.serial("mobile reaction details", () => {
   let serverId: string
   let channelId: string
   let messageId: string
+  let messageContent: string
   let emptyMessageId: string
   let threadId: string
   let threadOpenerId: string
@@ -81,7 +82,8 @@ test.describe.serial("mobile reaction details", () => {
     channelId = await seedChannel("alice", serverId, `reactions-${stamp}`)
     await seedJoinServer("alice", "bob", serverId)
     await seedJoinServer("alice", "carol", serverId)
-    messageId = await seedMessage("alice", channelId, `Hold a reaction ${stamp}`)
+    messageContent = `Hold a reaction ${stamp} — ${"long message preview ".repeat(8).trim()}`
+    messageId = await seedMessage("alice", channelId, messageContent)
     await seedReaction("alice", messageId, "👍")
     await seedReaction("bob", messageId, "👍")
     await seedReaction("bob", messageId, "🔥")
@@ -116,6 +118,14 @@ test.describe.serial("mobile reaction details", () => {
     await expect(fire).toBeVisible()
     await holdReaction(alice.page, fire)
     await expectDialogInsideViewport(alice.page, messageId)
+    const dialog = alice.page.getByTestId(tid.reactionDialog(messageId))
+    await expect(dialog.locator('[data-slot="dialog-title"]')).toContainText("e2e-alice-")
+    await expect(dialog.locator('[data-slot="dialog-description"]')).toHaveText(messageContent)
+    await expect(dialog.locator('[data-slot="dialog-description"]')).toHaveCSS("white-space", "nowrap")
+    await expect(dialog.locator('[data-slot="dialog-description"]')).toHaveCSS("text-overflow", "ellipsis")
+    await expect.poll(() => dialog.locator('[data-slot="dialog-description"]').evaluate(
+      (element) => element.scrollWidth > element.clientWidth,
+    )).toBe(true)
     await expect(alice.page.getByTestId(tid.reactionTab("🔥"))).toHaveAttribute("data-active", "")
     await expect(alice.page.getByTestId(tid.reactionMember(userId("bob")))).toBeVisible()
     await testInfo.attach("390-mobile-reaction-details.png", {
@@ -165,7 +175,7 @@ test.describe.serial("mobile reaction details", () => {
     }
   })
 
-  test("the emoji rail stays transparent and one-line with directional fades and tab keyboard semantics", async ({ asUser }, testInfo) => {
+  test("the emoji rail switches displayed reactors without mutating reactions", async ({ asUser }, testInfo) => {
     const alice = await asUser("alice")
     await alice.page.setViewportSize({ width: 320, height: 568 })
     await alice.page.emulateMedia({ colorScheme: "light" })
@@ -176,6 +186,13 @@ test.describe.serial("mobile reaction details", () => {
 
     const rail = alice.page.getByTestId(tid.reactionScroller(messageId))
     const panel = alice.page.getByRole("tabpanel")
+    const dialogMutations: string[] = []
+    alice.page.on("request", (request) => {
+      const pathname = new URL(request.url()).pathname
+      if (request.method() !== "GET" && pathname.includes(`/api/community/messages/${messageId}/reactions/`)) {
+        dialogMutations.push(`${request.method()} ${pathname}`)
+      }
+    })
     await expect(rail).toHaveRole("tablist")
     await expect(rail).toHaveAttribute("aria-label", "Reaction types")
     await expect(panel).toHaveAttribute("aria-labelledby", tid.reactionTab(OVERFLOW_EMOJIS[0]))
@@ -213,9 +230,10 @@ test.describe.serial("mobile reaction details", () => {
       element.scrollLeft = 0
       element.dispatchEvent(new Event("scroll"))
     })
-    await last.evaluate((element) => (element as HTMLElement).click())
+    await last.click()
     await expect(last).toHaveAttribute("data-active", "")
     await expect.poll(() => rail.evaluate((element) => element.scrollLeft)).toBeGreaterThan(0)
+    expect(dialogMutations).toEqual([])
 
     await rail.evaluate((element) => {
       element.scrollLeft = (element.scrollWidth - element.clientWidth) / 2
@@ -229,15 +247,29 @@ test.describe.serial("mobile reaction details", () => {
     await expect.poll(() => rail.evaluate((element) => element.scrollLeft)).toBe(0)
     await expect(alice.page.getByTestId(tid.reactionFadeLeft(messageId))).toHaveCount(0)
     await expect(alice.page.getByTestId(tid.reactionFadeRight(messageId))).toBeVisible()
-    await first.evaluate((element) => (element as HTMLElement).click())
+    await first.click()
     await expect(first).toHaveAttribute("data-active", "")
     await expect(alice.page.getByTestId(tid.reactionMember(userId("bob")))).toBeVisible()
+    expect(dialogMutations).toEqual([])
     await testInfo.attach("320-reaction-rail-overflow-light.png", {
       body: await alice.page.screenshot(),
       contentType: "image/png",
     })
     await alice.page.emulateMedia({ colorScheme: "dark" })
     await expect(alice.page.locator("html")).toHaveClass(/dark/)
+    const themeSurface = await alice.page.getByTestId(tid.reactionDialog(messageId)).evaluate((element, fadeTestId) => {
+      const fade = element.querySelector(`[data-testid="${fadeTestId}"]`)
+      const fadeStyle = fade ? getComputedStyle(fade) : null
+      return {
+        background: getComputedStyle(element).backgroundColor,
+        fadeEndpoint: fadeStyle?.getPropertyValue("--tw-gradient-from").trim() ?? "",
+        fade: fadeStyle?.backgroundImage ?? "",
+        transitionProperty: getComputedStyle(element).transitionProperty,
+      }
+    }, tid.reactionFadeRight(messageId))
+    expect(themeSurface.background).toBe(themeSurface.fadeEndpoint)
+    expect(themeSurface.fade).toContain(themeSurface.fadeEndpoint)
+    expect(themeSurface.transitionProperty).toBe("none")
     await testInfo.attach("320-reaction-rail-overflow-dark.png", {
       body: await alice.page.screenshot(),
       contentType: "image/png",

--- a/src/web/src/test/e2e-ui/44-mobile-reaction-details.spec.ts
+++ b/src/web/src/test/e2e-ui/44-mobile-reaction-details.spec.ts
@@ -231,7 +231,7 @@ test.describe.serial("mobile reaction details", () => {
     await expect(alice.page.getByTestId(tid.reactionFadeRight(messageId))).toBeVisible()
     await first.evaluate((element) => (element as HTMLElement).click())
     await expect(first).toHaveAttribute("data-active", "")
-    await expect(alice.page.getByTestId(tid.reactionMember(userId("alice")))).toBeVisible()
+    await expect(alice.page.getByTestId(tid.reactionMember(userId("bob")))).toBeVisible()
     await testInfo.attach("320-reaction-rail-overflow-light.png", {
       body: await alice.page.screenshot(),
       contentType: "image/png",

--- a/src/web/src/test/e2e-ui/44-mobile-reaction-details.spec.ts
+++ b/src/web/src/test/e2e-ui/44-mobile-reaction-details.spec.ts
@@ -260,8 +260,12 @@ test.describe.serial("mobile reaction details", () => {
     const themeSurface = await alice.page.getByTestId(tid.reactionDialog(messageId)).evaluate((element, fadeTestId) => {
       const fade = element.querySelector(`[data-testid="${fadeTestId}"]`)
       const fadeStyle = fade ? getComputedStyle(fade) : null
+      const close = element.querySelector<HTMLElement>("[data-slot=dialog-close]")
       return {
         background: getComputedStyle(element).backgroundColor,
+        color: getComputedStyle(element).color,
+        closeColor: close ? getComputedStyle(close).color : "",
+        closeTransitionProperty: close ? getComputedStyle(close).transitionProperty : "",
         fadeEndpoint: fadeStyle?.getPropertyValue("--tw-gradient-from").trim() ?? "",
         fade: fadeStyle?.backgroundImage ?? "",
         transitionProperty: getComputedStyle(element).transitionProperty,
@@ -270,6 +274,8 @@ test.describe.serial("mobile reaction details", () => {
     expect(themeSurface.background).toBe(themeSurface.fadeEndpoint)
     expect(themeSurface.fade).toContain(themeSurface.fadeEndpoint)
     expect(themeSurface.transitionProperty).toBe("none")
+    expect(themeSurface.closeColor).toBe(themeSurface.color)
+    expect(themeSurface.closeTransitionProperty).toBe("none")
     await testInfo.attach("320-reaction-rail-overflow-dark.png", {
       body: await alice.page.screenshot(),
       contentType: "image/png",


### PR DESCRIPTION
## Summary

- extract the Forum tag overflow/fade/selected-reveal/keyboard behavior into a shared community rail and reuse it for reaction detail tabs
- keep dialog reaction tabs transparent, single-line, horizontally scrollable, and selection-only: click or keyboard activation switches the displayed reactors without adding or removing reactions
- show the message author as the dialog title and the exact message content as a one-line truncated preview
- extract the Members 32px avatar/name/discriminator identity row and reuse it for authorized reactors without adding presence, status, roles, or management actions
- preserve realtime neighbor selection, authorized-profile privacy, Unknown fallback, long press, nested-surface focus restoration, and the existing API/D1/WS contract
- constrain long reactor lists to a vertically scrollable panel and synchronize the popover fade, background, and shared close-button foreground on the first theme-change frame

## Testing

- final exact head `1aaeeac5e4c024630ef22cc905292c7e71228db3`, base `c5e820b846fe6be40312a30fd0fab9c16cc075c7`
- full pre-commit gate: typecheck, lint, all tests, WS event boundary check, agent-driver boundary check, and knip
  - web: 688 files / 6098 tests
- independent exact-head QA:
  - focused component regressions: 28/28
  - force-fresh `44-mobile-reaction-details.spec.ts`: 7/7
  - expanded long-list/API/D1/WS journey: 1/1
  - targeted first-frame close color/contrast audit: 1/1
- widths 320, 390, 639, 640, and 1280; directional fades; Home/End/Arrow and manual tab activation; channel/thread opener/DM/context parity; hold/movement/focus/empty states
- verified zero non-GET reaction requests and identical ordered D1 reaction rows across dialog tab selection
- verified exact author/full-preview accessibility, true one-line overflow, 12-reactor vertical scrolling, API privacy/order, and profile/remove WebSocket reconciliation
- first dark sample resolved dialog/button/icon/stroke to the same foreground with close `transition-property: none`; contrast 14.44:1 normal and 13.26:1 hover
- hosted E2E UI and CI are fully green; all five UI shards, merged-report gate, coverage, backend E2E, static, artifact, and Lighthouse jobs passed; `codecov/patch` passed and the Codecov report confirms all modified coverable lines are covered

## Screenshots

Independent exact-head light/dark, first-frame close/hover, selected-tab, long-list, thread, empty-state, and desktop-tooltip screenshots are preserved under `.alook-qa-scratch/pr641-qa/screens/exact-1aaeeac5/` and attached in the Alook QA handoff.

