### PR TITLE
fix(web): fill selected reaction tab

### DIFF
--- a/src/web/src/components/community/messages/message-reactions.test.ts
+++ b/src/web/src/components/community/messages/message-reactions.test.ts
@@ -179,6 +179,18 @@ describe("MessageReactions", () => {
     expect(rail.props.className).toContain("bg-transparent!")
   })
 
+  it("fills only the active reaction tab without relying on the line indicator", () => {
+    vi.useFakeTimers()
+    const { renderer } = renderReactions()
+    const chip = renderer.root.findByProps({ "data-testid": tid.reactionChip("message_1", "👍") })
+    act(() => chip.props.onPointerDown({ pointerType: "touch", clientX: 10, clientY: 10, stopPropagation: vi.fn() }))
+    act(() => vi.advanceTimersByTime(450))
+    const tab = renderer.root.findByProps({ "data-testid": tid.reactionTab("👍") })
+    expect(tab.props.className).toContain("data-active:bg-accent!")
+    expect(tab.props.className).toContain("data-active:text-foreground!")
+    expect(tab.props.className).toContain("after:hidden")
+  })
+
   it("uses the message author and one-line message preview as its header", () => {
     vi.useFakeTimers()
     const { renderer } = renderReactions()

--- a/src/web/src/components/community/messages/message-reactions.tsx
+++ b/src/web/src/components/community/messages/message-reactions.tsx
@@ -246,7 +246,7 @@ function ReactionDetailsDialog({
                   data-testid={tid.reactionTab(reaction.emoji)}
                   aria-label={`${reaction.emoji}, ${reaction.count}`}
                   aria-controls={`${tid.reactionDialog(messageId)}-panel`}
-                  className="h-11! min-h-11 min-w-11"
+                  className="h-11! min-h-11 min-w-11 data-active:bg-accent! data-active:text-foreground! after:hidden"
                 >
                   <span aria-hidden="true">{reaction.emoji}</span>
                   <span>{reaction.count}</span>


### PR DESCRIPTION
# Why we need this PR?

The reaction-details line tabs lose their only visible selected marker because the rail clips the shared bottom indicator. The selected emoji must remain visibly selected after focus leaves.

## What changed

- Keep the reaction rail itself transparent.
- Apply a caller-scoped `bg-accent` / `text-foreground` fill to the active emoji tab in both themes.
- Hide the reaction trigger's clipped line indicator without changing the shared Tabs primitive or Forum tag appearance.
- Add a component regression for the active fill and indicator boundary.

## Checklist

- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

Normal pre-commit hooks passed: typecheck, lint, unit/integration tests (including 6,099 web tests), WS event boundary checks, agent-driver boundary checks, and knip.

Post-Draft real-browser light/dark selected, hover, focus, screenshot, and frozen-contract QA is intentionally handed to Madox.

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...
