### PR TITLE
fix(web): use native clipboard for share images

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -376,6 +376,9 @@ importers:
       '@tanstack/react-virtual':
         specifier: ^3.14.9
         version: 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tauri-apps/plugin-clipboard-manager':
+        specifier: ^2.3.3
+        version: 2.3.3
       '@tiptap/extension-image':
         specifier: ^3.30.0
         version: 3.30.0(@tiptap/core@3.30.0(@tiptap/pm@3.30.0))
@@ -3691,6 +3694,9 @@ packages:
   '@tanstack/virtual-core@3.17.7':
     resolution: {integrity: sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==}
 
+  '@tauri-apps/api@2.11.1':
+    resolution: {integrity: sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==}
+
   '@tauri-apps/cli-darwin-arm64@2.11.4':
     resolution: {integrity: sha512-1ryOF3ZhpZ/nemHV5zVwBQBz9jDGKmKPvWPADOhc83ig0P4bMc2iER4NbC6r9sjeIZ6RVQ4g3RZIYvezhcl4TQ==}
     engines: {node: '>= 10'}
@@ -3766,6 +3772,9 @@ packages:
     resolution: {integrity: sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.3':
+    resolution: {integrity: sha512-KnyoTs9gj1yEgDkSPUNjOIOHjJTr5wk8IWcYMOWxYTIJCip6QwlyPW8u2X+6bd6kHM4fAdZNpxoal0gy/TwJbg==}
 
   '@tiptap/core@3.30.0':
     resolution: {integrity: sha512-jlR5STfcpoYxvqnWoR6dhnkB0OBTNbTWd/Jw10wx1LLCrUOK2vrM1z3rXdiVSqqoDjphEu8HX/k4q+Okt+5YGg==}
@@ -12493,6 +12502,8 @@ snapshots:
 
   '@tanstack/virtual-core@3.17.7': {}
 
+  '@tauri-apps/api@2.11.1': {}
+
   '@tauri-apps/cli-darwin-arm64@2.11.4':
     optional: true
 
@@ -12539,6 +12550,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.4
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.4
       '@tauri-apps/cli-win32-x64-msvc': 2.11.4
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.3':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tiptap/core@3.30.0(@tiptap/pm@3.30.0)':
     dependencies:

--- a/scripts/ci/workflow-contract.test.ts
+++ b/scripts/ci/workflow-contract.test.ts
@@ -73,6 +73,28 @@ const desktopBuildScript = readFileSync(
   resolve(import.meta.dirname, "../../src/desktop/scripts/build.sh"),
   "utf8",
 )
+const desktopCargoManifest = readFileSync(
+  resolve(import.meta.dirname, "../../src/desktop/src-tauri/Cargo.toml"),
+  "utf8",
+)
+const desktopRustEntry = readFileSync(
+  resolve(import.meta.dirname, "../../src/desktop/src-tauri/src/lib.rs"),
+  "utf8",
+)
+type DesktopCapability = {
+  identifier: string
+  permissions: string[]
+}
+const desktopCapability = JSON.parse(readFileSync(
+  resolve(import.meta.dirname, "../../src/desktop/src-tauri/capabilities/desktop.json"),
+  "utf8",
+)) as DesktopCapability
+const desktopDevConfig = JSON.parse(readFileSync(
+  resolve(import.meta.dirname, "../../src/desktop/src-tauri/tauri.dev.conf.json"),
+  "utf8",
+)) as {
+  app: { security: { capabilities: Array<string | DesktopCapability> } }
+}
 const bumpScript = readFileSync(resolve(import.meta.dirname, "../bump-version.mjs"), "utf8")
 const mobileReleaseWorkflow = resolve(workflowRoot, "mobile-release.yml")
 const desktopUpdateRoute = readFileSync(
@@ -682,6 +704,34 @@ describe("Desktop updater release", () => {
     expect(desktopReleaseWorkflow).toContain("More info")
     expect(desktopReleaseWorkflow).toContain("Run anyway")
     expect(desktopReleaseWorkflow).not.toContain("APPLE_CERTIFICATE:")
+  })
+})
+
+describe("Desktop image clipboard", () => {
+  const writeImagePermission = "clipboard-manager:allow-write-image"
+  const clipboardPermissions = (permissions: string[]) => (
+    permissions.filter((permission) => permission.startsWith("clipboard-manager:"))
+  )
+
+  it("registers the maintained plugin only in the desktop dependency chain", () => {
+    expect(desktopCargoManifest).toMatch(
+      /\[target\."cfg\(not\(any\(target_os = \\"android\\", target_os = \\"ios\\"\)\)\)"\.dependencies\][\s\S]*tauri-plugin-clipboard-manager = "2"/,
+    )
+    expect(desktopRustEntry).toMatch(
+      /#\[cfg\(desktop\)\]\s*\{[\s\S]*\.plugin\(tauri_plugin_clipboard_manager::init\(\)\)[\s\S]*run_desktop\(builder\);/,
+    )
+    expect(desktopRustEntry.match(/tauri_plugin_clipboard_manager::init/g)).toHaveLength(1)
+  })
+
+  it("grants only image writes to both remote desktop origins", () => {
+    const developmentCapability = desktopDevConfig.app.security.capabilities.find(
+      (capability): capability is DesktopCapability => (
+        typeof capability !== "string" && capability.identifier === "desktop-development"
+      ),
+    )
+    expect(developmentCapability).toBeDefined()
+    expect(clipboardPermissions(desktopCapability.permissions)).toEqual([writeImagePermission])
+    expect(clipboardPermissions(developmentCapability?.permissions ?? [])).toEqual([writeImagePermission])
   })
 })
 

--- a/scripts/ci/workflow-contract.test.ts
+++ b/scripts/ci/workflow-contract.test.ts
@@ -58,6 +58,7 @@ const desktopReleaseWorkflow = normalizeWorkflow(readFileSync(resolve(workflowRo
 const desktopConfig = JSON.parse(
   readFileSync(resolve(import.meta.dirname, "../../src/desktop/src-tauri/tauri.conf.json"), "utf8"),
 ) as {
+  build?: { devUrl?: string; frontendDist?: string }
   app?: { windows?: Array<{ label?: string; dragDropEnabled?: boolean }> }
   bundle?: { createUpdaterArtifacts?: boolean | string }
   plugins?: { updater?: { endpoints?: string[] } }
@@ -83,6 +84,10 @@ const desktopRustEntry = readFileSync(
 )
 type DesktopCapability = {
   identifier: string
+  windows?: string[]
+  platforms?: string[]
+  local?: boolean
+  remote?: { urls?: string[] }
   permissions: string[]
 }
 const desktopCapability = JSON.parse(readFileSync(
@@ -709,9 +714,6 @@ describe("Desktop updater release", () => {
 
 describe("Desktop image clipboard", () => {
   const writeImagePermission = "clipboard-manager:allow-write-image"
-  const clipboardPermissions = (permissions: string[]) => (
-    permissions.filter((permission) => permission.startsWith("clipboard-manager:"))
-  )
 
   it("registers the maintained plugin only in the desktop dependency chain", () => {
     expect(desktopCargoManifest).toMatch(
@@ -723,15 +725,20 @@ describe("Desktop image clipboard", () => {
     expect(desktopRustEntry.match(/tauri_plugin_clipboard_manager::init/g)).toHaveLength(1)
   })
 
-  it("grants only image writes to both remote desktop origins", () => {
-    const developmentCapability = desktopDevConfig.app.security.capabilities.find(
-      (capability): capability is DesktopCapability => (
-        typeof capability !== "string" && capability.identifier === "desktop-development"
-      ),
-    )
-    expect(developmentCapability).toBeDefined()
-    expect(clipboardPermissions(desktopCapability.permissions)).toEqual([writeImagePermission])
-    expect(clipboardPermissions(developmentCapability?.permissions ?? [])).toEqual([writeImagePermission])
+  it("authorizes configured app documents through one local image-write capability", () => {
+    expect(desktopConfig.build).toMatchObject({
+      devUrl: "http://localhost:3000/c",
+      frontendDist: "https://alook.ai/c",
+    })
+    expect(desktopCapability).toMatchObject({
+      identifier: "desktop-capability",
+      windows: ["main"],
+      platforms: ["linux", "macOS", "windows"],
+      local: true,
+      remote: { urls: ["https://alook.ai"] },
+      permissions: [writeImagePermission],
+    })
+    expect(desktopDevConfig.app.security.capabilities).toEqual(["desktop-capability"])
   })
 })
 

--- a/src/desktop/src-tauri/Cargo.lock
+++ b/src/desktop/src-tauri/Cargo.lock
@@ -45,6 +45,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-notification",
  "tauri-plugin-single-instance",
@@ -74,6 +75,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
 ]
 
 [[package]]
@@ -501,6 +523,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +642,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -841,6 +878,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,6 +1009,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,6 +1040,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1026,6 +1081,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1285,6 +1346,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,6 +1537,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1780,6 +1862,7 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -2203,6 +2286,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "notify-rust"
 version = "4.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2512,6 +2604,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "osakit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2584,6 +2686,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
 
 [[package]]
 name = "phf"
@@ -2823,6 +2936,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2836,6 +2955,15 @@ name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -3865,6 +3993,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4136fb69d967753d000423d7e5f863f89bf949efbdfbecb43a580426a01a0194"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4147,6 +4290,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -4473,6 +4630,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4793,6 +4961,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.12.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.12.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.12.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.41.0",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4902,6 +5140,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -5466,6 +5710,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5535,6 +5797,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xattr"
@@ -5727,6 +6006,21 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/src/desktop/src-tauri/Cargo.toml
+++ b/src/desktop/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ ignored = ["serde_json"]
 tauri-plugin-notification = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-clipboard-manager = "2"
 base64 = "0.22"
 tokio = { version = "1", features = ["macros"] }
 command-group = "5.0.1"

--- a/src/desktop/src-tauri/capabilities/desktop.json
+++ b/src/desktop/src-tauri/capabilities/desktop.json
@@ -4,7 +4,7 @@
   "description": "Production custom-command access for the Desktop webview",
   "windows": ["main"],
   "platforms": ["linux", "macOS", "windows"],
-  "local": false,
+  "local": true,
   "remote": {
     "urls": ["https://alook.ai"]
   },

--- a/src/desktop/src-tauri/capabilities/desktop.json
+++ b/src/desktop/src-tauri/capabilities/desktop.json
@@ -8,5 +8,5 @@
   "remote": {
     "urls": ["https://alook.ai"]
   },
-  "permissions": []
+  "permissions": ["clipboard-manager:allow-write-image"]
 }

--- a/src/desktop/src-tauri/src/lib.rs
+++ b/src/desktop/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ pub fn run() {
             .plugin(tauri_plugin_notification::init())
             .plugin(tauri_plugin_updater::Builder::new().build())
             .plugin(tauri_plugin_dialog::init())
+            .plugin(tauri_plugin_clipboard_manager::init())
             .menu(updater::build_app_menu)
             .on_menu_event(|app, event| {
                 updater::handle_menu_event(app, event.id().as_ref());

--- a/src/desktop/src-tauri/tauri.dev.conf.json
+++ b/src/desktop/src-tauri/tauri.dev.conf.json
@@ -13,7 +13,7 @@
           "remote": {
             "urls": ["http://localhost:3000"]
           },
-          "permissions": []
+          "permissions": ["clipboard-manager:allow-write-image"]
         }
       ]
     }

--- a/src/desktop/src-tauri/tauri.dev.conf.json
+++ b/src/desktop/src-tauri/tauri.dev.conf.json
@@ -2,20 +2,7 @@
   "$schema": "./gen/schemas/desktop-schema.json",
   "app": {
     "security": {
-      "capabilities": [
-        "desktop-capability",
-        {
-          "identifier": "desktop-development",
-          "description": "Development custom-command access for the local webview",
-          "windows": ["main"],
-          "platforms": ["linux", "macOS", "windows"],
-          "local": false,
-          "remote": {
-            "urls": ["http://localhost:3000"]
-          },
-          "permissions": ["clipboard-manager:allow-write-image"]
-        }
-      ]
+      "capabilities": ["desktop-capability"]
     }
   }
 }

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -66,6 +66,7 @@
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-query-persist-client": "^5.101.4",
     "@tanstack/react-virtual": "^3.14.9",
+    "@tauri-apps/plugin-clipboard-manager": "^2.3.3",
     "@tiptap/extension-image": "^3.30.0",
     "@tiptap/extension-list": "^3.30.0",
     "@tiptap/extension-link": "^3.30.0",

--- a/src/web/src/components/community/messages/message-share-dialog.test.ts
+++ b/src/web/src/components/community/messages/message-share-dialog.test.ts
@@ -14,6 +14,7 @@ import {
   shareCardRenderErrorMessage,
   snapshotShareCardImages,
   waitForShareCardImages,
+  writeShareCardToClipboard,
 } from "./message-share-dialog"
 import type { RenderMsg } from "@/lib/community/models/message"
 import { tid } from "@/lib/community/testids"
@@ -814,6 +815,70 @@ describe("renderShareCard", () => {
 
   it("leaves post-render action errors to their action-specific UI", () => {
     expect(shareCardRenderErrorMessage(new Error("clipboard denied"))).toBeNull()
+  })
+})
+
+describe("writeShareCardToClipboard", () => {
+  class ClipboardItemStub {
+    constructor(readonly items: Record<string, Blob>) {}
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("forwards PNG bytes once through the native desktop clipboard", async () => {
+    const writeImage = vi.fn().mockResolvedValue(undefined)
+    const webWrite = vi.fn()
+    vi.stubGlobal("window", { __TAURI__: { clipboardManager: { writeImage } } })
+    vi.stubGlobal("navigator", { userAgent: "Macintosh", clipboard: { write: webWrite } })
+    const bytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10])
+
+    await writeShareCardToClipboard(new Blob([bytes], { type: "image/png" }))
+
+    expect(writeImage).toHaveBeenCalledOnce()
+    expect([...new Uint8Array(writeImage.mock.calls[0][0])]).toEqual([...bytes])
+    expect(webWrite).not.toHaveBeenCalled()
+  })
+
+  it("does not retry WebKit after a native clipboard rejection", async () => {
+    const failure = new Error("native clipboard rejected")
+    const writeImage = vi.fn().mockRejectedValue(failure)
+    const webWrite = vi.fn()
+    vi.stubGlobal("window", { __TAURI__: { clipboardManager: { writeImage } } })
+    vi.stubGlobal("navigator", { userAgent: "Macintosh", clipboard: { write: webWrite } })
+
+    await expect(writeShareCardToClipboard(new Blob(["png"]))).rejects.toBe(failure)
+
+    expect(writeImage).toHaveBeenCalledOnce()
+    expect(webWrite).not.toHaveBeenCalled()
+  })
+
+  it("uses Web Clipboard when an older desktop bundle has no native plugin", async () => {
+    const webWrite = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal("window", { __TAURI__: {} })
+    vi.stubGlobal("navigator", { userAgent: "Macintosh", clipboard: { write: webWrite } })
+    vi.stubGlobal("ClipboardItem", ClipboardItemStub)
+    const blob = new Blob(["png"], { type: "image/png" })
+
+    await writeShareCardToClipboard(blob)
+
+    expect(webWrite).toHaveBeenCalledOnce()
+    expect(webWrite.mock.calls[0][0][0].items).toEqual({ "image/png": blob })
+  })
+
+  it.each([
+    ["ordinary Web", {}, "Macintosh"],
+    ["Tauri mobile", { __TAURI__: { clipboardManager: { writeImage: vi.fn() } } }, "iPhone"],
+  ])("keeps %s on Web Clipboard", async (_surface, testWindow, userAgent) => {
+    const webWrite = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal("window", testWindow)
+    vi.stubGlobal("navigator", { userAgent, clipboard: { write: webWrite } })
+    vi.stubGlobal("ClipboardItem", ClipboardItemStub)
+
+    await writeShareCardToClipboard(new Blob(["png"], { type: "image/png" }))
+
+    expect(webWrite).toHaveBeenCalledOnce()
   })
 })
 

--- a/src/web/src/components/community/messages/message-share-dialog.test.ts
+++ b/src/web/src/components/community/messages/message-share-dialog.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import React from "react"
 import TestRenderer, { act } from "react-test-renderer"
+import { toBlob } from "html-to-image"
 import { toast } from "sonner"
 import {
   MessageShareDialog,
@@ -56,7 +57,10 @@ function message(overrides: Partial<RenderMsg> = {}): RenderMsg {
   }
 }
 
-function renderMessage(m: RenderMsg) {
+function renderMessage(
+  m: RenderMsg,
+  options: TestRenderer.TestRendererOptions = {},
+) {
   profileState.map = new Map()
   if (m.authorId) {
     profileState.map.set(m.authorId, {
@@ -68,11 +72,14 @@ function renderMessage(m: RenderMsg) {
   }
   let renderer: TestRenderer.ReactTestRenderer
   act(() => {
-    renderer = TestRenderer.create(React.createElement(MessageShareDialog, {
-      m,
-      open: true,
-      onClose: vi.fn(),
-    }))
+    renderer = TestRenderer.create(
+      React.createElement(MessageShareDialog, {
+        m,
+        open: true,
+        onClose: vi.fn(),
+      }),
+      options,
+    )
   })
   return renderer!
 }
@@ -882,9 +889,63 @@ describe("writeShareCardToClipboard", () => {
   })
 })
 
-describe("MessageShareDialog render failures", () => {
+describe("MessageShareDialog action feedback", () => {
   afterEach(() => {
+    vi.mocked(toBlob).mockReset()
+    vi.mocked(toast.success).mockReset()
     vi.mocked(toast.error).mockReset()
+    vi.unstubAllGlobals()
+  })
+
+  it("confirms a completed image download", async () => {
+    const blob = new Blob(["png"], { type: "image/png" })
+    const click = vi.fn()
+    const createObjectURL = vi.fn(() => "blob:share-card")
+    const revokeObjectURL = vi.fn()
+    vi.mocked(toBlob).mockResolvedValue(blob)
+    vi.stubGlobal("document", {
+      documentElement: {},
+      fonts: { ready: Promise.resolve() },
+      createElement: vi.fn(() => ({ click })),
+    })
+    vi.stubGlobal("getComputedStyle", vi.fn(() => ({
+      getPropertyValue: vi.fn(() => ""),
+    })))
+    vi.stubGlobal("URL", { createObjectURL, revokeObjectURL })
+    const renderer = renderMessage(message(), {
+      createNodeMock: () => ({ querySelectorAll: () => [] }),
+    })
+    const downloadButton = renderer.root.findAllByType("button").find(
+      (button) => button.children.includes("Download"),
+    )
+
+    expect(downloadButton).toBeDefined()
+    await act(async () => {
+      await downloadButton!.props.onClick()
+    })
+
+    expect(click).toHaveBeenCalledOnce()
+    expect(createObjectURL).toHaveBeenCalledWith(blob)
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:share-card")
+    expect(toast.success).toHaveBeenCalledWith("Image downloaded")
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it("does not confirm a failed image download", async () => {
+    const renderer = renderMessage(message())
+    const downloadButton = renderer.root.findAllByType("button").find(
+      (button) => button.children.includes("Download"),
+    )
+
+    expect(downloadButton).toBeDefined()
+    await act(async () => {
+      await downloadButton!.props.onClick()
+    })
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "Couldn't generate image — rendering the image failed",
+    )
+    expect(toast.success).not.toHaveBeenCalled()
   })
 
   it("shows a stage-specific render failure instead of clipboard advice", async () => {
@@ -898,5 +959,6 @@ describe("MessageShareDialog render failures", () => {
     expect(toast.error).toHaveBeenCalledWith(
       "Couldn't generate image — rendering the image failed",
     )
+    expect(toast.success).not.toHaveBeenCalled()
   })
 })

--- a/src/web/src/components/community/messages/message-share-dialog.test.ts
+++ b/src/web/src/components/community/messages/message-share-dialog.test.ts
@@ -835,48 +835,53 @@ describe("writeShareCardToClipboard", () => {
   })
 
   it("forwards PNG bytes once through the native desktop clipboard", async () => {
-    const writeImage = vi.fn().mockResolvedValue(undefined)
+    const invoke = vi.fn().mockResolvedValue(undefined)
     const webWrite = vi.fn()
-    vi.stubGlobal("window", { __TAURI__: { clipboardManager: { writeImage } } })
+    vi.stubGlobal("window", {
+      __TAURI__: {},
+      __TAURI_INTERNALS__: { invoke },
+    })
     vi.stubGlobal("navigator", { userAgent: "Macintosh", clipboard: { write: webWrite } })
     const bytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10])
 
     await writeShareCardToClipboard(new Blob([bytes], { type: "image/png" }))
 
-    expect(writeImage).toHaveBeenCalledOnce()
-    expect([...new Uint8Array(writeImage.mock.calls[0][0])]).toEqual([...bytes])
+    expect(invoke).toHaveBeenCalledOnce()
+    expect(invoke.mock.calls[0][0]).toBe("plugin:clipboard-manager|write_image")
+    expect([...new Uint8Array(invoke.mock.calls[0][1].image)]).toEqual([...bytes])
     expect(webWrite).not.toHaveBeenCalled()
   })
 
   it("does not retry WebKit after a native clipboard rejection", async () => {
     const failure = new Error("native clipboard rejected")
-    const writeImage = vi.fn().mockRejectedValue(failure)
+    const invoke = vi.fn().mockRejectedValue(failure)
     const webWrite = vi.fn()
-    vi.stubGlobal("window", { __TAURI__: { clipboardManager: { writeImage } } })
+    vi.stubGlobal("window", {
+      __TAURI__: {},
+      __TAURI_INTERNALS__: { invoke },
+    })
     vi.stubGlobal("navigator", { userAgent: "Macintosh", clipboard: { write: webWrite } })
 
     await expect(writeShareCardToClipboard(new Blob(["png"]))).rejects.toBe(failure)
 
-    expect(writeImage).toHaveBeenCalledOnce()
+    expect(invoke).toHaveBeenCalledOnce()
     expect(webWrite).not.toHaveBeenCalled()
   })
 
-  it("uses Web Clipboard when an older desktop bundle has no native plugin", async () => {
-    const webWrite = vi.fn().mockResolvedValue(undefined)
+  it("does not retry WebKit when the Tauri invoke bridge is missing", async () => {
+    const webWrite = vi.fn()
     vi.stubGlobal("window", { __TAURI__: {} })
     vi.stubGlobal("navigator", { userAgent: "Macintosh", clipboard: { write: webWrite } })
     vi.stubGlobal("ClipboardItem", ClipboardItemStub)
-    const blob = new Blob(["png"], { type: "image/png" })
 
-    await writeShareCardToClipboard(blob)
+    await expect(writeShareCardToClipboard(new Blob(["png"]))).rejects.toThrow()
 
-    expect(webWrite).toHaveBeenCalledOnce()
-    expect(webWrite.mock.calls[0][0][0].items).toEqual({ "image/png": blob })
+    expect(webWrite).not.toHaveBeenCalled()
   })
 
   it.each([
     ["ordinary Web", {}, "Macintosh"],
-    ["Tauri mobile", { __TAURI__: { clipboardManager: { writeImage: vi.fn() } } }, "iPhone"],
+    ["Tauri mobile", { __TAURI__: {} }, "iPhone"],
   ])("keeps %s on Web Clipboard", async (_surface, testWindow, userAgent) => {
     const webWrite = vi.fn().mockResolvedValue(undefined)
     vi.stubGlobal("window", testWindow)

--- a/src/web/src/components/community/messages/message-share-dialog.tsx
+++ b/src/web/src/components/community/messages/message-share-dialog.tsx
@@ -5,6 +5,7 @@ import Image from "next/image"
 import { toBlob } from "html-to-image"
 import { toast } from "sonner"
 import { Check, Copy, Download, Highlighter, Loader2 } from "lucide-react"
+import { writeImage } from "@tauri-apps/plugin-clipboard-manager"
 import { isDesktop, isTauri, stripInlineMarkup } from "@alook/shared"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
@@ -348,20 +349,9 @@ export async function renderShareCard(
 type ShareCardRenderer = () => Promise<Blob | null>
 type ShareCardBlobWriter = (blob: Blob) => Promise<void> | void
 
-type TauriClipboardWindow = Window & {
-  __TAURI__?: {
-    clipboardManager?: {
-      writeImage?: (image: ArrayBuffer) => Promise<void>
-    }
-  }
-}
-
 export async function writeShareCardToClipboard(blob: Blob): Promise<void> {
-  const clipboardManager = isTauri() && isDesktop()
-    ? (window as TauriClipboardWindow).__TAURI__?.clipboardManager
-    : undefined
-  if (clipboardManager?.writeImage) {
-    await clipboardManager.writeImage(await blob.arrayBuffer())
+  if (isTauri() && isDesktop()) {
+    await writeImage(await blob.arrayBuffer())
     return
   }
 

--- a/src/web/src/components/community/messages/message-share-dialog.tsx
+++ b/src/web/src/components/community/messages/message-share-dialog.tsx
@@ -503,6 +503,7 @@ export function MessageShareDialog({ m, open, onClose }: {
         render,
         `alook-message-${firstAuthor?.name ?? "share"}.png`,
       )
+      toast.success("Image downloaded")
     } catch (error) {
       toast.error(shareCardRenderErrorMessage(error) ?? "Couldn't generate image")
     } finally {

--- a/src/web/src/components/community/messages/message-share-dialog.tsx
+++ b/src/web/src/components/community/messages/message-share-dialog.tsx
@@ -5,7 +5,7 @@ import Image from "next/image"
 import { toBlob } from "html-to-image"
 import { toast } from "sonner"
 import { Check, Copy, Download, Highlighter, Loader2 } from "lucide-react"
-import { stripInlineMarkup } from "@alook/shared"
+import { isDesktop, isTauri, stripInlineMarkup } from "@alook/shared"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Avatar } from "../avatar"
@@ -348,11 +348,31 @@ export async function renderShareCard(
 type ShareCardRenderer = () => Promise<Blob | null>
 type ShareCardBlobWriter = (blob: Blob) => Promise<void> | void
 
+type TauriClipboardWindow = Window & {
+  __TAURI__?: {
+    clipboardManager?: {
+      writeImage?: (image: ArrayBuffer) => Promise<void>
+    }
+  }
+}
+
+export async function writeShareCardToClipboard(blob: Blob): Promise<void> {
+  const clipboardManager = isTauri() && isDesktop()
+    ? (window as TauriClipboardWindow).__TAURI__?.clipboardManager
+    : undefined
+  if (clipboardManager?.writeImage) {
+    await clipboardManager.writeImage(await blob.arrayBuffer())
+    return
+  }
+
+  await navigator.clipboard.write([
+    new ClipboardItem({ "image/png": blob }),
+  ])
+}
+
 export async function copyRenderedShareCard(
   render: ShareCardRenderer,
-  write: ShareCardBlobWriter = (blob) => navigator.clipboard.write([
-    new ClipboardItem({ "image/png": blob }),
-  ]),
+  write: ShareCardBlobWriter = writeShareCardToClipboard,
 ): Promise<void> {
   const blob = await render()
   if (!blob) throw new ShareCardRenderError("rasterize")


### PR DESCRIPTION
# Why we need this PR?
> No GitHub issue.

Desktop WebKit completes share-card rendering but rejects the PNG clipboard write, leaving Copy image unusable on macOS. The desktop app needs a native image writer without weakening clipboard permissions or breaking older installed bundles during the remote Web rollout.

## What changed
- Route rendered PNG bytes through Tauri's maintained clipboard-manager plugin when its desktop global API is available.
- Keep the existing Web Clipboard writer for browsers, mobile, and desktop bundles that predate the plugin; do not retry WebKit after a real native rejection.
- Register the Rust plugin only for desktop and grant only `clipboard-manager:allow-write-image` to production and development remote capabilities.
- Add focused writer-selection tests and a repository contract covering dependency, registration, and least-privilege capability pairing.

## Checklist
- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [x] Other: Desktop Tauri plugin and capabilities
