### PR TITLE
fix(desktop): route update checks once

### DIFF
--- a/src/desktop/src-tauri/src/commands.rs
+++ b/src/desktop/src-tauri/src/commands.rs
@@ -564,6 +564,22 @@ pub fn show_main_window(app: &AppHandle) {
     }
 }
 
+#[cfg(desktop)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TrayMenuAction {
+    Show,
+    Quit,
+}
+
+#[cfg(desktop)]
+fn tray_menu_action(id: &str) -> Option<TrayMenuAction> {
+    match id {
+        "show" => Some(TrayMenuAction::Show),
+        "quit" => Some(TrayMenuAction::Quit),
+        _ => None,
+    }
+}
+
 // --- System tray ---
 #[cfg(desktop)]
 pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
@@ -601,15 +617,15 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         .menu(&menu)
         .show_menu_on_left_click(false)
         .tooltip("Alook")
-        .on_menu_event(move |app, event| match event.id().as_ref() {
-            "show" => show_main_window(app),
-            "quit" => {
-                app.exit(0);
-            }
-            id => {
-                crate::updater::handle_menu_event(app, id);
-            }
-        })
+        .on_menu_event(
+            move |app, event| match tray_menu_action(event.id().as_ref()) {
+                Some(TrayMenuAction::Show) => show_main_window(app),
+                Some(TrayMenuAction::Quit) => {
+                    app.exit(0);
+                }
+                None => {}
+            },
+        )
         .on_tray_icon_event(|tray, event| {
             if let tauri::tray::TrayIconEvent::Click {
                 button: tauri::tray::MouseButton::Left,
@@ -683,6 +699,17 @@ mod tests {
             ]
         );
         assert!(release.cwd.is_none());
+    }
+
+    #[test]
+    fn tray_routes_only_tray_owned_actions() {
+        assert_eq!(tray_menu_action("show"), Some(TrayMenuAction::Show));
+        assert_eq!(tray_menu_action("quit"), Some(TrayMenuAction::Quit));
+        assert_eq!(
+            tray_menu_action(crate::updater::CHECK_FOR_UPDATES_MENU_ID),
+            None
+        );
+        assert_eq!(tray_menu_action("unknown"), None);
     }
 
     #[test]


### PR DESCRIPTION
# Why we need this PR?

One **Check for Updates…** selection was routed twice: the tray callback called the updater directly, then Tauri forwarded the same menu event to the application-level callback and called it again. The first check produced the normal result while the concurrent duplicate hit `UPDATE_IN_PROGRESS`, producing two native dialogs.

## What changed

- Restrict the tray callback to tray-owned **Open Alook** and **Quit** actions.
- Leave updater menu IDs to the single application-level updater handler.
- Add a direct classifier regression proving the update ID is not consumed by tray-specific routing.
- Preserve automatic checks, downloads, notifications, native menu placement, and Open/Quit behavior.

## Verification

- `cargo fmt --check`
- `cargo test` — 32 passed
- `cargo clippy --all-targets -- -D warnings`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — all 10 workspace tasks, agent-driver 617 passed / 4 skipped, CI scripts 129 passed
- typegrep checks and Knip through normal commit hooks

A local debug `.app` launched successfully for native QA. Computer Use could invoke the application menu but could not reliably expose/count the resulting native dialog or the macOS status-item menu, so exact one-dialog observation remains an explicit independent Mac QA residual.

## Checklist

- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [x] Other: Desktop Tauri menu routing
