### PR TITLE
fix(daemon): preserve provider runtime error codes

### DIFF
--- a/src/daemon/agent-driver/src/adapters/claude/normalizer.test.ts
+++ b/src/daemon/agent-driver/src/adapters/claude/normalizer.test.ts
@@ -398,8 +398,43 @@ describe("ClaudeEventNormalizer.normalizeLine", () => {
     const out = new ClaudeEventNormalizer().normalizeLine(
       J({ type: "result", is_error: true, result: "boom", session_id: "s1" }),
     );
-    expect(out.some((e) => e.kind === "error" && (e as any).message === "boom")).toBe(true);
+    expect(out).toContainEqual({
+      kind: "error",
+      code: "claude.result_error",
+      message: "boom",
+    });
     expect(out.some((e) => e.kind === "turn_end")).toBe(true);
+  });
+
+  it.each([
+    ["error_max_turns", "claude.error_max_turns"],
+    ["error_during_execution", "claude.error_during_execution"],
+    ["error_max_budget_usd", "claude.error_max_budget_usd"],
+    ["error_max_structured_output_retries", "claude.error_max_structured_output_retries"],
+    ["secret/provider/value", "claude.result_error"],
+  ])("maps Claude result subtype %s to %s", (subtype, code) => {
+    expect(new ClaudeEventNormalizer().normalizeLine(J({
+      type: "result",
+      subtype,
+      is_error: true,
+      result: "provider failed",
+      session_id: "s1",
+    }))).toContainEqual({
+      kind: "error",
+      code,
+      message: "provider failed",
+    });
+  });
+
+  it("classifies recognized assistant API errors without parsing text into a code", () => {
+    expect(new ClaudeEventNormalizer().normalizeLine(J({
+      type: "assistant",
+      message: { content: [{ type: "text", text: "API Error: 429 rate limited" }] },
+    }))).toEqual([{
+      kind: "error",
+      code: "claude.api_error",
+      message: "API Error: 429 rate limited",
+    }]);
   });
 
   it("errored result emits `error` BEFORE the trailing `turn_end` (the ordering B1's errored-turn marker relies on)", () => {

--- a/src/daemon/agent-driver/src/adapters/claude/normalizer.ts
+++ b/src/daemon/agent-driver/src/adapters/claude/normalizer.ts
@@ -19,6 +19,12 @@ import { tryParseJsonLine } from "../../internal/utils.js";
 import type { ClaudeTurnProtocol } from "./turnProtocol.js";
 
 const API_ERROR_RE = /API Error:.*(?:Connection error|\b[45]\d{2}\b)/i;
+const CLAUDE_RESULT_ERROR_CODES = new Map([
+  ["error_max_turns", "claude.error_max_turns"],
+  ["error_during_execution", "claude.error_during_execution"],
+  ["error_max_budget_usd", "claude.error_max_budget_usd"],
+  ["error_max_structured_output_retries", "claude.error_max_structured_output_retries"],
+]);
 const CLAUDE_USAGE_COMPONENTS = [
   "inputTokens",
   "outputTokens",
@@ -131,7 +137,9 @@ export class ClaudeEventNormalizer {
         out.push({ kind: "assistant_reasoning_completed", text: block.thinking ?? "" });
       } else if (block?.type === "text") {
         const text: string = block.text ?? "";
-        if (API_ERROR_RE.test(text)) out.push({ kind: "error", message: text });
+        if (API_ERROR_RE.test(text)) {
+          out.push({ kind: "error", code: "claude.api_error", message: text });
+        }
         else completedText.push(text);
       } else if (block?.type === "tool_use") {
         out.push({ kind: "tool_call", name: block.name ?? "unknown_tool", input: block.input });
@@ -165,7 +173,11 @@ export class ClaudeEventNormalizer {
     const usage = this.buildUsageTelemetry(event, rawOwner);
     if (usage) out.push(usage);
     if (event.is_error || event.subtype === "error_during_execution") {
-      out.push({ kind: "error", message: String(event.result ?? "Claude runtime error") });
+      out.push({
+        kind: "error",
+        code: CLAUDE_RESULT_ERROR_CODES.get(event.subtype) ?? "claude.result_error",
+        message: String(event.result ?? "Claude runtime error"),
+      });
     }
     out.push({
       kind: "turn_end",

--- a/src/daemon/agent-driver/src/adapters/codex/normalizer.test.ts
+++ b/src/daemon/agent-driver/src/adapters/codex/normalizer.test.ts
@@ -148,6 +148,46 @@ describe("CodexEventNormalizer — turn id tracking (for turn/steer expectedTurn
     expect(n.currentTurnId).toBeNull();
   });
 
+  it("preserves the official Codex turn error code and message", () => {
+    const n = new CodexEventNormalizer();
+    adoptRootTurn(n, "th_1", "turn_x");
+    expect(n.normalizeLine(notify("turn/completed", {
+      threadId: "th_1",
+      turn: {
+        id: "turn_x",
+        status: "failed",
+        error: {
+          message: "Selected model is at capacity. Please try a different model.",
+          codexErrorInfo: "serverOverloaded",
+        },
+      },
+    }))).toEqual([
+      {
+        kind: "error",
+        code: "codex.server_overloaded",
+        message: "Selected model is at capacity. Please try a different model.",
+      },
+      { kind: "turn_end", sessionId: "th_1", turnOwner: "codex:th_1:turn_x" },
+    ]);
+  });
+
+  it("rejects unknown Codex error labels instead of treating them as audit codes", () => {
+    const n = new CodexEventNormalizer();
+    adoptRootTurn(n, "th_1", "turn_x");
+    expect(n.normalizeLine(notify("turn/completed", {
+      threadId: "th_1",
+      turn: {
+        id: "turn_x",
+        status: "failed",
+        error: { message: "failed", codexErrorInfo: "secret/provider/value" },
+      },
+    }))![0]).toEqual({
+      kind: "error",
+      code: "codex.turn_failed",
+      message: "failed",
+    });
+  });
+
   it("ignores child and unknown completions without clearing or terminating the active root turn", () => {
     const n = new CodexEventNormalizer();
     adoptRootTurn(n, "root-thread", "root-turn");
@@ -226,8 +266,12 @@ describe("CodexEventNormalizer — turn id tracking (for turn/steer expectedTurn
       threadId: "root-thread",
       turnId: "root-turn",
       willRetry: false,
-      error: { message: "request failed" },
-    }))).toEqual([{ kind: "error", message: "request failed" }]);
+      error: { message: "request failed", codexErrorInfo: { responseStreamDisconnected: { httpStatusCode: 503 } } },
+    }))).toEqual([{
+      kind: "error",
+      code: "codex.response_stream_disconnected",
+      message: "request failed",
+    }]);
   });
 
   it("clears terminal ownership when a new thread is explicitly adopted and rejects an unowned terminal", () => {
@@ -437,7 +481,7 @@ describe("CodexEventNormalizer — complete owned event family", () => {
       { kind: "runtime_diagnostic", severity: "warning", source: "configWarning", message: "config" },
     ]);
     expect(n.normalizeLine(notify("error", { threadId: "root", message: "failed" }))).toEqual([
-      { kind: "error", message: "failed" },
+      { kind: "error", code: "codex.error", message: "failed" },
     ]);
     expect(n.normalizeLine(notify("unknown", { threadId: "root" }))).toEqual([]);
     expect(n.normalizeLine(notify("item/started", { threadId: "root", turnId: "turn", item: { type: "contextCompaction" } }))).toEqual([{ kind: "compaction_started" }]);
@@ -451,7 +495,7 @@ describe("CodexEventNormalizer — complete owned event family", () => {
     expect(n.normalizeLine(notify("thread/tokenUsage/updated", { threadId: "root", tokenUsage: {} }))).toEqual([]);
     expect(n.normalizeLine(notify("account/rateLimits/updated", { threadId: "root", rateLimits: {} }))).toEqual([]);
     expect(n.normalizeLine(notify("turn/completed", { threadId: "root", turn: { id: "turn", status: "interrupted" } }))).toEqual([
-      { kind: "error", message: "Codex turn interrupted" },
+      { kind: "error", code: "codex.turn_interrupted", message: "Codex turn interrupted" },
       { kind: "turn_end", sessionId: "root", turnOwner: "codex:root:turn" },
     ]);
   });

--- a/src/daemon/agent-driver/src/adapters/codex/normalizer.test.ts
+++ b/src/daemon/agent-driver/src/adapters/codex/normalizer.test.ts
@@ -458,6 +458,25 @@ describe("CodexEventNormalizer — session_init dedup (result + thread/started n
   });
 });
 
+describe("CodexEventNormalizer — RPC error envelopes", () => {
+  it.each([
+    { name: "safe integer", code: -32_603, expected: "codex.rpc.-32603" },
+    { name: "missing", code: undefined, expected: "codex.rpc_error" },
+    { name: "unsafe integer", code: Number.MAX_SAFE_INTEGER + 1, expected: "codex.rpc_error" },
+  ])("maps a $name code to $expected", ({ code, expected }) => {
+    const error = { message: "request failed", ...(code === undefined ? {} : { code }) };
+    expect(new CodexEventNormalizer().normalizeLine(JSON.stringify({
+      jsonrpc: "2.0",
+      id: 2,
+      error,
+    }))).toEqual([{
+      kind: "error",
+      code: expected,
+      message: "request failed",
+    }]);
+  });
+});
+
 describe("CodexEventNormalizer — complete owned event family", () => {
   it("normalizes diagnostics, telemetry, lifecycle boundaries, fallbacks, and invalid envelopes", () => {
     const n = new CodexEventNormalizer();

--- a/src/daemon/agent-driver/src/adapters/codex/normalizer.ts
+++ b/src/daemon/agent-driver/src/adapters/codex/normalizer.ts
@@ -8,6 +8,47 @@ let codexQuotaSourceEpoch = randomBytes(16).toString("base64url");
 let codexQuotaSourceGeneration = 0;
 let codexAccountFingerprint: string | null = null;
 
+const CODEX_ERROR_INFO_CODES = new Set([
+  "contextWindowExceeded",
+  "sessionBudgetExceeded",
+  "usageLimitExceeded",
+  "serverOverloaded",
+  "cyberPolicy",
+  "misalignmentPolicyViolation",
+  "internalServerError",
+  "unauthorized",
+  "badRequest",
+  "threadRollbackFailed",
+  "sandboxError",
+  "other",
+  "httpConnectionFailed",
+  "responseStreamConnectionFailed",
+  "responseStreamDisconnected",
+  "responseTooManyFailedAttempts",
+  "activeTurnNotSteerable",
+]);
+
+function snakeCase(value: string): string {
+  return value.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+}
+
+function codexErrorInfoCode(value: unknown, fallback: string): string {
+  const label = typeof value === "string"
+    ? value
+    : value && typeof value === "object" && !Array.isArray(value)
+      ? Object.keys(value)[0]
+      : undefined;
+  return label && CODEX_ERROR_INFO_CODES.has(label)
+    ? `codex.${snakeCase(label)}`
+    : fallback;
+}
+
+function codexRpcErrorCode(value: unknown): string {
+  return typeof value === "number" && Number.isSafeInteger(value)
+    ? `codex.rpc.${value}`
+    : "codex.rpc_error";
+}
+
 function rotateCodexQuotaSource(): void {
   codexQuotaSourceEpoch = randomBytes(16).toString("base64url");
   codexQuotaSourceGeneration += 1;
@@ -192,7 +233,11 @@ export class CodexEventNormalizer {
     }
 
     if (msg?.error && msg.id !== undefined) {
-      return [{ kind: "error", message: msg.error?.message ?? "Codex RPC error" }];
+      return [{
+        kind: "error",
+        code: codexRpcErrorCode(msg.error?.code),
+        message: msg.error?.message ?? "Codex RPC error",
+      }];
     }
 
     if (msg?.result?.thread?.id) {
@@ -282,13 +327,18 @@ export class CodexEventNormalizer {
         if (!this.acceptRootTerminal(params)) return [];
         this.releaseUsageForTurn(params.threadId, params.turn.id);
         if (params.turn.status === "failed") {
+          const error = params.turn.error;
           return [
-            { kind: "error", message: "Codex turn failed" },
+            {
+              kind: "error",
+              code: codexErrorInfoCode(error?.codexErrorInfo, "codex.turn_failed"),
+              message: error?.message ?? "Codex turn failed",
+            },
             { kind: "turn_end", sessionId: this.threadId ?? undefined, turnOwner: this.turnReceipt(params.threadId, params.turn.id) },
           ];
         }
         if (params.turn.status === "interrupted") {
-          return [{ kind: "error", message: "Codex turn interrupted" }, { kind: "turn_end", sessionId: this.threadId ?? undefined, turnOwner: this.turnReceipt(params.threadId, params.turn.id) }];
+          return [{ kind: "error", code: "codex.turn_interrupted", message: "Codex turn interrupted" }, { kind: "turn_end", sessionId: this.threadId ?? undefined, turnOwner: this.turnReceipt(params.threadId, params.turn.id) }];
         }
         return [{ kind: "turn_end", sessionId: this.threadId ?? undefined, turnOwner: this.turnReceipt(params.threadId, params.turn.id) }];
 
@@ -296,7 +346,11 @@ export class CodexEventNormalizer {
         if (params?.willRetry === true) {
           return [{ kind: "runtime_recovery", stage: "retrying", source: "codex_stream" }];
         }
-        return [{ kind: "error", message: params?.error?.message ?? params?.message ?? "Codex error" }];
+        return [{
+          kind: "error",
+          code: codexErrorInfoCode(params?.error?.codexErrorInfo, "codex.error"),
+          message: params?.error?.message ?? params?.message ?? "Codex error",
+        }];
 
       case "thread/tokenUsage/updated":
         return [];

--- a/src/daemon/agent-driver/src/adapters/cursor/acp-lane.ts
+++ b/src/daemon/agent-driver/src/adapters/cursor/acp-lane.ts
@@ -368,7 +368,11 @@ export class CursorAcpLane implements RuntimeLane {
     if (this.currentPromptRequestId !== prompt.requestId) return;
     const result = record(value);
     if (!result || typeof result.stopReason !== "string" || !PROMPT_STOP_REASONS.has(result.stopReason)) {
-      this.failPrompt(prompt, new Error("Cursor ACP prompt response did not contain a supported stopReason"));
+      this.failPrompt(
+        prompt,
+        new Error("Cursor ACP prompt response did not contain a supported stopReason"),
+        "cursor.invalid_stop_reason",
+      );
       return;
     }
     const terminalOwner = this.terminalOwner ?? prompt.receipt;
@@ -382,7 +386,7 @@ export class CursorAcpLane implements RuntimeLane {
     } satisfies AdapterEvent);
   }
 
-  private failPrompt(prompt: PromptRequest, error: unknown): void {
+  private failPrompt(prompt: PromptRequest, error: unknown, code = "cursor.prompt_failed"): void {
     if (this.currentPromptRequestId !== prompt.requestId) return;
     const terminalOwner = this.terminalOwner ?? prompt.receipt;
     this.currentPromptRequestId = null;
@@ -390,6 +394,7 @@ export class CursorAcpLane implements RuntimeLane {
     this.openToolCalls.clear();
     this.events.emit("runtime_event", {
       kind: "error",
+      code,
       message: error instanceof Error ? error.message : String(error),
     } satisfies AdapterEvent);
     this.events.emit("runtime_event", {
@@ -540,13 +545,20 @@ export class CursorAcpLane implements RuntimeLane {
       this.pending.delete(id);
       if (message.error !== undefined) {
         const payload = record(message.error);
-        this.failPrompt(pending.prompt, new CursorAcpRpcError(
-          pending.method,
-          typeof payload?.code === "number" ? payload.code : undefined,
-          rpcErrorMessage(message.error),
-        ));
+        const rpcCode = typeof payload?.code === "number" && Number.isSafeInteger(payload.code)
+          ? payload.code
+          : undefined;
+        this.failPrompt(
+          pending.prompt,
+          new CursorAcpRpcError(pending.method, rpcCode, rpcErrorMessage(message.error)),
+          rpcCode === undefined ? "cursor.rpc_error" : `cursor.rpc.${rpcCode}`,
+        );
       } else if (!("result" in message)) {
-        this.failPrompt(pending.prompt, new Error("Cursor ACP response omitted result"));
+        this.failPrompt(
+          pending.prompt,
+          new Error("Cursor ACP response omitted result"),
+          "cursor.invalid_response",
+        );
       } else {
         this.completePrompt(pending.prompt, message.result);
       }

--- a/src/daemon/agent-driver/src/adapters/cursor/index.test.ts
+++ b/src/daemon/agent-driver/src/adapters/cursor/index.test.ts
@@ -454,6 +454,30 @@ describe("CursorDriver persistent ACP transport", () => {
     expect(events.filter((event) => event.kind === "turn_end")).toHaveLength(1);
   });
 
+  it.each([
+    { name: "missing", error: { message: "missing code" } },
+    { name: "unsafe integer", error: { code: Number.MAX_SAFE_INTEGER + 1, message: "unsafe code" } },
+  ])("uses cursor.rpc_error for a prompt RPC error with a $name code", async ({ error }) => {
+    const server = installServer();
+    const lane = await new CursorDriver().openLane(baseCtx());
+    const events = eventsFrom(lane);
+    await lane.start({ text: "root" });
+    const process = spawned[0]!;
+
+    process.stdout.write(`${JSON.stringify({
+      jsonrpc: "2.0",
+      id: server.prompts[0]!.id,
+      error,
+    })}\n`);
+    await settle();
+
+    expect(events.filter((event) => event.kind === "error")).toEqual([{
+      kind: "error",
+      code: "cursor.rpc_error",
+      message: error.message,
+    }]);
+  });
+
   it("loads an ACP session without a fresh fallback and returns reset_required for an old incompatible id", async () => {
     killEmitsExit = true;
     const server = installServer({ sessionId: "legacy-print-id", loadError: "Session not found" });

--- a/src/daemon/agent-driver/src/adapters/cursor/index.test.ts
+++ b/src/daemon/agent-driver/src/adapters/cursor/index.test.ts
@@ -439,6 +439,7 @@ describe("CursorDriver persistent ACP transport", () => {
     await settle();
     expect(events.filter((event) => event.kind === "error")).toEqual([{
       kind: "error",
+      code: "cursor.rpc.-32000",
       message: "latest failed",
     }]);
     expect(events.filter((event) => event.kind === "turn_end")).toEqual([{
@@ -736,20 +737,29 @@ describe("CursorDriver persistent ACP transport", () => {
 
     fail(process, server.prompts[0]!, "Prompt failed", { message: "private vendor detail" });
     await settle();
-    expect(events).toContainEqual({ kind: "error", message: "Prompt failed: private vendor detail" });
+    expect(events).toContainEqual({
+      kind: "error",
+      code: "cursor.rpc.-32000",
+      message: "Prompt failed: private vendor detail",
+    });
 
     await lane.send({ text: "second", mode: "idle" });
     respond(process, server.prompts[1]!, { stopReason: "unknown" });
     await settle();
     expect(events).toContainEqual({
       kind: "error",
+      code: "cursor.invalid_stop_reason",
       message: "Cursor ACP prompt response did not contain a supported stopReason",
     });
 
     await lane.send({ text: "third", mode: "idle" });
     process.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id: server.prompts[2]!.id })}\n`);
     await settle();
-    expect(events).toContainEqual({ kind: "error", message: "Cursor ACP response omitted result" });
+    expect(events).toContainEqual({
+      kind: "error",
+      code: "cursor.invalid_response",
+      message: "Cursor ACP response omitted result",
+    });
 
     await lane.send({ text: "fourth", mode: "idle" });
     respond(process, server.prompts[3]!, {

--- a/src/daemon/agent-driver/src/adapters/opencode/service-lane.test.ts
+++ b/src/daemon/agent-driver/src/adapters/opencode/service-lane.test.ts
@@ -1386,6 +1386,27 @@ describe("OpenCodeServiceLane authenticated persistent protocol", () => {
     await lane.stop({ reason: "test", forceAfterMs: 0 });
   });
 
+  it("reports an unsupported final finish reason with its stable error code", async () => {
+    const lane = makeLane();
+    const { runtime } = collectEvents(lane);
+    await lane.start({ text: "root", terminalOwner: "msg_root" });
+    const service = factories.at(-1)!.service!;
+    killers.set(service.process.pid, () => service.close());
+    service.publish("session.next.step.ended", {
+      assistantMessageID: "msg_unsupported",
+      finish: "cancelled",
+    });
+    service.active = false;
+
+    await waitForTurn(runtime, 1);
+    expect(runtime).toContainEqual({
+      kind: "error",
+      code: "opencode.unsupported_finish",
+      message: "OpenCode reported an unsupported final step outcome",
+    });
+    await lane.stop({ reason: "test", forceAfterMs: 0 });
+  });
+
   it("accounts tool-call and terminal durable steps once across frontier replay", async () => {
     const lane = makeLane();
     const { runtime } = collectEvents(lane);

--- a/src/daemon/agent-driver/src/adapters/opencode/service-lane.test.ts
+++ b/src/daemon/agent-driver/src/adapters/opencode/service-lane.test.ts
@@ -1148,11 +1148,7 @@ describe("OpenCodeServiceLane authenticated persistent protocol", () => {
     service.publish("session.next.compaction.ended", { assistantMessageID: "msg_assistant" });
     service.publish("session.next.step.failed", {
       assistantMessageID: "msg_assistant",
-      error: { message: "secret vendor detail" },
-    });
-    service.publish("session.next.step.failed", {
-      assistantMessageID: "msg_assistant",
-      error: {},
+      error: { type: "unknown", message: "provider overloaded" },
     });
     service.active = false;
 
@@ -1164,8 +1160,32 @@ describe("OpenCodeServiceLane authenticated persistent protocol", () => {
     expect(runtime).toContainEqual({ kind: "tool_output", name: "OpenCode tool" });
     expect(runtime).toContainEqual({ kind: "compaction_started" });
     expect(runtime).toContainEqual({ kind: "compaction_finished" });
-    expect(runtime).toContainEqual({ kind: "error", message: "OpenCode reported an inconsistent turn outcome" });
-    expect(JSON.stringify(runtime)).not.toContain("secret vendor detail");
+    expect(runtime).toContainEqual({
+      kind: "error",
+      code: "opencode.unknown",
+      message: "provider overloaded",
+    });
+    await lane.stop({ reason: "test", forceAfterMs: 0 });
+  });
+
+  it("uses safe fallbacks for an inconsistent step failure payload", async () => {
+    const lane = makeLane();
+    const { runtime } = collectEvents(lane);
+    await lane.start({ text: "root", terminalOwner: "msg_root" });
+    const service = factories.at(-1)!.service!;
+
+    service.publish("session.next.step.failed", {
+      assistantMessageID: "msg_assistant",
+      error: { type: "secret/provider/value" },
+    });
+    service.active = false;
+
+    await waitForTurn(runtime, 1);
+    expect(runtime).toContainEqual({
+      kind: "error",
+      code: "opencode.step_failed",
+      message: "OpenCode reported an inconsistent turn outcome",
+    });
     await lane.stop({ reason: "test", forceAfterMs: 0 });
   });
 
@@ -1358,7 +1378,11 @@ describe("OpenCodeServiceLane authenticated persistent protocol", () => {
     });
     service.active = false;
     await waitForTurn(runtime, 1);
-    expect(runtime).toContainEqual({ kind: "error", message: "OpenCode drain settled without a durable turn outcome" });
+    expect(runtime).toContainEqual({
+      kind: "error",
+      code: "opencode.missing_outcome",
+      message: "OpenCode drain settled without a durable turn outcome",
+    });
     await lane.stop({ reason: "test", forceAfterMs: 0 });
   });
 

--- a/src/daemon/agent-driver/src/adapters/opencode/service-lane.ts
+++ b/src/daemon/agent-driver/src/adapters/opencode/service-lane.ts
@@ -38,6 +38,7 @@ interface ServiceIdentity {
 interface TurnOutcome {
   readonly seq: number;
   readonly ok: boolean;
+  readonly code?: string;
   readonly message?: string;
 }
 
@@ -149,7 +150,12 @@ function messageFromError(value: unknown): string {
   const message = typeof payload?.message === "string" && payload.message.trim()
     ? payload.message
     : undefined;
-  return message ? "OpenCode turn failed" : "OpenCode reported an inconsistent turn outcome";
+  return message ?? "OpenCode reported an inconsistent turn outcome";
+}
+
+function codeFromError(value: unknown): string {
+  const payload = record(value);
+  return payload?.type === "unknown" ? "opencode.unknown" : "opencode.step_failed";
 }
 
 export class OpenCodeServiceLane implements RuntimeLane {
@@ -848,7 +854,10 @@ export class OpenCodeServiceLane implements RuntimeLane {
           root.outcomes.push({
             seq,
             ok: successful,
-            ...(!successful ? { message: "OpenCode reported an unsupported final step outcome" } : {}),
+            ...(!successful ? {
+              code: "opencode.unsupported_finish",
+              message: "OpenCode reported an unsupported final step outcome",
+            } : {}),
           });
         }
         const tokens = record(data.tokens);
@@ -876,7 +885,12 @@ export class OpenCodeServiceLane implements RuntimeLane {
         break;
       }
       case "session.next.step.failed":
-        root.outcomes.push({ seq, ok: false, message: messageFromError(data.error) });
+        root.outcomes.push({
+          seq,
+          ok: false,
+          code: codeFromError(data.error),
+          message: messageFromError(data.error),
+        });
         break;
       default:
         break;
@@ -1086,11 +1100,21 @@ export class OpenCodeServiceLane implements RuntimeLane {
         .sort((left, right) => left.seq - right.seq)
         .at(-1);
       if (!root.interrupted && !outcome) {
-        this.settleRoot(root, false, "OpenCode drain settled without a durable turn outcome");
+        this.settleRoot(
+          root,
+          false,
+          "OpenCode drain settled without a durable turn outcome",
+          "opencode.missing_outcome",
+        );
         return;
       }
       if (outcome && !outcome.ok) {
-        this.settleRoot(root, false, outcome.message ?? "OpenCode turn failed");
+        this.settleRoot(
+          root,
+          false,
+          outcome.message ?? "OpenCode turn failed",
+          outcome.code ?? "opencode.turn_failed",
+        );
         return;
       }
       this.settleRoot(root, true);
@@ -1126,13 +1150,19 @@ export class OpenCodeServiceLane implements RuntimeLane {
       && this.identityMatches();
   }
 
-  private settleRoot(root: ActiveRoot, success: boolean, message?: string): void {
+  private settleRoot(
+    root: ActiveRoot,
+    success: boolean,
+    message?: string,
+    code = "opencode.turn_failed",
+  ): void {
     if (this.activeRoot !== root) return;
     this.activeRoot = null;
     this.toolNames.clear();
     if (!success) {
       this.events.emit("runtime_event", {
         kind: "error",
+        code,
         message: message ?? "OpenCode turn failed",
       } satisfies AdapterEvent);
     }

--- a/src/daemon/agent-driver/src/adapters/pi/index.test.ts
+++ b/src/daemon/agent-driver/src/adapters/pi/index.test.ts
@@ -359,7 +359,11 @@ describe("Pi SDK event-family coverage", () => {
     expect(mapPiSdkEvent({
       type: "message_update",
       assistantMessageEvent: { type: "error", error: { errorMessage: "provider failed" } },
-    }, "session", state)).toEqual([{ kind: "error", message: "provider failed" }]);
+    }, "session", state)).toEqual([{
+      kind: "error",
+      code: "pi.message_error",
+      message: "provider failed",
+    }]);
     expect(mapPiSdkEvent({
       type: "message_update",
       delta: { type: "text_end", content: "wrong outer field" },

--- a/src/daemon/agent-driver/src/adapters/pi/index.ts
+++ b/src/daemon/agent-driver/src/adapters/pi/index.ts
@@ -189,7 +189,11 @@ export function mapPiSdkEvent(event: any, sessionId: string, state: PiEventState
         return [{ kind: "assistant_message_completed", text: d.content ?? "" }];
       }
       case "error":
-        return [{ kind: "error", message: d.error?.errorMessage ?? "Pi error" }];
+        return [{
+          kind: "error",
+          code: "pi.message_error",
+          message: d.error?.errorMessage ?? "Pi error",
+        }];
       default:
         return [];
     }

--- a/src/daemon/agent-driver/src/controller/logical-session.test.ts
+++ b/src/daemon/agent-driver/src/controller/logical-session.test.ts
@@ -1664,6 +1664,25 @@ describe("backend-owned delivery behavior", () => {
     await session.stop({ reason: "shutdown", forceAfterMs: 10 });
   });
 
+  it.each([
+    { input: "codex.server_overloaded", expected: "codex.server_overloaded" },
+    { input: "secret/provider/value", expected: "runtime_error" },
+  ])("projects adapter error code $input as $expected", async ({ input, expected }) => {
+    const { session, driver } = makeSession("codex");
+    const iterator = session.events[Symbol.asyncIterator]();
+    await session.start({ id: "one", kind: "user", text: "start" });
+    await emit(driver, { kind: "error", code: input, message: "provider failed" });
+    await emit(driver, { kind: "turn_end", sessionId: "s1" });
+    const events = await take(iterator as never, 5);
+    expect(events.find((event) => event.type === "turn_completed")).toMatchObject({
+      result: {
+        outcome: "failed",
+        error: { code: expected, message: "provider failed" },
+      },
+    });
+    await session.stop({ reason: "shutdown", forceAfterMs: 10 });
+  });
+
   it("opencode keeps one persistent lane and admits busy input as steer", async () => {
     const { session, driver } = makeSession("opencode");
     await session.start({ id: "one", kind: "user", text: "start" });

--- a/src/daemon/agent-driver/src/controller/logical-session.ts
+++ b/src/daemon/agent-driver/src/controller/logical-session.ts
@@ -36,7 +36,7 @@ import {
 } from "../internal/adapter.js";
 import { BufferedEventQueue } from "./event-queue.js";
 import { writeAgentFile } from "../internal/agentFile.js";
-import { scrubDriverErrorMessage } from "../internal/errors.js";
+import { scrubDriverErrorMessage, stableErrorCode } from "../internal/errors.js";
 import { mkdirSync } from "node:fs";
 
 type SessionState = AgentSessionSnapshot["state"];
@@ -841,7 +841,12 @@ implements AgentSession<Specs, Id> {
       }
       case "error":
         this.toolBoundaryFlushDisabled = true;
-        this.turnError = driverError("process", "runtime_error", event.message, true);
+        this.turnError = driverError(
+          "process",
+          stableErrorCode(event.code, "runtime_error"),
+          event.message,
+          true,
+        );
         this.emit({
           type: "diagnostic",
           turnId,

--- a/src/daemon/agent-driver/src/internal/adapter.ts
+++ b/src/daemon/agent-driver/src/internal/adapter.ts
@@ -73,7 +73,7 @@ export type AdapterEvent =
   | { kind: "runtime_metric"; name: "sse_reconnect"; increment: 1 }
   | { kind: "turn_owner"; receipt: string; nativeTurnId?: string }
   | { kind: "turn_end"; sessionId?: string; turnOwner?: string }
-  | { kind: "error"; message: string }
+  | { kind: "error"; code?: string; message: string }
   | { kind: "telemetry"; name: "token_usage"; source: string; usage: TokenUsageDelta }
   | { kind: "telemetry"; name: "rate_limits"; source: string; quota: ProviderQuotaObservation };
 

--- a/src/daemon/src/manager/managerRuntime.test.ts
+++ b/src/daemon/src/manager/managerRuntime.test.ts
@@ -173,7 +173,7 @@ function fakeSession(sessionInstanceId = "test-instance"): FakeSession {
     },
     async fire(evt: string, ...args: unknown[]) {
       if (evt === "runtime_event") {
-        const event = args[0] as { kind: string; sessionId?: string; text?: string; name?: string; input?: unknown; message?: string; source?: string; itemType?: string; payloadBytes?: number };
+        const event = args[0] as { kind: string; sessionId?: string; text?: string; name?: string; input?: unknown; code?: string; message?: string; source?: string; itemType?: string; payloadBytes?: number };
         const turnId = "test-turn";
         switch (event.kind) {
           case "session_init":
@@ -188,7 +188,7 @@ function fakeSession(sessionInstanceId = "test-instance"): FakeSession {
           case "review_started":
           case "review_finished": push({ type: event.kind, turnId } as never); break;
           case "internal_progress": push({ type: "internal_progress", turnId, source: event.source, itemType: event.itemType, payloadBytes: event.payloadBytes } as never); break;
-          case "error": push({ type: "session_failed", error: { category: "process", code: "runtime_error", message: event.message ?? "Runtime error", retryable: true } } as never); break;
+          case "error": push({ type: "session_failed", error: { category: "process", code: event.code ?? "runtime_error", message: event.message ?? "Runtime error", retryable: true } } as never); break;
           case "turn_end": push({ type: "turn_completed", turnId, commandIds: ["test-start"], result: { outcome: "success", backendSessionId: event.sessionId ?? "test-session" } } as never); break;
           default: push({ type: "internal_progress", turnId, source: "test", itemType: event.kind } as never);
         }
@@ -2954,7 +2954,11 @@ describe("AgentProcessManager — error audit emission", () => {
 
     // Establish first so the error is session-level (runtime), not spawn.
     await session.fire("runtime_event", { kind: "session_init", sessionId: "s1" });
-    await session.fire("runtime_event", { kind: "error", message: "rate limited: 429 Too Many Requests" });
+    await session.fire("runtime_event", {
+      kind: "error",
+      code: "codex.server_overloaded",
+      message: "rate limited: 429 Too Many Requests",
+    });
 
     const errCalls = onBotAuditEvent.mock.calls.filter(
       ([, ev]) => (ev as { kind?: string })?.kind === "error",
@@ -2962,8 +2966,40 @@ describe("AgentProcessManager — error audit emission", () => {
     expect(errCalls).toHaveLength(1);
     const payload = (errCalls[0]![1] as { payload: { scope: string; code: string; message: string } }).payload;
     expect(payload.scope).toBe("runtime");
-    expect(payload.code).toBe("runtime_error");
+    expect(payload.code).toBe("codex.server_overloaded");
     expect(payload.message).toContain("429");
+  });
+
+  it("falls back to runtime_error when a driver error code is not audit-safe", () => {
+    const onBotAuditEvent = vi.fn();
+    const { mgr } = makeManager({ onBotAuditEvent });
+    const internal = mgr as unknown as {
+      activeSpawnState: Map<string, { superseded: boolean }>;
+      onAgentEvent(agentId: string, event: AgentEvent<BuiltinBackendSpecs, "codex">, runtimeId: "codex", owner: { superseded: boolean }): void;
+    };
+    mgr.deliver("a1", { seq: 1, text: "hello" });
+    const owner = internal.activeSpawnState.get("a1")!;
+    internal.onAgentEvent("a1", {
+      type: "session_failed",
+      error: {
+        category: "process",
+        code: "secret/provider/value",
+        message: "failed",
+        retryable: true,
+      },
+      sequence: 1,
+      sessionInstanceId: "test-instance",
+      at: Date.now(),
+    }, "codex", owner);
+
+    expect(onBotAuditEvent).toHaveBeenCalledWith(
+      "a1",
+      expect.objectContaining({
+        kind: "error",
+        payload: expect.objectContaining({ code: "runtime_error" }),
+      }),
+      expect.anything(),
+    );
   });
 
   it("emits the failed turn result message as a runtime error", () => {
@@ -3086,7 +3122,7 @@ describe("AgentProcessManager — error audit emission", () => {
     expect(logger.calls.warn.some(([m]) => m === "runtime error during a stuck reset window")).toBe(false);
   });
 
-  it("scrubs secrets out of an error message before it becomes an audit row", async () => {
+  it("scrubs secrets and caps an error message before it becomes an audit row", async () => {
     const onBotAuditEvent = vi.fn();
     const { mgr, session } = makeManager({ onBotAuditEvent });
     mgr.deliver("a1", { seq: 1, text: "hello" });
@@ -3094,7 +3130,7 @@ describe("AgentProcessManager — error audit emission", () => {
     await session.fire("runtime_event", { kind: "session_init", sessionId: "s1" });
     await session.fire("runtime_event", {
       kind: "error",
-      message: 'auth failed sk-ant-abc123DEF456 OPENAI_API_KEY=provider-secret {"apiKey":"json-secret"} Authorization: Basic basic-secret at /Users/Alice Smith/private key.json?token=query-secret',
+      message: `auth failed sk-ant-abc123DEF456 OPENAI_API_KEY=provider-secret {"apiKey":"json-secret"} Authorization: Basic basic-secret at /Users/Alice Smith/private key.json?token=query-secret\n${"x".repeat(3_000)}`,
     });
 
     const errCall = onBotAuditEvent.mock.calls.find(
@@ -3103,6 +3139,8 @@ describe("AgentProcessManager — error audit emission", () => {
     const message = (errCall![1] as { payload: { message: string } }).payload.message;
     expect(message).not.toMatch(/sk-ant-abc123DEF456|provider-secret|json-secret|basic-secret|Alice Smith|private key|query-secret/);
     expect(message).toContain("[redacted-token]");
+    expect(message).toHaveLength(1_000);
+    expect(message.length).toBeLessThanOrEqual(2_000);
   });
 });
 

--- a/src/daemon/src/manager/managerRuntime.ts
+++ b/src/daemon/src/manager/managerRuntime.ts
@@ -1859,11 +1859,12 @@ export class AgentProcessManager {
     rawMessage: string,
   ): void {
     if (!this.opts.onBotAuditEvent) return;
+    const stableCode = /^[A-Za-z0-9_.-]{1,100}$/.test(code) ? code : "runtime_error";
     const message = scrubRuntimeErrorDiagnosticText(rawMessage).slice(0, AUDIT_ERROR_MESSAGE_MAX_LEN);
     try {
       this.opts.onBotAuditEvent(agentId, {
         kind: "error",
-        payload: { scope, code, message, model: this.currentModelFor(agentId) },
+        payload: { scope, code: stableCode, message, model: this.currentModelFor(agentId) },
       }, {
         sessionId: this.liveSessions.get(agentId) ?? null,
         launchId: this.launchIds.get(agentId) ?? null,
@@ -1895,15 +1896,15 @@ export class AgentProcessManager {
       return;
     }
     const sessionSuperseded = owner.superseded;
-    const errorMessage = event.type === "session_failed"
-      ? event.error.message
+    const runtimeError = event.type === "session_failed"
+      ? event.error
       : event.type === "turn_completed" && event.result.outcome === "failed"
-        ? event.result.error.message
+        ? event.result.error
         : undefined;
-    if (errorMessage !== undefined && !sessionSuperseded) {
-      this.emitErrorAudit(agentId, "runtime", "runtime_error", errorMessage);
+    if (runtimeError !== undefined && !sessionSuperseded) {
+      this.emitErrorAudit(agentId, "runtime", runtimeError.code, runtimeError.message);
       if (this.nonCleanEndMarker.get(agentId)?.cause !== "killed_stalled") {
-        this.nonCleanEndMarker.set(agentId, { cause: "runtime_error", detail: errorMessage });
+        this.nonCleanEndMarker.set(agentId, { cause: "runtime_error", detail: runtimeError.message });
       }
       const agent = this.state.agents[agentId];
       if (
@@ -1914,7 +1915,7 @@ export class AgentProcessManager {
         this.log.warn("runtime error during a stuck reset window", {
           agentId,
           resettingForMs: this.now() - agent.resettingSince,
-          message: errorMessage,
+          message: runtimeError.message,
         });
       }
     }


### PR DESCRIPTION
## Why we need this PR?

Provider-native runtime error codes were being collapsed to the generic runtime_error code at the daemon boundary, hiding actionable failures from audit logs and callers.

## What changed

- Preserve declared provider runtime error codes through the daemon manager.
- Keep runtime_error as the fallback for undeclared or missing codes.
- Add focused regression coverage across agent-driver and manager-runtime boundaries.

## Verification

- Agent-driver tests: 628 passed, 4 skipped.
- Focused manager-runtime tests: 253 passed.
- Repository typecheck and lint passed.
- Exact-head live QA passed across Codex, Claude, Cursor, OpenCode, and Pi.
- Live OpenCode provider failure surfaced opencode.unknown end to end rather than runtime_error.
- Independent exact-head review passed at e768b492b4410afc20670edc6d8ab89856a7e1e3.

## Checklist

- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (@alook/shared)
- [ ] Web app (@alook/web)
- [ ] CLI (@alook/cli)
- [ ] Email Worker (@alook/email-worker)
- [ ] WebSocket DO (@alook/ws-do)
- [ ] CI/CD
- [x] Other: daemon runtime error propagation