### PR TITLE
fix(web): bound share image render lifecycle

### DIFF
--- a/src/web/src/components/community/messages/message-share-dialog.test.ts
+++ b/src/web/src/components/community/messages/message-share-dialog.test.ts
@@ -1,18 +1,22 @@
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import React from "react"
 import TestRenderer, { act } from "react-test-renderer"
+import { toast } from "sonner"
 import {
   MessageShareDialog,
   ShareCardImageTimeoutError,
+  ShareCardRenderError,
   ShareImageSnapshotError,
   copyRenderedShareCard,
   createShareImageSnapshot,
   downloadRenderedShareCard,
   renderShareCard,
+  shareCardRenderErrorMessage,
   snapshotShareCardImages,
   waitForShareCardImages,
 } from "./message-share-dialog"
 import type { RenderMsg } from "@/lib/community/models/message"
+import { tid } from "@/lib/community/testids"
 
 const profileState = vi.hoisted(() => ({ map: new Map<string, Record<string, unknown>>() }))
 vi.mock("@/stores/community/ws", () => ({
@@ -514,20 +518,241 @@ describe("snapshotShareCardImages", () => {
 })
 
 describe("renderShareCard", () => {
-  it("does not rasterize when image snapshot preparation fails", async () => {
-    const node = {} as HTMLElement
-    const snapshotImages = vi.fn().mockRejectedValue(new ShareImageSnapshotError())
+  const node = {} as HTMLElement
+  const style = { getPropertyValue: vi.fn(() => "") }
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it("records the complete render lifecycle and restores snapshots once", async () => {
+    vi.stubGlobal("getComputedStyle", vi.fn(() => style))
+    const stages: string[] = []
+    const restore = vi.fn()
+    const blob = new Blob(["png"], { type: "image/png" })
+    const snapshotImages = vi.fn().mockResolvedValue(restore)
+    const loadFonts = vi.fn().mockResolvedValue(undefined)
+    const rasterize = vi.fn().mockResolvedValue(blob)
+
+    await expect(renderShareCard(node, snapshotImages, rasterize, {
+      loadFonts,
+      onStage: (stage) => stages.push(stage),
+    })).resolves.toBe(blob)
+
+    expect(stages).toEqual(["snapshot", "fonts", "rasterize", "cleanup"])
+    expect(loadFonts).toHaveBeenCalledOnce()
+    expect(restore).toHaveBeenCalledOnce()
+  })
+
+  it("types snapshot preparation failures and skips rasterization", async () => {
+    const failure = new ShareImageSnapshotError()
+    const snapshotImages = vi.fn().mockRejectedValue(failure)
     const rasterize = vi.fn()
 
-    await expect(renderShareCard(node, snapshotImages, rasterize)).rejects.toThrow(
-      ShareImageSnapshotError,
-    )
+    await expect(renderShareCard(node, snapshotImages, rasterize, {
+      loadFonts: vi.fn(),
+    })).rejects.toMatchObject({
+      stage: "snapshot",
+      timedOut: false,
+      cause: failure,
+    })
 
     expect(rasterize).not.toHaveBeenCalled()
   })
 
-  it("does not reach clipboard or download writes when snapshot preparation fails", async () => {
-    const failure = new ShareImageSnapshotError()
+  it("keeps font loading best-effort and proceeds to rasterization", async () => {
+    vi.stubGlobal("getComputedStyle", vi.fn(() => style))
+    const restore = vi.fn()
+    const blob = new Blob(["png"], { type: "image/png" })
+    const rasterize = vi.fn().mockResolvedValue(blob)
+
+    await expect(renderShareCard(
+      node,
+      vi.fn().mockResolvedValue(restore),
+      rasterize,
+      { loadFonts: vi.fn().mockRejectedValue(new Error("font unavailable")) },
+    )).resolves.toBe(blob)
+
+    expect(rasterize).toHaveBeenCalledOnce()
+    expect(restore).toHaveBeenCalledOnce()
+  })
+
+  it("uses the real document font contract when no font waiter is injected", async () => {
+    const load = vi.fn().mockResolvedValue(undefined)
+    const ready = Promise.resolve()
+    vi.stubGlobal("document", { documentElement: {}, fonts: { load, ready } })
+    vi.stubGlobal("getComputedStyle", vi.fn((target) => (
+      target === document.documentElement
+        ? { getPropertyValue: vi.fn(() => "Caveat") }
+        : style
+    )))
+
+    await renderShareCard(
+      node,
+      vi.fn().mockResolvedValue(vi.fn()),
+      vi.fn().mockResolvedValue(new Blob(["png"])),
+    )
+
+    expect(load).toHaveBeenCalledWith("16px Caveat")
+  })
+
+  it.each([
+    {
+      name: "a rejected rasterizer",
+      result: () => Promise.reject(new Error("raster failed")),
+    },
+    {
+      name: "a null rasterizer result",
+      result: () => Promise.resolve(null),
+    },
+  ])("types $name and restores snapshots once", async ({ result }) => {
+    vi.stubGlobal("getComputedStyle", vi.fn(() => style))
+    const restore = vi.fn()
+
+    await expect(renderShareCard(
+      node,
+      vi.fn().mockResolvedValue(restore),
+      vi.fn(result),
+      { loadFonts: vi.fn().mockResolvedValue(undefined) },
+    )).rejects.toMatchObject({ stage: "rasterize", timedOut: false })
+
+    expect(restore).toHaveBeenCalledOnce()
+  })
+
+  it.each(["snapshot", "fonts", "rasterize"] as const)(
+    "applies the single total deadline while in %s",
+    async (blockedStage) => {
+      vi.useFakeTimers()
+      vi.stubGlobal("getComputedStyle", vi.fn(() => style))
+      const never = () => new Promise<never>(() => {})
+      const restore = vi.fn()
+      const snapshotImages = blockedStage === "snapshot"
+        ? vi.fn(never)
+        : vi.fn().mockResolvedValue(restore)
+      const loadFonts = blockedStage === "fonts"
+        ? vi.fn(never)
+        : vi.fn().mockResolvedValue(undefined)
+      const rasterize = blockedStage === "rasterize"
+        ? vi.fn(never)
+        : vi.fn().mockResolvedValue(new Blob(["png"]))
+      const rendering = renderShareCard(node, snapshotImages, rasterize, {
+        timeoutMs: 50,
+        loadFonts,
+      })
+      const rejected = expect(rendering).rejects.toMatchObject({
+        stage: blockedStage,
+        timedOut: true,
+      })
+
+      await vi.advanceTimersByTimeAsync(50)
+      await rejected
+
+      expect(restore).toHaveBeenCalledTimes(blockedStage === "snapshot" ? 0 : 1)
+    },
+  )
+
+  it("restores a late snapshot result after the caller deadline has fired", async () => {
+    vi.useFakeTimers()
+    let finishSnapshot: ((restore: () => void) => void) | undefined
+    const restore = vi.fn()
+    const snapshotImages = vi.fn(() => new Promise<() => void>((resolve) => {
+      finishSnapshot = resolve
+    }))
+    const rasterize = vi.fn()
+    const rendering = renderShareCard(node, snapshotImages, rasterize, {
+      timeoutMs: 50,
+      loadFonts: vi.fn(),
+    })
+    const rejected = expect(rendering).rejects.toMatchObject({
+      stage: "snapshot",
+      timedOut: true,
+    })
+
+    await vi.advanceTimersByTimeAsync(50)
+    await rejected
+    finishSnapshot?.(restore)
+    await vi.waitFor(() => expect(restore).toHaveBeenCalledOnce())
+
+    expect(rasterize).not.toHaveBeenCalled()
+  })
+
+  it.each(["fonts", "rasterize"] as const)(
+    "stops after a late %s result and keeps cleanup exact",
+    async (blockedStage) => {
+      vi.useFakeTimers()
+      vi.stubGlobal("getComputedStyle", vi.fn(() => style))
+      let finishStage: (() => void) | undefined
+      const restore = vi.fn()
+      const loadFonts = blockedStage === "fonts"
+        ? vi.fn(() => new Promise<void>((resolve) => { finishStage = resolve }))
+        : vi.fn().mockResolvedValue(undefined)
+      const rasterize = blockedStage === "rasterize"
+        ? vi.fn(() => new Promise<Blob>((resolve) => {
+            finishStage = () => resolve(new Blob(["png"]))
+          }))
+        : vi.fn().mockResolvedValue(new Blob(["png"]))
+      const rendering = renderShareCard(
+        node,
+        vi.fn().mockResolvedValue(restore),
+        rasterize,
+        { timeoutMs: 50, loadFonts },
+      )
+      const outcome = rendering.catch((error) => error)
+
+      await vi.advanceTimersByTimeAsync(50)
+      expect(await outcome).toMatchObject({ stage: blockedStage, timedOut: true })
+      finishStage?.()
+      await vi.waitFor(() => expect(restore).toHaveBeenCalledOnce())
+
+      expect(rasterize).toHaveBeenCalledTimes(blockedStage === "fonts" ? 0 : 1)
+    },
+  )
+
+  it("surfaces cleanup failure when the deadline restores a blocked raster", async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal("getComputedStyle", vi.fn(() => style))
+    const failure = new Error("restore failed")
+    const restore = vi.fn(() => { throw failure })
+    const rendering = renderShareCard(
+      node,
+      vi.fn().mockResolvedValue(restore),
+      vi.fn(() => new Promise<never>(() => {})),
+      { timeoutMs: 50, loadFonts: vi.fn().mockResolvedValue(undefined) },
+    )
+    const outcome = rendering.catch((error) => error)
+
+    await vi.advanceTimersByTimeAsync(50)
+
+    expect(await outcome).toMatchObject({
+      stage: "cleanup",
+      timedOut: false,
+      cause: failure,
+    })
+    expect(restore).toHaveBeenCalledOnce()
+  })
+
+  it("types cleanup failures and never repeats the restore callback", async () => {
+    vi.stubGlobal("getComputedStyle", vi.fn(() => style))
+    const failure = new Error("restore failed")
+    const restore = vi.fn(() => { throw failure })
+
+    await expect(renderShareCard(
+      node,
+      vi.fn().mockResolvedValue(restore),
+      vi.fn().mockResolvedValue(new Blob(["png"])),
+      { loadFonts: vi.fn().mockResolvedValue(undefined) },
+    )).rejects.toMatchObject({
+      stage: "cleanup",
+      timedOut: false,
+      cause: failure,
+    })
+
+    expect(restore).toHaveBeenCalledOnce()
+  })
+
+  it("does not reach clipboard or download writers when rendering fails", async () => {
+    const failure = new ShareCardRenderError("fonts", true)
     const render = vi.fn().mockRejectedValue(failure)
     const clipboardWrite = vi.fn()
     const downloadSave = vi.fn()
@@ -537,5 +762,76 @@ describe("renderShareCard", () => {
 
     expect(clipboardWrite).not.toHaveBeenCalled()
     expect(downloadSave).not.toHaveBeenCalled()
+  })
+
+  it("types a renderer that resolves without a blob before action writers", async () => {
+    const render = vi.fn().mockResolvedValue(null)
+    const clipboardWrite = vi.fn()
+    const downloadSave = vi.fn()
+
+    await expect(copyRenderedShareCard(render, clipboardWrite)).rejects.toMatchObject({
+      stage: "rasterize",
+      timedOut: false,
+    })
+    await expect(downloadRenderedShareCard(render, "share.png", downloadSave)).rejects.toMatchObject({
+      stage: "rasterize",
+      timedOut: false,
+    })
+
+    expect(clipboardWrite).not.toHaveBeenCalled()
+    expect(downloadSave).not.toHaveBeenCalled()
+  })
+
+  it("writes only after a completed render", async () => {
+    const order: string[] = []
+    const blob = new Blob(["png"], { type: "image/png" })
+    const render = vi.fn(async () => {
+      order.push("render")
+      return blob
+    })
+    const clipboardWrite = vi.fn(() => { order.push("copy") })
+    const downloadSave = vi.fn(() => { order.push("download") })
+
+    await copyRenderedShareCard(render, clipboardWrite)
+    await downloadRenderedShareCard(render, "share.png", downloadSave)
+
+    expect(order).toEqual(["render", "copy", "render", "download"])
+  })
+
+  it.each([
+    ["snapshot", "preparing images"],
+    ["fonts", "loading fonts"],
+    ["rasterize", "rendering the image"],
+    ["cleanup", "restoring the preview"],
+  ] as const)("formats visible %s stage failures", (stage, label) => {
+    expect(shareCardRenderErrorMessage(new ShareCardRenderError(stage))).toBe(
+      `Couldn't generate image — ${label} failed`,
+    )
+    expect(shareCardRenderErrorMessage(new ShareCardRenderError(stage, true))).toBe(
+      `Couldn't generate image — ${label} took too long`,
+    )
+  })
+
+  it("leaves post-render action errors to their action-specific UI", () => {
+    expect(shareCardRenderErrorMessage(new Error("clipboard denied"))).toBeNull()
+  })
+})
+
+describe("MessageShareDialog render failures", () => {
+  afterEach(() => {
+    vi.mocked(toast.error).mockReset()
+  })
+
+  it("shows a stage-specific render failure instead of clipboard advice", async () => {
+    const renderer = renderMessage(message())
+    const copyButton = renderer.root.findByProps({ "data-testid": tid.messageShareCopy })
+
+    await act(async () => {
+      await copyButton.props.onClick()
+    })
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "Couldn't generate image — rendering the image failed",
+    )
   })
 })

--- a/src/web/src/components/community/messages/message-share-dialog.tsx
+++ b/src/web/src/components/community/messages/message-share-dialog.tsx
@@ -19,7 +19,22 @@ import { useProfilesByUserId } from "@/stores/community/ws"
 import { readCommunityProfile } from "@/lib/community/profile-read"
 
 const SHARE_IMAGE_READY_TIMEOUT_MS = 5_000
+const SHARE_IMAGE_RENDER_TIMEOUT_MS = 15_000
 const SHARE_IMAGE_PIXEL_RATIO = 2
+
+export type ShareCardRenderStage = "snapshot" | "fonts" | "rasterize" | "cleanup"
+
+export class ShareCardRenderError extends Error {
+  constructor(
+    readonly stage: ShareCardRenderStage,
+    readonly timedOut = false,
+    cause?: unknown,
+  ) {
+    super(`Share-card render ${timedOut ? "timed out" : "failed"} during ${stage}`)
+    this.name = "ShareCardRenderError"
+    this.cause = cause
+  }
+}
 
 export class ShareCardImageTimeoutError extends Error {
   constructor() {
@@ -229,33 +244,104 @@ export async function snapshotShareCardImages(
 
 type ShareCardImageSnapshotter = (node: HTMLElement) => Promise<() => void>
 type ShareCardRasterizer = typeof toBlob
+type ShareCardRenderOptions = {
+  timeoutMs?: number
+  loadFonts?: () => Promise<void>
+  onStage?: (stage: ShareCardRenderStage) => void
+}
+
+async function loadShareCardFonts(): Promise<void> {
+  const caveatFont = getComputedStyle(document.documentElement)
+    .getPropertyValue("--font-caveat")
+    .trim()
+  if (document.fonts?.load && caveatFont) await document.fonts.load(`16px ${caveatFont}`)
+  await document.fonts?.ready
+}
 
 export async function renderShareCard(
   node: HTMLElement,
   snapshotImages: ShareCardImageSnapshotter = snapshotShareCardImages,
   rasterize: ShareCardRasterizer = toBlob,
-): Promise<Blob | null> {
-  const restoreImages = await snapshotImages(node)
-  try {
-    try {
-      const caveatFont = getComputedStyle(document.documentElement)
-        .getPropertyValue("--font-caveat")
-        .trim()
-      if (document.fonts?.load && caveatFont) await document.fonts.load(`16px ${caveatFont}`)
-      await document.fonts?.ready
-    } catch {
-      // Font API unavailable / load rejected — proceed; worst case is the
-      // footer's fallback font, not a failed export.
-    }
-    return await rasterize(node, {
-      pixelRatio: SHARE_IMAGE_PIXEL_RATIO,
-      fetchRequestInit: { credentials: "same-origin" },
-      // Solid backdrop so the exported PNG never bleeds transparent corners
-      // (the card's own rounded bg sits on top of this).
-      backgroundColor: getComputedStyle(node).getPropertyValue("--card")?.trim() || undefined,
-    })
-  } finally {
+  options: ShareCardRenderOptions = {},
+): Promise<Blob> {
+  const timeoutMs = options.timeoutMs ?? SHARE_IMAGE_RENDER_TIMEOUT_MS
+  const loadFonts = options.loadFonts ?? loadShareCardFonts
+  let stage: ShareCardRenderStage = "snapshot"
+  let restoreImages: (() => void) | null = null
+  let cleanupRequested = false
+  let cleanupComplete = false
+  let timedOut = false
+  let timeoutError: ShareCardRenderError | null = null
+
+  const enterStage = (nextStage: ShareCardRenderStage) => {
+    stage = nextStage
+    options.onStage?.(nextStage)
+  }
+  const cleanup = () => {
+    cleanupRequested = true
+    if (!restoreImages || cleanupComplete) return
+    enterStage("cleanup")
+    cleanupComplete = true
     restoreImages()
+  }
+
+  enterStage("snapshot")
+  let rejectDeadline!: (reason: ShareCardRenderError) => void
+  const deadline = new Promise<never>((_resolve, reject) => {
+    rejectDeadline = reject
+  })
+  const timer = setTimeout(() => {
+    timedOut = true
+    timeoutError = new ShareCardRenderError(stage, true)
+    try {
+      cleanup()
+      rejectDeadline(timeoutError)
+    } catch (error) {
+      rejectDeadline(new ShareCardRenderError("cleanup", false, error))
+    }
+  }, timeoutMs)
+
+  const lifecycle = async (): Promise<Blob> => {
+    try {
+      restoreImages = await snapshotImages(node)
+      if (cleanupRequested) cleanup()
+      if (timedOut) throw timeoutError
+
+      enterStage("fonts")
+      try {
+        await loadFonts()
+      } catch {
+        // Font loading is best-effort; the fallback font is still renderable.
+      }
+      if (timedOut) throw timeoutError
+
+      enterStage("rasterize")
+      const blob = await rasterize(node, {
+        pixelRatio: SHARE_IMAGE_PIXEL_RATIO,
+        fetchRequestInit: { credentials: "same-origin" },
+        // Solid backdrop so the exported PNG never bleeds transparent corners
+        // (the card's own rounded bg sits on top of this).
+        backgroundColor: getComputedStyle(node).getPropertyValue("--card")?.trim() || undefined,
+      })
+      if (timedOut) throw timeoutError
+      if (!blob) throw new Error("Rasterizer returned no image")
+      return blob
+    } catch (error) {
+      if (error instanceof ShareCardRenderError) throw error
+      throw new ShareCardRenderError(stage, false, error)
+    } finally {
+      try {
+        cleanup()
+      } catch (error) {
+        throw new ShareCardRenderError("cleanup", false, error)
+      }
+    }
+  }
+
+  try {
+    return await Promise.race([lifecycle(), deadline])
+  } finally {
+    clearTimeout(timer)
   }
 }
 
@@ -269,7 +355,7 @@ export async function copyRenderedShareCard(
   ]),
 ): Promise<void> {
   const blob = await render()
-  if (!blob) throw new Error("render failed")
+  if (!blob) throw new ShareCardRenderError("rasterize")
   await write(blob)
 }
 
@@ -289,8 +375,21 @@ export async function downloadRenderedShareCard(
   },
 ): Promise<void> {
   const blob = await render()
-  if (!blob) throw new Error("render failed")
+  if (!blob) throw new ShareCardRenderError("rasterize")
   await save(blob)
+}
+
+export function shareCardRenderErrorMessage(error: unknown): string | null {
+  if (!(error instanceof ShareCardRenderError)) return null
+  const stage = {
+    snapshot: "preparing images",
+    fonts: "loading fonts",
+    rasterize: "rendering the image",
+    cleanup: "restoring the preview",
+  }[error.stage]
+  return error.timedOut
+    ? `Couldn't generate image — ${stage} took too long`
+    : `Couldn't generate image — ${stage} failed`
 }
 
 // Share one OR several messages as an image. Renders a self-contained "share
@@ -366,8 +465,8 @@ export function MessageShareDialog({ m, open, onClose }: {
       setCopied(true)
       toast.success("Image copied to clipboard")
       window.setTimeout(() => setCopied(false), 1600)
-    } catch {
-      toast.error("Couldn't copy image — try Download instead")
+    } catch (error) {
+      toast.error(shareCardRenderErrorMessage(error) ?? "Couldn't copy image — try Download instead")
     } finally {
       setBusy(null)
     }
@@ -384,8 +483,8 @@ export function MessageShareDialog({ m, open, onClose }: {
         render,
         `alook-message-${firstAuthor?.name ?? "share"}.png`,
       )
-    } catch {
-      toast.error("Couldn't generate image")
+    } catch (error) {
+      toast.error(shareCardRenderErrorMessage(error) ?? "Couldn't generate image")
     } finally {
       setBusy(null)
     }


### PR DESCRIPTION
# Why we need this PR?
> No linked GitHub issue.

Share Image rendering can remain busy indefinitely when WebKit stalls while preparing fonts or rasterizing the card. Copy and Download need one bounded render contract that identifies the blocked stage and always restores the preview.

## What changed
- Added a single 15-second deadline across snapshot, font, rasterize, and cleanup stages.
- Added typed stage-aware failures with concise user-visible messages shared by Copy and Download.
- Kept font loading best-effort and kept clipboard/download writers after render completion.
- Added focused coverage for every stage, late settlement, null output, cleanup failure, and writer ordering; all modified coverable lines are exercised locally.
- Verified the complete commit hook: typecheck, lint, tests, boundary checks, and Knip.

## Checklist
- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...
