### PR TITLE
fix(daemon): make inbox pull always acknowledge

### DIFF
--- a/src/daemon/src/cli/index.test.ts
+++ b/src/daemon/src/cli/index.test.ts
@@ -526,24 +526,28 @@ describe("inbox pull", () => {
     expect(env.success.pulledAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}$/);
   });
 
-  it("--no-ack skips advancing the waterline", async () => {
-    const ackSpy = vi.fn(async (req: { cursors: Array<{ channel: string; seq: number }> }) => ({
-      ok: true, applied: req.cursors, failed: [],
+  it("removes --no-ack from inbox pull help", async () => {
+    await main(["inbox", "pull", "-h"]);
+    expect(cap.lines().join("")).not.toContain("--no-ack");
+  });
+
+  it("rejects --no-ack before calling inbox APIs", async () => {
+    const pullSpy = vi.fn(async () => ({
+      messages: [{ seq: "#2", channel: "/s#0042/general", sender: "@x", content: { text: "yo" }, time: "" }],
+      hasMore: false,
+      markedCount: 0,
     }));
+    const ackSpy = vi.fn();
     setApiForTesting(
       stubApi({
-        inboxPull: async () => ({
-          messages: [{ seq: "#2", channel: "/s#0042/general", sender: "@x", content: { text: "yo" }, time: "" }],
-          hasMore: false,
-          markedCount: 0,
-        }),
+        inboxPull: pullSpy,
         ack: ackSpy,
       }),
     );
     await main(["inbox", "pull", "--no-ack"]);
-    const env = parseEnvelope(cap.lines()) as { success: { acked: number } };
+    expect(parseEnvelope(cap.lines()).error).toContain("unknown option '--no-ack'");
+    expect(pullSpy).not.toHaveBeenCalled();
     expect(ackSpy).not.toHaveBeenCalled();
-    expect(env.success.acked).toBe(0);
   });
 
   it("surfaces ackError instead of poisoning the whole pull when ack throws", async () => {

--- a/src/daemon/src/cli/index.ts
+++ b/src/daemon/src/cli/index.ts
@@ -603,7 +603,7 @@ async function cmdInboxPull(opts: Record<string, unknown>): Promise<unknown> {
   let acked = 0;
   let ackError: string | undefined;
   let failed: AckFailure[] | undefined;
-  if (opts.ack !== false && messages.length > 0) {
+  if (messages.length > 0) {
     const latest = new Map<string, Cursor>();
     for (const m of messages) {
       const seqN = Number(m.seq.replace("#", ""));
@@ -876,7 +876,6 @@ function buildProgram(stdin: CliInputStream): Command {
     .command("pull")
     .description("fetch unread messages from all channels")
     .option("--max <n>", "max messages to return")
-    .option("--no-ack", "do not advance read waterlines (peek only)")
     .exitOverride()
     .configureOutput({ writeOut: () => {}, writeErr: () => {} })
     .action(async function (this: Command) {

--- a/src/daemon/src/drivers/systemPrompt.ts
+++ b/src/daemon/src/drivers/systemPrompt.ts
@@ -105,7 +105,7 @@ function cliCommandsSection(): string {
     "",
     "### Messaging",
     "",
-    `1. \`${CLI} inbox pull\` — fetch unread messages; \`--no-ack\` peeks without advancing.`,
+    `1. \`${CLI} inbox pull\` — fetch unread messages and advance their read waterlines.`,
     `2. \`${CLI} message send --target <ref> --remind-after <0|Nm|Nh> --stdin\` — send to a ` +
       `channel, DM, or thread. ` +
       `The body is required through \`--stdin\` and limited to 1 KiB of UTF-8. ` +
@@ -392,7 +392,7 @@ function executionModelSection(): string {
     "On wake, restore durable context from `memory.md` and the context timeline, then pull your inbox. " +
       "Follow *Outstanding work marks* below before taking new work.",
     "",
-    "`inbox pull` advances your read waterline by default — pulled messages won't come back in a " +
+    "`inbox pull` advances your read waterline — pulled messages won't come back in a " +
       "future pull. A task-bearing message stays durable through its server mark even after the " +
       "read waterline advances."
   ].join("\n");

--- a/src/web/src/lib/community/audit-event-summary.test.ts
+++ b/src/web/src/lib/community/audit-event-summary.test.ts
@@ -32,6 +32,10 @@ describe("summarizeAuditEvent", () => {
     })).toBe("alook inbox pull")
     expect(summarizeAuditEvent({
       kind: "cli_invocation",
+      payload: { subcommand: "inboxSnapshot" },
+    })).toBe("alook inbox snapshot")
+    expect(summarizeAuditEvent({
+      kind: "cli_invocation",
       payload: { subcommand: "attachmentUpload" },
     })).toBe("alook message attachment upload")
     expect(summarizeAuditEvent({

--- a/src/web/src/lib/community/audit-event-summary.test.ts
+++ b/src/web/src/lib/community/audit-event-summary.test.ts
@@ -33,7 +33,7 @@ describe("summarizeAuditEvent", () => {
     expect(summarizeAuditEvent({
       kind: "cli_invocation",
       payload: { subcommand: "inboxSnapshot" },
-    })).toBe("alook inbox snapshot")
+    })).toBe("alook inbox pull")
     expect(summarizeAuditEvent({
       kind: "cli_invocation",
       payload: { subcommand: "attachmentUpload" },

--- a/src/web/src/lib/community/audit-event-summary.ts
+++ b/src/web/src/lib/community/audit-event-summary.ts
@@ -48,7 +48,7 @@ const ALOOK_COMMAND_BY_SUBCOMMAND: Record<string, string> = {
   listFriends: "friend list",
   friendRequest: "friend request",
   inboxPull: "inbox pull",
-  inboxSnapshot: "inbox snapshot",
+  inboxSnapshot: "inbox pull",
   profileBioUpdate: "setting profile",
   profileAvatarUpdate: "setting profile",
   nap: "nap",

--- a/src/web/src/lib/community/audit-event-summary.ts
+++ b/src/web/src/lib/community/audit-event-summary.ts
@@ -48,7 +48,7 @@ const ALOOK_COMMAND_BY_SUBCOMMAND: Record<string, string> = {
   listFriends: "friend list",
   friendRequest: "friend request",
   inboxPull: "inbox pull",
-  inboxSnapshot: "inbox pull --no-ack",
+  inboxSnapshot: "inbox snapshot",
   profileBioUpdate: "setting profile",
   profileAvatarUpdate: "setting profile",
   nap: "nap",


### PR DESCRIPTION
## Why we need this PR?

The public no-ack escape hatch lets an agent pull the same unread message without advancing its waterline, which can inject the exact same message again on a later acknowledged pull.

## What changed

- Remove the --no-ack option from inbox pull.
- Make every successful inbox pull attempt to acknowledge the latest returned cursor per channel.
- Update generated agent instructions to state that inbox pull advances read waterlines.
- Remove the old option from the user-facing inbox snapshot audit label.
- Replace the old no-ack behavior test with parser/help rejection coverage.

The internal inboxSnapshot server operation remains unchanged; only its stale CLI-style label was corrected.

## Verification

- Focused daemon and Web tests: 155 passed.
- Independent QA: 170 focused tests passed across pull+ack, removed-option, prompt, audit label, and snapshot mapping journeys.
- Repository typecheck passed.
- Repository lint passed.
- Full repository test suite passed.
- Pre-commit typecheck, lint, full tests, typegrep, agent-driver boundary check, and knip passed.
- git diff --check passed.

## Checklist

- [x] Tests added/updated as needed
- [x] All local checks pass
- [x] PR targets the correct branch

## Impact Areas

- [x] Web app (@alook/web)
- [x] CLI/daemon (@alook/daemon)
- [ ] Shared library (@alook/shared)
- [ ] Email Worker (@alook/email-worker)
- [ ] WebSocket DO (@alook/ws-do)
- [ ] CI/CD