### PR TITLE
fix(web): separate tauri mode from service routing

### DIFF
--- a/src/web/src/components/community/machines/pair-machine-sheet.test.ts
+++ b/src/web/src/components/community/machines/pair-machine-sheet.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
   apiFetch: vi.fn(),
   invoke: vi.fn(),
   isTauri: vi.fn(() => true),
-  isLocalMode: vi.fn(() => false),
+  isLocalServiceEnvironment: vi.fn(() => false),
   toastSuccess: vi.fn(),
   toastError: vi.fn(),
 }))
@@ -27,7 +27,7 @@ vi.mock("@/lib/api/client", () => ({
 }))
 
 vi.mock("@/lib/utils", () => ({
-  isLocalMode: mocks.isLocalMode,
+  isLocalServiceEnvironment: mocks.isLocalServiceEnvironment,
   WS_DO_PORT_DEFAULT: 8788,
 }))
 
@@ -56,7 +56,7 @@ describe("PairMachineSheet desktop daemon integration", () => {
     vi.clearAllMocks()
     vi.stubGlobal("location", { origin: "https://alook.ai" })
     mocks.isTauri.mockReturnValue(true)
-    mocks.isLocalMode.mockReturnValue(false)
+    mocks.isLocalServiceEnvironment.mockReturnValue(false)
     mocks.apiFetch.mockResolvedValue({ tokenId: "cmt_generated", expiresAt: "soon" })
     mocks.invoke.mockImplementation((command: string) => {
       if (command === "daemon_runtime_capability") {
@@ -245,7 +245,7 @@ describe("PairMachineSheet desktop daemon integration", () => {
   })
 
   it("keeps explicit endpoints only for local development", async () => {
-    mocks.isLocalMode.mockReturnValue(true)
+    mocks.isLocalServiceEnvironment.mockReturnValue(true)
     vi.stubGlobal("location", { origin: "http://localhost:3000" })
 
     let renderer!: TestRenderer.ReactTestRenderer

--- a/src/web/src/components/community/machines/pair-machine-sheet.tsx
+++ b/src/web/src/components/community/machines/pair-machine-sheet.tsx
@@ -8,7 +8,7 @@ import { CommunitySheet } from "@/components/community/shell/community-sheet"
 import { Button } from "@/components/ui/button"
 import { apiFetch, toastApiError } from "@/lib/api/client"
 import { tid } from "@/lib/community/testids"
-import { isLocalMode, WS_DO_PORT_DEFAULT } from "@/lib/utils"
+import { isLocalServiceEnvironment, WS_DO_PORT_DEFAULT } from "@/lib/utils"
 import { websocketUrl } from "@/lib/websocket-url"
 
 // Production daemons use their built-in endpoints. Local development appends
@@ -16,7 +16,7 @@ import { websocketUrl } from "@/lib/websocket-url"
 // Only ever called once `pendingTokenId` is set, which happens from a
 // client-only effect — safe to touch `location` in the local branch.
 function buildPairCommand(machineKey: string, machineId?: string): string {
-  const isLocal = isLocalMode()
+  const isLocal = isLocalServiceEnvironment()
   const bin = isLocal
     ? "pnpm daemon"
     : "npx --yes @alook/daemon@latest daemon"

--- a/src/web/src/lib/use-user-ws.ts
+++ b/src/web/src/lib/use-user-ws.ts
@@ -18,10 +18,10 @@ import {
   type CommunityWsSocketReadyState,
   type CommunityWsSuspensionDurationBucket,
 } from "@/lib/analytics"
-import { isLocalMode, WS_DO_PORT_DEFAULT } from "@/lib/utils"
+import { isLocalServiceEnvironment, WS_DO_PORT_DEFAULT } from "@/lib/utils"
 import { websocketUrl } from "@/lib/websocket-url"
 
-const isLocal = isLocalMode()
+const useLocalServices = isLocalServiceEnvironment()
 const WS_RECONNECT_INIT = Number(process.env.NEXT_PUBLIC_WS_RECONNECT_DELAY_MS) || 1000
 const WS_RECONNECT_MAX = Number(process.env.NEXT_PUBLIC_WS_RECONNECT_MAX_DELAY_MS) || 30_000
 const WS_TOKEN_TIMEOUT_MS = Number(process.env.NEXT_PUBLIC_WS_TOKEN_TIMEOUT_MS) || 10_000
@@ -350,7 +350,7 @@ export function useUserWs(
       }
     }
 
-    const wsBaseUrl = isLocal
+    const wsBaseUrl = useLocalServices
       ? websocketUrl("user", { local: true, port: wsPort })
       : websocketUrl("user", { local: false, origin: location.origin })
     const url = `${wsBaseUrl}?userId=${userId}`

--- a/src/web/src/lib/utils.test.ts
+++ b/src/web/src/lib/utils.test.ts
@@ -1,83 +1,73 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  cliCmd,
+  daemonStartCmd,
+  getAppMode,
+  isLocalServiceEnvironment,
+} from "./utils"
 
-let mockHostname: string | undefined;
+const originalWindow = globalThis.window
 
-vi.mock("./utils", async () => {
-  const actual = await vi.importActual<typeof import("./utils")>("./utils");
-  return {
-    ...actual,
-    isLocalMode: () => {
-      if (mockHostname && ["localhost", "127.0.0.1"].includes(mockHostname)) return true;
-      return process.env.NODE_ENV === "development";
+function setBrowser(hostname: string, tauri = false) {
+  vi.stubGlobal("window", {
+    ...(tauri ? { __TAURI__: {} } : {}),
+    location: { hostname },
+  })
+}
+
+describe("browser runtime and service environment", () => {
+  beforeEach(() => {
+    vi.stubEnv("NODE_ENV", "production")
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    if (originalWindow === undefined) vi.unstubAllGlobals()
+    else vi.stubGlobal("window", originalWindow)
+  })
+
+  it("keeps hosted Tauri in desktop mode while using production services", () => {
+    setBrowser("alook.ai", true)
+
+    expect(getAppMode()).toBe("desktop")
+    expect(isLocalServiceEnvironment()).toBe(false)
+    expect(cliCmd()).toBe("npx @alook/cli")
+    expect(daemonStartCmd()).toBe("npx @alook/cli daemon start")
+  })
+
+  it("keeps localhost Tauri in desktop mode while using local services", () => {
+    setBrowser("localhost", true)
+
+    expect(getAppMode()).toBe("desktop")
+    expect(isLocalServiceEnvironment()).toBe(true)
+  })
+
+  it("uses production services in a normal hosted browser", () => {
+    setBrowser("alook.ai")
+
+    expect(getAppMode()).toBe("production")
+    expect(isLocalServiceEnvironment()).toBe(false)
+  })
+
+  it("uses production services during server rendering", () => {
+    vi.unstubAllGlobals()
+
+    expect(isLocalServiceEnvironment()).toBe(false)
+  })
+
+  it.each(["localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"])(
+    "uses local services for %s",
+    (hostname) => {
+      setBrowser(hostname)
+      expect(isLocalServiceEnvironment()).toBe(true)
     },
-    cliCmd: () => {
-      if (process.env.NODE_ENV === "development") return "pnpm dev:cli";
-      if (mockHostname && ["localhost", "127.0.0.1"].includes(mockHostname)) {
-        return "npx @alook/app cli";
-      }
-      return "npx @alook/cli";
-    },
-    daemonStartCmd: () => {
-      let base: string;
-      if (process.env.NODE_ENV === "development") base = "pnpm dev:cli";
-      else if (mockHostname && ["localhost", "127.0.0.1"].includes(mockHostname)) base = "npx @alook/app cli";
-      else base = "npx @alook/cli";
-      const cmd = `${base} daemon start`;
-      if (process.env.NODE_ENV === "development") return `${cmd} --foreground`;
-      return cmd;
-    },
-  };
-});
+  )
 
-import { isLocalMode, cliCmd, daemonStartCmd } from "./utils";
+  it("uses local services for a development build independently of runtime mode", () => {
+    vi.stubEnv("NODE_ENV", "development")
+    setBrowser("alook.ai", true)
 
-beforeEach(() => {
-  mockHostname = undefined;
-});
-
-afterEach(() => {
-  mockHostname = undefined;
-});
-
-describe("isLocalMode", () => {
-  it("returns true on localhost", () => {
-    mockHostname = "localhost";
-    expect(isLocalMode()).toBe(true);
-  });
-
-  it("returns true on 127.0.0.1", () => {
-    mockHostname = "127.0.0.1";
-    expect(isLocalMode()).toBe(true);
-  });
-
-  it("returns false for non-local hostname in production build", () => {
-    mockHostname = "alook.ai";
-    expect(isLocalMode()).toBe(false);
-  });
-});
-
-describe("cliCmd", () => {
-  it("returns 'npx @alook/cli' in production cloud", () => {
-    mockHostname = "alook.ai";
-    expect(cliCmd()).toBe("npx @alook/cli");
-  });
-
-  it("returns 'npx @alook/app cli' on localhost (app mode)", () => {
-    mockHostname = "localhost";
-    expect(cliCmd()).toBe("npx @alook/app cli");
-  });
-});
-
-describe("daemonStartCmd", () => {
-  it("no --foreground in production cloud", () => {
-    mockHostname = "alook.ai";
-    expect(daemonStartCmd()).toBe("npx @alook/cli daemon start");
-    expect(daemonStartCmd()).not.toContain("--foreground");
-  });
-
-  it("no --foreground in app mode (localhost, production build)", () => {
-    mockHostname = "localhost";
-    expect(daemonStartCmd()).toBe("npx @alook/app cli daemon start");
-    expect(daemonStartCmd()).not.toContain("--foreground");
-  });
-});
+    expect(getAppMode()).toBe("desktop")
+    expect(isLocalServiceEnvironment()).toBe(true)
+  })
+})

--- a/src/web/src/lib/utils.ts
+++ b/src/web/src/lib/utils.ts
@@ -20,8 +20,18 @@ export function getAppMode(): AlookMode {
   return getMode()
 }
 
-export function isLocalMode(): boolean {
-  return getMode() !== "production"
+const LOCAL_SERVICE_HOSTNAMES = new Set([
+  "localhost",
+  "127.0.0.1",
+  "0.0.0.0",
+  "::1",
+  "[::1]",
+])
+
+export function isLocalServiceEnvironment(): boolean {
+  if (process.env.NODE_ENV === "development") return true
+  const hostname = typeof window !== "undefined" ? window.location.hostname : undefined
+  return hostname !== undefined && LOCAL_SERVICE_HOSTNAMES.has(hostname)
 }
 
 // The local dev WS Durable Object port (see DEV_WS_DO_URL in @alook/shared).


### PR DESCRIPTION
# Why we need this PR?

Production Tauri shells load `https://alook.ai/c`, but the existing `isLocalMode()` helper treated every non-browser runtime mode as a local service environment. Desktop clients therefore tried to connect the user WebSocket and machine-pair fallback to localhost, leaving Community stuck at `Connecting…` even though the hosted page and account session loaded normally.

## What changed

- Keep `desktop` / `mobile` as runtime-surface modes while deciding local service routing only from development or loopback host signals.
- Route the user WebSocket through the new connection-environment predicate.
- Keep machine-pair local endpoint flags only for local development; hosted Tauri uses the published daemon command.
- Replace mocked mode coverage with real hosted/local Tauri and browser combinations.

## Verification

- Focused Vitest coverage for runtime/service routing and machine-pair command behavior.
- `pnpm typecheck`
- `pnpm test`
- `pnpm lint`
- typegrep checks and Knip through the normal commit hooks.
- Independent code/harness QA passed for hosted Tauri, local Tauri, and normal hosted browser routing. Signed-in production Tauri frame observation remains a documented residual because no signed-in production shell session was available.

## Checklist

- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other
