### PR TITLE
fix(web): keep forum parents for child unreads

### DIFF
--- a/src/web/src/app/api/community/users/me/inbox/unreads/route.test.ts
+++ b/src/web/src/app/api/community/users/me/inbox/unreads/route.test.ts
@@ -226,6 +226,7 @@ describe("GET /api/community/users/me/inbox/unreads", () => {
     const parent = body.servers[0].channels[0]
     expect(parent.channelId).toBe("c1")
     expect(parent.channelName).toBe("general")
+    expect(parent.hasDirectUnread).toBe(false)
     expect(parent.children.map((c: { channelId: string }) => c.channelId)).toEqual(["t1"])
   })
 

--- a/src/web/src/components/community/shell/community-inbox-popover.test.ts
+++ b/src/web/src/components/community/shell/community-inbox-popover.test.ts
@@ -117,9 +117,71 @@ describe("InboxPopover thread opener rows", () => {
     expect(onOpenChannel).not.toHaveBeenCalled()
   })
 
-  it("omits a structural parent button while retaining its child rows", async () => {
+  it("keeps a structural parent row when only its child is unread", async () => {
     const unreads = unreadFixture()
     unreads[0]!.channels[0]!.hasDirectUnread = false
+    const onOpenChannel = vi.fn()
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(React.createElement(InboxPopover, {
+        unreads,
+        unreadDms: [],
+        mentions: [],
+        marked: [],
+        onOpenChannel,
+        onOpenThread: vi.fn(),
+      }))
+    })
+    const parentRows = renderer.root.findAllByProps({
+      "data-testid": tid.inboxUnreadChannel("f1"),
+    })
+    expect(parentRows).toHaveLength(1)
+    expect(renderer.root.findAllByProps({
+      "data-testid": tid.inboxUnreadChild("p1"),
+    })).toHaveLength(1)
+    await act(async () => parentRows[0]!.props.onClick())
+    expect(onOpenChannel).toHaveBeenCalledWith(
+      unreads[0],
+      unreads[0]!.channels[0],
+      false,
+    )
+  })
+
+  it("keeps one parent row with its children when both are unread", async () => {
+    const onOpenChannel = vi.fn()
+    const unreads = unreadFixture()
+    unreads[0]!.channels[0]!.mentionCount = 2
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(React.createElement(InboxPopover, {
+        unreads,
+        unreadDms: [],
+        mentions: [],
+        marked: [],
+        onOpenChannel,
+        onOpenThread: vi.fn(),
+      }))
+    })
+    const parentRows = renderer.root.findAllByProps({
+      "data-testid": tid.inboxUnreadChannel("f1"),
+    })
+    expect(parentRows).toHaveLength(1)
+    expect(renderer.root.findAllByProps({
+      "data-testid": tid.inboxUnreadChild("p1"),
+    })).toHaveLength(1)
+    expect(textOf(parentRows[0]!)).toContain("2")
+    await act(async () => parentRows[0]!.props.onClick())
+    expect(onOpenChannel).toHaveBeenCalledWith(
+      unreads[0],
+      unreads[0]!.channels[0],
+      true,
+    )
+  })
+
+  it("removes a structural parent after its only child is projected away", async () => {
+    const unreads = unreadFixture()
+    unreads[0]!.channels[0]!.hasDirectUnread = false
+    unreads[0]!.channels[0]!.children = unreads[0]!.channels[0]!.children.slice(0, 1)
     let renderer!: TestRenderer.ReactTestRenderer
     await act(async () => {
       renderer = TestRenderer.create(React.createElement(InboxPopover, {
@@ -128,6 +190,7 @@ describe("InboxPopover thread opener rows", () => {
         mentions: [],
         marked: [],
         onOpenThread: vi.fn(),
+        isProjected: (target) => target?.kind === "thread",
       }))
     })
     expect(renderer.root.findAllByProps({
@@ -135,30 +198,45 @@ describe("InboxPopover thread opener rows", () => {
     })).toHaveLength(0)
     expect(renderer.root.findAllByProps({
       "data-testid": tid.inboxUnreadChild("p1"),
-    })).toHaveLength(1)
+    })).toHaveLength(0)
+    expect(renderer.root.findAllByProps({
+      "data-testid": tid.inboxUnreadChild("t1"),
+    })).toHaveLength(0)
   })
 
-  it("hides only a projected direct parent and keeps sibling children", async () => {
+  it("retains a projected direct parent as structural while children remain", async () => {
+    const onOpenChannel = vi.fn()
+    const unreads = unreadFixture()
+    unreads[0]!.channels[0]!.mentionCount = 2
     let renderer!: TestRenderer.ReactTestRenderer
     await act(async () => {
       renderer = TestRenderer.create(React.createElement(InboxPopover, {
-        unreads: unreadFixture(),
+        unreads,
         unreadDms: [],
         mentions: [],
         marked: [],
+        onOpenChannel,
         onOpenThread: vi.fn(),
         isProjected: (target) => target?.kind === "channel-direct",
       }))
     })
-    expect(renderer.root.findAllByProps({
+    const parentRows = renderer.root.findAllByProps({
       "data-testid": tid.inboxUnreadChannel("f1"),
-    })).toHaveLength(0)
+    })
+    expect(parentRows).toHaveLength(1)
     expect(renderer.root.findAllByProps({
       "data-testid": tid.inboxUnreadChild("p1"),
     })).toHaveLength(1)
     expect(renderer.root.findAllByProps({
       "data-testid": tid.inboxUnreadChild("t1"),
     })).toHaveLength(1)
+    expect(textOf(parentRows[0]!)).not.toContain("2")
+    await act(async () => parentRows[0]!.props.onClick())
+    expect(onOpenChannel).toHaveBeenCalledWith(
+      unreads[0],
+      unreads[0]!.channels[0],
+      false,
+    )
   })
 })
 

--- a/src/web/src/components/community/shell/community-inbox-popover.tsx
+++ b/src/web/src/components/community/shell/community-inbox-popover.tsx
@@ -37,7 +37,11 @@ function UnreadsTab({ servers, dms, loading, onOpenChannel, onOpenThread, onOpen
   servers: UnreadServer[]
   dms: UnreadDm[]
   loading?: boolean
-  onOpenChannel?: (server: UnreadServer, channel: UnreadChannel) => void
+  onOpenChannel?: (
+    server: UnreadServer,
+    channel: UnreadChannel,
+    directUnreadVisible: boolean,
+  ) => void
   onOpenThread: (server: UnreadServer, parent: UnreadChannel, child: UnreadChild) => void
   onOpenDm?: (dm: UnreadDm) => void
   isProjected: (target: InboxRowTarget | null) => boolean
@@ -46,14 +50,16 @@ function UnreadsTab({ servers, dms, loading, onOpenChannel, onOpenThread, onOpen
   const visibleDms = dms.filter((dm) => !isProjected(inboxDmRowTarget(dm)))
   const visibleServers = servers.map((server) => ({
     server,
-    channels: server.channels.map((channel) => ({
-      channel,
-      directVisible: !isProjected(inboxChannelRowTarget(server, channel))
-        && channel.hasDirectUnread !== false,
-      children: channel.children.filter((child) => (
-        !isProjected(inboxThreadRowTarget(server, channel, child))
-      )),
-    })).filter((group) => group.directVisible || group.children.length > 0),
+    channels: server.channels.map((channel) => {
+      const directTarget = inboxChannelRowTarget(server, channel)
+      return {
+        channel,
+        directVisible: directTarget !== null && !isProjected(directTarget),
+        children: channel.children.filter((child) => (
+          !isProjected(inboxThreadRowTarget(server, channel, child))
+        )),
+      }
+    }).filter((group) => group.directVisible || group.children.length > 0),
   })).filter((group) => group.channels.length > 0)
   const nothingUnread = visibleServers.length === 0 && visibleDms.length === 0
   return (
@@ -88,16 +94,16 @@ function UnreadsTab({ servers, dms, loading, onOpenChannel, onOpenThread, onOpen
           <div className="px-2 pb-1 text-xs font-semibold text-muted-foreground">{server.serverName}</div>
           {channels.map(({ channel, directVisible, children }) => (
             <div key={channel.channelId}>
-              {directVisible && <button
+              <button
                 data-testid={tid.inboxUnreadChannel(channel.channelId)}
-                onClick={() => onOpenChannel?.(server, channel)}
+                onClick={() => onOpenChannel?.(server, channel, directVisible)}
                 className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm hover:bg-accent"
               >
                 <EntityIcon kind={channel.type} className="size-4 shrink-0 text-muted-foreground" />
                 <span className="min-w-0 flex-1 truncate">{channel.channelName}</span>
-                <MentionBadge count={channel.mentionCount} />
+                {directVisible && <MentionBadge count={channel.mentionCount} />}
                 <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
-              </button>}
+              </button>
               {children.map((child) => (
                 <button
                   key={child.channelId}
@@ -256,7 +262,11 @@ export function InboxPopover({
   loading?: boolean
   hasProjectedUnreads?: boolean
   hasProjectedMentions?: boolean
-  onOpenChannel?: (server: UnreadServer, channel: UnreadChannel) => void
+  onOpenChannel?: (
+    server: UnreadServer,
+    channel: UnreadChannel,
+    directUnreadVisible: boolean,
+  ) => void
   onOpenThread?: (server: UnreadServer, parent: UnreadChannel, child: UnreadChild) => void
   /** Compatibility for non-community showcase fixtures; product wiring uses onOpenThread. */
   onOpenForumThread?: (

--- a/src/web/src/components/community/shell/use-shell-inbox-controller.test.ts
+++ b/src/web/src/components/community/shell/use-shell-inbox-controller.test.ts
@@ -206,9 +206,26 @@ describe("useShellInboxController", () => {
   it("closes/projects before cancel and pushes a direct channel without data work", async () => {
     const hook = await renderController()
     order.length = 0
-    await act(async () => hook.current.popoverProps.onOpenChannel?.(server, server.channels[0]!))
+    await act(async () => hook.current.popoverProps.onOpenChannel?.(
+      server,
+      server.channels[0]!,
+      true,
+    ))
     expect(order).toEqual(["project", "cancel", "clear", "push", "submitted"])
     expect(hook.pushed).toEqual(["/c/channels/s1/c1"])
+  })
+
+  it("opens a structural-only parent without projecting any unread", async () => {
+    const hook = await renderController()
+    order.length = 0
+    await act(async () => hook.current.popoverProps.onOpenChannel?.(
+      server,
+      server.channels[0]!,
+      false,
+    ))
+    expect(order).toEqual(["close", "cancel", "clear", "push"])
+    expect(hook.pushed).toEqual(["/c/channels/s1/c1"])
+    expect(mocks.begin).not.toHaveBeenCalled()
   })
 
   it("upserts a DM only after projection/cancel and verifies only after push", async () => {
@@ -274,6 +291,7 @@ describe("useShellInboxController", () => {
     await expect(act(async () => hook.current.popoverProps.onOpenChannel?.(
       server,
       server.channels[0]!,
+      true,
     ))).rejects.toThrow("push failed")
     expect(order).toEqual([
       "project",
@@ -315,7 +333,11 @@ describe("useShellInboxController", () => {
     const holder: { hook?: Awaited<ReturnType<typeof renderController>> } = {}
     const hook = await renderController(undefined, (href) => {
       if (href !== "/c/channels/s1/c1") return
-      holder.hook!.current.popoverProps.onOpenChannel?.(serverB, serverB.channels[0]!)
+      holder.hook!.current.popoverProps.onOpenChannel?.(
+        serverB,
+        serverB.channels[0]!,
+        true,
+      )
       throw new Error("stale A failed")
     })
     holder.hook = hook
@@ -324,6 +346,7 @@ describe("useShellInboxController", () => {
     await expect(act(async () => hook.current.popoverProps.onOpenChannel?.(
       server,
       server.channels[0]!,
+      true,
     ))).rejects.toThrow("stale A failed")
 
     expect(hook.pushed).toEqual([

--- a/src/web/src/components/community/shell/use-shell-inbox-controller.test.ts
+++ b/src/web/src/components/community/shell/use-shell-inbox-controller.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   submitted: vi.fn(),
   rollback: vi.fn(),
   close: vi.fn(),
+  onOpenChange: vi.fn(),
   latestEpoch: 0,
 }))
 
@@ -73,7 +74,7 @@ vi.mock("@/hooks/community/use-inbox", () => ({
 vi.mock("@/hooks/community/use-inbox-auto-collapse", () => ({
   useInboxAutoCollapse: () => ({
     open: true,
-    onOpenChange: vi.fn(),
+    onOpenChange: (...args: unknown[]) => mocks.onOpenChange(...args),
     beginProjection: (...args: unknown[]) => mocks.begin(...args),
     markProjectionSubmitted: (...args: unknown[]) => mocks.submitted(...args),
     rollbackProjection: (...args: unknown[]) => mocks.rollback(...args),
@@ -172,6 +173,7 @@ describe("useShellInboxController", () => {
       mocks.submitted,
       mocks.rollback,
       mocks.close,
+      mocks.onOpenChange,
     ]) mock.mockReset()
     mocks.latestEpoch = 0
     mocks.begin.mockImplementation(() => {
@@ -185,6 +187,7 @@ describe("useShellInboxController", () => {
     })
     mocks.rollback.mockImplementation(() => { order.push("rollback"); return true })
     mocks.close.mockImplementation(() => { order.push("close"); return true })
+    mocks.onOpenChange.mockImplementation(() => { order.push("reopen") })
     mocks.clearOpener.mockImplementation(() => { order.push("clear") })
     mocks.armOpener.mockImplementation(() => {
       order.push("arm")
@@ -225,6 +228,20 @@ describe("useShellInboxController", () => {
     ))
     expect(order).toEqual(["close", "cancel", "clear", "push"])
     expect(hook.pushed).toEqual(["/c/channels/s1/c1"])
+    expect(mocks.begin).not.toHaveBeenCalled()
+  })
+
+  it("reopens a structural-only parent surface when navigation throws", async () => {
+    const error = new Error("push failed")
+    const hook = await renderController(undefined, () => { throw error })
+    order.length = 0
+    await expect(act(async () => hook.current.popoverProps.onOpenChannel?.(
+      server,
+      server.channels[0]!,
+      false,
+    ))).rejects.toThrow("push failed")
+    expect(order).toEqual(["close", "cancel", "clear", "push", "cancel", "reopen"])
+    expect(mocks.onOpenChange).toHaveBeenCalledWith(true)
     expect(mocks.begin).not.toHaveBeenCalled()
   })
 

--- a/src/web/src/components/community/shell/use-shell-inbox-controller.ts
+++ b/src/web/src/components/community/shell/use-shell-inbox-controller.ts
@@ -96,12 +96,27 @@ export function useShellInboxController({
   const openServerChannel = useCallback((
     server: UnreadServer,
     channel: UnreadChannel,
+    directUnreadVisible: boolean,
   ) => {
-    const target = inboxChannelRowTarget(server, channel)
-    if (!target) return
     const href = channelHref(server.serverId, channel.channelId)
+    const target = directUnreadVisible
+      ? inboxChannelRowTarget(server, channel)
+      : null
+    if (!target) {
+      const previousOpen = inbox.closeWithoutProjection()
+      cancelPendingNavigation()
+      clearThreadOpenerReadHandoff(queryClient)
+      try {
+        router.push(href)
+      } catch (error) {
+        cancelPendingNavigation()
+        inbox.onOpenChange(previousOpen)
+        throw error
+      }
+      return
+    }
     pushProjected(target, href)
-  }, [pushProjected])
+  }, [cancelPendingNavigation, inbox, pushProjected, queryClient, router])
 
   const openThread = useCallback((
     server: UnreadServer,


### PR DESCRIPTION
# Why we need this PR?
> No linked GitHub issue. Child-only forum unreads currently lose their parent row in the community Inbox, flattening the server → forum → post hierarchy.

## What changed
- Keep a forum parent row visible whenever at least one unread child remains visible.
- Separate structural parent navigation from direct unread projection so opening a child-only parent does not consume child unread state.
- Hide direct mention/read indicators after the parent direct unread is projected while retaining the structural row for surviving children.
- Add component, controller, and API regressions for child-only, parent-and-child, projected-child removal, and parent backfill semantics.

## Checklist
- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...
