### PR TITLE
Fix missing images in Share Image exports

### DIFF
--- a/src/web/src/components/community/messages/message-share-dialog.test.ts
+++ b/src/web/src/components/community/messages/message-share-dialog.test.ts
@@ -4,7 +4,12 @@ import TestRenderer, { act } from "react-test-renderer"
 import {
   MessageShareDialog,
   ShareCardImageTimeoutError,
-  inlineShareCardImages,
+  ShareImageSnapshotError,
+  copyRenderedShareCard,
+  createShareImageSnapshot,
+  downloadRenderedShareCard,
+  renderShareCard,
+  snapshotShareCardImages,
   waitForShareCardImages,
 } from "./message-share-dialog"
 import type { RenderMsg } from "@/lib/community/models/message"
@@ -217,6 +222,7 @@ describe("waitForShareCardImages", () => {
     const value = {
       complete: false,
       naturalWidth: 0,
+      naturalHeight: 0,
       decode: vi.fn().mockResolvedValue(undefined),
       addEventListener: vi.fn((type: string, listener: () => void) => listeners.set(type, listener)),
       removeEventListener: vi.fn((type: string) => listeners.delete(type)),
@@ -236,6 +242,7 @@ describe("waitForShareCardImages", () => {
 
     expect(paint).not.toHaveBeenCalled()
     Object.defineProperty(avatar.value, "naturalWidth", { value: 40 })
+    Object.defineProperty(avatar.value, "naturalHeight", { value: 40 })
     avatar.listeners.get("load")?.()
     await waiting
 
@@ -243,19 +250,19 @@ describe("waitForShareCardImages", () => {
     expect(paint).toHaveBeenCalledOnce()
   })
 
-  it("continues after an image error so Base UI can paint its fallback", async () => {
+  it("rejects an image error before paint so capture cannot snapshot an empty branch", async () => {
     const avatar = image()
     const paint = vi.fn().mockResolvedValue(undefined)
     const waiting = waitForShareCardImages(card([avatar.value]), paint)
     avatar.listeners.get("error")?.()
-    await waiting
+    await expect(waiting).rejects.toBeInstanceOf(ShareImageSnapshotError)
 
     expect(avatar.value.decode).not.toHaveBeenCalled()
-    expect(paint).toHaveBeenCalledOnce()
+    expect(paint).not.toHaveBeenCalled()
   })
 
   it("decodes an already-loaded cached avatar without waiting for another event", async () => {
-    const avatar = image({ complete: true, naturalWidth: 40 })
+    const avatar = image({ complete: true, naturalWidth: 40, naturalHeight: 40 })
     const paint = vi.fn().mockResolvedValue(undefined)
     await waitForShareCardImages(card([avatar.value]), paint)
 
@@ -289,6 +296,7 @@ describe("waitForShareCardImages", () => {
       const avatar = image({
         complete: true,
         naturalWidth: 40,
+        naturalHeight: 40,
         decode: vi.fn(() => new Promise<void>(() => {})),
       })
       const paint = vi.fn().mockResolvedValue(undefined)
@@ -305,107 +313,229 @@ describe("waitForShareCardImages", () => {
   })
 })
 
-describe("inlineShareCardImages", () => {
-  function image({
-    src,
-    currentSrc,
-    srcset,
-  }: {
-    src: string
-    currentSrc?: string
-    srcset?: string
-  }) {
-    const attributes = new Map<string, string>([["src", src]])
-    if (srcset !== undefined) attributes.set("srcset", srcset)
+describe("snapshotShareCardImages", () => {
+  function image() {
+    return { replaceWith: vi.fn() } as unknown as HTMLImageElement
+  }
+
+  function canvas() {
     return {
-      src,
-      currentSrc: currentSrc ?? src,
-      getAttribute: vi.fn((name: string) => attributes.get(name) ?? null),
-      setAttribute: vi.fn((name: string, value: string) => attributes.set(name, value)),
-      removeAttribute: vi.fn((name: string) => attributes.delete(name)),
-      attributes,
-    } as unknown as HTMLImageElement & { attributes: Map<string, string> }
+      parentNode: {},
+      replaceWith: vi.fn(),
+    } as unknown as HTMLCanvasElement
   }
 
   function card(images: HTMLImageElement[]): HTMLElement {
     return { querySelectorAll: () => images } as unknown as HTMLElement
   }
 
-  it("inlines each rendered image once and restores the React-owned attributes", async () => {
-    const avatar = image({
-      src: "/avatar?v=2",
-      currentSrc: "https://alook.test/avatar?v=2",
-      srcset: "/avatar?v=2 1x, /avatar?v=2&dpr=2 2x",
-    })
-    const duplicate = image({
-      src: "/avatar?v=2",
-      currentSrc: "https://alook.test/avatar?v=2",
-    })
-    const attachment = image({ src: "/attachments/photo" })
-    const loadDataUrl = vi.fn(async (url: string) => `data:image/png;base64,${url}`)
+  it("replaces every live image with its local canvas snapshot and restores it", async () => {
+    const avatar = image()
+    const attachment = image()
+    const avatarCanvas = canvas()
+    const attachmentCanvas = canvas()
+    const createSnapshot = vi.fn()
+      .mockReturnValueOnce(avatarCanvas)
+      .mockReturnValueOnce(attachmentCanvas)
     const waitForImages = vi.fn().mockResolvedValue(undefined)
+    const waitForPaint = vi.fn().mockResolvedValue(undefined)
 
-    const restore = await inlineShareCardImages(
-      card([avatar, duplicate, attachment]),
-      loadDataUrl,
-      waitForImages,
-    )
-
-    expect(loadDataUrl).toHaveBeenCalledTimes(2)
-    expect(loadDataUrl).toHaveBeenCalledWith("https://alook.test/avatar?v=2")
-    expect(loadDataUrl).toHaveBeenCalledWith("/attachments/photo")
-    expect(avatar.attributes.get("src")).toBe(
-      "data:image/png;base64,https://alook.test/avatar?v=2",
-    )
-    expect(avatar.attributes.get("srcset")).toBe("")
-    expect(attachment.attributes.get("src")).toBe(
-      "data:image/png;base64,/attachments/photo",
-    )
-    expect(waitForImages).toHaveBeenCalledTimes(2)
-
-    restore()
-    restore()
-    expect(avatar.attributes.get("src")).toBe("/avatar?v=2")
-    expect(avatar.attributes.get("srcset")).toBe("/avatar?v=2 1x, /avatar?v=2&dpr=2 2x")
-    expect(duplicate.attributes.has("srcset")).toBe(false)
-    expect(attachment.attributes.get("src")).toBe("/attachments/photo")
-  })
-
-  it("does not mutate the preview when an image cannot be inlined", async () => {
-    const avatar = image({ src: "/avatar" })
-    const attachment = image({ src: "/attachment" })
-    const waitForImages = vi.fn().mockResolvedValue(undefined)
-
-    await expect(inlineShareCardImages(
+    const restore = await snapshotShareCardImages(
       card([avatar, attachment]),
-      async (url) => {
-        if (url === "/attachment") throw new Error("fetch failed")
-        return "data:image/png;base64,avatar"
-      },
+      createSnapshot,
       waitForImages,
-    )).rejects.toThrow("fetch failed")
+      waitForPaint,
+    )
 
-    expect(avatar.attributes.get("src")).toBe("/avatar")
-    expect(attachment.attributes.get("src")).toBe("/attachment")
     expect(waitForImages).toHaveBeenCalledOnce()
+    expect(createSnapshot).toHaveBeenNthCalledWith(1, avatar)
+    expect(createSnapshot).toHaveBeenNthCalledWith(2, attachment)
+    expect(avatar.replaceWith).toHaveBeenCalledWith(avatarCanvas)
+    expect(attachment.replaceWith).toHaveBeenCalledWith(attachmentCanvas)
+    expect(waitForPaint).toHaveBeenCalledOnce()
+
+    restore()
+    restore()
+    expect(avatarCanvas.replaceWith).toHaveBeenCalledOnce()
+    expect(avatarCanvas.replaceWith).toHaveBeenCalledWith(avatar)
+    expect(attachmentCanvas.replaceWith).toHaveBeenCalledOnce()
+    expect(attachmentCanvas.replaceWith).toHaveBeenCalledWith(attachment)
   })
 
-  it("restores the preview when an inlined bitmap fails to settle", async () => {
-    const avatar = image({ src: "/avatar", srcset: "/avatar 1x" })
-    const waitForImages = vi
-      .fn()
-      .mockResolvedValueOnce(undefined)
-      .mockRejectedValueOnce(new Error("decode failed"))
+  it("supports consecutive captures of the same React-owned images", async () => {
+    const avatar = image()
+    const firstCanvas = canvas()
+    const secondCanvas = canvas()
+    const createSnapshot = vi.fn()
+      .mockReturnValueOnce(firstCanvas)
+      .mockReturnValueOnce(secondCanvas)
+    const waitForImages = vi.fn().mockResolvedValue(undefined)
+    const waitForPaint = vi.fn().mockResolvedValue(undefined)
+
+    const restoreFirst = await snapshotShareCardImages(
+      card([avatar]),
+      createSnapshot,
+      waitForImages,
+      waitForPaint,
+    )
+    restoreFirst()
+    const restoreSecond = await snapshotShareCardImages(
+      card([avatar]),
+      createSnapshot,
+      waitForImages,
+      waitForPaint,
+    )
+    restoreSecond()
+
+    expect(createSnapshot).toHaveBeenCalledTimes(2)
+    expect(avatar.replaceWith).toHaveBeenNthCalledWith(1, firstCanvas)
+    expect(avatar.replaceWith).toHaveBeenNthCalledWith(2, secondCanvas)
+    expect(firstCanvas.replaceWith).toHaveBeenCalledWith(avatar)
+    expect(secondCanvas.replaceWith).toHaveBeenCalledWith(avatar)
+  })
+
+  it("restores every replaced image when the snapshot paint fails", async () => {
+    const avatar = image()
+    const attachment = image()
+    const avatarCanvas = canvas()
+    const attachmentCanvas = canvas()
+    const createSnapshot = vi.fn()
+      .mockReturnValueOnce(avatarCanvas)
+      .mockReturnValueOnce(attachmentCanvas)
 
     await expect(
-      inlineShareCardImages(
-        card([avatar]),
-        async () => "data:image/png;base64,avatar",
-        waitForImages,
+      snapshotShareCardImages(
+        card([avatar, attachment]),
+        createSnapshot,
+        vi.fn().mockResolvedValue(undefined),
+        vi.fn().mockRejectedValue(new Error("paint failed")),
       ),
-    ).rejects.toThrow("decode failed")
+    ).rejects.toThrow("paint failed")
 
-    expect(avatar.attributes.get("src")).toBe("/avatar")
-    expect(avatar.attributes.get("srcset")).toBe("/avatar 1x")
+    expect(avatarCanvas.replaceWith).toHaveBeenCalledWith(avatar)
+    expect(attachmentCanvas.replaceWith).toHaveBeenCalledWith(attachment)
+  })
+
+  it("restores earlier images when a later snapshot fails", async () => {
+    const avatar = image()
+    const attachment = image()
+    const avatarCanvas = canvas()
+    const createSnapshot = vi.fn()
+      .mockReturnValueOnce(avatarCanvas)
+      .mockImplementationOnce(() => { throw new ShareImageSnapshotError() })
+
+    await expect(
+      snapshotShareCardImages(
+        card([avatar, attachment]),
+        createSnapshot,
+        vi.fn().mockResolvedValue(undefined),
+        vi.fn().mockResolvedValue(undefined),
+      ),
+    ).rejects.toBeInstanceOf(ShareImageSnapshotError)
+
+    expect(avatarCanvas.replaceWith).toHaveBeenCalledWith(avatar)
+  })
+
+  it("aborts capture instead of replacing a tainted image with a blank canvas", () => {
+    const drawImage = vi.fn()
+    const canvas = {
+      className: "",
+      style: { cssText: "", width: "", height: "" },
+      setAttribute: vi.fn(),
+      getContext: vi.fn(() => ({ drawImage })),
+      toDataURL: vi.fn(() => { throw new Error("tainted") }),
+    }
+    const createElement = vi.fn(() => canvas)
+    vi.stubGlobal("document", { createElement })
+    vi.stubGlobal("getComputedStyle", () => ({ objectFit: "cover" }))
+
+    expect(() => createShareImageSnapshot({
+      naturalWidth: 512,
+      naturalHeight: 512,
+      className: "rounded-full",
+      style: { cssText: "" },
+      attributes: [],
+      getBoundingClientRect: () => ({ width: 40, height: 40 }),
+    } as unknown as HTMLImageElement)).toThrow(ShareImageSnapshotError)
+
+    expect(drawImage).toHaveBeenCalledOnce()
+    expect(canvas.toDataURL).toHaveBeenCalledOnce()
+    expect(createElement).toHaveBeenCalledOnce()
+    vi.unstubAllGlobals()
+  })
+
+  it.each([
+    { name: "zero intrinsic size", naturalWidth: 0, naturalHeight: 0, context: { drawImage: vi.fn() } },
+    { name: "missing 2D context", naturalWidth: 512, naturalHeight: 512, context: null },
+  ])("rejects $name instead of returning a blank canvas", ({ naturalWidth, naturalHeight, context }) => {
+    const canvas = {
+      className: "",
+      style: { cssText: "", width: "", height: "" },
+      setAttribute: vi.fn(),
+      getContext: vi.fn(() => context),
+      toDataURL: vi.fn(),
+    }
+    vi.stubGlobal("document", { createElement: vi.fn(() => canvas) })
+    vi.stubGlobal("getComputedStyle", () => ({ objectFit: "cover" }))
+
+    expect(() => createShareImageSnapshot({
+      naturalWidth,
+      naturalHeight,
+      className: "rounded-full",
+      style: { cssText: "" },
+      attributes: [],
+      getBoundingClientRect: () => ({ width: 40, height: 40 }),
+    } as unknown as HTMLImageElement)).toThrow(ShareImageSnapshotError)
+
+    expect(canvas.toDataURL).not.toHaveBeenCalled()
+    vi.unstubAllGlobals()
+  })
+
+  it("skips a zero-size image while snapshotting the remaining images", async () => {
+    const hiddenImage = image()
+    const attachment = image()
+    const attachmentCanvas = canvas()
+    const createSnapshot = vi.fn()
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(attachmentCanvas)
+
+    const restore = await snapshotShareCardImages(
+      card([hiddenImage, attachment]),
+      createSnapshot,
+      vi.fn().mockResolvedValue(undefined),
+      vi.fn().mockResolvedValue(undefined),
+    )
+
+    expect(hiddenImage.replaceWith).not.toHaveBeenCalled()
+    expect(attachment.replaceWith).toHaveBeenCalledWith(attachmentCanvas)
+    restore()
+    expect(attachmentCanvas.replaceWith).toHaveBeenCalledWith(attachment)
+  })
+})
+
+describe("renderShareCard", () => {
+  it("does not rasterize when image snapshot preparation fails", async () => {
+    const node = {} as HTMLElement
+    const snapshotImages = vi.fn().mockRejectedValue(new ShareImageSnapshotError())
+    const rasterize = vi.fn()
+
+    await expect(renderShareCard(node, snapshotImages, rasterize)).rejects.toThrow(
+      ShareImageSnapshotError,
+    )
+
+    expect(rasterize).not.toHaveBeenCalled()
+  })
+
+  it("does not reach clipboard or download writes when snapshot preparation fails", async () => {
+    const failure = new ShareImageSnapshotError()
+    const render = vi.fn().mockRejectedValue(failure)
+    const clipboardWrite = vi.fn()
+    const downloadSave = vi.fn()
+
+    await expect(copyRenderedShareCard(render, clipboardWrite)).rejects.toBe(failure)
+    await expect(downloadRenderedShareCard(render, "share.png", downloadSave)).rejects.toBe(failure)
+
+    expect(clipboardWrite).not.toHaveBeenCalled()
+    expect(downloadSave).not.toHaveBeenCalled()
   })
 })

--- a/src/web/src/components/community/messages/message-share-dialog.tsx
+++ b/src/web/src/components/community/messages/message-share-dialog.tsx
@@ -19,6 +19,7 @@ import { useProfilesByUserId } from "@/stores/community/ws"
 import { readCommunityProfile } from "@/lib/community/profile-read"
 
 const SHARE_IMAGE_READY_TIMEOUT_MS = 5_000
+const SHARE_IMAGE_PIXEL_RATIO = 2
 
 export class ShareCardImageTimeoutError extends Error {
   constructor() {
@@ -27,35 +28,47 @@ export class ShareCardImageTimeoutError extends Error {
   }
 }
 
+export class ShareImageSnapshotError extends Error {
+  constructor() {
+    super("Share-card image pixels are not readable")
+    this.name = "ShareImageSnapshotError"
+  }
+}
+
 async function waitForImageLoad(
   image: HTMLImageElement,
   timeoutMs: number,
 ): Promise<void> {
   if (!image.complete) {
-    const settled = await new Promise<boolean>((resolve) => {
+    const result = await new Promise<"loaded" | "error" | "timeout">((resolve) => {
       let finished = false
-      const finish = (didSettle: boolean) => {
+      const finish = (result: "loaded" | "error" | "timeout") => {
         if (finished) return
         finished = true
-        image.removeEventListener("load", settle)
-        image.removeEventListener("error", settle)
+        image.removeEventListener("load", loaded)
+        image.removeEventListener("error", failed)
         clearTimeout(timer)
-        resolve(didSettle)
+        resolve(result)
       }
-      const settle = () => finish(true)
-      const timer = setTimeout(() => finish(false), timeoutMs)
-      image.addEventListener("load", settle, { once: true })
-      image.addEventListener("error", settle, { once: true })
+      const loaded = () => finish("loaded")
+      const failed = () => finish("error")
+      const timer = setTimeout(() => finish("timeout"), timeoutMs)
+      image.addEventListener("load", loaded, { once: true })
+      image.addEventListener("error", failed, { once: true })
       // Close the tiny race where the resource settles between the initial
       // `complete` read and listener registration.
-      if (image.complete) settle()
+      if (image.complete) finish(image.naturalWidth > 0 ? "loaded" : "error")
     })
     // A request that never emits load/error must fail this capture attempt so
     // Download/Copy leave their busy state and the user can retry; capturing
     // the avatar's transient empty branch would silently recreate the bug.
-    if (!settled) throw new ShareCardImageTimeoutError()
+    if (result === "timeout") throw new ShareCardImageTimeoutError()
+    if (result === "error") throw new ShareImageSnapshotError()
   }
-  if (image.naturalWidth > 0 && image.decode) {
+  if (image.naturalWidth <= 0 || image.naturalHeight <= 0) {
+    throw new ShareImageSnapshotError()
+  }
+  if (image.decode) {
     // Once load has supplied a real bitmap, decode() is only an optimization.
     // Mobile WebKit may reject or never resolve it for cached images, so bound
     // this wait and degrade to the already-loaded bitmap instead of deadlocking.
@@ -96,93 +109,188 @@ export async function waitForShareCardImages(
   await waitForPaint()
 }
 
-type ShareImageDataUrlLoader = (url: string) => Promise<string>
 type ShareImageWaiter = (node: HTMLElement) => Promise<void>
+type ShareImageSnapshotter = (image: HTMLImageElement) => HTMLCanvasElement | null
 
-function blobToDataUrl(blob: Blob): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onerror = () => reject(reader.error ?? new Error("Failed to read share-card image"))
-    reader.onloadend = () => typeof reader.result === "string"
-      ? resolve(reader.result)
-      : reject(new Error("Failed to encode share-card image"))
-    reader.readAsDataURL(blob)
-  })
+function copySnapshotPresentation(
+  image: HTMLImageElement,
+  canvas: HTMLCanvasElement,
+  width: number,
+  height: number,
+): void {
+  canvas.className = image.className
+  canvas.style.cssText = image.style.cssText
+  for (const attribute of [...image.attributes]) {
+    if (attribute.name.startsWith("data-") || attribute.name.startsWith("aria-")) {
+      canvas.setAttribute(attribute.name, attribute.value)
+    }
+  }
+  canvas.style.width = `${width}px`
+  canvas.style.height = `${height}px`
 }
 
-async function loadShareImageDataUrl(url: string): Promise<string> {
-  if (url.startsWith("data:")) return url
+function drawShareImageSnapshot(
+  image: HTMLImageElement,
+  canvas: HTMLCanvasElement,
+  objectFit: string,
+): void {
+  if (image.naturalWidth <= 0 || image.naturalHeight <= 0) {
+    throw new ShareImageSnapshotError()
+  }
+  const context = canvas.getContext("2d")
+  if (!context) throw new ShareImageSnapshotError()
 
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), SHARE_IMAGE_READY_TIMEOUT_MS)
+  const sourceWidth = image.naturalWidth
+  const sourceHeight = image.naturalHeight
+  const targetWidth = canvas.width
+  const targetHeight = canvas.height
+  const containScale = Math.min(targetWidth / sourceWidth, targetHeight / sourceHeight)
+  const coverScale = Math.max(targetWidth / sourceWidth, targetHeight / sourceHeight)
+  const scale = objectFit === "contain"
+    ? containScale
+    : objectFit === "cover"
+      ? coverScale
+      : objectFit === "none"
+        ? SHARE_IMAGE_PIXEL_RATIO
+        : objectFit === "scale-down"
+          ? Math.min(SHARE_IMAGE_PIXEL_RATIO, containScale)
+          : null
+
+  if (scale === null) {
+    context.drawImage(image, 0, 0, targetWidth, targetHeight)
+    return
+  }
+
+  const width = sourceWidth * scale
+  const height = sourceHeight * scale
+  context.drawImage(
+    image,
+    (targetWidth - width) / 2,
+    (targetHeight - height) / 2,
+    width,
+    height,
+  )
+}
+
+export function createShareImageSnapshot(image: HTMLImageElement): HTMLCanvasElement | null {
+  const rect = image.getBoundingClientRect()
+  if (rect.width <= 0 || rect.height <= 0) return null
+
+  const createCanvas = () => {
+    const canvas = document.createElement("canvas")
+    canvas.width = Math.max(1, Math.round(rect.width * SHARE_IMAGE_PIXEL_RATIO))
+    canvas.height = Math.max(1, Math.round(rect.height * SHARE_IMAGE_PIXEL_RATIO))
+    copySnapshotPresentation(image, canvas, rect.width, rect.height)
+    return canvas
+  }
+
+  const canvas = createCanvas()
   try {
-    const response = await fetch(url, {
-      cache: "force-cache",
-      credentials: "same-origin",
-      signal: controller.signal,
-    })
-    if (!response.ok) throw new Error(`Share-card image request failed (${response.status})`)
-    const blob = await response.blob()
-    if (!blob.type.startsWith("image/")) {
-      throw new Error(`Share-card image returned ${blob.type || "an unknown content type"}`)
-    }
-    return await blobToDataUrl(blob)
-  } finally {
-    clearTimeout(timer)
+    drawShareImageSnapshot(image, canvas, getComputedStyle(image).objectFit)
+    canvas.toDataURL()
+    return canvas
+  } catch {
+    throw new ShareImageSnapshotError()
   }
 }
 
-/**
- * html-to-image clones the card and independently fetches every image URL. Its
- * module-level resource cache stores a failed fetch as an empty string, so one
- * transient failure can leave later exports blank even while the live preview
- * still shows the browser's already-loaded bitmap. Inline the exact `currentSrc`
- * of every visible image before capture, then restore the React-owned attributes.
- */
-export async function inlineShareCardImages(
+export async function snapshotShareCardImages(
   node: HTMLElement,
-  loadDataUrl: ShareImageDataUrlLoader = loadShareImageDataUrl,
+  createSnapshot: ShareImageSnapshotter = createShareImageSnapshot,
   waitForImages: ShareImageWaiter = waitForShareCardImages,
+  waitForPaint: () => Promise<void> = nextPaint,
 ): Promise<() => void> {
   await waitForImages(node)
   const images = [...node.querySelectorAll("img")]
-  const dataByUrl = new Map<string, Promise<string>>()
-  const sources = images.map((image) => image.currentSrc || image.src)
-  const dataUrls = await Promise.all(sources.map((source) => {
-    const existing = dataByUrl.get(source)
-    if (existing) return existing
-    const pending = loadDataUrl(source)
-    dataByUrl.set(source, pending)
-    return pending
-  }))
-  const snapshots = images.map((image) => ({
-    image,
-    src: image.getAttribute("src"),
-    srcset: image.getAttribute("srcset"),
-  }))
+  const snapshots: Array<{ image: HTMLImageElement; canvas: HTMLCanvasElement }> = []
   let restored = false
   const restore = () => {
     if (restored) return
     restored = true
-    for (const snapshot of snapshots) {
-      if (snapshot.src === null) snapshot.image.removeAttribute("src")
-      else snapshot.image.setAttribute("src", snapshot.src)
-      if (snapshot.srcset === null) snapshot.image.removeAttribute("srcset")
-      else snapshot.image.setAttribute("srcset", snapshot.srcset)
+    for (const { image, canvas } of snapshots) {
+      if (canvas.parentNode) canvas.replaceWith(image)
     }
   }
 
   try {
-    images.forEach((image, index) => {
-      image.setAttribute("srcset", "")
-      image.setAttribute("src", dataUrls[index]!)
-    })
-    await waitForImages(node)
+    for (const image of images) {
+      const canvas = createSnapshot(image)
+      if (!canvas) continue
+      image.replaceWith(canvas)
+      snapshots.push({ image, canvas })
+    }
+    await waitForPaint()
     return restore
   } catch (error) {
     restore()
     throw error
   }
+}
+
+type ShareCardImageSnapshotter = (node: HTMLElement) => Promise<() => void>
+type ShareCardRasterizer = typeof toBlob
+
+export async function renderShareCard(
+  node: HTMLElement,
+  snapshotImages: ShareCardImageSnapshotter = snapshotShareCardImages,
+  rasterize: ShareCardRasterizer = toBlob,
+): Promise<Blob | null> {
+  const restoreImages = await snapshotImages(node)
+  try {
+    try {
+      const caveatFont = getComputedStyle(document.documentElement)
+        .getPropertyValue("--font-caveat")
+        .trim()
+      if (document.fonts?.load && caveatFont) await document.fonts.load(`16px ${caveatFont}`)
+      await document.fonts?.ready
+    } catch {
+      // Font API unavailable / load rejected — proceed; worst case is the
+      // footer's fallback font, not a failed export.
+    }
+    return await rasterize(node, {
+      pixelRatio: SHARE_IMAGE_PIXEL_RATIO,
+      fetchRequestInit: { credentials: "same-origin" },
+      // Solid backdrop so the exported PNG never bleeds transparent corners
+      // (the card's own rounded bg sits on top of this).
+      backgroundColor: getComputedStyle(node).getPropertyValue("--card")?.trim() || undefined,
+    })
+  } finally {
+    restoreImages()
+  }
+}
+
+type ShareCardRenderer = () => Promise<Blob | null>
+type ShareCardBlobWriter = (blob: Blob) => Promise<void> | void
+
+export async function copyRenderedShareCard(
+  render: ShareCardRenderer,
+  write: ShareCardBlobWriter = (blob) => navigator.clipboard.write([
+    new ClipboardItem({ "image/png": blob }),
+  ]),
+): Promise<void> {
+  const blob = await render()
+  if (!blob) throw new Error("render failed")
+  await write(blob)
+}
+
+export async function downloadRenderedShareCard(
+  render: ShareCardRenderer,
+  filename: string,
+  save: ShareCardBlobWriter = (blob) => {
+    const url = URL.createObjectURL(blob)
+    try {
+      const anchor = document.createElement("a")
+      anchor.href = url
+      anchor.download = filename
+      anchor.click()
+    } finally {
+      URL.revokeObjectURL(url)
+    }
+  },
+): Promise<void> {
+  const blob = await render()
+  if (!blob) throw new Error("render failed")
+  await save(blob)
 }
 
 // Share one OR several messages as an image. Renders a self-contained "share
@@ -243,51 +351,18 @@ export function MessageShareDialog({ m, open, onClose }: {
     setHighlighted(false)
   }, [])
 
-  // Rasterise the card node to a PNG blob. pixelRatio 2 for a crisp image on
-  // retina / when pasted into other apps. `cacheBust` avoids stale cross-origin
-  // image reuse; the card is same-origin so fonts + the logo embed cleanly.
+  // Rasterise the card node to a PNG blob. pixelRatio 2 keeps the live image
+  // snapshots and the rest of the card crisp when pasted into other apps.
   const render = async (): Promise<Blob | null> => {
     const node = cardRef.current
     if (!node) return null
-    const restoreImages = await inlineShareCardImages(node)
-    try {
-      // Guarantee the Caveat brand font is loaded BEFORE rasterising. html-to-image
-      // inlines webfonts into the SVG it draws; if Caveat's async @font-face hasn't
-      // resolved yet, the footer silently falls back to a default font and the PNG
-      // differs machine-to-machine ("fine on mine, blurry/wrong on theirs"). Awaiting
-      // the specific face (then the global ready signal) closes that race.
-      try {
-        const caveatFont = getComputedStyle(document.documentElement)
-          .getPropertyValue("--font-caveat")
-          .trim()
-        if (document.fonts?.load && caveatFont) await document.fonts.load(`16px ${caveatFont}`)
-        await document.fonts?.ready
-      } catch {
-        // Font API unavailable / load rejected — proceed; worst case is the
-        // footer's fallback font, not a failed export.
-      }
-      return await toBlob(node, {
-        pixelRatio: 2,
-        // Every <img> is already a data URL here. Keep authenticated fetch
-        // options for CSS/font resources that html-to-image still embeds.
-        cacheBust: true,
-        fetchRequestInit: { credentials: "same-origin" },
-        // Solid backdrop so the exported PNG never bleeds transparent corners
-        // (the card's own rounded bg sits on top of this).
-        backgroundColor: getComputedStyle(node).getPropertyValue("--card")?.trim() || undefined,
-      })
-    } finally {
-      restoreImages()
-    }
+    return renderShareCard(node)
   }
 
   const copy = async () => {
     setBusy("copy")
     try {
-      const blob = await render()
-      if (!blob) throw new Error("render failed")
-      // ClipboardItem image write — supported in modern Chromium/Safari/FF.
-      await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })])
+      await copyRenderedShareCard(render)
       setCopied(true)
       toast.success("Image copied to clipboard")
       window.setTimeout(() => setCopied(false), 1600)
@@ -301,18 +376,14 @@ export function MessageShareDialog({ m, open, onClose }: {
   const download = async () => {
     setBusy("download")
     try {
-      const blob = await render()
-      if (!blob) throw new Error("render failed")
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement("a")
-      a.href = url
       const firstAuthorId = messages[0]?.authorId
       const firstAuthor = firstAuthorId
         ? readCommunityProfile(profilesByUserId.get(firstAuthorId), firstAuthorId)
         : null
-      a.download = `alook-message-${firstAuthor?.name ?? "share"}.png`
-      a.click()
-      URL.revokeObjectURL(url)
+      await downloadRenderedShareCard(
+        render,
+        `alook-message-${firstAuthor?.name ?? "share"}.png`,
+      )
     } catch {
       toast.error("Couldn't generate image")
     } finally {

--- a/src/web/src/test/e2e-ui/51-share-image-assets.spec.ts
+++ b/src/web/src/test/e2e-ui/51-share-image-assets.spec.ts
@@ -1,19 +1,20 @@
 import { test, expect } from "./_fixtures/community-fixture"
 import { gotoAfterUserWsAuth } from "./_fixtures/actions"
-import { seedChannel, seedServer } from "./_fixtures/seed"
+import { createInvite, seedChannel, seedServer } from "./_fixtures/seed"
 import { tid } from "./_fixtures/testids"
 
 type SamplePoint = { x: number; y: number }
 
-test("downloaded share image keeps the rendered avatar and message image", async ({ asUser }) => {
+test("consecutive share-image exports reuse rendered avatar, attachment, and invite icon pixels", async ({ asUser }) => {
   test.setTimeout(120_000)
   const serverId = await seedServer("alice", `Share assets ${Date.now()}`)
   const channelId = await seedChannel("alice", serverId, "share-assets")
+  const inviteToken = await createInvite("alice", serverId)
   const { page } = await asUser("alice")
   const route = `/c/channels/${serverId}/${channelId}`
   await gotoAfterUserWsAuth(page, route)
 
-  const seeded = await page.evaluate(async (targetId) => {
+  const seeded = await page.evaluate(async ({ targetId, targetServerId, token }) => {
     async function solidPng(color: string, width: number, height: number): Promise<Blob> {
       const canvas = document.createElement("canvas")
       canvas.width = width
@@ -35,6 +36,14 @@ test("downloaded share image keeps the rendered avatar and message image", async
       credentials: "include",
     })
 
+    const iconForm = new FormData()
+    iconForm.append("file", await solidPng("rgb(25, 180, 80)", 64, 64), "server-icon.png")
+    const iconResponse = await fetch(`/api/community/servers/${targetServerId}/icon`, {
+      method: "POST",
+      body: iconForm,
+      credentials: "include",
+    })
+
     const attachmentForm = new FormData()
     attachmentForm.append(
       "file",
@@ -53,7 +62,7 @@ test("downloaded share image keeps the rendered avatar and message image", async
       credentials: "include",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        content: "Both rendered images must survive export",
+        content: `All rendered images must survive export\n/c/invite/${token}`,
         attachments: [attachment.id],
         nonce: `e2e:${crypto.randomUUID()}`,
       }),
@@ -61,13 +70,19 @@ test("downloaded share image keeps the rendered avatar and message image", async
     const message = await messageResponse.json() as { message: { id: string } }
     return {
       avatarStatus: avatarResponse.status,
+      iconStatus: iconResponse.status,
       attachmentStatus: attachmentResponse.status,
       messageStatus: messageResponse.status,
       messageId: message.message.id,
     }
-  }, channelId)
+  }, { targetId: channelId, targetServerId: serverId, token: inviteToken })
 
-  expect(seeded).toMatchObject({ avatarStatus: 200, attachmentStatus: 200, messageStatus: 201 })
+  expect(seeded).toMatchObject({
+    avatarStatus: 200,
+    iconStatus: 200,
+    attachmentStatus: 200,
+    messageStatus: 201,
+  })
   await gotoAfterUserWsAuth(page, route)
   const row = page.getByTestId(tid.message(seeded.messageId))
   await expect(row).toBeVisible()
@@ -80,16 +95,21 @@ test("downloaded share image keeps the rendered avatar and message image", async
   const avatar = card.locator('[data-slot="avatar-image"]')
   const attachmentId = tid.messageShareImage(seeded.messageId, 0)
   const attachment = card.getByTestId(attachmentId)
+  const inviteIcon = card.getByTestId(tid.inviteCard(inviteToken)).locator("img")
   await expect(avatar).toBeVisible()
   await expect(attachment).toBeVisible()
+  await expect(inviteIcon).toBeVisible()
   await expect.poll(() => avatar.evaluate((image: HTMLImageElement) => (
     image.complete && image.naturalWidth > 0
   ))).toBe(true)
   await expect.poll(() => attachment.evaluate((image: HTMLImageElement) => (
     image.complete && image.naturalWidth > 0
   ))).toBe(true)
+  await expect.poll(() => inviteIcon.evaluate((image: HTMLImageElement) => (
+    image.complete && image.naturalWidth > 0
+  ))).toBe(true)
 
-  const points = await card.evaluate((cardNode, imageTestId) => {
+  const points = await card.evaluate((cardNode, { imageTestId, inviteTestId }) => {
     const cardRect = cardNode.getBoundingClientRect()
     const sample = (image: Element): SamplePoint => {
       const rect = image.getBoundingClientRect()
@@ -101,51 +121,93 @@ test("downloaded share image keeps the rendered avatar and message image", async
     return {
       avatar: sample(cardNode.querySelector('[data-slot="avatar-image"]')!),
       attachment: sample(cardNode.querySelector(`[data-testid="${imageTestId}"]`)!),
+      inviteIcon: sample(cardNode.querySelector(`[data-testid="${inviteTestId}"] img`)!),
     }
-  }, attachmentId)
+  }, { imageTestId: attachmentId, inviteTestId: tid.inviteCard(inviteToken) })
 
   await page.evaluate(() => {
     const nativeCreateObjectUrl = URL.createObjectURL.bind(URL)
-    ;(window as typeof window & { __shareImageBlob?: Blob }).__shareImageBlob = undefined
+    ;(window as typeof window & { __shareImageBlobs?: Blob[] }).__shareImageBlobs = []
     URL.createObjectURL = ((value: Blob | MediaSource) => {
       if (value instanceof Blob && value.type === "image/png") {
-        ;(window as typeof window & { __shareImageBlob?: Blob }).__shareImageBlob = value
+        ;(window as typeof window & { __shareImageBlobs?: Blob[] }).__shareImageBlobs!.push(value)
       }
       return nativeCreateObjectUrl(value)
     }) as typeof URL.createObjectURL
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        write: async (items: ClipboardItem[]) => {
+          const blob = await items[0]!.getType("image/png")
+          ;(window as typeof window & { __shareImageBlobs?: Blob[] }).__shareImageBlobs!.push(blob)
+        },
+      },
+    })
   })
 
+  const dynamicImagePaths = [
+    "/avatar",
+    "/attachments/",
+    "/icon",
+  ]
+  const imageRequestsDuringCapture: string[] = []
+  let captureStarted = false
+  page.on("request", (request) => {
+    if (!captureStarted || request.method() !== "GET") return
+    const pathname = new URL(request.url()).pathname
+    if (dynamicImagePaths.some((suffix) => pathname.includes(suffix))) {
+      imageRequestsDuringCapture.push(pathname)
+    }
+  })
+
+  captureStarted = true
   const downloadStarted = page.waitForEvent("download")
   await dialog.getByRole("button", { name: "Download" }).click()
   const download = await downloadStarted
   expect(download.suggestedFilename()).toMatch(/^alook-message-.*\.png$/)
+  await dialog.getByRole("button", { name: "Copy image" }).click()
+  await expect(dialog.getByRole("button", { name: "Copied" })).toBeVisible()
 
-  const pixels = await page.evaluate(async ({ avatarPoint, attachmentPoint }) => {
-    const blob = (window as typeof window & { __shareImageBlob?: Blob }).__shareImageBlob
-    if (!blob) throw new Error("Share image blob was not captured")
-    const bitmap = await createImageBitmap(blob)
-    const canvas = document.createElement("canvas")
-    canvas.width = bitmap.width
-    canvas.height = bitmap.height
-    const context = canvas.getContext("2d")!
-    context.drawImage(bitmap, 0, 0)
-    const read = ({ x, y }: SamplePoint) => [
-      ...context.getImageData(Math.round(x), Math.round(y), 1, 1).data,
-    ]
-    return {
-      avatar: read(avatarPoint),
-      attachment: read(attachmentPoint),
-      width: bitmap.width,
-      height: bitmap.height,
-    }
-  }, { avatarPoint: points.avatar, attachmentPoint: points.attachment })
+  const exports = await page.evaluate(async ({ avatarPoint, attachmentPoint, inviteIconPoint }) => {
+    const blobs = (window as typeof window & { __shareImageBlobs?: Blob[] }).__shareImageBlobs
+    if (!blobs || blobs.length !== 2) throw new Error("Share image blobs were not captured")
+    return Promise.all(blobs.map(async (blob) => {
+      const bitmap = await createImageBitmap(blob)
+      const canvas = document.createElement("canvas")
+      canvas.width = bitmap.width
+      canvas.height = bitmap.height
+      const context = canvas.getContext("2d")!
+      context.drawImage(bitmap, 0, 0)
+      const read = ({ x, y }: SamplePoint) => [
+        ...context.getImageData(Math.round(x), Math.round(y), 1, 1).data,
+      ]
+      return {
+        avatar: read(avatarPoint),
+        attachment: read(attachmentPoint),
+        inviteIcon: read(inviteIconPoint),
+        width: bitmap.width,
+        height: bitmap.height,
+      }
+    }))
+  }, {
+    avatarPoint: points.avatar,
+    attachmentPoint: points.attachment,
+    inviteIconPoint: points.inviteIcon,
+  })
 
-  expect(pixels.width).toBeGreaterThan(0)
-  expect(pixels.height).toBeGreaterThan(0)
-  expect(pixels.avatar[0]).toBeGreaterThan(180)
-  expect(pixels.avatar[1]).toBeLessThan(80)
-  expect(pixels.avatar[2]).toBeLessThan(100)
-  expect(pixels.attachment[0]).toBeLessThan(80)
-  expect(pixels.attachment[1]).toBeGreaterThan(70)
-  expect(pixels.attachment[2]).toBeGreaterThan(180)
+  expect(imageRequestsDuringCapture).toEqual([])
+  expect(exports).toHaveLength(2)
+  for (const pixels of exports) {
+    expect(pixels.width).toBeGreaterThan(0)
+    expect(pixels.height).toBeGreaterThan(0)
+    expect(pixels.avatar[0]).toBeGreaterThan(180)
+    expect(pixels.avatar[1]).toBeLessThan(80)
+    expect(pixels.avatar[2]).toBeLessThan(100)
+    expect(pixels.attachment[0]).toBeLessThan(80)
+    expect(pixels.attachment[1]).toBeGreaterThan(70)
+    expect(pixels.attachment[2]).toBeGreaterThan(180)
+    expect(pixels.inviteIcon[0]).toBeLessThan(80)
+    expect(pixels.inviteIcon[1]).toBeGreaterThan(140)
+    expect(pixels.inviteIcon[2]).toBeLessThan(120)
+  }
 })


### PR DESCRIPTION
## Summary

- snapshot the preview's already-decoded image pixels into temporary canvases before `html-to-image` clones the card
- remove capture-time image refetching/cache busting and restore every React-owned image after success or failure
- abort the export before rasterization if an image emits `error`, has zero intrinsic size, lacks a 2D canvas context, or cannot be read safely, so no failed source can produce a partial PNG
- cover repeated Download/Copy exports, avatar + attachment + invite icon pixels, and cleanup/failure boundaries

## Root cause

The previous fix waited for the live `<img>` elements, then refetched each source into data URLs immediately before capture. The preview could therefore be complete while `html-to-image` cloned a newly-mutated image tree during decode or reused a failed resource-cache entry, producing blank images. The new path uses the browser's decoded live pixels directly and performs no capture-time dynamic image requests.

Production evidence confirms the affected avatar and server-icon URLs are same-origin `/api/community/...` resources. This is a frontend clone/capture race; no proxy change is needed.

## Verification

- `pnpm --filter @alook/web test --run src/components/community/messages/message-share-dialog.test.ts` — 24 passed
- `pnpm --filter @alook/web typecheck` — passed
- isolated Chromium `51-share-image-assets.spec.ts` — passed; final Download and Copy PNG pixels verified for avatar, attachment, and invite/server icon; zero capture-time dynamic-image GETs
- independent QA opened both actual exported PNGs: 1344×682 RGBA, identical output, all image regions visible
- `pnpm typecheck` — passed
- `pnpm lint` — passed
- `pnpm test` — passed (web: 702 files / 6,257 tests; agent-driver: 38 files / 617 tests; root: 12 files / 129 tests)
