### PR TITLE
fix(agent-driver): steer active Cursor ACP turns

### DIFF
--- a/src/daemon/README.md
+++ b/src/daemon/README.md
@@ -97,12 +97,14 @@ Pi declares the `in_process_sdk` transport and
 `midTurnDelivery: "steer"`. Its lane delegates prompt, steer, abort, and dispose
 to the SDK while preserving the same receipts, events, and terminal contract.
 
-### Persistent queued runtime (Cursor)
+### Persistent steering runtime (Cursor)
 
 Cursor keeps one `cursor-agent acp` process and ACP session for the logical
-session. Each idle command is a `session/prompt` request; while one is active,
-later commands remain in the logical next-turn FIFO until its correlated
-response arrives. Interrupt sends `session/cancel` without killing the process.
+session. A root command starts a `session/prompt`; busy commands steer the same
+logical turn through concurrent prompt requests. Each request has its own
+JSON-RPC id, while the root receipt remains the stable terminal owner. Old
+responses cannot settle the current turn. Interrupt sends `session/cancel`
+without killing the process.
 
 ### Persistent service runtime (OpenCode)
 
@@ -120,7 +122,7 @@ live stream handles permissions.
 | **claude** | persistent session | stream-json NDJSON | `safe_boundary_queue` | stdin user-message line | stream-json |
 | **codex** | persistent session | JSON-RPC 2.0 (`app-server --listen stdio://`) | `safe_boundary_queue` | `initialize` → `thread/start`/`resume` | JSON-RPC notifications |
 | **pi** | persistent session | `@earendil-works/pi-coding-agent` | `steer` | `session.prompt()` | SDK callback |
-| **cursor** | persistent session | ACP JSON-RPC 2.0 (`cursor-agent acp`) | `next_turn_queue` | `session/prompt` | `session/update` + correlated prompt response |
+| **cursor** | persistent session | ACP JSON-RPC 2.0 (`cursor-agent acp`) | `steer` | `session/prompt` | `session/update` + correlated prompt response |
 | **opencode** | persistent session | authenticated HTTP + SSE (`opencode serve --pure`) | `steer` | v2 session prompt API | durable + live SSE |
 
 (Exact launch flags live in `agent-driver/src/adapters/<backend>/`.)

--- a/src/daemon/agent-driver/README.md
+++ b/src/daemon/agent-driver/README.md
@@ -64,7 +64,7 @@ There is no per-turn built-in fallback.
 |---|---|---|---|---|
 | Claude | session | `stdio_stream` / `claude.stream-json.v1` | `safe_boundary_queue` | `vendor_message` |
 | Codex | session | `stdio_rpc` / `codex.app-server.v1` | `safe_boundary_queue` | `transport_request` |
-| Cursor | session | `stdio_rpc` / `cursor.acp.v1` | `next_turn_queue` | `transport_request` |
+| Cursor | session | `stdio_rpc` / `cursor.acp.v1` | `steer` | `transport_request` |
 | OpenCode | session | `http_sse` / `opencode.v2.service.1.17.20` | `steer` | `transport_request` |
 | Pi | session | `in_process_sdk` / `pi_sdk` | `steer` | `prompt_invocation` |
 

--- a/src/daemon/agent-driver/src/adapters/cursor/acp-lane.ts
+++ b/src/daemon/agent-driver/src/adapters/cursor/acp-lane.ts
@@ -41,7 +41,7 @@ interface PendingCall {
 interface PendingPrompt {
   readonly kind: "prompt";
   readonly method: "session/prompt";
-  readonly active: ActivePrompt;
+  readonly prompt: PromptRequest;
 }
 
 type PendingRequest = PendingCall | PendingPrompt;
@@ -51,7 +51,7 @@ interface RpcRequest {
   readonly promise: Promise<unknown>;
 }
 
-interface ActivePrompt {
+interface PromptRequest {
   readonly requestId: number;
   readonly receipt: string;
 }
@@ -114,7 +114,8 @@ export class CursorAcpLane implements RuntimeLane {
   private started = false;
   private ready = false;
   private sessionId: string | null = null;
-  private activePrompt: ActivePrompt | null = null;
+  private currentPromptRequestId: number | null = null;
+  private terminalOwner: string | null = null;
   private requestedStopReason?: string;
   private spawnPromise?: Promise<SpawnedProcess>;
   private stopPromise?: Promise<void>;
@@ -193,17 +194,20 @@ export class CursorAcpLane implements RuntimeLane {
 
   async send(input: LaneSendInput): Promise<LaneAdmission> {
     if (!this.ready || !this.process || this.isClosed()) return { ok: false, reason: "closed" };
-    if (input.mode !== "idle") {
-      return { ok: false, reason: "unsupported", error: "Cursor ACP does not support mid-turn steering" };
+    if (input.mode === "busy") {
+      if (this.currentPromptRequestId === null) {
+        return { ok: false, reason: "runtime_busy", error: "Cursor ACP has no active prompt to steer" };
+      }
+      return this.admitPrompt(input.text, "steer");
     }
-    if (this.activePrompt) {
+    if (this.currentPromptRequestId !== null) {
       return { ok: false, reason: "runtime_busy", error: "Cursor ACP prompt is still active" };
     }
     return this.admitPrompt(input.text);
   }
 
   async interrupt(_input: LaneInterruptInput): Promise<boolean> {
-    if (!this.ready || !this.sessionId || !this.activePrompt || this.isClosed()) return false;
+    if (!this.ready || !this.sessionId || this.currentPromptRequestId === null || this.isClosed()) return false;
     this.write({ jsonrpc: "2.0", method: "session/cancel", params: { sessionId: this.sessionId } });
     return true;
   }
@@ -211,7 +215,8 @@ export class CursorAcpLane implements RuntimeLane {
   stop(input: LaneStopInput = {}): Promise<void> {
     this.requestedStopReason ??= input.reason ?? "requested_stop";
     this.ready = false;
-    this.activePrompt = null;
+    this.currentPromptRequestId = null;
+    this.terminalOwner = null;
     this.openToolCalls.clear();
     this.rejectAllPending(new Error("Cursor ACP lane stopped"));
     this.stopPromise ??= this.stopPhysicalOnce(input);
@@ -322,17 +327,20 @@ export class CursorAcpLane implements RuntimeLane {
     }
   }
 
-  private admitPrompt(text: string): LaneAdmission {
+  private admitPrompt(text: string, delivery: "prompt" | "steer" = "prompt"): LaneAdmission {
     if (!this.sessionId) return { ok: false, reason: "not_ready", error: "Cursor ACP session is not ready" };
-    if (this.activePrompt) return { ok: false, reason: "runtime_busy", error: "Cursor ACP prompt is still active" };
     const requestId = ++this.requestSequence;
-    const active: ActivePrompt = {
+    const prompt: PromptRequest = {
       requestId,
       receipt: `cursor:acp:${requestId}`,
     };
+    const previousPromptRequestId = this.currentPromptRequestId;
+    const previousTerminalOwner = this.terminalOwner;
+    const previousOpenToolCalls = new Set(this.openToolCalls);
+    if (delivery === "prompt") this.terminalOwner = prompt.receipt;
+    this.currentPromptRequestId = requestId;
     this.openToolCalls.clear();
-    this.activePrompt = active;
-    this.pending.set(requestId, { kind: "prompt", method: "session/prompt", active });
+    this.pending.set(requestId, { kind: "prompt", method: "session/prompt", prompt });
     try {
       this.write({
         jsonrpc: "2.0",
@@ -345,31 +353,40 @@ export class CursorAcpLane implements RuntimeLane {
       });
     } catch (error) {
       this.pending.delete(requestId);
-      if (this.activePrompt?.requestId === requestId) this.activePrompt = null;
+      if (this.currentPromptRequestId === requestId) {
+        this.currentPromptRequestId = previousPromptRequestId;
+        this.terminalOwner = previousTerminalOwner;
+        this.openToolCalls.clear();
+        for (const toolCallId of previousOpenToolCalls) this.openToolCalls.add(toolCallId);
+      }
       throw error;
     }
-    return { ok: true, acceptedAs: "prompt", receipt: active.receipt };
+    return { ok: true, acceptedAs: delivery, receipt: prompt.receipt };
   }
 
-  private completePrompt(active: ActivePrompt, value: unknown): void {
-    if (this.activePrompt?.requestId !== active.requestId) return;
+  private completePrompt(prompt: PromptRequest, value: unknown): void {
+    if (this.currentPromptRequestId !== prompt.requestId) return;
     const result = record(value);
     if (!result || typeof result.stopReason !== "string" || !PROMPT_STOP_REASONS.has(result.stopReason)) {
-      this.failPrompt(active, new Error("Cursor ACP prompt response did not contain a supported stopReason"));
+      this.failPrompt(prompt, new Error("Cursor ACP prompt response did not contain a supported stopReason"));
       return;
     }
-    this.activePrompt = null;
+    const terminalOwner = this.terminalOwner ?? prompt.receipt;
+    this.currentPromptRequestId = null;
+    this.terminalOwner = null;
     this.openToolCalls.clear();
     this.events.emit("runtime_event", {
       kind: "turn_end",
       sessionId: this.sessionId ?? undefined,
-      turnOwner: active.receipt,
+      turnOwner: terminalOwner,
     } satisfies AdapterEvent);
   }
 
-  private failPrompt(active: ActivePrompt, error: unknown): void {
-    if (this.activePrompt?.requestId !== active.requestId) return;
-    this.activePrompt = null;
+  private failPrompt(prompt: PromptRequest, error: unknown): void {
+    if (this.currentPromptRequestId !== prompt.requestId) return;
+    const terminalOwner = this.terminalOwner ?? prompt.receipt;
+    this.currentPromptRequestId = null;
+    this.terminalOwner = null;
     this.openToolCalls.clear();
     this.events.emit("runtime_event", {
       kind: "error",
@@ -378,7 +395,7 @@ export class CursorAcpLane implements RuntimeLane {
     this.events.emit("runtime_event", {
       kind: "turn_end",
       sessionId: this.sessionId ?? undefined,
-      turnOwner: active.receipt,
+      turnOwner: terminalOwner,
     } satisfies AdapterEvent);
   }
 
@@ -462,7 +479,8 @@ export class CursorAcpLane implements RuntimeLane {
       }
       this.processTerminal = true;
       this.ready = false;
-      this.activePrompt = null;
+      this.currentPromptRequestId = null;
+      this.terminalOwner = null;
       this.openToolCalls.clear();
       this.stopPromise ??= this.stopPhysicalOnce({ reason: "runtime_error", forceAfterMs: 0 });
       void this.stopPromise.catch(() => {});
@@ -478,7 +496,8 @@ export class CursorAcpLane implements RuntimeLane {
       if (this.processTerminal || this.process !== proc) return;
       this.processTerminal = true;
       this.ready = false;
-      this.activePrompt = null;
+      this.currentPromptRequestId = null;
+      this.terminalOwner = null;
       this.openToolCalls.clear();
       this.rejectAllPending(new Error("Cursor ACP process exited"));
       if (this.suppressExit || !this.processActivated) return;
@@ -521,15 +540,15 @@ export class CursorAcpLane implements RuntimeLane {
       this.pending.delete(id);
       if (message.error !== undefined) {
         const payload = record(message.error);
-        this.failPrompt(pending.active, new CursorAcpRpcError(
+        this.failPrompt(pending.prompt, new CursorAcpRpcError(
           pending.method,
           typeof payload?.code === "number" ? payload.code : undefined,
           rpcErrorMessage(message.error),
         ));
       } else if (!("result" in message)) {
-        this.failPrompt(pending.active, new Error("Cursor ACP response omitted result"));
+        this.failPrompt(pending.prompt, new Error("Cursor ACP response omitted result"));
       } else {
-        this.completePrompt(pending.active, message.result);
+        this.completePrompt(pending.prompt, message.result);
       }
       return;
     }
@@ -576,7 +595,7 @@ export class CursorAcpLane implements RuntimeLane {
       && typeof option.optionId === "string"
       && option.optionId.trim().length > 0
     ));
-    if (!this.ready || !this.activePrompt || !sameSession || !allowOnce) {
+    if (!this.ready || this.currentPromptRequestId === null || !sameSession || !allowOnce) {
       this.write({ jsonrpc: "2.0", id, result: { outcome: { outcome: "cancelled" } } });
       this.diagnostic("error", "Cursor ACP permission request was not allowed for the active prompt");
       return;
@@ -602,7 +621,7 @@ export class CursorAcpLane implements RuntimeLane {
       this.diagnostic("warning", "Cursor ACP emitted an update for a different session");
       return;
     }
-    if (!this.ready || !this.activePrompt) {
+    if (!this.ready || this.currentPromptRequestId === null) {
       this.diagnostic("warning", "Cursor ACP emitted a session update without an active prompt");
       return;
     }

--- a/src/daemon/agent-driver/src/adapters/cursor/index.test.ts
+++ b/src/daemon/agent-driver/src/adapters/cursor/index.test.ts
@@ -242,9 +242,9 @@ describe("CursorDriver persistent ACP transport", () => {
       error: "Cursor ACP session already started",
     });
     await expect(lane.send({ text: "busy", mode: "busy" })).resolves.toEqual({
-      ok: false,
-      reason: "unsupported",
-      error: "Cursor ACP does not support mid-turn steering",
+      ok: true,
+      acceptedAs: "steer",
+      receipt: "cursor:acp:5",
     });
     await expect(lane.send({ text: "idle", mode: "idle" })).resolves.toEqual({
       ok: false,
@@ -261,6 +261,7 @@ describe("CursorDriver persistent ACP transport", () => {
       "authenticate",
       "session/new",
       "session/prompt",
+      "session/prompt",
     ]);
     expect(server.messages[0]!.params).toMatchObject({
       protocolVersion: 1,
@@ -270,7 +271,186 @@ describe("CursorDriver persistent ACP transport", () => {
       sessionId: "cursor-acp-session",
       prompt: [{ type: "text", text: "say hi" }],
     });
+    expect(server.prompts[1]!.params).toEqual({
+      sessionId: "cursor-acp-session",
+      prompt: [{ type: "text", text: "busy" }],
+    });
     expect(events).toEqual([{ kind: "session_init", sessionId: "cursor-acp-session" }]);
+  });
+
+  it("keeps one root terminal owner across repeated steers and ignores every old response shape", async () => {
+    const server = installServer();
+    const lane = await new CursorDriver().openLane(baseCtx());
+    const events = eventsFrom(lane);
+    const root = await lane.start({ text: "root" });
+    const firstSteer = await lane.send({ text: "first steer", mode: "busy" });
+    const secondSteer = await lane.send({ text: "second steer", mode: "busy" });
+    const thirdSteer = await lane.send({ text: "third steer", mode: "busy" });
+    const process = spawned[0]!;
+
+    expect(root).toEqual({ ok: true, acceptedAs: "prompt", receipt: "cursor:acp:4" });
+    expect(firstSteer).toEqual({ ok: true, acceptedAs: "steer", receipt: "cursor:acp:5" });
+    expect(secondSteer).toEqual({ ok: true, acceptedAs: "steer", receipt: "cursor:acp:6" });
+    expect(thirdSteer).toEqual({ ok: true, acceptedAs: "steer", receipt: "cursor:acp:7" });
+    expect(new Set(server.prompts.map((prompt) => prompt.id)).size).toBe(4);
+
+    process.stdout.write(`${JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "cursor-acp-session",
+        update: { sessionUpdate: "tool_call", toolCallId: "current-tool", title: "Current tool" },
+      },
+    })}\n`);
+    completePrompt(process, server.prompts[0]!, "cancelled");
+    fail(process, server.prompts[1]!, "old prompt failed");
+    completePrompt(process, server.prompts[2]!);
+    await settle();
+
+    expect(events.filter((event) => event.kind === "error")).toEqual([]);
+    expect(events.filter((event) => event.kind === "turn_end")).toEqual([]);
+    process.stdout.write(`${JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "cursor-acp-session",
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "current-tool",
+          title: "Current tool",
+          status: "completed",
+        },
+      },
+    })}\n`);
+    expect(events).toContainEqual({ kind: "tool_output", name: "Current tool" });
+
+    completePrompt(process, server.prompts[3]!, "cancelled");
+    await settle();
+    expect(events.filter((event) => event.kind === "turn_end")).toEqual([{
+      kind: "turn_end",
+      sessionId: "cursor-acp-session",
+      turnOwner: "cursor:acp:4",
+    }]);
+
+    completePrompt(process, server.prompts[0]!);
+    fail(process, server.prompts[1]!, "duplicate old failure");
+    await settle();
+    expect(events.filter((event) => event.kind === "turn_end")).toHaveLength(1);
+    expect(events.filter((event) => event.kind === "runtime_diagnostic")).toHaveLength(2);
+  });
+
+  it("rejects busy delivery after the active prompt has finished", async () => {
+    const server = installServer();
+    const lane = await new CursorDriver().openLane(baseCtx());
+    await lane.start({ text: "root" });
+
+    completePrompt(spawned[0]!, server.prompts[0]!);
+    await settle();
+
+    await expect(lane.send({ text: "too late", mode: "busy" })).resolves.toEqual({
+      ok: false,
+      reason: "runtime_busy",
+      error: "Cursor ACP has no active prompt to steer",
+    });
+    expect(server.prompts).toHaveLength(1);
+  });
+
+  it("registers a steer before write so a synchronous response owns the current prompt", async () => {
+    const server = installServer();
+    const lane = await new CursorDriver().openLane(baseCtx());
+    const events = eventsFrom(lane);
+    await lane.start({ text: "root" });
+    const original = onClientMessage;
+    onClientMessage = (process, message) => {
+      original(process, message);
+      if (message.method === "session/prompt" && server.prompts.length === 2) {
+        respond(process, message, { stopReason: "end_turn" });
+      }
+    };
+
+    await expect(lane.send({ text: "synchronous steer", mode: "busy" })).resolves.toEqual({
+      ok: true,
+      acceptedAs: "steer",
+      receipt: "cursor:acp:5",
+    });
+    expect(events.filter((event) => event.kind === "turn_end")).toEqual([{
+      kind: "turn_end",
+      sessionId: "cursor-acp-session",
+      turnOwner: "cursor:acp:4",
+    }]);
+    completePrompt(spawned[0]!, server.prompts[0]!);
+    await settle();
+    expect(events.filter((event) => event.kind === "turn_end")).toHaveLength(1);
+  });
+
+  it("rolls a failed steer write back to the exact previous prompt and tool state", async () => {
+    const server = installServer();
+    const lane = await new CursorDriver().openLane(baseCtx());
+    const events = eventsFrom(lane);
+    await lane.start({ text: "root" });
+    const process = spawned[0]!;
+    process.stdout.write(`${JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "cursor-acp-session",
+        update: { sessionUpdate: "tool_call", toolCallId: "root-tool", title: "Root tool" },
+      },
+    })}\n`);
+    vi.spyOn(process.stdin, "write").mockImplementationOnce(() => {
+      throw new Error("steer write failed");
+    });
+
+    await expect(lane.send({ text: "must roll back", mode: "busy" })).rejects.toThrow("steer write failed");
+    expect(server.prompts).toHaveLength(1);
+    process.stdout.write(`${JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "cursor-acp-session",
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "root-tool",
+          title: "Root tool",
+          status: "completed",
+        },
+      },
+    })}\n`);
+    expect(events).toContainEqual({ kind: "tool_output", name: "Root tool" });
+
+    completePrompt(process, server.prompts[0]!);
+    await settle();
+    expect(events.filter((event) => event.kind === "turn_end")).toEqual([{
+      kind: "turn_end",
+      sessionId: "cursor-acp-session",
+      turnOwner: "cursor:acp:4",
+    }]);
+  });
+
+  it("lets only the latest prompt RPC error fail the root turn", async () => {
+    const server = installServer();
+    const lane = await new CursorDriver().openLane(baseCtx());
+    const events = eventsFrom(lane);
+    await lane.start({ text: "root" });
+    await lane.send({ text: "latest", mode: "busy" });
+    const process = spawned[0]!;
+
+    fail(process, server.prompts[1]!, "latest failed");
+    await settle();
+    expect(events.filter((event) => event.kind === "error")).toEqual([{
+      kind: "error",
+      message: "latest failed",
+    }]);
+    expect(events.filter((event) => event.kind === "turn_end")).toEqual([{
+      kind: "turn_end",
+      sessionId: "cursor-acp-session",
+      turnOwner: "cursor:acp:4",
+    }]);
+
+    fail(process, server.prompts[0]!, "old failed later");
+    await settle();
+    expect(events.filter((event) => event.kind === "error")).toHaveLength(1);
+    expect(events.filter((event) => event.kind === "turn_end")).toHaveLength(1);
   });
 
   it("loads an ACP session without a fresh fallback and returns reset_required for an old incompatible id", async () => {
@@ -1138,7 +1318,7 @@ describe("CursorDriver persistent ACP transport", () => {
   });
 
   it("turns an activated process error into one killed crash exit", async () => {
-    installServer();
+    const server = installServer();
     const lane = await new CursorDriver().openLane(baseCtx());
     const errors: Error[] = [];
     const exits: unknown[] = [];
@@ -1146,7 +1326,16 @@ describe("CursorDriver persistent ACP transport", () => {
     lane.on("runtime_event", () => {});
     lane.on("exit", (exit) => exits.push(exit));
     await lane.start({ text: "crash" });
+    await lane.send({ text: "first steer", mode: "busy" });
+    await lane.send({ text: "second steer", mode: "busy" });
     const process = spawned[0]!;
+    const internals = lane as unknown as {
+      pending: Map<number, unknown>;
+      currentPromptRequestId: number | null;
+      terminalOwner: string | null;
+    };
+    expect(server.prompts).toHaveLength(3);
+    expect(internals.pending.size).toBe(3);
 
     process.emit("error", new Error("EIO"));
     process.emit("error", new Error("duplicate"));
@@ -1155,6 +1344,9 @@ describe("CursorDriver persistent ACP transport", () => {
     expect(errors).toEqual([new Error("EIO")]);
     expect(exits).toEqual([{ code: null, signal: null, reason: "runtime_exit" }]);
     expect(process.kill).toHaveBeenCalledOnce();
+    expect(internals.pending.size).toBe(0);
+    expect(internals.currentPromptRequestId).toBeNull();
+    expect(internals.terminalOwner).toBeNull();
 
     process.finish(17, null);
     process.emit("error", new Error("late"));
@@ -1164,7 +1356,7 @@ describe("CursorDriver persistent ACP transport", () => {
   });
 
   it("ignores a process error after an authoritative exit", async () => {
-    installServer();
+    const server = installServer();
     const lane = await new CursorDriver().openLane(baseCtx());
     const errors: Error[] = [];
     const exits: unknown[] = [];
@@ -1172,7 +1364,16 @@ describe("CursorDriver persistent ACP transport", () => {
     lane.on("runtime_event", () => {});
     lane.on("exit", (exit) => exits.push(exit));
     await lane.start({ text: "crash" });
+    await lane.send({ text: "first steer", mode: "busy" });
+    await lane.send({ text: "second steer", mode: "busy" });
     const process = spawned[0]!;
+    const internals = lane as unknown as {
+      pending: Map<number, unknown>;
+      currentPromptRequestId: number | null;
+      terminalOwner: string | null;
+    };
+    expect(server.prompts).toHaveLength(3);
+    expect(internals.pending.size).toBe(3);
 
     process.finish(17, null);
     process.emit("error", new Error("late"));
@@ -1180,6 +1381,9 @@ describe("CursorDriver persistent ACP transport", () => {
     expect(exits).toEqual([{ code: 17, signal: null, reason: "runtime_exit" }]);
     expect(errors).toEqual([]);
     expect(process.kill).not.toHaveBeenCalled();
+    expect(internals.pending.size).toBe(0);
+    expect(internals.currentPromptRequestId).toBeNull();
+    expect(internals.terminalOwner).toBeNull();
   });
 
   it("keeps requested stop ownership when the process errors during cleanup", async () => {

--- a/src/daemon/agent-driver/src/adapters/cursor/index.ts
+++ b/src/daemon/agent-driver/src/adapters/cursor/index.ts
@@ -1,11 +1,11 @@
 /**
  * Cursor driver — persistent Agent Client Protocol (ACP) over stdio.
  *
- * One `cursor-agent acp` process owns one physical Cursor session. Root
- * prompts are correlated by their JSON-RPC request ids; the matching
- * `session/prompt` response is the only authoritative terminal for that turn.
- * Cursor does not accept mid-turn steering here, so LogicalAgentSession keeps
- * busy input in its next-turn FIFO until the active prompt settles.
+ * One `cursor-agent acp` process owns one physical Cursor session. A root
+ * prompt establishes the stable terminal owner; busy input steers through a
+ * concurrent `session/prompt` with its own JSON-RPC request id. Superseded
+ * responses settle only their own request, and only the current prompt can
+ * emit the root terminal.
  */
 import type {
   AdapterLaunchContext,

--- a/src/daemon/agent-driver/src/contract.ts
+++ b/src/daemon/agent-driver/src/contract.ts
@@ -121,7 +121,7 @@ export type FixedCapabilities<
 
 export type ClaudeCapabilities = FixedCapabilities<true, true, true, true, true, "safe_boundary_queue", "persistent">;
 export type CodexCapabilities = FixedCapabilities<false, true, true, false, true, "safe_boundary_queue", "persistent">;
-export type CursorCapabilities = FixedCapabilities<false, false, false, false, true, "next_turn_queue", "persistent">;
+export type CursorCapabilities = FixedCapabilities<false, false, false, false, true, "steer", "persistent">;
 export type OpenCodeCapabilities = FixedCapabilities<false, false, false, false, true, "steer", "persistent">;
 export type PiCapabilities = FixedCapabilities<true, true, false, false, false, "steer", "persistent">;
 

--- a/src/daemon/agent-driver/src/controller/logical-session.test.ts
+++ b/src/daemon/agent-driver/src/controller/logical-session.test.ts
@@ -8,8 +8,10 @@ import type { ChildProcess } from "node:child_process";
 import type {
   AgentDriverError,
   AgentEvent,
+  BackendCapabilities,
   BuiltinBackendId,
   BuiltinBackendSpecs,
+  CapabilitiesOf,
   ConfigOf,
   PreparedExecutionResource,
   RuntimeSettingsUpdate,
@@ -280,6 +282,7 @@ function makeSession<Id extends BuiltinBackendId>(
     execution?: BackendExecution;
     lane?: RuntimeLane;
     authoritativeOwner?: boolean;
+    capabilities?: BackendCapabilities;
     promptAdmissionTimeoutMs?: number;
     now?: () => number;
   } = {},
@@ -308,7 +311,8 @@ function makeSession<Id extends BuiltinBackendId>(
       resumeSessionId: options.resumeSessionId,
     },
     driver as unknown as BackendAdapter<Id, ConfigOf<BuiltinBackendSpecs, Id>>,
-    capabilitiesFor(backend),
+    // A test-only override exercises provider-agnostic queue semantics without widening production registrations.
+    (options.capabilities ?? capabilitiesFor(backend)) as CapabilitiesOf<BuiltinBackendSpecs, Id>,
     host,
     prepared,
     options.timeout ?? 100,
@@ -944,8 +948,15 @@ describe("logical delivery diagnostics", () => {
     await steering;
 
     const queueLane = new ControlledRuntimeLane();
-    queueLane.startAdmission = { ok: true, acceptedAs: "prompt", receipt: "cursor:test:1" };
-    const { session: queueSession } = makeSession("cursor", { lane: queueLane });
+    queueLane.startAdmission = { ok: true, acceptedAs: "prompt", receipt: "opencode:test:1" };
+    const queueCapabilities: BackendCapabilities = {
+      ...capabilitiesFor("opencode"),
+      midTurnDelivery: "next_turn_queue",
+    };
+    const { session: queueSession } = makeSession("opencode", {
+      lane: queueLane,
+      capabilities: queueCapabilities,
+    });
     await queueSession.start({ id: "root", kind: "user", text: "root" });
     queueLane.emit({ kind: "tool_call", name: "Read", input: {} });
     expect(await queueSession.send({ id: "next", kind: "user", text: "next" })).toMatchObject({ status: "queued" });

--- a/src/daemon/agent-driver/src/registry.test.ts
+++ b/src/daemon/agent-driver/src/registry.test.ts
@@ -15,7 +15,7 @@ import { ADAPTER_AUTHOR_CONTRACT_VERSION } from "./adapter-author.js";
 const EXPECTED: Record<BuiltinBackendId, BackendCapabilities> = {
   claude: { modelSelection: "launchable", providerConfiguration: true, reasoningEffort: true, fastMode: true, disallowedTools: true, commandOverride: true, resume: "by_id", sessionLifetime: "persistent", midTurnDelivery: "safe_boundary_queue", interrupt: true },
   codex: { modelSelection: "launchable", providerConfiguration: false, reasoningEffort: true, fastMode: true, disallowedTools: false, commandOverride: true, resume: "by_id", sessionLifetime: "persistent", midTurnDelivery: "safe_boundary_queue", interrupt: true },
-  cursor: { modelSelection: "launchable", providerConfiguration: false, reasoningEffort: false, fastMode: false, disallowedTools: false, commandOverride: true, resume: "by_id", sessionLifetime: "persistent", midTurnDelivery: "next_turn_queue", interrupt: true },
+  cursor: { modelSelection: "launchable", providerConfiguration: false, reasoningEffort: false, fastMode: false, disallowedTools: false, commandOverride: true, resume: "by_id", sessionLifetime: "persistent", midTurnDelivery: "steer", interrupt: true },
   opencode: { modelSelection: "launchable", providerConfiguration: false, reasoningEffort: false, fastMode: false, disallowedTools: false, commandOverride: true, resume: "by_id", sessionLifetime: "persistent", midTurnDelivery: "steer", interrupt: true },
   pi: { modelSelection: "launchable", providerConfiguration: true, reasoningEffort: true, fastMode: false, disallowedTools: false, commandOverride: false, resume: "by_id", sessionLifetime: "persistent", midTurnDelivery: "steer", interrupt: true },
 };

--- a/src/daemon/agent-driver/src/registry.ts
+++ b/src/daemon/agent-driver/src/registry.ts
@@ -192,7 +192,7 @@ const capabilities = {
   },
   cursor: {
     modelSelection: "launchable", providerConfiguration: false, reasoningEffort: false, fastMode: false,
-    disallowedTools: false, commandOverride: true, resume: "by_id", sessionLifetime: "persistent", midTurnDelivery: "next_turn_queue", interrupt: true,
+    disallowedTools: false, commandOverride: true, resume: "by_id", sessionLifetime: "persistent", midTurnDelivery: "steer", interrupt: true,
   },
   opencode: {
     modelSelection: "launchable", providerConfiguration: false, reasoningEffort: false, fastMode: false,

--- a/src/daemon/agent-driver/src/testing/builtin-adapter-conformance.test.ts
+++ b/src/daemon/agent-driver/src/testing/builtin-adapter-conformance.test.ts
@@ -13,7 +13,7 @@ describe("builtin adapter protocol conformance", () => {
     const expected = {
       claude: ["session", "stdio_stream", "claude.stream-json.v1", "safe_boundary_queue", "vendor_message"],
       codex: ["session", "stdio_rpc", "codex.app-server.v1", "safe_boundary_queue", "transport_request"],
-      cursor: ["session", "stdio_rpc", "cursor.acp.v1", "next_turn_queue", "transport_request"],
+      cursor: ["session", "stdio_rpc", "cursor.acp.v1", "steer", "transport_request"],
       opencode: ["session", "http_sse", "opencode.v2.service.1.17.20", "steer", "transport_request"],
       pi: ["session", "in_process_sdk", "pi_sdk", "steer", "prompt_invocation"],
     } as const;

--- a/src/daemon/agent-driver/src/testing/builtin-session-conformance.test.ts
+++ b/src/daemon/agent-driver/src/testing/builtin-session-conformance.test.ts
@@ -435,7 +435,7 @@ async function runPublicSessionLifecycle(backend: BuiltinBackendId): Promise<voi
   });
 
   const busy = await session.send({ id: "busy", kind: "user", text: "busy" });
-  expect(busy.status).toBe(backend === "pi" || backend === "opencode" ? "accepted" : "queued");
+  expect(busy.status).toBe(backend === "pi" || backend === "opencode" || backend === "cursor" ? "accepted" : "queued");
   const interrupted = await session.interrupt({ requestId: "interrupt-1", reason: "conformance" });
   expect(interrupted.status).toBe("accepted");
   harness.completeTurn(1);
@@ -552,7 +552,7 @@ describe.each(["claude", "codex", "cursor", "opencode", "pi"] as const)(
 
       const busy = ids.slice(1, 6).map((id) => fixture.session.send({ id, kind: "user", text: id }));
       await Promise.all(busy);
-      fixture.harness.completeTurn(1);
+      fixture.harness.completeTurn(backend === "cursor" ? 6 : 1);
       await settle();
 
       const idleBurst = ids.slice(6).map((id) => fixture.session.send({ id, kind: "user", text: id }));
@@ -562,7 +562,7 @@ describe.each(["claude", "codex", "cursor", "opencode", "pi"] as const)(
       }
       await Promise.all(idleBurst);
       if (backend !== "codex" && backend !== "cursor") fixture.harness.sessionReady(2);
-      let turn = 2;
+      let turn = backend === "cursor" ? 10 : 2;
       let staleTerminalEmitted = false;
       let completedTurnId: string | undefined;
       while (
@@ -886,7 +886,7 @@ describe("codex persistent terminal ownership", () => {
 });
 
 describe("cursor persistent ACP ownership", () => {
-  it("keeps a queued second root off the wire and fences a late first response by JSON-RPC id", async () => {
+  it("steers a busy message on the wire and lets only the current JSON-RPC id settle the root", async () => {
     const harness = installVendorHarness("cursor");
     const host = createFakeAgentDriverHost();
     const sdk = createAgentDriverSdkWithRegistry({ host, registry: createBuiltinAgentDriverRegistry() });
@@ -909,21 +909,23 @@ describe("cursor persistent ACP ownership", () => {
       .toMatchObject({ status: "accepted" });
     expect(harness.stdinMessages.filter((message) => message.method === "session/prompt")).toHaveLength(1);
     expect(await opened.session.send({ id: "second", kind: "user", text: "same" }))
-      .toEqual({ status: "queued", reason: "runtime_busy", commandId: "second" });
-    expect(harness.stdinMessages.filter((message) => message.method === "session/prompt")).toHaveLength(1);
+      .toMatchObject({ status: "accepted", delivery: "steer", commandId: "second" });
+    expect(harness.stdinMessages.filter((message) => message.method === "session/prompt")).toHaveLength(2);
+    expect(opened.session.snapshot().activeTurn?.commandIds).toEqual(["first", "second"]);
 
     harness.completeTurn(1);
-    await vi.waitFor(() => {
-      expect(harness.stdinMessages.filter((message) => message.method === "session/prompt")).toHaveLength(2);
-    });
-    const secondTurnId = opened.session.snapshot().activeTurn?.turnId;
+    await settle();
     harness.duplicateTurn(1);
     await settle();
-    expect(opened.session.snapshot().activeTurn?.turnId).toBe(secondTurnId);
-    expect(events.filter((event) => event.type === "turn_completed")).toHaveLength(1);
+    expect(opened.session.snapshot().activeTurn?.commandIds).toEqual(["first", "second"]);
+    expect(events.filter((event) => event.type === "turn_completed")).toHaveLength(0);
 
     harness.completeTurn(2);
-    await vi.waitFor(() => expect(events.filter((event) => event.type === "turn_completed")).toHaveLength(2));
+    await vi.waitFor(() => expect(events.filter((event) => event.type === "turn_completed")).toHaveLength(1));
+    expect(events.filter((event) => event.type === "turn_completed")).toMatchObject([{
+      commandIds: ["first", "second"],
+      result: { outcome: "success" },
+    }]);
     expect(harness.processes).toHaveLength(1);
     await opened.session.stop({ reason: "shutdown", forceAfterMs: 10 });
     await collecting;

--- a/src/daemon/src/manager/managerRuntime.test.ts
+++ b/src/daemon/src/manager/managerRuntime.test.ts
@@ -5063,15 +5063,15 @@ describe("B1 red gate — exact-once terminal matrix", () => {
     expect(session.stop).toHaveBeenCalledTimes(1);
   });
 
-  it("does not expire a driver-acknowledged next-turn queue while the active root keeps making progress", async () => {
+  it("does not expire a driver-acknowledged queued admission while the active root keeps making progress", async () => {
     vi.useFakeTimers();
     try {
       let now = 0;
       const rows: B1TraceRow[] = [];
-      const session = b1Session([], "cursor", "root-turn");
+      const session = b1Session([], "codex", "root-turn");
       const { mgr } = b1Manager({
         sessions: [session],
-        driver: fakeDriver("cursor"),
+        driver: fakeDriver("codex"),
         trace: (row) => rows.push(row),
         now: () => now,
         tickIntervalMs: 5,
@@ -5097,14 +5097,14 @@ describe("B1 red gate — exact-once terminal matrix", () => {
       await Promise.resolve();
       expect(mgr.snapshot().agents.a1.pendingAdmissions).toHaveLength(1);
 
-      // The queued command is waiting for Cursor's next-turn boundary, while
-      // the original root is demonstrably healthy. Its queue dwell may exceed
-      // the generic admission watchdog without turning into a send stall.
+      // The driver owns the queued command while the original root is
+      // demonstrably healthy. Queue dwell may exceed the generic admission
+      // watchdog without turning into a send stall.
       now = 55;
       await session.pushAgentEvent({
         type: "internal_progress",
         turnId: "root-turn",
-        source: "cursor",
+        source: "codex",
       });
       now = 70;
       await vi.advanceTimersByTimeAsync(10);
@@ -5128,7 +5128,7 @@ describe("B1 red gate — exact-once terminal matrix", () => {
       let now = 0;
       let deliveryPhase: "working" | "tool_wait" | "next_turn_queued" = "working";
       const rows: B1TraceRow[] = [];
-      const session = b1Session([], "cursor", "root-turn");
+      const session = b1Session([], "codex", "root-turn");
       const baseSnapshot = session.snapshot.bind(session);
       session.snapshot = () => ({
         ...baseSnapshot(),
@@ -5149,7 +5149,7 @@ describe("B1 red gate — exact-once terminal matrix", () => {
       });
       const { mgr } = b1Manager({
         sessions: [session],
-        driver: fakeDriver("cursor"),
+        driver: fakeDriver("codex"),
         trace: (row) => rows.push(row),
         now: () => now,
         tickIntervalMs: 5,


### PR DESCRIPTION
## Summary

- advertise Cursor ACP's verified mid-turn steering capability instead of queueing busy input
- keep the root terminal receipt stable while each concurrent `session/prompt` owns a distinct request/transport receipt
- fence old success, error, cancellation, duplicate, and late responses from current prompt ownership
- atomically register steering state before write and restore the prior prompt/tool state on write failure
- update execution docs and provider-agnostic queue/watchdog fixtures

## Verification

- `pnpm typecheck` — 11/11 tasks passed
- `pnpm test` — 10/10 Turbo tasks, daemon 1292 unit + 6 packed, agent-driver 616 passed / 4 skipped, CI scripts 129 passed
- pre-commit `typecheck`, `lint`, and full `test` gate passed
- focused agent-driver suite — 5 files / 236 tests passed
- actual Cursor ACP `2026.08.25-3e8eec8` through the public Alook SDK and `LogicalAgentSession`: root `accepted/prompt`, busy message `accepted/steer` on the same turn, only `STEERED` emitted, one successful `turn_completed` owning both command IDs, one physical open, no queued command, clean close

## Ownership guarantees

- old prompt terminals settle only their pending request
- only the current prompt can emit the logical root terminal
- the root terminal receipt remains stable across repeated steers
- interruption classification remains solely controller-owned
