### PR TITLE
feat(web): add ordered list continuation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,6 +382,9 @@ importers:
       '@tiptap/extension-link':
         specifier: ^3.30.0
         version: 3.30.0(@tiptap/core@3.30.0(@tiptap/pm@3.30.0))(@tiptap/pm@3.30.0)
+      '@tiptap/extension-list':
+        specifier: ^3.30.0
+        version: 3.30.0(@tiptap/core@3.30.0(@tiptap/pm@3.30.0))(@tiptap/pm@3.30.0)
       '@tiptap/extension-mention':
         specifier: ^3.30.0
         version: 3.30.0(@tiptap/core@3.30.0(@tiptap/pm@3.30.0))(@tiptap/pm@3.30.0)(@tiptap/suggestion@3.30.0(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.0(@tiptap/pm@3.30.0))(@tiptap/pm@3.30.0))

--- a/scripts/ci/e2e-shards.mjs
+++ b/scripts/ci/e2e-shards.mjs
@@ -62,6 +62,7 @@ export const SPEC_SECONDS = {
   "50-daemon-update-notice.spec.ts": 35,
   "51-mobile-forum-tag-editor.spec.ts": 60,
   "51-share-image-assets.spec.ts": 20,
+  "52-chat-composer-ordered-list.spec.ts": 90,
 }
 
 function walk(directory) {

--- a/scripts/ci/e2e-shards.test.ts
+++ b/scripts/ci/e2e-shards.test.ts
@@ -70,7 +70,7 @@ describe("planE2eShards", () => {
     expect(first).toHaveLength(E2E_SHARD_COUNT)
     expect([...assigned].sort()).toEqual(specs)
     expect(new Set(assigned).size).toBe(specs.length)
-    expect(totals.sort((left, right) => left - right)).toEqual([465, 465, 465, 466, 469])
+    expect(totals.sort((left, right) => left - right)).toEqual([483, 483, 483, 484, 487])
     expect(Math.max(...totals) / Math.min(...totals)).toBeLessThanOrEqual(1.15)
   })
 

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -58,6 +58,7 @@
     "@tanstack/react-query-persist-client": "^5.101.4",
     "@tanstack/react-virtual": "^3.14.9",
     "@tiptap/extension-image": "^3.30.0",
+    "@tiptap/extension-list": "^3.30.0",
     "@tiptap/extension-link": "^3.30.0",
     "@tiptap/extension-mention": "^3.30.0",
     "@tiptap/extension-placeholder": "^3.30.0",

--- a/src/web/src/components/community/messages/composer-keydown.test.ts
+++ b/src/web/src/components/community/messages/composer-keydown.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({ normalize: vi.fn() }))
+
+vi.mock("./consecutive-hard-break", () => ({
+  normalizeConsecutiveTerminalHardBreak: (...args: unknown[]) =>
+    mocks.normalize(...args),
+}))
+
+import { handleComposerEditorKeyDown } from "./composer-keydown"
+
+function event(overrides: Partial<KeyboardEvent> = {}): KeyboardEvent {
+  return {
+    key: "Enter",
+    shiftKey: false,
+    isComposing: false,
+    preventDefault: vi.fn(),
+    ...overrides,
+  } as unknown as KeyboardEvent
+}
+
+function options(overrides: Record<string, unknown> = {}) {
+  return {
+    hoverCapable: true,
+    channelRefOpen: false,
+    isForumThreadBody: false,
+    mentionOpen: false,
+    send: vi.fn(),
+    liftEmptyBlock: vi.fn(() => false),
+    splitListItem: vi.fn(() => false),
+    undoInputRule: vi.fn(() => false),
+    ...overrides,
+  }
+}
+
+describe("handleComposerEditorKeyDown", () => {
+  beforeEach(() => {
+    mocks.normalize.mockReset()
+    mocks.normalize.mockReturnValue(false)
+  })
+
+  it("keeps hover Enter as send before list keymaps", () => {
+    const key = event()
+    const opts = options()
+    expect(handleComposerEditorKeyDown({} as never, key, opts)).toBe(true)
+    expect(key.preventDefault).toHaveBeenCalledOnce()
+    expect(opts.send).toHaveBeenCalledOnce()
+    expect(opts.splitListItem).not.toHaveBeenCalled()
+  })
+
+  it("routes unshifted Mod-z through official input-rule undo before history", () => {
+    const key = event({ key: "z", metaKey: true })
+    const opts = options({ undoInputRule: vi.fn(() => true) })
+    expect(handleComposerEditorKeyDown({} as never, key, opts)).toBe(true)
+    expect(opts.undoInputRule).toHaveBeenCalledOnce()
+    expect(key.preventDefault).toHaveBeenCalledOnce()
+    expect(mocks.normalize).not.toHaveBeenCalled()
+  })
+
+  it("leaves Mod-z to normal editor history when no input rule can be undone", () => {
+    const key = event({ key: "z", ctrlKey: true })
+    const opts = options()
+    expect(handleComposerEditorKeyDown({} as never, key, opts)).toBe(false)
+    expect(opts.undoInputRule).toHaveBeenCalledOnce()
+    expect(key.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it("delegates hover Shift+Enter to official splitListItem", () => {
+    const key = event({ shiftKey: true })
+    const opts = options({ splitListItem: vi.fn(() => true) })
+    expect(handleComposerEditorKeyDown({} as never, key, opts)).toBe(true)
+    expect(opts.splitListItem).toHaveBeenCalledOnce()
+    expect(opts.liftEmptyBlock).not.toHaveBeenCalled()
+    expect(key.preventDefault).toHaveBeenCalledOnce()
+    expect(mocks.normalize).not.toHaveBeenCalled()
+  })
+
+  it("uses official liftEmptyBlock after splitListItem declines an empty top-level item", () => {
+    const key = event({ shiftKey: true })
+    const opts = options({ liftEmptyBlock: vi.fn(() => true) })
+    expect(handleComposerEditorKeyDown({} as never, key, opts)).toBe(true)
+    expect(opts.splitListItem).toHaveBeenCalledOnce()
+    expect(opts.liftEmptyBlock).toHaveBeenCalledOnce()
+    expect(opts.splitListItem.mock.invocationCallOrder[0]).toBeLessThan(
+      opts.liftEmptyBlock.mock.invocationCallOrder[0],
+    )
+    expect(key.preventDefault).toHaveBeenCalledOnce()
+    expect(mocks.normalize).not.toHaveBeenCalled()
+  })
+
+  it("falls through to the existing hard-break path when both official commands decline", () => {
+    const key = event({ shiftKey: true })
+    const view = { identity: "view" }
+    const opts = options()
+    mocks.normalize.mockReturnValue(true)
+    expect(handleComposerEditorKeyDown(view as never, key, opts)).toBe(true)
+    expect(opts.splitListItem).toHaveBeenCalledOnce()
+    expect(opts.liftEmptyBlock).toHaveBeenCalledOnce()
+    expect(mocks.normalize).toHaveBeenCalledWith(view, key)
+  })
+
+  it("leaves coarse Enter for Tiptap ListItem and never calls the desktop adapter", () => {
+    const key = event()
+    const opts = options({ hoverCapable: false })
+    expect(handleComposerEditorKeyDown({} as never, key, opts)).toBe(false)
+    expect(opts.send).not.toHaveBeenCalled()
+    expect(opts.splitListItem).not.toHaveBeenCalled()
+    expect(opts.liftEmptyBlock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    { mentionOpen: true },
+    { channelRefOpen: true },
+  ])("keeps suggestion ownership for %o", (override) => {
+    const key = event({ shiftKey: true })
+    const opts = options(override)
+    expect(handleComposerEditorKeyDown({} as never, key, opts)).toBe(false)
+    expect(opts.splitListItem).not.toHaveBeenCalled()
+    expect(opts.liftEmptyBlock).not.toHaveBeenCalled()
+    expect(mocks.normalize).not.toHaveBeenCalled()
+  })
+
+  it("does not send or split during IME composition", () => {
+    const key = event({ shiftKey: true, isComposing: true })
+    const opts = options()
+    expect(handleComposerEditorKeyDown({} as never, key, opts)).toBe(false)
+    expect(opts.send).not.toHaveBeenCalled()
+    expect(opts.splitListItem).not.toHaveBeenCalled()
+    expect(opts.liftEmptyBlock).not.toHaveBeenCalled()
+    expect(mocks.normalize).not.toHaveBeenCalled()
+  })
+
+  it("keeps forum Shift+Enter submit and forum Enter newline unchanged", () => {
+    const opts = options({ isForumThreadBody: true })
+    const submit = event({ shiftKey: true })
+    expect(handleComposerEditorKeyDown({} as never, submit, opts)).toBe(true)
+    expect(opts.send).toHaveBeenCalledOnce()
+    expect(opts.splitListItem).not.toHaveBeenCalled()
+
+    const newline = event()
+    expect(handleComposerEditorKeyDown({} as never, newline, opts)).toBe(false)
+  })
+})

--- a/src/web/src/components/community/messages/composer-keydown.ts
+++ b/src/web/src/components/community/messages/composer-keydown.ts
@@ -7,6 +7,29 @@ type ComposerKeyDownOptions = {
   isForumThreadBody: boolean
   mentionOpen: boolean
   send: () => void
+  liftEmptyBlock: () => boolean
+  splitListItem: () => boolean
+  undoInputRule: () => boolean
+}
+
+function undoComposerInputRuleForKeyDown(
+  event: KeyboardEvent,
+  options: ComposerKeyDownOptions,
+): boolean {
+  if (
+    options.isForumThreadBody
+    || event.isComposing
+    || event.altKey
+    || event.shiftKey
+    || (!event.ctrlKey && !event.metaKey)
+    || event.key.toLowerCase() !== "z"
+    || !options.undoInputRule()
+  ) {
+    return false
+  }
+
+  event.preventDefault()
+  return true
 }
 
 function submitComposerForKeyDown(
@@ -37,6 +60,7 @@ export function handleComposerEditorKeyDown(
   event: KeyboardEvent,
   options: ComposerKeyDownOptions,
 ): boolean {
+  if (undoComposerInputRuleForKeyDown(event, options)) return true
   const submitted = submitComposerForKeyDown(event, options)
   if (
     submitted
@@ -45,6 +69,18 @@ export function handleComposerEditorKeyDown(
     || event.isComposing
   ) {
     return submitted
+  }
+  if (
+    !options.isForumThreadBody
+    && options.hoverCapable
+    && event.key === "Enter"
+    && event.shiftKey
+  ) {
+    const handled = options.splitListItem() || options.liftEmptyBlock()
+    if (handled) {
+      event.preventDefault()
+      return true
+    }
   }
   return normalizeConsecutiveTerminalHardBreak(view, event)
 }

--- a/src/web/src/components/community/messages/composer-ordered-list.tiptap.test.ts
+++ b/src/web/src/components/community/messages/composer-ordered-list.tiptap.test.ts
@@ -1,0 +1,336 @@
+import { Node, Editor } from "@tiptap/react"
+import type { EditorState } from "@tiptap/pm/state"
+import { afterEach, describe, expect, it } from "vitest"
+import {
+  composerOrderedListInputRule,
+  composerDocumentExtensions,
+  serializeComposerDocument,
+} from "./composer-ordered-list"
+
+const TestMention = Node.create({
+  name: "mention",
+  inline: true,
+  group: "inline",
+  atom: true,
+  addAttributes() {
+    return { label: { default: null } }
+  },
+  renderText({ node }) {
+    return `@${node.attrs.label}`
+  },
+  renderHTML({ node }) {
+    return ["span", `@${node.attrs.label}`]
+  },
+})
+
+const TestChannelRef = Node.create({
+  name: "channelRef",
+  inline: true,
+  group: "inline",
+  atom: true,
+  addAttributes() {
+    return { path: { default: null } }
+  },
+  renderText({ node }) {
+    return node.attrs.path
+  },
+  renderHTML({ node }) {
+    return ["span", node.attrs.path]
+  },
+})
+
+const editors: Editor[] = []
+
+function createChatEditor(content?: Parameters<typeof Editor>[0]["content"]): Editor {
+  const editor = new Editor({
+    element: null,
+    extensions: [
+      ...composerDocumentExtensions(false),
+      TestMention,
+      TestChannelRef,
+    ],
+    content: content ?? { type: "doc", content: [{ type: "paragraph" }] },
+  })
+  editors.push(editor)
+  return editor
+}
+
+function matchOrderedMarker(editor: Editor, marker: string) {
+  const rule = composerOrderedListInputRule(editor.schema.nodes.orderedList)
+  return typeof rule.find === "function"
+    ? rule.find(marker)
+    : rule.find.exec(marker)
+}
+
+function applyOrderedMarker(editor: Editor, marker: string) {
+  const rule = composerOrderedListInputRule(editor.schema.nodes.orderedList)
+  const match = matchOrderedMarker(editor, marker)
+  if (!match) throw new Error(`Expected ${marker} to match the ordered-list rule`)
+
+  const markerText = marker.slice(0, -1)
+  let markerStart = -1
+  editor.state.doc.descendants((node, position) => {
+    if (node.type.name === "paragraph" && node.textContent === markerText) {
+      markerStart = position + 1
+    }
+  })
+  if (markerStart < 0) throw new Error(`Missing marker paragraph for ${marker}`)
+
+  const transaction = editor.state.tr
+  const chainableState = Object.create(editor.state) as EditorState
+  Object.defineProperty(chainableState, "tr", { get: () => transaction })
+  rule.handler({
+    state: chainableState,
+    range: { from: markerStart, to: markerStart + markerText.length },
+    match: match as never,
+    commands: {} as never,
+    chain: (() => ({})) as never,
+    can: (() => ({})) as never,
+  })
+  return editor.state.apply(transaction).doc.toJSON()
+}
+
+function paragraph(text?: string) {
+  return {
+    type: "paragraph",
+    ...(text ? { content: [{ type: "text", text }] } : {}),
+  }
+}
+
+afterEach(() => {
+  editors.splice(0).forEach((editor) => editor.destroy())
+})
+
+describe("ComposerOrderedList", () => {
+  it("installs exactly one orderedList node in chat and none in forum mode", () => {
+    const chat = createChatEditor()
+    expect(
+      chat.extensionManager.extensions.filter(({ name }) => name === "orderedList"),
+    ).toHaveLength(1)
+    expect(
+      chat.extensionManager.extensions.some(({ name }) => name === "trailingNode"),
+    ).toBe(false)
+    const forum = new Editor({
+      element: null,
+      extensions: composerDocumentExtensions(true),
+      content: { type: "doc", content: [{ type: "paragraph" }] },
+    })
+    editors.push(forum)
+    expect(forum.schema.nodes.orderedList).toBeUndefined()
+    expect(
+      forum.extensionManager.extensions.some(({ name }) => name === "trailingNode"),
+    ).toBe(true)
+  })
+
+  it.each(["1. ", "9. ", "42. "])(
+    "wraps canonical positive marker %s with its exact start",
+    (marker) => {
+      const editor = createChatEditor()
+      const markerEditor = createChatEditor({
+        type: "doc",
+        content: [paragraph(marker.slice(0, -1))],
+      })
+      expect(applyOrderedMarker(markerEditor, marker)).toMatchObject({
+        content: [{
+          type: "orderedList",
+          attrs: { start: Number.parseInt(marker, 10) },
+          content: [{ type: "listItem" }],
+        }],
+      })
+      expect(matchOrderedMarker(editor, marker)).not.toBeNull()
+    },
+  )
+
+  it.each(["0. ", "01. ", "1) ", "a. ", "一. ", "- ", "* ", "word 1. "])(
+    "leaves non-canonical marker %s as literal paragraph text",
+    (marker) => {
+      const editor = createChatEditor()
+      expect(matchOrderedMarker(editor, marker)).toBeNull()
+    },
+  )
+
+  it("joins only the next canonical number onto an existing list", () => {
+    const editor = createChatEditor({
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          attrs: { start: 9 },
+          content: [{ type: "listItem", content: [paragraph("first")] }],
+        },
+        paragraph("10."),
+      ],
+    })
+    expect(applyOrderedMarker(editor, "10. ").content).toMatchObject([{
+      type: "orderedList",
+      attrs: { start: 9 },
+      content: [
+        { type: "listItem", content: [paragraph("first")] },
+        { type: "listItem", content: [paragraph()] },
+      ],
+    }])
+  })
+
+  it("starts a separate mismatched list without renumbering the earlier list", () => {
+    const editor = createChatEditor({
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          attrs: { start: 3 },
+          content: [{
+            type: "listItem",
+            content: [{
+              type: "paragraph",
+              content: [{ type: "text", text: "earlier" }],
+            }],
+          }],
+        },
+        paragraph("9."),
+      ],
+    })
+    const content = applyOrderedMarker(editor, "9. ").content as Array<{
+      type: string
+      attrs?: { start?: number }
+    }>
+    expect(content.map((node) => ({
+      type: node.type,
+      start: node.attrs?.start,
+    }))).toEqual([
+      { type: "orderedList", start: 3 },
+      { type: "orderedList", start: 9 },
+    ])
+  })
+})
+
+describe("serializeComposerDocument", () => {
+  it("pins nested content-column indentation, block boundaries, and pill text", () => {
+    const editor = createChatEditor({
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          attrs: { start: 9 },
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "parent" }],
+                },
+                {
+                  type: "orderedList",
+                  attrs: { start: 3 },
+                  content: [
+                    {
+                      type: "listItem",
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [
+                            { type: "mention", attrs: { label: "Alice#0001" } },
+                            { type: "hardBreak" },
+                            { type: "text", text: "child hard break " },
+                            {
+                              type: "channelRef",
+                              attrs: { path: "/demo#1234/general" },
+                            },
+                          ],
+                        },
+                        {
+                          type: "paragraph",
+                          content: [{ type: "text", text: "second paragraph" }],
+                        },
+                        {
+                          type: "orderedList",
+                          attrs: { start: 1 },
+                          content: [{
+                            type: "listItem",
+                            content: [{
+                              type: "paragraph",
+                              content: [{ type: "text", text: "grandchild" }],
+                            }],
+                          }],
+                        },
+                      ],
+                    },
+                    {
+                      type: "listItem",
+                      content: [{
+                        type: "paragraph",
+                        content: [{ type: "text", text: "next" }],
+                      }],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [{
+                type: "paragraph",
+                content: [{ type: "text", text: "sibling" }],
+              }],
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(serializeComposerDocument(editor)).toBe([
+      "9. parent",
+      "   3. @Alice#0001",
+      "      child hard break /demo#1234/general",
+      "",
+      "      second paragraph",
+      "      1. grandchild",
+      "   4. next",
+      "10. sibling",
+    ].join("\n"))
+  })
+
+  it("uses the actual multi-digit marker width and preserves top-level block gaps", () => {
+    const editor = createChatEditor({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "before" }],
+        },
+        {
+          type: "orderedList",
+          attrs: { start: 10 },
+          content: [{
+            type: "listItem",
+            content: [
+              {
+                type: "paragraph",
+                content: [{ type: "text", text: "parent" }],
+              },
+              {
+                type: "orderedList",
+                attrs: { start: 1 },
+                content: [{
+                  type: "listItem",
+                  content: [{
+                    type: "paragraph",
+                    content: [{ type: "text", text: "child" }],
+                  }],
+                }],
+              },
+            ],
+          }],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "after" }],
+        },
+      ],
+    })
+
+    expect(serializeComposerDocument(editor)).toBe(
+      "before\n\n10. parent\n    1. child\n\nafter",
+    )
+  })
+})

--- a/src/web/src/components/community/messages/composer-ordered-list.tiptap.test.ts
+++ b/src/web/src/components/community/messages/composer-ordered-list.tiptap.test.ts
@@ -1,9 +1,10 @@
 import { Node, Editor } from "@tiptap/react"
 import type { EditorState } from "@tiptap/pm/state"
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import {
   composerOrderedListInputRule,
   composerDocumentExtensions,
+  preserveComposerPlainTextPaste,
   serializeComposerDocument,
 } from "./composer-ordered-list"
 
@@ -110,6 +111,9 @@ describe("ComposerOrderedList", () => {
     expect(
       chat.extensionManager.extensions.some(({ name }) => name === "trailingNode"),
     ).toBe(false)
+    expect(
+      chat.extensionManager.plugins.some(({ spec }) => spec.isInputRules),
+    ).toBe(true)
     const forum = new Editor({
       element: null,
       extensions: composerDocumentExtensions(true),
@@ -200,6 +204,54 @@ describe("ComposerOrderedList", () => {
       { type: "orderedList", start: 3 },
       { type: "orderedList", start: 9 },
     ])
+  })
+})
+
+describe("preserveComposerPlainTextPaste", () => {
+  it.each([
+    { text: "", html: undefined },
+    { text: "1. alpha", html: "<p>1. alpha</p>" },
+  ])("does not consume non-text-only paste %#", ({ text, html }) => {
+    const dispatch = vi.fn()
+
+    expect(
+      preserveComposerPlainTextPaste(
+        { dispatch } as never,
+        text,
+        html,
+        {} as never,
+      ),
+    ).toBe(false)
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it("dispatches the exact parsed Slice with paste metadata", () => {
+    const slice = { content: "parsed plain text" }
+    const transaction = {
+      replaceSelection: vi.fn(),
+      scrollIntoView: vi.fn(),
+      setMeta: vi.fn(),
+    }
+    transaction.replaceSelection.mockReturnValue(transaction)
+    transaction.scrollIntoView.mockReturnValue(transaction)
+    transaction.setMeta.mockReturnValue(transaction)
+    const dispatch = vi.fn()
+    const view = { state: { tr: transaction }, dispatch }
+
+    expect(
+      preserveComposerPlainTextPaste(
+        view as never,
+        "1. alpha\n2. beta",
+        undefined,
+        slice as never,
+      ),
+    ).toBe(true)
+    expect(transaction.replaceSelection).toHaveBeenCalledWith(slice)
+    expect(transaction.scrollIntoView).toHaveBeenCalledOnce()
+    expect(transaction.setMeta).toHaveBeenNthCalledWith(1, "paste", true)
+    expect(transaction.setMeta).toHaveBeenNthCalledWith(2, "uiEvent", "paste")
+    expect(dispatch).toHaveBeenCalledOnce()
+    expect(dispatch).toHaveBeenCalledWith(transaction)
   })
 })
 

--- a/src/web/src/components/community/messages/composer-ordered-list.ts
+++ b/src/web/src/components/community/messages/composer-ordered-list.ts
@@ -1,0 +1,149 @@
+import { OrderedList } from "@tiptap/extension-list"
+import StarterKit from "@tiptap/starter-kit"
+import {
+  getText,
+  getTextSerializersFromSchema,
+  wrappingInputRule,
+  type Editor,
+} from "@tiptap/react"
+import type { Node as ProseMirrorNode, NodeType, Slice } from "@tiptap/pm/model"
+import type { EditorView } from "@tiptap/pm/view"
+
+const POSITIVE_ORDERED_LIST_INPUT_REGEX = /^([1-9]\d*)\.\s$/
+
+export function composerOrderedListInputRule(type: NodeType) {
+  return wrappingInputRule({
+    find: POSITIVE_ORDERED_LIST_INPUT_REGEX,
+    type,
+    getAttributes: (match) => ({ start: Number(match[1]) }),
+    joinPredicate: (match, node) => {
+      const hasDefaultType = !node.attrs.type || node.attrs.type === "1"
+      return hasDefaultType && node.childCount + node.attrs.start === Number(match[1])
+    },
+  })
+}
+
+const ComposerOrderedList = OrderedList.extend({
+  addInputRules() {
+    return [composerOrderedListInputRule(this.type)]
+  },
+})
+
+export function composerDocumentExtensions(isForumThreadBody: boolean) {
+  return [
+    StarterKit.configure({
+      heading: false,
+      horizontalRule: false,
+      codeBlock: false,
+      code: false,
+      blockquote: false,
+      bold: false,
+      italic: false,
+      strike: false,
+      bulletList: false,
+      orderedList: false,
+      listItem: isForumThreadBody ? false : {},
+      listKeymap: isForumThreadBody ? false : {},
+      trailingNode: isForumThreadBody ? {} : false,
+    }),
+    ...(isForumThreadBody ? [] : [ComposerOrderedList]),
+  ]
+}
+
+export function preserveComposerPlainTextPaste(
+  view: EditorView,
+  text: string | undefined,
+  html: string | undefined,
+  slice: Slice,
+): boolean {
+  if (!text || html) return false
+  view.dispatch(
+    view.state.tr
+      .replaceSelection(slice)
+      .scrollIntoView()
+      .setMeta("paste", true)
+      .setMeta("uiEvent", "paste"),
+  )
+  return true
+}
+
+type TextSerializers = ReturnType<typeof getTextSerializersFromSchema>
+
+function indentContinuationLines(text: string, indent: number): string {
+  return text.replaceAll("\n", `\n${" ".repeat(indent)}`)
+}
+
+function indentEveryLine(text: string, indent: number): string {
+  const prefix = " ".repeat(indent)
+  return `${prefix}${indentContinuationLines(text, indent)}`
+}
+
+function serializeTextBlock(
+  node: ProseMirrorNode,
+  serializers: TextSerializers,
+): string {
+  return getText(node, {
+    blockSeparator: "\n\n",
+    textSerializers: serializers,
+  })
+}
+
+function orderedListStart(node: ProseMirrorNode): number {
+  return typeof node.attrs.start === "number" ? node.attrs.start : 1
+}
+
+function serializeListItem(
+  node: ProseMirrorNode,
+  number: number,
+  baseIndent: number,
+  serializers: TextSerializers,
+): string {
+  const marker = `${number}. `
+  const contentIndent = baseIndent + marker.length
+  let text = `${" ".repeat(baseIndent)}${marker}`
+  let hasBlock = false
+
+  node.forEach((child) => {
+    if (child.type.name === "orderedList") {
+      text += `\n${serializeOrderedList(child, contentIndent, serializers)}`
+      hasBlock = true
+      return
+    }
+
+    const block = serializeTextBlock(child, serializers)
+    if (!hasBlock) {
+      text += indentContinuationLines(block, contentIndent)
+    } else {
+      text += `\n\n${indentEveryLine(block, contentIndent)}`
+    }
+    hasBlock = true
+  })
+
+  return text
+}
+
+function serializeOrderedList(
+  node: ProseMirrorNode,
+  baseIndent: number,
+  serializers: TextSerializers,
+): string {
+  const items: string[] = []
+  const start = orderedListStart(node)
+  node.forEach((item, _offset, index) => {
+    items.push(serializeListItem(item, start + index, baseIndent, serializers))
+  })
+  return items.join("\n")
+}
+
+export function serializeComposerDocument(editor: Editor): string {
+  const serializers = getTextSerializersFromSchema(editor.schema)
+  const blocks: string[] = []
+  editor.state.doc.forEach((node) => {
+    blocks.push(
+      node.type.name === "orderedList"
+        ? serializeOrderedList(node, 0, serializers)
+        : serializeTextBlock(node, serializers),
+    )
+  })
+  return blocks.join("\n\n")
+}

--- a/src/web/src/components/community/messages/composer.send-lifecycle.test.ts
+++ b/src/web/src/components/community/messages/composer.send-lifecycle.test.ts
@@ -5,6 +5,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const mocks = vi.hoisted(() => ({
   useEditor: vi.fn(),
   useFileAttachments: vi.fn(),
+  composerDocumentExtensions: vi.fn(),
+  preservePlainTextPaste: vi.fn(),
+  serializeDocument: vi.fn(),
 }))
 
 vi.mock("@tiptap/react", () => ({
@@ -46,6 +49,15 @@ vi.mock("@/hooks/use-hover-capable", () => ({
   useHoverCapable: () => true,
 }))
 
+vi.mock("./composer-ordered-list", () => ({
+  composerDocumentExtensions: (...args: unknown[]) =>
+    mocks.composerDocumentExtensions(...args),
+  preserveComposerPlainTextPaste: (...args: unknown[]) =>
+    mocks.preservePlainTextPaste(...args),
+  serializeComposerDocument: (...args: unknown[]) =>
+    mocks.serializeDocument(...args),
+}))
+
 import { Composer, type ComposerProps } from "./composer"
 import type { PendingFile } from "@/hooks/use-file-attachments"
 
@@ -64,6 +76,9 @@ describe("Composer committed send lifecycle", () => {
     firstEditorOptions = undefined
     mocks.useEditor.mockReset()
     mocks.useFileAttachments.mockReset()
+    mocks.composerDocumentExtensions.mockReturnValue([{ name: "document-extensions" }])
+    mocks.preservePlainTextPaste.mockReturnValue(true)
+    mocks.serializeDocument.mockReturnValue("9. latest\n10. draft")
     pendingFiles = []
     clearContent = vi.fn()
     transferPendingFiles = vi.fn(() => pendingFiles)
@@ -76,7 +91,9 @@ describe("Composer committed send lifecycle", () => {
       commands: {
         clearContent,
         focus: vi.fn(),
+        liftEmptyBlock: vi.fn(() => false),
         setContent: vi.fn(),
+        splitListItem: vi.fn(() => false),
       },
       chain: vi.fn(() => ({
         focus: vi.fn(() => ({
@@ -155,7 +172,7 @@ describe("Composer committed send lifecycle", () => {
     expect(preventRejected).toHaveBeenCalledOnce()
     expect(initialAccept).not.toHaveBeenCalled()
     expect(rejectLatest).toHaveBeenCalledWith(
-      "latest draft",
+      "9. latest\n10. draft",
       [{ file, previewObjectUrl: undefined, width: undefined, height: undefined }],
       undefined,
     )
@@ -183,7 +200,7 @@ describe("Composer committed send lifecycle", () => {
     })
 
     expect(acceptedLatest).toHaveBeenCalledWith(
-      "latest draft",
+      "9. latest\n10. draft",
       [{ file, previewObjectUrl: undefined, width: undefined, height: undefined }],
       undefined,
     )
@@ -239,7 +256,7 @@ describe("Composer committed send lifecycle", () => {
       await Promise.resolve()
     })
     expect(accept).toHaveBeenCalledOnce()
-    expect(accept).toHaveBeenCalledWith("latest draft", [{
+    expect(accept).toHaveBeenCalledWith("9. latest\n10. draft", [{
       file,
       thumbnailBlob,
       previewObjectUrl: "blob:thumbnail",

--- a/src/web/src/components/community/messages/use-composer-controller.test.ts
+++ b/src/web/src/components/community/messages/use-composer-controller.test.ts
@@ -26,6 +26,9 @@ const mocks = vi.hoisted(() => ({
   fromSchema: vi.fn(),
   parseSlice: vi.fn(),
   normalizeHardBreak: vi.fn(),
+  composerDocumentExtensions: vi.fn(),
+  preservePlainTextPaste: vi.fn(),
+  serializeDocument: vi.fn(),
   hoverCapable: true,
 }))
 
@@ -86,6 +89,14 @@ vi.mock("./consecutive-hard-break", () => ({
   normalizeConsecutiveTerminalHardBreak: (...args: unknown[]) =>
     mocks.normalizeHardBreak(...args),
 }))
+vi.mock("./composer-ordered-list", () => ({
+  composerDocumentExtensions: (...args: unknown[]) =>
+    mocks.composerDocumentExtensions(...args),
+  preserveComposerPlainTextPaste: (...args: unknown[]) =>
+    mocks.preservePlainTextPaste(...args),
+  serializeComposerDocument: (...args: unknown[]) =>
+    mocks.serializeDocument(...args),
+}))
 
 import { useComposerController } from "./use-composer-controller"
 import type { ComposerHandle, ComposerProps } from "./composer-types"
@@ -95,7 +106,7 @@ type EditorOptions = {
   editorProps: {
     attributes: Record<string, string>
     handleKeyDown: (_view: unknown, event: KeyboardEvent) => boolean
-    handlePaste: (_view: unknown, event: ClipboardEvent) => boolean
+    handlePaste: (_view: unknown, event: ClipboardEvent, slice?: unknown) => boolean
     clipboardTextParser: (text: string, context: never) => unknown
   }
   onUpdate: (props: { editor: TestEditor }) => void
@@ -122,7 +133,10 @@ type TestEditor = {
   commands: {
     clearContent: ReturnType<typeof vi.fn>
     focus: ReturnType<typeof vi.fn>
+    liftEmptyBlock: ReturnType<typeof vi.fn>
     setContent: ReturnType<typeof vi.fn>
+    splitListItem: ReturnType<typeof vi.fn>
+    undoInputRule: ReturnType<typeof vi.fn>
   }
   chain: ReturnType<typeof vi.fn>
 }
@@ -192,11 +206,19 @@ describe("useComposerController", () => {
       commands: {
         clearContent,
         focus,
+        liftEmptyBlock: vi.fn(() => false),
         setContent,
+        splitListItem: vi.fn(() => false),
+        undoInputRule: vi.fn(() => false),
       },
       chain: vi.fn(() => ({ focus: chainFocus })),
     }
     mocks.starterConfigure.mockReturnValue({ name: "starter-kit" })
+    mocks.composerDocumentExtensions.mockReturnValue([{ name: "document-extensions" }])
+    mocks.preservePlainTextPaste.mockReturnValue(true)
+    mocks.serializeDocument.mockImplementation((currentEditor: TestEditor) =>
+      currentEditor.getText({ blockSeparator: "\n\n" }),
+    )
     mocks.placeholderConfigure.mockReturnValue({ name: "placeholder" })
     mocks.fromSchema.mockReturnValue({ parseSlice: mocks.parseSlice })
     mocks.useEditor.mockImplementation((options) => {
@@ -451,15 +473,23 @@ describe("useComposerController", () => {
     ).toBe(true)
     expect(preventDefault).toHaveBeenCalledOnce()
     expect(mocks.addPendingFiles).toHaveBeenCalledWith([file])
+    const pasteView = { state: {} }
+    const pasteSlice = { content: "parsed clipboard" }
     expect(
-      editorOptions.editorProps.handlePaste({} as never, {
+      editorOptions.editorProps.handlePaste(pasteView, {
         clipboardData: {
           items: { length: 0 },
-          getData: () => "x".repeat(1_000),
+          getData: (type: string) => type === "text/plain" ? "x".repeat(1_000) : "",
         },
         preventDefault: vi.fn(),
-      } as unknown as ClipboardEvent),
-    ).toBe(false)
+      } as unknown as ClipboardEvent, pasteSlice),
+    ).toBe(true)
+    expect(mocks.preservePlainTextPaste).toHaveBeenCalledWith(
+      pasteView,
+      "x".repeat(1_000),
+      "",
+      pasteSlice,
+    )
 
     const preventLongPaste = vi.fn()
     expect(
@@ -617,7 +647,9 @@ describe("useComposerController", () => {
       .editor
     expect(secondEditor).toBe(firstEditor)
     expect(mocks.useEditor).toHaveBeenCalledTimes(2)
-    expect(mocks.starterConfigure).toHaveBeenCalledTimes(2)
+    expect(mocks.composerDocumentExtensions).toHaveBeenCalledTimes(2)
+    expect(mocks.composerDocumentExtensions).toHaveBeenNthCalledWith(1, false)
+    expect(mocks.composerDocumentExtensions).toHaveBeenNthCalledWith(2, false)
     expect(mocks.placeholderConfigure).toHaveBeenCalledTimes(2)
   })
 
@@ -1156,6 +1188,14 @@ describe("useComposerController", () => {
     ).toBe(false)
     expect(mocks.normalizeHardBreak).not.toHaveBeenCalled()
     expect(accept).not.toHaveBeenCalled()
+
+    editor.commands.undoInputRule.mockReturnValueOnce(true)
+    const undoKey = key({ key: "z", metaKey: true })
+    expect(editorOptions.editorProps.handleKeyDown(editorView, undoKey)).toBe(
+      true,
+    )
+    expect(editor.commands.undoInputRule).toHaveBeenCalledOnce()
+    expect(undoKey.preventDefault).toHaveBeenCalledOnce()
 
     const forumProps: ComposerProps = {
       channel: "forum",

--- a/src/web/src/components/community/messages/use-composer-controller.ts
+++ b/src/web/src/components/community/messages/use-composer-controller.ts
@@ -8,8 +8,7 @@ import {
   type DragEvent,
   type ForwardedRef,
 } from "react"
-import { useEditor, type JSONContent } from "@tiptap/react"
-import StarterKit from "@tiptap/starter-kit"
+import { useEditor, type Editor, type JSONContent } from "@tiptap/react"
 import Placeholder from "@tiptap/extension-placeholder"
 import { DOMParser as PMDOMParser } from "@tiptap/pm/model"
 import { MAX_ATTACHMENTS_PER_MESSAGE, MAX_ATTACHMENT_SIZE_BYTES } from "@alook/shared"
@@ -28,6 +27,7 @@ import {
   pendingFilesToSendAttachments,
 } from "./composer-file-utils"
 import { handleComposerEditorKeyDown } from "./composer-keydown"
+import { composerDocumentExtensions, preserveComposerPlainTextPaste, serializeComposerDocument } from "./composer-ordered-list"
 import type { ComposerHandle, ComposerProps } from "./composer-types"
 import { mentionNodesForCaretInsertion, textNodeForCaretInsertion } from "./caret-text-insertion"
 import type { ComposerViewProps } from "./composer-view"
@@ -91,6 +91,7 @@ export function useComposerController(
   }, [pendingFiles])
   const typingTimer = useRef<NodeJS.Timeout | null>(null)
   const sendRef = useRef<() => void>(() => {})
+  const editorRef = useRef<Editor | null>(null)
   const sendInFlightRef = useRef<Promise<void> | null>(null)
   const lifecycleVersionRef = useRef(0)
   const draftKeyRef = useRef(draftKey)
@@ -135,20 +136,7 @@ export function useComposerController(
   const editor = useEditor({
     immediatelyRender: false,
     extensions: [
-      StarterKit.configure({
-        heading: false,
-        horizontalRule: false,
-        codeBlock: false,
-        code: false,
-        blockquote: false,
-        bold: false,
-        italic: false,
-        strike: false,
-        bulletList: false,
-        orderedList: false,
-        listItem: false,
-        listKeymap: false,
-      }),
+      ...composerDocumentExtensions(isForumThreadBody),
       // eslint-disable-next-line react-hooks/refs
       Placeholder.configure({
         placeholder: resolvePlaceholder,
@@ -173,8 +161,11 @@ export function useComposerController(
             suggestions.mentionPopupRef.current.items.length > 0 &&
             suggestions.mentionPopupRef.current.command !== null,
           send: () => sendRef.current(),
+          liftEmptyBlock: () => editorRef.current?.commands.liftEmptyBlock() ?? false,
+          splitListItem: () => editorRef.current?.commands.splitListItem("listItem") ?? false,
+          undoInputRule: () => editorRef.current?.commands.undoInputRule() ?? false,
         }),
-      handlePaste: (_view, event) => {
+      handlePaste: (view, event, slice) => {
         const files = clipboardFiles(event.clipboardData?.items)
         if (files.length > 0) {
           event.preventDefault()
@@ -182,17 +173,25 @@ export function useComposerController(
           return true
         }
 
+        const clipboardText = event.clipboardData?.getData("text/plain")
         const attachment = createLongPasteAttachment(
-          event.clipboardData?.getData("text/plain"),
+          clipboardText,
           pendingFilesRef.current.map(({ file }) => file.name),
           nextLongPasteIndexRef.current,
         )
-        if (!attachment) return false
+        if (attachment) {
+          event.preventDefault()
+          nextLongPasteIndexRef.current = attachment.nextIndex
+          void addPendingFiles([attachment.file])
+          return true
+        }
 
-        event.preventDefault()
-        nextLongPasteIndexRef.current = attachment.nextIndex
-        void addPendingFiles([attachment.file])
-        return true
+        return preserveComposerPlainTextPaste(
+          view,
+          clipboardText,
+          event.clipboardData?.getData("text/html"),
+          slice,
+        )
       },
       clipboardTextParser: (text, $context) => {
         const dom = buildPasteDom(text, document)
@@ -216,8 +215,11 @@ export function useComposerController(
       }
     },
   })
-  const enterKeyHint =
-    isForumThreadBody || !hoverCapable ? "enter" : "send"
+  useLayoutEffect(() => {
+    editorRef.current = editor
+    return () => { if (editorRef.current === editor) editorRef.current = null }
+  }, [editor])
+  const enterKeyHint = isForumThreadBody || !hoverCapable ? "enter" : "send"
   useLayoutEffect(() => {
     editor?.view?.dom?.setAttribute("enterkeyhint", enterKeyHint)
   }, [editor, enterKeyHint])
@@ -245,7 +247,6 @@ export function useComposerController(
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor, draftKey])
-
   const previousHasContentRef = useRef(false)
   const onDirtyRef = useRef(onDirty)
   useEffect(() => {
@@ -278,7 +279,7 @@ export function useComposerController(
       if (editor.isEmpty && preparedFiles.length === 0) return
       const markdown = editor.isEmpty
         ? ""
-        : editor.getText({ blockSeparator: "\n\n" }).trim()
+        : serializeComposerDocument(editor).trim()
       const mentionType = detectMentionType(markdown)
       const payload = pendingFilesToSendAttachments([...preparedFiles])
       if (sendContract === "accepted") {

--- a/src/web/src/lib/community/composer-draft.test.ts
+++ b/src/web/src/lib/community/composer-draft.test.ts
@@ -24,6 +24,42 @@ const DOC_WITH_PILL = {
   ],
 }
 
+const DOC_WITH_ORDERED_LIST_AND_PILLS = {
+  type: "doc",
+  content: [{
+    type: "orderedList",
+    attrs: { start: 42, type: null },
+    content: [
+      {
+        type: "listItem",
+        content: [{
+          type: "paragraph",
+          content: [
+            { type: "mention", attrs: { id: "u1", label: "Alice#0001" } },
+            { type: "text", text: " see " },
+            {
+              type: "channelRef",
+              attrs: {
+                id: "c1",
+                label: "general",
+                serverId: "s1",
+                serverName: "demo",
+              },
+            },
+          ],
+        }],
+      },
+      {
+        type: "listItem",
+        content: [{
+          type: "paragraph",
+          content: [{ type: "text", text: "second" }],
+        }],
+      },
+    ],
+  }],
+}
+
 describe("composer-draft", () => {
   let storage: Record<string, string>
 
@@ -52,6 +88,12 @@ describe("composer-draft", () => {
   it("round-trips a ProseMirror doc losslessly (pills preserved)", () => {
     writeComposerDraft("srv/chan", DOC_WITH_PILL)
     expect(readComposerDraft("srv/chan")).toEqual(DOC_WITH_PILL)
+  })
+
+  it("round-trips ordered-list start, items, and pills losslessly", () => {
+    writeComposerDraft("srv/chan", DOC_WITH_ORDERED_LIST_AND_PILLS)
+    expect(readComposerDraft("srv/chan"))
+      .toEqual(DOC_WITH_ORDERED_LIST_AND_PILLS)
   })
 
   it("persists as JSON under the key", () => {

--- a/src/web/src/test/e2e-ui/52-chat-composer-ordered-list.spec.ts
+++ b/src/web/src/test/e2e-ui/52-chat-composer-ordered-list.spec.ts
@@ -1,0 +1,288 @@
+import type { Locator, Page, TestInfo } from "@playwright/test"
+import { test, expect, userId } from "./_fixtures/community-fixture"
+import {
+  composerEditable,
+  ignoreNextDevToolsPointerCapture,
+  installInputCapability,
+} from "./_fixtures/actions"
+import {
+  communityFrameEvents,
+  proxyCommunityWebSockets,
+  type CapturedCommunityFrame,
+} from "./_fixtures/community-ws-proxy"
+import {
+  seedChannel,
+  seedDm,
+  seedMessage,
+  seedServer,
+  seedThread,
+} from "./_fixtures/seed"
+import { tid } from "./_fixtures/testids"
+
+type MessageResponse = {
+  message: { id: string; channelId: string; content: string }
+}
+
+function createdMessage(
+  frames: CapturedCommunityFrame[],
+  channelId: string,
+  messageId: string,
+) {
+  return frames.flatMap(communityFrameEvents).find((event) => (
+    event.type === "community:message.create"
+    && event.channelId === channelId
+    && event.message?.id === messageId
+  ))
+}
+
+async function expectExactMessageCommit({
+  page,
+  channelId,
+  content,
+  frames,
+  submit,
+}: {
+  page: Page
+  channelId: string
+  content: string
+  frames: CapturedCommunityFrame[]
+  submit: () => Promise<void>
+}) {
+  const responsePromise = page.waitForResponse((response) => (
+    response.request().method() === "POST"
+    && new URL(response.url()).pathname === `/api/community/channels/${channelId}/messages`
+  ))
+  await submit()
+  const response = await responsePromise
+  expect(response.status()).toBe(201)
+  expect(response.request().postDataJSON()).toMatchObject({ content })
+  const payload = await response.json() as MessageResponse
+  expect(payload.message).toMatchObject({ channelId, content })
+  await expect(page.getByTestId(tid.message(payload.message.id))).toBeVisible()
+  await expect.poll(() => createdMessage(frames, channelId, payload.message.id)?.message?.content)
+    .toBe(content)
+  return payload.message.id
+}
+
+async function typeCanonicalMarker(
+  page: Page,
+  start: number,
+  text: string,
+  root: Page | Locator = page,
+) {
+  const editable = composerEditable(page, root)
+  await editable.click()
+  await editable.pressSequentially(`${start}. ${text}`)
+  await expect(editable.locator("ol")).toHaveCount(1)
+  if (start !== 1) await expect(editable.locator("ol")).toHaveAttribute("start", String(start))
+  return editable
+}
+
+test.describe.serial("chat composer ordered-list continuation", () => {
+  let serverId: string
+  let channelAId: string
+  let channelBId: string
+  let forumId: string
+  let threadId: string
+  let dmId: string
+
+  test.beforeAll(async () => {
+    serverId = await seedServer("alice", `composer-lists-${Date.now()}`)
+    channelAId = await seedChannel("alice", serverId, "composer-lists-a")
+    channelBId = await seedChannel("alice", serverId, "composer-lists-b")
+    forumId = await seedChannel("alice", serverId, "composer-lists-forum", "forum")
+    const openerId = await seedMessage("alice", channelAId, "ordered-list thread opener")
+    threadId = await seedThread("alice", openerId, "ordered-list-thread")
+    dmId = await seedDm("alice", userId("bob"))
+  })
+
+  test("desktop nests with official list keys and commits exact numbered text", async ({ asUser }, testInfo: TestInfo) => {
+    const { page, context } = await asUser("alice")
+    await installInputCapability(page, true)
+    const proxy = await proxyCommunityWebSockets(context)
+    await page.goto(`/c/channels/${serverId}/${channelAId}`, { waitUntil: "commit" })
+    await ignoreNextDevToolsPointerCapture(page)
+
+    const editable = await typeCanonicalMarker(page, 9, "parent")
+    await page.keyboard.press("Shift+Enter")
+    await page.keyboard.press("Tab")
+    await editable.pressSequentially("child")
+    await page.keyboard.press("Shift+Enter")
+    await editable.pressSequentially("next")
+    await page.keyboard.press("Shift+Enter")
+    await page.keyboard.press("Shift+Tab")
+    await editable.pressSequentially("sibling")
+
+    const topLevelItems = editable.locator(":scope > ol > li")
+    await expect(topLevelItems).toHaveCount(2)
+    await expect(topLevelItems.first().locator(":scope > ol > li")).toHaveCount(2)
+    await expect(editable).toHaveAttribute("enterkeyhint", "send")
+    await editable.evaluate((element) => {
+      ;(element as HTMLElement).dataset.e2eEditorIdentity = "ordered-list-editor"
+    })
+    await page.setViewportSize({ width: 639, height: 844 })
+    await expect(editable).toHaveAttribute("data-e2e-editor-identity", "ordered-list-editor")
+    await expect(editable).toHaveAttribute("enterkeyhint", "send")
+    await page.setViewportSize({ width: 640, height: 844 })
+    await expect(editable).toHaveAttribute("data-e2e-editor-identity", "ordered-list-editor")
+
+    await testInfo.attach("ordered-list-desktop-nested.png", {
+      body: await page.screenshot(),
+      contentType: "image/png",
+    })
+    const content = "9. parent\n   1. child\n   2. next\n10. sibling"
+    const messageId = await expectExactMessageCommit({
+      page,
+      channelId: channelAId,
+      content,
+      frames: proxy.frames,
+      submit: async () => { await page.keyboard.press("Enter") },
+    })
+    await expect(editable).toHaveText("")
+    await page.reload({ waitUntil: "commit" })
+    await expect(page.getByTestId(tid.message(messageId))).toContainText("parent")
+    await expect(page.getByTestId(tid.message(messageId))).toContainText("sibling")
+  })
+
+  test("touch Enter continues and exits while only the send button commits", async ({ asUser }, testInfo: TestInfo) => {
+    const { page, context } = await asUser("alice", { viewport: { width: 390, height: 844 } })
+    await installInputCapability(page, false)
+    const proxy = await proxyCommunityWebSockets(context)
+    let posts = 0
+    page.on("request", (request) => {
+      if (
+        request.method() === "POST"
+        && new URL(request.url()).pathname === `/api/community/channels/${channelAId}/messages`
+      ) posts += 1
+    })
+    await page.goto(`/c/channels/${serverId}/${channelAId}`, { waitUntil: "commit" })
+    await ignoreNextDevToolsPointerCapture(page)
+
+    const editable = await typeCanonicalMarker(page, 9, "first")
+    const send = page.getByTestId(tid.composerSend)
+    await expect(editable).toHaveAttribute("enterkeyhint", "enter")
+    await expect(send).toBeVisible()
+    await page.keyboard.press("Enter")
+    await editable.pressSequentially("second")
+    await page.keyboard.press("Enter")
+    await page.keyboard.press("Enter")
+    await editable.pressSequentially("tail")
+    await expect(editable.locator(":scope > ol > li")).toHaveCount(2)
+    await expect(editable.locator(":scope > p").filter({ hasText: "tail" })).toHaveCount(1)
+    expect(posts).toBe(0)
+
+    await testInfo.attach("ordered-list-touch-exit.png", {
+      body: await page.screenshot(),
+      contentType: "image/png",
+    })
+    await expectExactMessageCommit({
+      page,
+      channelId: channelAId,
+      content: "9. first\n10. second\n\ntail",
+      frames: proxy.frames,
+      submit: async () => { await send.click() },
+    })
+    expect(posts).toBe(1)
+  })
+
+  test("child thread and DM commits stay in their exact channel scope", async ({ asUser }) => {
+    const { page, context } = await asUser("alice")
+    await installInputCapability(page, true)
+    const proxy = await proxyCommunityWebSockets(context)
+    const routes = [
+      { route: `/c/channels/${serverId}/${threadId}`, channelId: threadId, start: 42 },
+      { route: `/c/me/${dmId}`, channelId: dmId, start: 7 },
+    ]
+
+    for (const { route, channelId, start } of routes) {
+      await page.goto(route, { waitUntil: "commit" })
+      const root = channelId === threadId ? page.getByTestId(tid.threadSplitPanel) : page
+      const editable = await typeCanonicalMarker(page, start, "first", root)
+      await page.keyboard.press("Shift+Enter")
+      await editable.pressSequentially("second")
+      await expectExactMessageCommit({
+        page,
+        channelId,
+        content: `${start}. first\n${start + 1}. second`,
+        frames: proxy.frames,
+        submit: async () => { await page.keyboard.press("Enter") },
+      })
+    }
+  })
+
+  test("draft, undo, IME, plain paste, and forum-body boundaries remain stable", async ({ asUser }) => {
+    const { page } = await asUser("alice")
+    await installInputCapability(page, true)
+    let messagePosts = 0
+    page.on("request", (request) => {
+      if (request.method() === "POST" && new URL(request.url()).pathname.endsWith("/messages")) {
+        messagePosts += 1
+      }
+    })
+    await page.goto(`/c/channels/${serverId}/${channelAId}`, { waitUntil: "commit" })
+    let editable = await typeCanonicalMarker(page, 42, "draft")
+    await page.keyboard.press("Shift+Enter")
+    await editable.pressSequentially("restored")
+    await page.goto(`/c/channels/${serverId}/${channelBId}`, { waitUntil: "commit" })
+    await expect(composerEditable(page)).toHaveText("")
+    await page.goto(`/c/channels/${serverId}/${channelAId}`, { waitUntil: "commit" })
+    editable = composerEditable(page)
+    await expect(editable.locator("ol")).toHaveAttribute("start", "42")
+    await expect(editable.locator("li")).toHaveCount(2)
+
+    await editable.press("ControlOrMeta+A")
+    await editable.press("Backspace")
+    await editable.pressSequentially("7. ")
+    await expect(editable.locator("ol")).toHaveCount(1)
+    await editable.press("ControlOrMeta+Z")
+    await expect(editable.locator("ol")).toHaveCount(0)
+    await expect(editable).toHaveText("7. ")
+    await editable.pressSequentially("plain")
+    await editable.evaluate((element) => {
+      element.dispatchEvent(new KeyboardEvent("keydown", {
+        key: "Enter",
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+        isComposing: true,
+      }))
+    })
+    await expect(editable).toHaveText("7. plain")
+    expect(messagePosts).toBe(0)
+
+    await editable.press("ControlOrMeta+A")
+    await editable.press("Backspace")
+    await editable.evaluate((element) => {
+      const transfer = new DataTransfer()
+      transfer.setData("text/plain", "1. alpha\n2. beta")
+      element.dispatchEvent(new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: transfer,
+      }))
+    })
+    await expect(editable.locator("ol")).toHaveCount(0)
+    await expect(editable).toContainText("1. alpha")
+    await expect(editable).toContainText("2. beta")
+    expect(messagePosts).toBe(0)
+
+    await editable.press("ControlOrMeta+A")
+    await editable.press("Backspace")
+    await editable.pressSequentially("5. exit")
+    await page.keyboard.press("Shift+Enter")
+    await page.keyboard.press("Shift+Enter")
+    await expect(editable.locator(":scope > ol > li")).toHaveCount(1)
+    await expect(editable.locator(":scope > ol > li br")).toHaveCount(0)
+    await expect(editable.locator(":scope > p")).toHaveCount(1)
+    expect(messagePosts).toBe(0)
+
+    await page.goto(`/c/channels/${serverId}/${forumId}`, { waitUntil: "commit" })
+    await page.getByRole("button", { name: "New Post" }).click()
+    const forumBody = composerEditable(page)
+    await expect(forumBody).toBeVisible()
+    await forumBody.pressSequentially("1. literal forum body")
+    await expect(forumBody.locator("ol")).toHaveCount(0)
+    await expect(forumBody).toHaveText("1. literal forum body")
+    expect(messagePosts).toBe(0)
+  })
+})


### PR DESCRIPTION
# Why we need this PR?

Community DM, text-channel, and child-thread composers cannot currently author structured ordered lists while preserving their keyboard send behavior and exact plain-text delivery contract.

## What changed

- enable Tiptap ordered-list input rules only in chat composers for canonical positive decimal markers
- preserve hover/coarse Enter behavior, empty-item exit, official input-rule undo, draft structure, pills, IME, paste, and forum isolation
- serialize arbitrary-start and nested lists to deterministic plaintext through accepted/deferred send paths
- add focused Tiptap/controller/lifecycle/draft coverage and a four-journey `/c` Playwright spec with deterministic shard weight

## Checklist

- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [ ] Other

Local validation: root typecheck, lint, tests, typegrep, and knip pass. Independent `/c` QA passed all four committed journeys with exact POST/201/WS/D1/reload evidence.
