### PR TITLE
fix(desktop): restore Finder file drops

### DIFF
--- a/scripts/ci/workflow-contract.test.ts
+++ b/scripts/ci/workflow-contract.test.ts
@@ -58,6 +58,7 @@ const desktopReleaseWorkflow = normalizeWorkflow(readFileSync(resolve(workflowRo
 const desktopConfig = JSON.parse(
   readFileSync(resolve(import.meta.dirname, "../../src/desktop/src-tauri/tauri.conf.json"), "utf8"),
 ) as {
+  app?: { windows?: Array<{ label?: string; dragDropEnabled?: boolean }> }
   bundle?: { createUpdaterArtifacts?: boolean | string }
   plugins?: { updater?: { endpoints?: string[] } }
 }
@@ -621,6 +622,13 @@ describe("Turbo CI execution", () => {
     expect(wakeNode).not.toContain("returns 200 { status: ok } for GET /health")
     expect(wakeRuntime).toContain("rejects invalid JSON and non-POST dev requests at the real entrypoint")
     expect(wakeRuntime).toContain("loads production migrations and serves the production entrypoint")
+  })
+})
+
+describe("Desktop window contract", () => {
+  it("delegates external file drops to the webview attachment lifecycle", () => {
+    const mainWindow = desktopConfig.app?.windows?.find((window) => window.label === "main")
+    expect(mainWindow?.dragDropEnabled).toBe(false)
   })
 })
 

--- a/src/desktop/src-tauri/tauri.conf.json
+++ b/src/desktop/src-tauri/tauri.conf.json
@@ -28,6 +28,7 @@
       {
         "label": "main",
         "title": "Alook",
+        "dragDropEnabled": false,
         "width": 1200,
         "height": 800,
         "minWidth": 800,

--- a/src/web/src/hooks/use-file-attachments.test.ts
+++ b/src/web/src/hooks/use-file-attachments.test.ts
@@ -78,6 +78,94 @@ async function renderCapture(options?: Parameters<typeof useFileAttachments>[0])
   }
 }
 
+async function dropFiles(
+  hook: Awaited<ReturnType<typeof renderCapture>>,
+  files: File[],
+) {
+  const preventDefault = vi.fn()
+  const stopPropagation = vi.fn()
+  act(() => {
+    hook.current.handleDrop({
+      preventDefault,
+      stopPropagation,
+      dataTransfer: { files },
+    } as unknown as React.DragEvent)
+  })
+  await act(async () => {
+    await hook.current.awaitPendingFiles()
+  })
+  expect(preventDefault).toHaveBeenCalledOnce()
+  expect(stopPropagation).toHaveBeenCalledOnce()
+}
+
+describe("useFileAttachments — DOM drop ownership", () => {
+  it("routes picker selection and DOM drop through the same pending-file lifecycle", async () => {
+    generateThumbnailMock.mockResolvedValue(null)
+    const hook = await renderCapture()
+    const selected = new File(["picker"], "picker.txt", { type: "text/plain" })
+    const dropped = new File(["drop"], "drop.png", { type: "image/png" })
+    const target = { files: [selected], value: "picker.txt" }
+
+    act(() => {
+      hook.current.handleFileSelect({ target } as unknown as React.ChangeEvent<HTMLInputElement>)
+    })
+    await act(async () => {
+      await hook.current.awaitPendingFiles()
+    })
+    await dropFiles(hook, [dropped])
+
+    expect(target.value).toBe("")
+    expect(hook.current.pendingFiles.map(({ file }) => file)).toEqual([selected, dropped])
+    expect(generateThumbnailMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("keeps oversize DOM drops out of pending state and shows the existing error", async () => {
+    generateThumbnailMock.mockResolvedValue(null)
+    const hook = await renderCapture({ maxFileSize: 1024 * 1024 })
+    const dropped = new File(
+      [new Uint8Array(1024 * 1024 + 1)],
+      "too-large.png",
+      { type: "image/png" },
+    )
+
+    await dropFiles(hook, [dropped])
+
+    expect(hook.current.pendingFiles).toEqual([])
+    expect(toastErrorMock).toHaveBeenCalledWith('"too-large.png" exceeds 1 MB limit')
+    expect(generateThumbnailMock).not.toHaveBeenCalled()
+  })
+
+  it("keeps over-count DOM drops out of pending state and shows the existing error", async () => {
+    generateThumbnailMock.mockResolvedValue(null)
+    const hook = await renderCapture({ maxFiles: 1 })
+    const files = [
+      new File(["a"], "a.txt", { type: "text/plain" }),
+      new File(["b"], "b.txt", { type: "text/plain" }),
+    ]
+
+    await dropFiles(hook, files)
+
+    expect(hook.current.pendingFiles).toEqual([])
+    expect(toastErrorMock).toHaveBeenCalledWith("You can attach up to 1 files")
+    expect(generateThumbnailMock).not.toHaveBeenCalled()
+  })
+
+  it("removes a DOM-dropped Community image when preparation fails visibly", async () => {
+    prepareCommunityImageMock.mockRejectedValue(new Error("decode failed"))
+    const hook = await renderCapture({
+      thumbnailPolicy: "community",
+      draftSessionScope: "server/channel",
+    })
+    const dropped = new File(["image"], "broken.png", { type: "image/png" })
+
+    await dropFiles(hook, [dropped])
+
+    expect(hook.current.pendingFiles).toEqual([])
+    expect(readComposerAttachmentSession("server/channel")).toEqual([])
+    expect(toastErrorMock).toHaveBeenCalledWith('Could not prepare "broken.png" for upload')
+  })
+})
+
 describe("useFileAttachments — PendingFile width/height", () => {
   it("carries the image's natural width/height from generateThumbnail onto the PendingFile", async () => {
     generateThumbnailMock.mockResolvedValue({ blob: { size: 1 } as Blob, width: 1920, height: 1080 })


### PR DESCRIPTION
## Summary

- disable Tauri's native file-drop handler for the main window so DOM drops reach the existing web attachment lifecycle
- add a desktop configuration contract for that ownership boundary
- cover picker/drop convergence and the existing size, count, and preparation-failure rejection paths

## Scope

- based directly on `c2494c871508871dbeb10e6bdaacbb505003b089`
- changes exactly three files: Tauri config plus two test files
- no production web or Rust changes, filesystem capability/path bridge, native event handler, second validator, 52B/52C, or #53 work
- no real message or upload was sent

## Validation

- focused CI contract: 38 tests passed
- attachment hook/controller/view: 42 tests passed
- server-rail drag regressions: 59 tests passed
- `cargo check --manifest-path src/desktop/src-tauri/Cargo.toml`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm typegrep:ws`
- `pnpm typegrep:agent-driver`
- `pnpm knip`
- full pre-commit hook passed

## QA handoff

Manual macOS window/fullscreen verification for DM, channel, and thread composers remains for independent QA after this Draft opens.
