### PR TITLE
fix(web): preserve images in shared message exports

### DIFF
--- a/scripts/ci/e2e-shards.mjs
+++ b/scripts/ci/e2e-shards.mjs
@@ -58,6 +58,7 @@ export const SPEC_SECONDS = {
   "41-community-initial-load-module-skeletons.spec.ts": 30,
   "42-versioned-avatar-identity.spec.ts": 50,
   "44-mobile-reaction-details.spec.ts": 70,
+  "51-share-image-assets.spec.ts": 20,
 }
 
 function walk(directory) {

--- a/scripts/ci/e2e-shards.test.ts
+++ b/scripts/ci/e2e-shards.test.ts
@@ -70,7 +70,7 @@ describe("planE2eShards", () => {
     expect(first).toHaveLength(E2E_SHARD_COUNT)
     expect([...assigned].sort()).toEqual(specs)
     expect(new Set(assigned).size).toBe(specs.length)
-    expect(totals.sort((left, right) => left - right)).toEqual([429, 430, 430, 432, 434])
+    expect(totals.sort((left, right) => left - right)).toEqual([432, 433, 436, 437, 437])
     expect(Math.max(...totals) / Math.min(...totals)).toBeLessThanOrEqual(1.15)
   })
 

--- a/src/web/src/components/community/messages/message-share-dialog.test.ts
+++ b/src/web/src/components/community/messages/message-share-dialog.test.ts
@@ -4,6 +4,7 @@ import TestRenderer, { act } from "react-test-renderer"
 import {
   MessageShareDialog,
   ShareCardImageTimeoutError,
+  inlineShareCardImages,
   waitForShareCardImages,
 } from "./message-share-dialog"
 import type { RenderMsg } from "@/lib/community/models/message"
@@ -301,5 +302,110 @@ describe("waitForShareCardImages", () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+})
+
+describe("inlineShareCardImages", () => {
+  function image({
+    src,
+    currentSrc,
+    srcset,
+  }: {
+    src: string
+    currentSrc?: string
+    srcset?: string
+  }) {
+    const attributes = new Map<string, string>([["src", src]])
+    if (srcset !== undefined) attributes.set("srcset", srcset)
+    return {
+      src,
+      currentSrc: currentSrc ?? src,
+      getAttribute: vi.fn((name: string) => attributes.get(name) ?? null),
+      setAttribute: vi.fn((name: string, value: string) => attributes.set(name, value)),
+      removeAttribute: vi.fn((name: string) => attributes.delete(name)),
+      attributes,
+    } as unknown as HTMLImageElement & { attributes: Map<string, string> }
+  }
+
+  function card(images: HTMLImageElement[]): HTMLElement {
+    return { querySelectorAll: () => images } as unknown as HTMLElement
+  }
+
+  it("inlines each rendered image once and restores the React-owned attributes", async () => {
+    const avatar = image({
+      src: "/avatar?v=2",
+      currentSrc: "https://alook.test/avatar?v=2",
+      srcset: "/avatar?v=2 1x, /avatar?v=2&dpr=2 2x",
+    })
+    const duplicate = image({
+      src: "/avatar?v=2",
+      currentSrc: "https://alook.test/avatar?v=2",
+    })
+    const attachment = image({ src: "/attachments/photo" })
+    const loadDataUrl = vi.fn(async (url: string) => `data:image/png;base64,${url}`)
+    const waitForImages = vi.fn().mockResolvedValue(undefined)
+
+    const restore = await inlineShareCardImages(
+      card([avatar, duplicate, attachment]),
+      loadDataUrl,
+      waitForImages,
+    )
+
+    expect(loadDataUrl).toHaveBeenCalledTimes(2)
+    expect(loadDataUrl).toHaveBeenCalledWith("https://alook.test/avatar?v=2")
+    expect(loadDataUrl).toHaveBeenCalledWith("/attachments/photo")
+    expect(avatar.attributes.get("src")).toBe(
+      "data:image/png;base64,https://alook.test/avatar?v=2",
+    )
+    expect(avatar.attributes.get("srcset")).toBe("")
+    expect(attachment.attributes.get("src")).toBe(
+      "data:image/png;base64,/attachments/photo",
+    )
+    expect(waitForImages).toHaveBeenCalledTimes(2)
+
+    restore()
+    restore()
+    expect(avatar.attributes.get("src")).toBe("/avatar?v=2")
+    expect(avatar.attributes.get("srcset")).toBe("/avatar?v=2 1x, /avatar?v=2&dpr=2 2x")
+    expect(duplicate.attributes.has("srcset")).toBe(false)
+    expect(attachment.attributes.get("src")).toBe("/attachments/photo")
+  })
+
+  it("does not mutate the preview when an image cannot be inlined", async () => {
+    const avatar = image({ src: "/avatar" })
+    const attachment = image({ src: "/attachment" })
+    const waitForImages = vi.fn().mockResolvedValue(undefined)
+
+    await expect(inlineShareCardImages(
+      card([avatar, attachment]),
+      async (url) => {
+        if (url === "/attachment") throw new Error("fetch failed")
+        return "data:image/png;base64,avatar"
+      },
+      waitForImages,
+    )).rejects.toThrow("fetch failed")
+
+    expect(avatar.attributes.get("src")).toBe("/avatar")
+    expect(attachment.attributes.get("src")).toBe("/attachment")
+    expect(waitForImages).toHaveBeenCalledOnce()
+  })
+
+  it("restores the preview when an inlined bitmap fails to settle", async () => {
+    const avatar = image({ src: "/avatar", srcset: "/avatar 1x" })
+    const waitForImages = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("decode failed"))
+
+    await expect(
+      inlineShareCardImages(
+        card([avatar]),
+        async () => "data:image/png;base64,avatar",
+        waitForImages,
+      ),
+    ).rejects.toThrow("decode failed")
+
+    expect(avatar.attributes.get("src")).toBe("/avatar")
+    expect(avatar.attributes.get("srcset")).toBe("/avatar 1x")
   })
 })

--- a/src/web/src/components/community/messages/message-share-dialog.tsx
+++ b/src/web/src/components/community/messages/message-share-dialog.tsx
@@ -96,6 +96,95 @@ export async function waitForShareCardImages(
   await waitForPaint()
 }
 
+type ShareImageDataUrlLoader = (url: string) => Promise<string>
+type ShareImageWaiter = (node: HTMLElement) => Promise<void>
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onerror = () => reject(reader.error ?? new Error("Failed to read share-card image"))
+    reader.onloadend = () => typeof reader.result === "string"
+      ? resolve(reader.result)
+      : reject(new Error("Failed to encode share-card image"))
+    reader.readAsDataURL(blob)
+  })
+}
+
+async function loadShareImageDataUrl(url: string): Promise<string> {
+  if (url.startsWith("data:")) return url
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), SHARE_IMAGE_READY_TIMEOUT_MS)
+  try {
+    const response = await fetch(url, {
+      cache: "force-cache",
+      credentials: "same-origin",
+      signal: controller.signal,
+    })
+    if (!response.ok) throw new Error(`Share-card image request failed (${response.status})`)
+    const blob = await response.blob()
+    if (!blob.type.startsWith("image/")) {
+      throw new Error(`Share-card image returned ${blob.type || "an unknown content type"}`)
+    }
+    return await blobToDataUrl(blob)
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * html-to-image clones the card and independently fetches every image URL. Its
+ * module-level resource cache stores a failed fetch as an empty string, so one
+ * transient failure can leave later exports blank even while the live preview
+ * still shows the browser's already-loaded bitmap. Inline the exact `currentSrc`
+ * of every visible image before capture, then restore the React-owned attributes.
+ */
+export async function inlineShareCardImages(
+  node: HTMLElement,
+  loadDataUrl: ShareImageDataUrlLoader = loadShareImageDataUrl,
+  waitForImages: ShareImageWaiter = waitForShareCardImages,
+): Promise<() => void> {
+  await waitForImages(node)
+  const images = [...node.querySelectorAll("img")]
+  const dataByUrl = new Map<string, Promise<string>>()
+  const sources = images.map((image) => image.currentSrc || image.src)
+  const dataUrls = await Promise.all(sources.map((source) => {
+    const existing = dataByUrl.get(source)
+    if (existing) return existing
+    const pending = loadDataUrl(source)
+    dataByUrl.set(source, pending)
+    return pending
+  }))
+  const snapshots = images.map((image) => ({
+    image,
+    src: image.getAttribute("src"),
+    srcset: image.getAttribute("srcset"),
+  }))
+  let restored = false
+  const restore = () => {
+    if (restored) return
+    restored = true
+    for (const snapshot of snapshots) {
+      if (snapshot.src === null) snapshot.image.removeAttribute("src")
+      else snapshot.image.setAttribute("src", snapshot.src)
+      if (snapshot.srcset === null) snapshot.image.removeAttribute("srcset")
+      else snapshot.image.setAttribute("srcset", snapshot.srcset)
+    }
+  }
+
+  try {
+    images.forEach((image, index) => {
+      image.setAttribute("srcset", "")
+      image.setAttribute("src", dataUrls[index]!)
+    })
+    await waitForImages(node)
+    return restore
+  } catch (error) {
+    restore()
+    throw error
+  }
+}
+
 // Share one OR several messages as an image. Renders a self-contained "share
 // card" that mirrors the in-app message blob(s) (avatar / name / content — NO
 // timestamp, per spec) plus an Alook brand footer, then rasterises THAT SAME
@@ -160,34 +249,36 @@ export function MessageShareDialog({ m, open, onClose }: {
   const render = async (): Promise<Blob | null> => {
     const node = cardRef.current
     if (!node) return null
-    await waitForShareCardImages(node)
-    // Guarantee the Caveat brand font is loaded BEFORE rasterising. html-to-image
-    // inlines webfonts into the SVG it draws; if Caveat's async @font-face hasn't
-    // resolved yet, the footer silently falls back to a default font and the PNG
-    // differs machine-to-machine ("fine on mine, blurry/wrong on theirs"). Awaiting
-    // the specific face (then the global ready signal) closes that race.
+    const restoreImages = await inlineShareCardImages(node)
     try {
-      const caveatFont = getComputedStyle(document.documentElement)
-        .getPropertyValue("--font-caveat")
-        .trim()
-      if (document.fonts?.load && caveatFont) await document.fonts.load(`16px ${caveatFont}`)
-      await document.fonts?.ready
-    } catch {
-      // Font API unavailable / load rejected — proceed; worst case is the
-      // footer's fallback font, not a failed export.
+      // Guarantee the Caveat brand font is loaded BEFORE rasterising. html-to-image
+      // inlines webfonts into the SVG it draws; if Caveat's async @font-face hasn't
+      // resolved yet, the footer silently falls back to a default font and the PNG
+      // differs machine-to-machine ("fine on mine, blurry/wrong on theirs"). Awaiting
+      // the specific face (then the global ready signal) closes that race.
+      try {
+        const caveatFont = getComputedStyle(document.documentElement)
+          .getPropertyValue("--font-caveat")
+          .trim()
+        if (document.fonts?.load && caveatFont) await document.fonts.load(`16px ${caveatFont}`)
+        await document.fonts?.ready
+      } catch {
+        // Font API unavailable / load rejected — proceed; worst case is the
+        // footer's fallback font, not a failed export.
+      }
+      return await toBlob(node, {
+        pixelRatio: 2,
+        // Every <img> is already a data URL here. Keep authenticated fetch
+        // options for CSS/font resources that html-to-image still embeds.
+        cacheBust: true,
+        fetchRequestInit: { credentials: "same-origin" },
+        // Solid backdrop so the exported PNG never bleeds transparent corners
+        // (the card's own rounded bg sits on top of this).
+        backgroundColor: getComputedStyle(node).getPropertyValue("--card")?.trim() || undefined,
+      })
+    } finally {
+      restoreImages()
     }
-    return toBlob(node, {
-      pixelRatio: 2,
-      // Re-fetch + inline external images (e.g. an uploaded CDN avatar) rather
-      // than reusing a possibly-tainted cached bitmap — avoids the canvas-taint
-      // path that would drop the avatar from the PNG. Beam fallbacks are our own
-      // inline SVG, so they're unaffected either way.
-      cacheBust: true,
-      fetchRequestInit: { credentials: "same-origin" },
-      // Solid backdrop so the exported PNG never bleeds transparent corners
-      // (the card's own rounded bg sits on top of this).
-      backgroundColor: getComputedStyle(node).getPropertyValue("--card")?.trim() || undefined,
-    })
   }
 
   const copy = async () => {
@@ -256,6 +347,7 @@ export function MessageShareDialog({ m, open, onClose }: {
               exported but doesn't blow the popup out. */}
           <div
             ref={cardRef}
+            data-share-card
             className="rounded-xl bg-card p-5 shadow-(--e1)"
           >
             {messages.map((msg) => {
@@ -342,7 +434,7 @@ export function MessageShareDialog({ m, open, onClose }: {
                               className="w-fit max-w-full overflow-hidden rounded-lg border border-border"
                             >
                               <img
-                                data-testid={`message-share-image-${msg.id}-${index}`}
+                                data-testid={tid.messageShareImage(msg.id, index)}
                                 src={attachment.url}
                                 alt={attachment.name}
                                 width={attachment.width}

--- a/src/web/src/lib/community/testids.ts
+++ b/src/web/src/lib/community/testids.ts
@@ -137,6 +137,8 @@ export const tid = {
   reactionMember: (userId: string) => `community-reaction-member-${userId}`,
   reactionEmpty: (msgId: string) => `community-reaction-empty-${msgId}`,
   messageShare: (msgId: string) => `community-message-share-${msgId}`,
+  messageShareImage: (msgId: string, index: number) =>
+    `message-share-image-${msgId}-${index}`,
   messageShareCopy: `community-message-share-copy`,
   threadIndicator: (msgId: string) => `community-thread-indicator-${msgId}`,
   railUnreadBadge: (serverId: string) => `community-rail-unread-badge-${serverId}`,

--- a/src/web/src/test/e2e-ui/51-share-image-assets.spec.ts
+++ b/src/web/src/test/e2e-ui/51-share-image-assets.spec.ts
@@ -1,0 +1,151 @@
+import { test, expect } from "./_fixtures/community-fixture"
+import { gotoAfterUserWsAuth } from "./_fixtures/actions"
+import { seedChannel, seedServer } from "./_fixtures/seed"
+import { tid } from "./_fixtures/testids"
+
+type SamplePoint = { x: number; y: number }
+
+test("downloaded share image keeps the rendered avatar and message image", async ({ asUser }) => {
+  test.setTimeout(120_000)
+  const serverId = await seedServer("alice", `Share assets ${Date.now()}`)
+  const channelId = await seedChannel("alice", serverId, "share-assets")
+  const { page } = await asUser("alice")
+  const route = `/c/channels/${serverId}/${channelId}`
+  await gotoAfterUserWsAuth(page, route)
+
+  const seeded = await page.evaluate(async (targetId) => {
+    async function solidPng(color: string, width: number, height: number): Promise<Blob> {
+      const canvas = document.createElement("canvas")
+      canvas.width = width
+      canvas.height = height
+      const context = canvas.getContext("2d")!
+      context.fillStyle = color
+      context.fillRect(0, 0, width, height)
+      return new Promise((resolve, reject) => canvas.toBlob(
+        (blob) => blob ? resolve(blob) : reject(new Error("PNG encode failed")),
+        "image/png",
+      ))
+    }
+
+    const avatarForm = new FormData()
+    avatarForm.append("file", await solidPng("rgb(220, 35, 60)", 48, 48), "avatar.png")
+    const avatarResponse = await fetch("/api/community/users/me/avatar", {
+      method: "POST",
+      body: avatarForm,
+      credentials: "include",
+    })
+
+    const attachmentForm = new FormData()
+    attachmentForm.append(
+      "file",
+      await solidPng("rgb(20, 105, 220)", 96, 64),
+      "blue-message.png",
+    )
+    const attachmentResponse = await fetch(`/api/community/channels/${targetId}/attachments`, {
+      method: "POST",
+      body: attachmentForm,
+      credentials: "include",
+    })
+    const attachment = await attachmentResponse.json() as { id: string }
+
+    const messageResponse = await fetch(`/api/community/channels/${targetId}/messages`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        content: "Both rendered images must survive export",
+        attachments: [attachment.id],
+        nonce: `e2e:${crypto.randomUUID()}`,
+      }),
+    })
+    const message = await messageResponse.json() as { message: { id: string } }
+    return {
+      avatarStatus: avatarResponse.status,
+      attachmentStatus: attachmentResponse.status,
+      messageStatus: messageResponse.status,
+      messageId: message.message.id,
+    }
+  }, channelId)
+
+  expect(seeded).toMatchObject({ avatarStatus: 200, attachmentStatus: 200, messageStatus: 201 })
+  await gotoAfterUserWsAuth(page, route)
+  const row = page.getByTestId(tid.message(seeded.messageId))
+  await expect(row).toBeVisible()
+  await row.hover()
+  await page.getByTestId(tid.messageShare(seeded.messageId)).click()
+  await page.getByRole("button", { name: "Share 1 selected messages as image" }).click()
+
+  const dialog = page.getByRole("dialog", { name: "Share message" })
+  const card = dialog.locator("[data-share-card]")
+  const avatar = card.locator('[data-slot="avatar-image"]')
+  const attachmentId = tid.messageShareImage(seeded.messageId, 0)
+  const attachment = card.getByTestId(attachmentId)
+  await expect(avatar).toBeVisible()
+  await expect(attachment).toBeVisible()
+  await expect.poll(() => avatar.evaluate((image: HTMLImageElement) => (
+    image.complete && image.naturalWidth > 0
+  ))).toBe(true)
+  await expect.poll(() => attachment.evaluate((image: HTMLImageElement) => (
+    image.complete && image.naturalWidth > 0
+  ))).toBe(true)
+
+  const points = await card.evaluate((cardNode, imageTestId) => {
+    const cardRect = cardNode.getBoundingClientRect()
+    const sample = (image: Element): SamplePoint => {
+      const rect = image.getBoundingClientRect()
+      return {
+        x: (rect.left - cardRect.left + rect.width / 2) * 2,
+        y: (rect.top - cardRect.top + rect.height / 2) * 2,
+      }
+    }
+    return {
+      avatar: sample(cardNode.querySelector('[data-slot="avatar-image"]')!),
+      attachment: sample(cardNode.querySelector(`[data-testid="${imageTestId}"]`)!),
+    }
+  }, attachmentId)
+
+  await page.evaluate(() => {
+    const nativeCreateObjectUrl = URL.createObjectURL.bind(URL)
+    ;(window as typeof window & { __shareImageBlob?: Blob }).__shareImageBlob = undefined
+    URL.createObjectURL = ((value: Blob | MediaSource) => {
+      if (value instanceof Blob && value.type === "image/png") {
+        ;(window as typeof window & { __shareImageBlob?: Blob }).__shareImageBlob = value
+      }
+      return nativeCreateObjectUrl(value)
+    }) as typeof URL.createObjectURL
+  })
+
+  const downloadStarted = page.waitForEvent("download")
+  await dialog.getByRole("button", { name: "Download" }).click()
+  const download = await downloadStarted
+  expect(download.suggestedFilename()).toMatch(/^alook-message-.*\.png$/)
+
+  const pixels = await page.evaluate(async ({ avatarPoint, attachmentPoint }) => {
+    const blob = (window as typeof window & { __shareImageBlob?: Blob }).__shareImageBlob
+    if (!blob) throw new Error("Share image blob was not captured")
+    const bitmap = await createImageBitmap(blob)
+    const canvas = document.createElement("canvas")
+    canvas.width = bitmap.width
+    canvas.height = bitmap.height
+    const context = canvas.getContext("2d")!
+    context.drawImage(bitmap, 0, 0)
+    const read = ({ x, y }: SamplePoint) => [
+      ...context.getImageData(Math.round(x), Math.round(y), 1, 1).data,
+    ]
+    return {
+      avatar: read(avatarPoint),
+      attachment: read(attachmentPoint),
+      width: bitmap.width,
+      height: bitmap.height,
+    }
+  }, { avatarPoint: points.avatar, attachmentPoint: points.attachment })
+
+  expect(pixels.width).toBeGreaterThan(0)
+  expect(pixels.height).toBeGreaterThan(0)
+  expect(pixels.avatar[0]).toBeGreaterThan(180)
+  expect(pixels.avatar[1]).toBeLessThan(80)
+  expect(pixels.avatar[2]).toBeLessThan(100)
+  expect(pixels.attachment[0]).toBeLessThan(80)
+  expect(pixels.attachment[1]).toBeGreaterThan(70)
+  expect(pixels.attachment[2]).toBeGreaterThan(180)
+})


### PR DESCRIPTION
## Summary
- inline the exact rendered avatar and attachment bitmaps before html-to-image capture
- restore all React-owned image attributes after export, including error paths
- add a real browser regression that downloads and pixel-checks both image types

## Verification
- full pre-commit suite: typecheck, lint, 6102 web tests, 613 agent-driver tests, 129 CI-script tests, typegrep, knip
- targeted Playwright E2E: 1 passed
- focused unit tests: 17 passed