### PR TITLE
Make mobile token heatmap tappable

### DIFF
--- a/src/web/src/components/community/bots/bot-token-usage-chart.test.ts
+++ b/src/web/src/components/community/bots/bot-token-usage-chart.test.ts
@@ -1,7 +1,13 @@
 import React from "react"
 import TestRenderer, { act } from "react-test-renderer"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { BotTokenUsage, BotUsageDay } from "@/hooks/community/use-bots"
+
+const mocks = vi.hoisted(() => ({ breakpoint: "desktop" as "unknown" | "desktop" | "mobile" }))
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useBreakpoint: () => mocks.breakpoint,
+}))
 
 vi.mock("@/components/ui/tooltip", () => ({
   Tooltip: ({ children }: React.PropsWithChildren) => React.createElement(React.Fragment, null, children),
@@ -9,6 +15,21 @@ vi.mock("@/components/ui/tooltip", () => ({
     React.cloneElement(render, { "data-cell": true }),
   TooltipContent: ({ children }: React.PropsWithChildren) =>
     React.createElement("tooltip-content", null, children),
+}))
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) =>
+    React.createElement("mock-dialog", props, children),
+  DialogTrigger: ({ render, children }: { render: React.ReactElement; children?: React.ReactNode }) =>
+    React.cloneElement(render, {}, children),
+  DialogContent: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) =>
+    React.createElement("dialog-content", props, children),
+  DialogDescription: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) =>
+    React.createElement("dialog-description", props, children),
+  DialogHeader: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) =>
+    React.createElement("dialog-header", props, children),
+  DialogTitle: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) =>
+    React.createElement("dialog-title", props, children),
 }))
 
 import {
@@ -82,6 +103,10 @@ describe("daily token heat presentation", () => {
 })
 
 describe("BotTokenUsageHeatmap", () => {
+  beforeEach(() => {
+    mocks.breakpoint = "desktop"
+  })
+
   it("renders the original 30-cell 3-by-10 shell oldest to newest", () => {
     const usage: BotTokenUsage = {
       capability: "supported",
@@ -138,5 +163,84 @@ describe("BotTokenUsageHeatmap", () => {
   it("omits missing and unsupported usage without reserving a heatmap slot", () => {
     expect(render({ capability: "unsupported", days: [] }).toJSON()).toBeNull()
     expect(render().toJSON()).toBeNull()
+  })
+
+  it("turns the whole mobile heatmap into one 44px dialog trigger", () => {
+    mocks.breakpoint = "mobile"
+    const usage: BotTokenUsage = { capability: "supported", days: thirtyDays() }
+    const renderer = render(usage)
+    const trigger = renderer.root.findByProps({
+      "data-testid": "community-bot-usage-trigger-bot_1",
+    })
+    expect(trigger.props["aria-label"]).toBe("Open token usage details")
+    expect(trigger.props["aria-haspopup"]).toBe("dialog")
+    expect(trigger.props.className).toContain("min-h-11")
+    expect(renderer.root.findAllByProps({ "data-cell": true })).toHaveLength(0)
+    expect(renderer.root.findAll((node) => String(node.props["data-testid"] ?? "")
+      .startsWith("community-bot-usage-day-bot_1-"))).toHaveLength(30)
+  })
+
+  it("opens mobile details on the newest day with Total and all metric values", () => {
+    mocks.breakpoint = "mobile"
+    const usage: BotTokenUsage = {
+      capability: "supported",
+      days: thirtyDays({
+        30: { input: 8, output: 2, cache: 10 },
+      }),
+    }
+    const renderer = render(usage)
+    const newest = renderer.root.findByProps({
+      "data-testid": "community-bot-usage-dialog-day-bot_1-2026-08-30",
+    })
+    expect(newest.props["aria-pressed"]).toBe(true)
+    expect(newest.props.className).toContain("font-medium")
+    const summary = renderer.root.findByProps({
+      "data-testid": "community-bot-usage-dialog-summary-bot_1",
+    })
+    expect(text(summary)).toContain("Aug 30")
+    expect(text(summary)).toContain("Total 20")
+    expect(text(summary)).toContain("Input 8")
+    expect(text(summary)).toContain("Output 2")
+    expect(text(summary)).toContain("Cache 10")
+  })
+
+  it("updates mobile values and pressed state when an older date is selected", () => {
+    mocks.breakpoint = "mobile"
+    const usage: BotTokenUsage = {
+      capability: "supported",
+      days: thirtyDays({
+        28: { input: 6_000_000, output: 3_000_000, cache: unavailable },
+        30: { input: 8, output: 2, cache: 10 },
+      }),
+    }
+    const renderer = render(usage)
+    const older = renderer.root.findByProps({
+      "data-testid": "community-bot-usage-dialog-day-bot_1-2026-08-28",
+    })
+    act(() => older.props.onClick())
+    expect(older.props["aria-pressed"]).toBe(true)
+    expect(renderer.root.findByProps({
+      "data-testid": "community-bot-usage-dialog-day-bot_1-2026-08-30",
+    }).props["aria-pressed"]).toBe(false)
+    const summary = renderer.root.findByProps({
+      "data-testid": "community-bot-usage-dialog-summary-bot_1",
+    })
+    expect(text(summary)).toContain("Aug 28")
+    expect(text(summary)).toContain("Total 9,000,000")
+    expect(text(summary)).toContain("Cache Unavailable")
+  })
+
+  it("shows unavailable rather than fabricating a zero total for an unknown day", () => {
+    mocks.breakpoint = "mobile"
+    const renderer = render({ capability: "supported", days: thirtyDays() })
+    const unknown = renderer.root.findByProps({
+      "data-testid": "community-bot-usage-dialog-day-bot_1-2026-08-25",
+    })
+    act(() => unknown.props.onClick())
+    const summary = renderer.root.findByProps({
+      "data-testid": "community-bot-usage-dialog-summary-bot_1",
+    })
+    expect(text(summary)).toContain("Total Unavailable")
+    expect(text(summary).match(/Unavailable/g)).toHaveLength(4)
   })
 })

--- a/src/web/src/components/community/bots/bot-token-usage-chart.tsx
+++ b/src/web/src/components/community/bots/bot-token-usage-chart.tsx
@@ -1,10 +1,20 @@
 "use client"
 
+import { useEffect, useRef, useState } from "react"
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { useBreakpoint } from "@/hooks/use-mobile"
 import { tid } from "@/lib/community/testids"
 import type { BotTokenUsage, BotUsageDay } from "@/hooks/community/use-bots"
 import type { DailyUsageMetric } from "@alook/shared"
@@ -81,16 +91,73 @@ function accessibleDayLabel(day: BotUsageDay): string {
   ].join(". ")
 }
 
-function UsageDayDetail({ day }: { day: BotUsageDay }) {
+function UsageDayDetail({ day, includeTotal = false }: { day: BotUsageDay; includeTotal?: boolean }) {
+  const presentation = usageDayPresentation(day)
   return (
     <span className="flex min-w-44 flex-col gap-1">
       <span className="font-medium">{fullDayLabel(day)}</span>
+      {includeTotal && (
+        <span className="flex items-center justify-between gap-4 font-medium">
+          <span>Total</span>
+          <span className="font-mono tabular-nums">
+            {presentation.unavailable ? "Unavailable" : TOKEN_FMT.format(presentation.knownTotal)}
+          </span>
+        </span>
+      )}
       {METRICS.map((metric) => (
         <span key={metric.key} className="flex items-center justify-between gap-4">
           <span>{metric.label}</span>
           <span className="font-mono tabular-nums">{metricLabel(day.metrics[metric.key])}</span>
         </span>
       ))}
+    </span>
+  )
+}
+
+function UsageHeatmapGrid({
+  botId,
+  days,
+  interactive,
+  ariaLabel,
+  className,
+}: {
+  botId: string
+  days: BotUsageDay[]
+  interactive: boolean
+  ariaLabel?: string
+  className?: string
+}) {
+  return (
+    <span
+      role={interactive ? "img" : undefined}
+      aria-label={interactive ? ariaLabel : undefined}
+      aria-hidden={interactive ? undefined : true}
+      data-testid={tid.botUsage(botId)}
+      className={[
+        "grid w-fit grid-flow-col gap-[3px] [grid-template-rows:repeat(3,minmax(0,1fr))]",
+        className ?? "",
+      ].join(" ")}
+    >
+      {days.map((day) => {
+        const bucket = tokenHeatBucket(usageDayPresentation(day))
+        const cell = (
+          <span
+            key={day.day}
+            aria-label={interactive ? accessibleDayLabel(day) : undefined}
+            data-testid={tid.botUsageDay(botId, day.day)}
+            className={["size-3 rounded-[2px]", BUCKET_CLASSES[bucket]].join(" ")}
+          />
+        )
+        if (!interactive) return cell
+        return (
+          <Tooltip key={day.day}>
+            <TooltipTrigger render={cell} />
+            <TooltipContent className="items-start">
+              <UsageDayDetail day={day} />
+            </TooltipContent>
+          </Tooltip>
+        )
+      })}
     </span>
   )
 }
@@ -104,42 +171,112 @@ export function BotTokenUsageHeatmap({
   usage?: BotTokenUsage
   className?: string
 }) {
+  const breakpoint = useBreakpoint()
+  const newestDay = usage?.capability === "supported" ? usage.days.at(-1) : undefined
+  const [open, setOpen] = useState(false)
+  const [selectedDayKey, setSelectedDayKey] = useState(newestDay?.day ?? "")
+  const dateRailRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!newestDay || usage?.days.some((day) => day.day === selectedDayKey)) return
+    setSelectedDayKey(newestDay.day)
+  }, [newestDay, selectedDayKey, usage])
+
+  useEffect(() => {
+    if (breakpoint !== "mobile") setOpen(false)
+  }, [breakpoint])
+
+  useEffect(() => {
+    if (!open || !dateRailRef.current) return
+    dateRailRef.current.scrollLeft = dateRailRef.current.scrollWidth
+  }, [open])
+
   if (!usage || usage.capability !== "supported") return null
 
   const total = usage.days.reduce(
     (sum, day) => sum + usageDayPresentation(day).knownTotal,
     0,
   )
+  const ariaLabel = `Token usage over the last 30 days: ${TOKEN_FMT.format(total)} known tokens total`
+
+  if (breakpoint === "mobile") {
+    const selectedDay = usage.days.find((day) => day.day === selectedDayKey) ?? newestDay
+    return (
+      <Dialog
+        open={open}
+        onOpenChange={(nextOpen) => {
+          if (nextOpen && newestDay) setSelectedDayKey(newestDay.day)
+          setOpen(nextOpen)
+        }}
+      >
+        <DialogTrigger
+          render={
+            <button
+              type="button"
+              aria-label="Open token usage details"
+              aria-haspopup="dialog"
+              data-testid={tid.botUsageTrigger(botId)}
+              className={[
+                "grid min-h-11 place-items-center rounded-md px-1 outline-none active:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                className ?? "",
+              ].join(" ")}
+            />
+          }
+        >
+          <UsageHeatmapGrid botId={botId} days={usage.days} interactive={false} />
+        </DialogTrigger>
+        <DialogContent data-testid={tid.botUsageDialog(botId)} className="gap-4">
+          <DialogHeader>
+            <DialogTitle>Token usage</DialogTitle>
+            <DialogDescription>Choose a date to view exact token totals.</DialogDescription>
+          </DialogHeader>
+          <div
+            ref={dateRailRef}
+            data-testid={tid.botUsageDateRail(botId)}
+            className="-mx-1 flex min-w-0 gap-2 overflow-x-auto px-1 pb-1 overscroll-x-contain thin-scrollbar scrollbar-none"
+          >
+            {usage.days.map((day) => {
+              const selected = day.day === selectedDay?.day
+              return (
+                <button
+                  key={day.day}
+                  type="button"
+                  aria-pressed={selected}
+                  data-testid={tid.botUsageDialogDay(botId, day.day)}
+                  className={[
+                    "h-11 shrink-0 whitespace-nowrap rounded-md border px-3 text-sm outline-none active:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                    selected
+                      ? "border-foreground bg-foreground font-medium text-background"
+                      : "border-border bg-background text-muted-foreground hover:bg-accent hover:text-foreground",
+                  ].join(" ")}
+                  onClick={() => setSelectedDayKey(day.day)}
+                >
+                  {fullDayLabel(day)}
+                </button>
+              )
+            })}
+          </div>
+          {selectedDay && (
+            <div
+              aria-live="polite"
+              data-testid={tid.botUsageDialogSummary(botId)}
+              className="border-t pt-4"
+            >
+              <UsageDayDetail day={selectedDay} includeTotal />
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    )
+  }
 
   return (
-    <div
-      role="img"
-      aria-label={`Token usage over the last 30 days: ${TOKEN_FMT.format(total)} known tokens total`}
-      data-testid={tid.botUsage(botId)}
-      className={[
-        "grid w-fit grid-flow-col gap-[3px] [grid-template-rows:repeat(3,minmax(0,1fr))]",
-        className ?? "",
-      ].join(" ")}
-    >
-      {usage.days.map((day) => {
-        const bucket = tokenHeatBucket(usageDayPresentation(day))
-        return (
-          <Tooltip key={day.day}>
-            <TooltipTrigger
-              render={
-                <span
-                  aria-label={accessibleDayLabel(day)}
-                  data-testid={tid.botUsageDay(botId, day.day)}
-                  className={["size-3 rounded-[2px]", BUCKET_CLASSES[bucket]].join(" ")}
-                />
-              }
-            />
-            <TooltipContent className="items-start">
-              <UsageDayDetail day={day} />
-            </TooltipContent>
-          </Tooltip>
-        )
-      })}
-    </div>
+    <UsageHeatmapGrid
+      botId={botId}
+      days={usage.days}
+      interactive
+      ariaLabel={ariaLabel}
+      className={className}
+    />
   )
 }

--- a/src/web/src/lib/community/testids.ts
+++ b/src/web/src/lib/community/testids.ts
@@ -85,6 +85,12 @@ export const tid = {
   botReasoningEffort: "community-bot-reasoning-effort",
   botCardModel: "bot-card-model",
   botUsage: (botId: string) => `community-bot-usage-${botId}`,
+  botUsageTrigger: (botId: string) => `community-bot-usage-trigger-${botId}`,
+  botUsageDialog: (botId: string) => `community-bot-usage-dialog-${botId}`,
+  botUsageDateRail: (botId: string) => `community-bot-usage-date-rail-${botId}`,
+  botUsageDialogDay: (botId: string, day: string) =>
+    `community-bot-usage-dialog-day-${botId}-${day}`,
+  botUsageDialogSummary: (botId: string) => `community-bot-usage-dialog-summary-${botId}`,
   botUsageDay: (botId: string, day: string) => `community-bot-usage-day-${botId}-${day}`,
   machineQuota: (machineId: string) => `community-machine-quota-${machineId}`,
   machineQuotaDetail: (machineId: string) => `community-machine-quota-detail-${machineId}`,

--- a/src/web/src/test/e2e-ui/35-bot-token-usage-quota.spec.ts
+++ b/src/web/src/test/e2e-ui/35-bot-token-usage-quota.spec.ts
@@ -88,7 +88,7 @@ const machine = {
   platform: "darwin",
   arch: "arm64",
   osRelease: "26.0",
-  daemonVersion: "0.1.24",
+  daemonVersion: "0.1.29",
   lastSeenAt: "2026-08-29T01:00:00.000Z",
   status: "online",
   availableRuntimes: [
@@ -209,6 +209,18 @@ const bots = [
     dailyActivity: [],
     usage: { capability: "supported", days: smallerDays },
   },
+  {
+    id: "bot_cursor",
+    name: "Cursor",
+    description: "",
+    image: null,
+    machineId: machine.id,
+    runtime: "cursor",
+    modelName: null,
+    lastRefreshContextAt: null,
+    dailyActivity: [],
+    usage: { capability: "unsupported", days: [] },
+  },
 ]
 
 async function attachScreenshot(page: Page, testInfo: TestInfo, name: string) {
@@ -219,6 +231,11 @@ async function attachScreenshot(page: Page, testInfo: TestInfo, name: string) {
 
 async function expectNoHorizontalOverflow(page: Page) {
   expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true)
+}
+
+async function expectDarkTheme(page: Page, expected: boolean) {
+  await expect.poll(() => page.evaluate(() => document.documentElement.classList.contains("dark")))
+    .toBe(expected)
 }
 
 test("My Bots restores the 30-day token heatmap across PC and mobile", async ({ asUser }, testInfo) => {
@@ -232,6 +249,13 @@ test("My Bots restores the 30-day token heatmap across PC and mobile", async ({ 
   await page.emulateMedia({ reducedMotion: "reduce", colorScheme: "light" })
   await page.setViewportSize({ width: 1280, height: 900 })
   await gotoAfterUserWsAuth(page, "/c/me/bots")
+  await expectDarkTheme(page, false)
+  const writeRequests: string[] = []
+  page.on("request", (request) => {
+    if (["POST", "PUT", "PATCH", "DELETE"].includes(request.method())) {
+      writeRequests.push(`${request.method()} ${new URL(request.url()).pathname}`)
+    }
+  })
 
   const usage = page.getByTestId(tid.botUsage("bot_codex"))
   const dayCells = usage.locator(`[data-testid^="${tid.botUsageDay("bot_codex", "")}"]`)
@@ -263,6 +287,8 @@ test("My Bots restores the 30-day token heatmap across PC and mobile", async ({ 
     `[data-testid^="${tid.botUsageDay("bot_pi", "")}"]`,
   )).toHaveCount(30)
   await expect(page.getByText("Token usage not supported")).toHaveCount(0)
+  await expect(page.getByTestId(tid.botUsage("bot_cursor"))).toHaveCount(0)
+  await expect(page.getByTestId(tid.botUsageTrigger("bot_cursor"))).toHaveCount(0)
   await expect(page.locator(
     `[data-testid^="${tid.botUsageDay("bot_claude", "")}"]`,
   )).toHaveCount(30)
@@ -285,6 +311,11 @@ test("My Bots restores the 30-day token heatmap across PC and mobile", async ({ 
   const usageDay = page.getByTestId(tid.botUsageDay("bot_codex", "2026-08-26"))
   await expectNoHorizontalOverflow(page)
   await attachScreenshot(page, testInfo, "my-bots-token-heatmap-pc")
+  await page.emulateMedia({ reducedMotion: "reduce", colorScheme: "dark" })
+  await expectDarkTheme(page, true)
+  await attachScreenshot(page, testInfo, "my-bots-token-heatmap-pc-dark")
+  await page.emulateMedia({ reducedMotion: "reduce", colorScheme: "light" })
+  await expectDarkTheme(page, false)
   await usageDay.hover()
   const tooltip = page.locator('[data-slot="tooltip-content"]:visible')
   await expect(tooltip).toContainText("Aug 26")
@@ -321,6 +352,17 @@ test("My Bots restores the 30-day token heatmap across PC and mobile", async ({ 
   await expect(dayCells).toHaveCount(30)
   await expect.poll(async () => (await usage.boundingBox())?.height ?? 0).toBe(42)
   await expect.poll(async () => (await usage.boundingBox())?.width ?? 0).toBe(147)
+  const narrowBoundaryTrigger = page.getByTestId(tid.botUsageTrigger("bot_codex"))
+  await expect(narrowBoundaryTrigger).toBeVisible()
+  await expect.poll(async () => (await narrowBoundaryTrigger.boundingBox())?.height ?? 0)
+    .toBeGreaterThanOrEqual(44)
+  await narrowBoundaryTrigger.click()
+  const narrowBoundaryDialog = page.getByTestId(tid.botUsageDialog("bot_codex"))
+  await expect(narrowBoundaryDialog).toBeVisible()
+  await expect(page.getByTestId(tid.botUsageDialogDay("bot_codex", "2026-08-30")))
+    .toHaveAttribute("aria-pressed", "true")
+  await page.getByRole("button", { name: "Close" }).click()
+  await expect(narrowBoundaryDialog).toBeHidden()
   const [narrowBoundaryUsageBox, narrowBoundaryMetaBox] = await Promise.all([
     usage.boundingBox(),
     botCard.getByTestId(tid.botCardModel).boundingBox(),
@@ -342,6 +384,10 @@ test("My Bots restores the 30-day token heatmap across PC and mobile", async ({ 
   await expect(dayCells).toHaveCount(30)
   await expect.poll(async () => (await usage.boundingBox())?.height ?? 0).toBe(42)
   await expect.poll(async () => (await usage.boundingBox())?.width ?? 0).toBe(147)
+  const mobileTrigger = page.getByTestId(tid.botUsageTrigger("bot_codex"))
+  await expect(mobileTrigger).toBeVisible()
+  await expect.poll(async () => (await mobileTrigger.boundingBox())?.height ?? 0)
+    .toBeGreaterThanOrEqual(44)
   const [mobileUsageBox, mobileMetaBox] = await Promise.all([
     usage.boundingBox(),
     botCard.getByTestId(tid.botCardModel).boundingBox(),
@@ -350,20 +396,47 @@ test("My Bots restores the 30-day token heatmap across PC and mobile", async ({ 
   expect(mobileMetaBox).not.toBeNull()
   expect(mobileUsageBox!.y).toBeGreaterThan(mobileMetaBox!.y + mobileMetaBox!.height)
   await attachScreenshot(page, testInfo, "my-bots-token-heatmap-mobile")
-  await usageDay.hover()
-  await expect(tooltip).toContainText("Aug 26")
-  await expect(tooltip).toContainText("Input6,000,000")
-  await expect(tooltip).toContainText("Output3,000,000")
-  await expect(tooltip).toContainText("CacheUnavailable")
-  await expect(tooltip).toHaveCSS("opacity", "1")
-  await attachScreenshot(page, testInfo, "my-bots-token-heatmap-mobile-hover")
+  await mobileTrigger.click()
+  const usageDialog = page.getByTestId(tid.botUsageDialog("bot_codex"))
+  const dateRail = page.getByTestId(tid.botUsageDateRail("bot_codex"))
+  const newestDay = page.getByTestId(tid.botUsageDialogDay("bot_codex", "2026-08-30"))
+  const selectedDay = page.getByTestId(tid.botUsageDialogDay("bot_codex", "2026-08-26"))
+  const dialogSummary = page.getByTestId(tid.botUsageDialogSummary("bot_codex"))
+  await expect(usageDialog).toBeVisible()
+  await expect(newestDay).toHaveAttribute("aria-pressed", "true")
+  await expect(dialogSummary).toContainText("TotalUnavailable")
+  expect(await dateRail.evaluate((element) => element.scrollWidth > element.clientWidth)).toBe(true)
+  await selectedDay.click()
+  await expect(selectedDay).toHaveAttribute("aria-pressed", "true")
+  await expect(newestDay).toHaveAttribute("aria-pressed", "false")
+  await expect(dialogSummary).toContainText("Aug 26")
+  await expect(dialogSummary).toContainText("Total9,000,000")
+  await expect(dialogSummary).toContainText("Input6,000,000")
+  await expect(dialogSummary).toContainText("Output3,000,000")
+  await expect(dialogSummary).toContainText("CacheUnavailable")
+  await attachScreenshot(page, testInfo, "my-bots-token-heatmap-mobile-dialog")
+  const lightDialogBackground = await usageDialog.evaluate(
+    (element) => getComputedStyle(element).backgroundColor,
+  )
+  await page.emulateMedia({ reducedMotion: "reduce", colorScheme: "dark" })
+  await expectDarkTheme(page, true)
+  await expect.poll(() => usageDialog.evaluate(
+    (element) => getComputedStyle(element).backgroundColor,
+  )).not.toBe(lightDialogBackground)
+  await attachScreenshot(page, testInfo, "my-bots-token-heatmap-mobile-dialog-dark")
+  await page.emulateMedia({ reducedMotion: "reduce", colorScheme: "light" })
+  await expectDarkTheme(page, false)
+  await page.getByRole("button", { name: "Close" }).click()
+  await expect(usageDialog).toBeHidden()
 
   await page.setViewportSize({ width: 640, height: 844 })
+  await expect(page.getByTestId(tid.botUsageTrigger("bot_codex"))).toHaveCount(0)
   await expect(dayCells).toHaveCount(30)
   await expect.poll(async () => (await usage.boundingBox())?.height ?? 0).toBe(42)
   const desktopBoundaryDay = page.getByTestId(tid.botUsageDay("bot_codex", "2026-08-26"))
   await desktopBoundaryDay.hover()
   await expect(page.locator('[data-slot="tooltip-content"]:visible')).toContainText("Input6,000,000")
+  expect(writeRequests).toEqual([])
 })
 
 test("My Bots renders Pi usage through real D1 and the unmocked bots API", async ({ asUser }, testInfo) => {
@@ -491,18 +564,21 @@ test("My Bots renders Pi usage through real D1 and the unmocked bots API", async
     const todayTarget = page.locator(
       `[data-testid="${tid.botUsageDay(botId, today)}"]:visible`,
     )
-    await expect(todayTarget).toHaveAttribute("aria-label", /Input 129/)
-    await todayTarget.hover()
-    await expect(page.locator('[data-slot="tooltip-content"]:visible')).toContainText("Input129")
-    await expect(page.locator('[data-slot="tooltip-content"]:visible')).toContainText("Output39")
-    await expect(page.locator('[data-slot="tooltip-content"]:visible')).toContainText("Cache1,029")
+    await expect(todayTarget).toBeVisible()
+    await page.getByTestId(tid.botUsageTrigger(botId)).click()
+    const todayButton = page.getByTestId(tid.botUsageDialogDay(botId, today))
+    const todaySummary = page.getByTestId(tid.botUsageDialogSummary(botId))
+    await expect(todayButton).toHaveAttribute("aria-pressed", "true")
+    await expect(todaySummary).toContainText("Input129")
+    await expect(todaySummary).toContainText("Output39")
+    await expect(todaySummary).toContainText("Cache1,029")
     const browserEvidencePath = testInfo.outputPath("real-pi-browser-observation.json")
     writeFileSync(browserEvidencePath, `${JSON.stringify({
       route: "/c/me/bots",
       botId,
       visibleDayTestIds,
       today,
-      todayLabel: await todayTarget.getAttribute("aria-label"),
+      todaySummary: await todaySummary.innerText(),
     }, null, 2)}\n`)
     await testInfo.attach("real-pi-browser-observation.json", { path: browserEvidencePath })
     await attachScreenshot(page, testInfo, "real-pi-d1-local-today")


### PR DESCRIPTION
## Summary
- make the entire mobile token heatmap a 44px+ dialog trigger
- add a horizontally scrollable 30-day picker with exact Total, Input, Output, and Cache values
- preserve the existing desktop hover interaction and unsupported-runtime behavior

## Tests
- `pnpm typecheck`
- `pnpm test`
- focused component tests: 9/9
- focused Playwright E2E: 2/2, including 390px/639px, light/dark, unsupported runtime, and real D1 → API → dialog
- independent `alook-c-qa`: PASS
