### PR TITLE
fix(web): isolate dialog portal events

### DIFF
--- a/src/web/src/components/ui/dialog.test.ts
+++ b/src/web/src/components/ui/dialog.test.ts
@@ -1,0 +1,60 @@
+import React from "react"
+import TestRenderer, { act } from "react-test-renderer"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@base-ui/react/dialog", () => ({
+  Dialog: {
+    Root: ({ children, ...props }: React.ComponentProps<"div">) =>
+      React.createElement("mock-dialog-root", props, children),
+    Trigger: ({ children, ...props }: React.ComponentProps<"button">) =>
+      React.createElement("mock-dialog-trigger", props, children),
+    Portal: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    Backdrop: (props: React.ComponentProps<"div">) =>
+      React.createElement("mock-dialog-backdrop", props),
+    Popup: ({ children, ...props }: React.ComponentProps<"div">) =>
+      React.createElement("mock-dialog-popup", props, children),
+    Close: ({ children, ...props }: React.ComponentProps<"button">) =>
+      React.createElement("mock-dialog-close", props, children),
+    Title: ({ children, ...props }: React.ComponentProps<"h2">) =>
+      React.createElement("mock-dialog-title", props, children),
+    Description: ({ children, ...props }: React.ComponentProps<"p">) =>
+      React.createElement("mock-dialog-description", props, children),
+  },
+}))
+
+import { DialogContent } from "./dialog"
+
+describe("DialogContent", () => {
+  it("runs popup interaction handlers and stops portal propagation", () => {
+    const handlerNames = [
+      "onClick",
+      "onContextMenu",
+      "onPointerCancel",
+      "onPointerDown",
+      "onPointerMove",
+      "onPointerUp",
+      "onTouchCancel",
+      "onTouchEnd",
+      "onTouchMove",
+      "onTouchStart",
+    ] as const
+    const handlers = Object.fromEntries(handlerNames.map((name) => [name, vi.fn()]))
+    let renderer: TestRenderer.ReactTestRenderer
+
+    act(() => {
+      renderer = TestRenderer.create(
+        React.createElement(DialogContent, handlers, "Dialog body"),
+      )
+    })
+
+    const popup = renderer!.root.findByType("mock-dialog-popup")
+    for (const name of handlerNames) {
+      const event = { stopPropagation: vi.fn() }
+      act(() => popup.props[name](event))
+      expect(handlers[name]).toHaveBeenCalledOnce()
+      expect(handlers[name]).toHaveBeenCalledWith(event)
+      expect(event.stopPropagation).toHaveBeenCalledOnce()
+    }
+  })
+})

--- a/src/web/src/components/ui/dialog.tsx
+++ b/src/web/src/components/ui/dialog.tsx
@@ -7,6 +7,15 @@ import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { XIcon } from "lucide-react"
 
+function stopPropagationAfter<Event extends React.SyntheticEvent>(
+  handler: ((event: Event) => void) | undefined,
+) {
+  return (event: Event) => {
+    handler?.(event)
+    event.stopPropagation()
+  }
+}
+
 function Dialog({ ...props }: DialogPrimitive.Root.Props) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />
 }
@@ -43,6 +52,16 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  onClick,
+  onContextMenu,
+  onPointerCancel,
+  onPointerDown,
+  onPointerMove,
+  onPointerUp,
+  onTouchCancel,
+  onTouchEnd,
+  onTouchMove,
+  onTouchStart,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
@@ -57,6 +76,16 @@ function DialogContent({
           className
         )}
         {...props}
+        onClick={stopPropagationAfter(onClick)}
+        onContextMenu={stopPropagationAfter(onContextMenu)}
+        onPointerCancel={stopPropagationAfter(onPointerCancel)}
+        onPointerDown={stopPropagationAfter(onPointerDown)}
+        onPointerMove={stopPropagationAfter(onPointerMove)}
+        onPointerUp={stopPropagationAfter(onPointerUp)}
+        onTouchCancel={stopPropagationAfter(onTouchCancel)}
+        onTouchEnd={stopPropagationAfter(onTouchEnd)}
+        onTouchMove={stopPropagationAfter(onTouchMove)}
+        onTouchStart={stopPropagationAfter(onTouchStart)}
       >
         {children}
         {showCloseButton && (

--- a/src/web/src/test/e2e-ui/44-mobile-reaction-details.spec.ts
+++ b/src/web/src/test/e2e-ui/44-mobile-reaction-details.spec.ts
@@ -65,6 +65,40 @@ async function expectDialogInsideViewport(page: Page, messageId: string) {
   expect(geometry.bottom).toBeLessThanOrEqual(geometry.height)
 }
 
+async function clickDialogBodyWithoutOpeningMessageMenu(page: Page, messageId: string) {
+  const dialog = page.getByTestId(tid.reactionDialog(messageId))
+  await dialog.locator('[data-slot="dialog-description"]').click()
+  await expect(dialog).toBeVisible()
+  await expect(page.getByRole("menuitem")).toHaveCount(0)
+}
+
+async function swipeDialogBodyWithoutStartingMessageReply(page: Page, messageId: string) {
+  const messageRow = page.getByTestId(tid.message(messageId)).locator("div.group").first()
+  await messageRow.evaluate((element) => {
+    ;(element as HTMLElement).setPointerCapture = () => {}
+  })
+  const body = page.getByTestId(tid.reactionDialog(messageId))
+    .locator('[data-slot="dialog-description"]')
+  const box = await body.boundingBox()
+  if (!box) throw new Error("reaction dialog body has no box")
+  const start = { x: box.x + box.width / 3, y: box.y + box.height / 2 }
+  const pointer = { pointerType: "touch", pointerId: 43, isPrimary: true, button: 0 }
+  await body.dispatchEvent("pointerdown", { ...pointer, clientX: start.x, clientY: start.y })
+  await body.dispatchEvent("pointermove", {
+    ...pointer,
+    buttons: 1,
+    clientX: start.x + 72,
+    clientY: start.y + 2,
+  })
+  await body.dispatchEvent("pointerup", {
+    ...pointer,
+    clientX: start.x + 72,
+    clientY: start.y + 2,
+  })
+  await expect(page.locator('[data-slot="composer-reply-preview"]')).toHaveCount(0)
+  await expect(page.getByTestId(tid.reactionDialog(messageId))).toBeVisible()
+}
+
 test.describe.serial("mobile reaction details", () => {
   let serverId: string
   let channelId: string
@@ -126,6 +160,8 @@ test.describe.serial("mobile reaction details", () => {
     await expect.poll(() => dialog.locator('[data-slot="dialog-description"]').evaluate(
       (element) => element.scrollWidth > element.clientWidth,
     )).toBe(true)
+    await clickDialogBodyWithoutOpeningMessageMenu(alice.page, messageId)
+    await swipeDialogBodyWithoutStartingMessageReply(alice.page, messageId)
     await expect(alice.page.getByTestId(tid.reactionTab("🔥"))).toHaveAttribute("data-active", "")
     await expect(alice.page.getByTestId(tid.reactionMember(userId("bob")))).toBeVisible()
     await testInfo.attach("390-mobile-reaction-details.png", {
@@ -312,6 +348,7 @@ test.describe.serial("mobile reaction details", () => {
     await expect(chip).toBeVisible()
     await holdReaction(alice.page, chip)
     await expectDialogInsideViewport(alice.page, threadOpenerId)
+    await clickDialogBodyWithoutOpeningMessageMenu(alice.page, threadOpenerId)
     await testInfo.attach("390-thread-opener-reaction-details.png", {
       body: await alice.page.screenshot(),
       contentType: "image/png",
@@ -325,6 +362,7 @@ test.describe.serial("mobile reaction details", () => {
     await gotoAfterUserWsAuth(dm.page, `/c/me/${dmId}`)
     await holdReaction(dm.page, dm.page.getByTestId(tid.reactionChip(dmMessageId, "👍")))
     await expectDialogInsideViewport(dm.page, dmMessageId)
+    await clickDialogBodyWithoutOpeningMessageMenu(dm.page, dmMessageId)
     await expect(dm.page.getByTestId(tid.reactionMember(userId("bob")))).toBeVisible()
     await dm.page.getByRole("button", { name: "Close" }).click()
     await dm.context.close()
@@ -337,6 +375,7 @@ test.describe.serial("mobile reaction details", () => {
     await expect(sheet).toBeVisible()
     await holdReaction(context.page, sheet.getByTestId(tid.reactionChip(messageId, OVERFLOW_EMOJIS[0])))
     await expectDialogInsideViewport(context.page, messageId)
+    await clickDialogBodyWithoutOpeningMessageMenu(context.page, messageId)
   })
 
   test("removing the last reaction keeps the dialog open on its empty state", async ({ asUser }, testInfo) => {


### PR DESCRIPTION
# Why we need this PR?

On coarse/mobile input, the reaction-details dialog is rendered through a React portal from inside a message row. React synthetic pointer, touch, context-menu, and click events could therefore bubble through the component tree to the originating row, opening its action menu or starting swipe-to-reply even though the dialog visually covered it.

## What changed

- Make the shared `DialogContent` popup an interaction boundary while preserving consumer handlers and Base UI default behavior.
- Cover click, context-menu, pointer, and touch lifecycles without preventing default dismissal, focus, or scrolling behavior.
- Add primitive contract coverage plus mobile channel/thread/DM/message-context E2E probes for blank-body clicks and touch swipes.

## Verification

- Focused Dialog primitive test: 1/1 passed.
- Mobile reaction-details E2E: 7/7 passed, zero retries, isolated runtime.
- `pnpm typecheck`: 11/11 package tasks passed.
- `pnpm test`: passed across all packages.
- Normal commit hooks passed typecheck, lint, tests, WS/agent-driver boundary checks, and knip.
- Independent `/c` QA: PASS on exact head. Channel/thread opener/DM/message-context click/swipe isolation, X/Escape/backdrop/reopen/tab/scroll lifecycle, zero reaction mutations/WS frames, unchanged reaction-details JSON, and seeded D1 row counts were verified. Visual evidence is attached in the Alook tracking thread; this PR remains Draft for hosted CI/Codecov.

## Checklist

- [x] Tests added/updated as needed
- [ ] All hosted CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other
