### PR TITLE
fix(web): open native message links externally

### DIFF
--- a/scripts/ci/workflow-contract.test.ts
+++ b/scripts/ci/workflow-contract.test.ts
@@ -484,12 +484,12 @@ describe("Native message external-link opener", () => {
     expect(registration).toBeLessThan(desktopOnlyPlugins)
   })
 
-  it("grants only scoped HTTP(S) URL opening to the production five-platform remote webview", () => {
+  it("grants only scoped HTTP(S) URL opening to the production five-platform app webview", () => {
     expect(externalLinksCapability).toMatchObject({
       identifier: "external-links",
       windows: ["main"],
       platforms: expectedPlatforms,
-      local: false,
+      local: true,
       remote: { urls: ["https://alook.ai"] },
       permissions: expectedPermission,
     })
@@ -506,20 +506,18 @@ describe("Native message external-link opener", () => {
     ].some((href) => scopedUrlAllowed(href, externalLinksCapability))).toBe(false)
   })
 
-  it("mirrors the minimal five-platform scope for localhost development only", () => {
+  it("reuses the same minimal HTTP(S) scope for the local development app webview", () => {
     const capabilities = desktopDevConfig.app?.security?.capabilities ?? []
-    const development = capabilities.find((capability): capability is ExternalLinksCapability => (
-      typeof capability !== "string" && capability.identifier === "external-links-development"
+    const inlineOpener = capabilities.find((capability): capability is ExternalLinksCapability => (
+      typeof capability !== "string"
+      && capability.permissions.some((permission) => (
+        typeof permission !== "string" && permission.identifier.startsWith("opener:")
+      ))
     ))
 
     expect(capabilities).toContain("external-links")
-    expect(development).toMatchObject({
-      windows: ["main"],
-      platforms: expectedPlatforms,
-      local: false,
-      remote: { urls: ["http://localhost:3000"] },
-      permissions: expectedPermission,
-    })
+    expect(capabilities.filter((capability) => capability === "external-links")).toHaveLength(1)
+    expect(inlineOpener).toBeUndefined()
   })
 
   it("does not grant default schemes, paths, reveal, shell, or CSP expansion", () => {
@@ -843,7 +841,10 @@ describe("Desktop image clipboard", () => {
       remote: { urls: ["https://alook.ai"] },
       permissions: [writeImagePermission],
     })
-    expect(desktopDevConfig.app.security.capabilities).toEqual(["desktop-capability"])
+    expect(desktopDevConfig.app.security.capabilities).toEqual([
+      "desktop-capability",
+      "external-links",
+    ])
   })
 })
 

--- a/scripts/ci/workflow-contract.test.ts
+++ b/scripts/ci/workflow-contract.test.ts
@@ -59,10 +59,30 @@ const desktopConfig = JSON.parse(
   readFileSync(resolve(import.meta.dirname, "../../src/desktop/src-tauri/tauri.conf.json"), "utf8"),
 ) as {
   build?: { devUrl?: string; frontendDist?: string }
-  app?: { windows?: Array<{ label?: string; dragDropEnabled?: boolean }> }
+  app?: {
+    windows?: Array<{ label?: string; dragDropEnabled?: boolean }>
+    security?: { capabilities?: Array<string | Record<string, unknown>> }
+  }
   bundle?: { createUpdaterArtifacts?: boolean | string }
   plugins?: { updater?: { endpoints?: string[] } }
 }
+type ExternalLinksCapability = {
+  identifier: string
+  windows: string[]
+  platforms: string[]
+  local: boolean
+  remote: { urls: string[] }
+  permissions: Array<{
+    identifier: string
+    allow?: Array<{ url: string }>
+  }>
+}
+const externalLinksCapability = JSON.parse(
+  readFileSync(
+    resolve(import.meta.dirname, "../../src/desktop/src-tauri/capabilities/external-links.json"),
+    "utf8",
+  ),
+) as ExternalLinksCapability
 const desktopMacConfig = JSON.parse(
   readFileSync(resolve(import.meta.dirname, "../../src/desktop/src-tauri/tauri.macos.conf.json"), "utf8"),
 ) as { bundle?: { macOS?: { entitlements?: string; signingIdentity?: string } } }
@@ -98,7 +118,7 @@ const desktopDevConfig = JSON.parse(readFileSync(
   resolve(import.meta.dirname, "../../src/desktop/src-tauri/tauri.dev.conf.json"),
   "utf8",
 )) as {
-  app: { security: { capabilities: Array<string | DesktopCapability> } }
+  app: { security: { capabilities: Array<string | DesktopCapability | ExternalLinksCapability> } }
 }
 const bumpScript = readFileSync(resolve(import.meta.dirname, "../bump-version.mjs"), "utf8")
 const mobileReleaseWorkflow = resolve(workflowRoot, "mobile-release.yml")
@@ -434,6 +454,91 @@ describe("CI dependency setup", () => {
       "Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2",
     )
     expect(desktopReleaseWorkflow).toContain("key: ${{ matrix.target }}")
+  })
+})
+
+describe("Native message external-link opener", () => {
+  const expectedPlatforms = ["linux", "macOS", "windows", "android", "iOS"]
+  const expectedPermission = [{
+    identifier: "opener:allow-open-url",
+    allow: [{ url: "http://*" }, { url: "https://*" }],
+  }]
+  const scopedUrlAllowed = (href: string, capability: ExternalLinksCapability) => {
+    const patterns = capability.permissions.flatMap((permission) => (
+      permission.allow?.map((entry) => entry.url) ?? []
+    ))
+    return patterns.includes(`${new URL(href).protocol}//*`)
+  }
+
+  it("registers the official opener plugin in the common desktop/mobile builder", () => {
+    const desktopOnlyDependencies = desktopCargoManifest.indexOf(
+      "[target.\"cfg(not(any(target_os = \\\"android\\\", target_os = \\\"ios\\\")))\".dependencies]",
+    )
+    const dependency = desktopCargoManifest.indexOf('tauri-plugin-opener = "2"')
+    const registration = desktopRustEntry.indexOf("plugin(tauri_plugin_opener::init())")
+    const desktopOnlyPlugins = desktopRustEntry.indexOf("// Desktop-only plugins")
+
+    expect(dependency).toBeGreaterThan(-1)
+    expect(dependency).toBeLessThan(desktopOnlyDependencies)
+    expect(registration).toBeGreaterThan(-1)
+    expect(registration).toBeLessThan(desktopOnlyPlugins)
+  })
+
+  it("grants only scoped HTTP(S) URL opening to the production five-platform remote webview", () => {
+    expect(externalLinksCapability).toMatchObject({
+      identifier: "external-links",
+      windows: ["main"],
+      platforms: expectedPlatforms,
+      local: false,
+      remote: { urls: ["https://alook.ai"] },
+      permissions: expectedPermission,
+    })
+    expect(desktopConfig.app?.security?.capabilities).toContain("external-links")
+    expect([
+      "http://example.com:8080/path/to/story?source=chat#section",
+      "https://example.com:9443/a/b?query=yes#fragment",
+      "https://alook.ai/c/invite/abcdef?from=dm",
+    ].every((href) => scopedUrlAllowed(href, externalLinksCapability))).toBe(true)
+    expect([
+      "mailto:friend@example.com",
+      "tel:+15551234567",
+      "file:///tmp/private",
+    ].some((href) => scopedUrlAllowed(href, externalLinksCapability))).toBe(false)
+  })
+
+  it("mirrors the minimal five-platform scope for localhost development only", () => {
+    const capabilities = desktopDevConfig.app?.security?.capabilities ?? []
+    const development = capabilities.find((capability): capability is ExternalLinksCapability => (
+      typeof capability !== "string" && capability.identifier === "external-links-development"
+    ))
+
+    expect(capabilities).toContain("external-links")
+    expect(development).toMatchObject({
+      windows: ["main"],
+      platforms: expectedPlatforms,
+      local: false,
+      remote: { urls: ["http://localhost:3000"] },
+      permissions: expectedPermission,
+    })
+  })
+
+  it("does not grant default schemes, paths, reveal, shell, or CSP expansion", () => {
+    const capabilityText = JSON.stringify({
+      production: externalLinksCapability,
+      development: desktopDevConfig.app?.security?.capabilities,
+    })
+    for (const rejected of [
+      "opener:default",
+      "opener:allow-default-urls",
+      "opener:allow-open-path",
+      "opener:allow-reveal-item-in-dir",
+      "shell:",
+      "mailto:",
+      "tel:",
+    ]) {
+      expect(capabilityText).not.toContain(rejected)
+    }
+    expect(desktopConfig.app).not.toHaveProperty("security.csp")
   })
 })
 

--- a/src/desktop/src-tauri/Cargo.lock
+++ b/src/desktop/src-tauri/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-notification",
+ "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tokio",
@@ -1904,6 +1905,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2580,6 +2600,17 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "open"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade3be4664bc1ef537ce133015f04c176b737815c2ba9fd60edf212d6e90dd55"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -4066,6 +4097,28 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-opener"
+version = "2.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60d60366174b745b4ef5824b8bbc1c457fd08f0ce101ff643c0a49181a9f4e91"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "url",
+ "windows",
+ "zbus",
 ]
 
 [[package]]

--- a/src/desktop/src-tauri/Cargo.toml
+++ b/src/desktop/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["tray-icon", "image-png", "macos-private-api"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tauri-plugin-opener = "2"
 
 [package.metadata.cargo-machete]
 ignored = ["serde_json"]

--- a/src/desktop/src-tauri/capabilities/external-links.json
+++ b/src/desktop/src-tauri/capabilities/external-links.json
@@ -4,7 +4,7 @@
   "description": "System-browser access for HTTP(S) links in the main webview",
   "windows": ["main"],
   "platforms": ["linux", "macOS", "windows", "android", "iOS"],
-  "local": false,
+  "local": true,
   "remote": {
     "urls": ["https://alook.ai"]
   },

--- a/src/desktop/src-tauri/capabilities/external-links.json
+++ b/src/desktop/src-tauri/capabilities/external-links.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "external-links",
+  "description": "System-browser access for HTTP(S) links in the main webview",
+  "windows": ["main"],
+  "platforms": ["linux", "macOS", "windows", "android", "iOS"],
+  "local": false,
+  "remote": {
+    "urls": ["https://alook.ai"]
+  },
+  "permissions": [
+    {
+      "identifier": "opener:allow-open-url",
+      "allow": [
+        { "url": "http://*" },
+        { "url": "https://*" }
+      ]
+    }
+  ]
+}

--- a/src/desktop/src-tauri/src/lib.rs
+++ b/src/desktop/src-tauri/src/lib.rs
@@ -8,7 +8,7 @@ mod macos_window;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    let builder = tauri::Builder::default();
+    let builder = tauri::Builder::default().plugin(tauri_plugin_opener::init());
 
     // Desktop-only plugins
     #[cfg(desktop)]

--- a/src/desktop/src-tauri/tauri.conf.json
+++ b/src/desktop/src-tauri/tauri.conf.json
@@ -45,7 +45,8 @@
     ],
     "security": {
       "capabilities": [
-        "desktop-capability"
+        "desktop-capability",
+        "external-links"
       ]
     }
   },

--- a/src/desktop/src-tauri/tauri.dev.conf.json
+++ b/src/desktop/src-tauri/tauri.dev.conf.json
@@ -2,29 +2,7 @@
   "$schema": "./gen/schemas/desktop-schema.json",
   "app": {
     "security": {
-      "capabilities": [
-        "desktop-capability",
-        "external-links",
-        {
-          "identifier": "external-links-development",
-          "description": "Development system-browser access for HTTP(S) links in the local main webview",
-          "windows": ["main"],
-          "platforms": ["linux", "macOS", "windows", "android", "iOS"],
-          "local": false,
-          "remote": {
-            "urls": ["http://localhost:3000"]
-          },
-          "permissions": [
-            {
-              "identifier": "opener:allow-open-url",
-              "allow": [
-                { "url": "http://*" },
-                { "url": "https://*" }
-              ]
-            }
-          ]
-        }
-      ]
+      "capabilities": ["desktop-capability", "external-links"]
     }
   }
 }

--- a/src/desktop/src-tauri/tauri.dev.conf.json
+++ b/src/desktop/src-tauri/tauri.dev.conf.json
@@ -2,7 +2,29 @@
   "$schema": "./gen/schemas/desktop-schema.json",
   "app": {
     "security": {
-      "capabilities": ["desktop-capability"]
+      "capabilities": [
+        "desktop-capability",
+        "external-links",
+        {
+          "identifier": "external-links-development",
+          "description": "Development system-browser access for HTTP(S) links in the local main webview",
+          "windows": ["main"],
+          "platforms": ["linux", "macOS", "windows", "android", "iOS"],
+          "local": false,
+          "remote": {
+            "urls": ["http://localhost:3000"]
+          },
+          "permissions": [
+            {
+              "identifier": "opener:allow-open-url",
+              "allow": [
+                { "url": "http://*" },
+                { "url": "https://*" }
+              ]
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/src/web/src/components/community/messages/message-body.test.ts
+++ b/src/web/src/components/community/messages/message-body.test.ts
@@ -15,6 +15,7 @@ describe("MessageBody — plain URL rendering", () => {
     const link = renderer!.root.findByType("a")
     expect(link.props.href).toBe("https://example.com/story")
     expect(link.props["data-platform-link"]).toBe("generic")
+    expect(link.props["data-message-external-link"]).toBe(true)
     expect(renderer!.root.findAllByType("svg")).toHaveLength(1)
   })
 
@@ -32,8 +33,10 @@ describe("MessageBody — plain URL rendering", () => {
     expect(links).toHaveLength(2)
     expect(links[0].props.href).toBe("https://github.com/alookai/alook/pull/598")
     expect(links[0].props["data-platform-link"]).toBe("github")
+    expect(links[0].props["data-message-external-link"]).toBe(true)
     expect(links[1].props.href).toBe("https://example.com/story")
     expect(links[1].props["data-platform-link"]).toBe("generic")
+    expect(links[1].props["data-message-external-link"]).toBe(true)
   })
 })
 

--- a/src/web/src/components/community/messages/message-external-link.test.ts
+++ b/src/web/src/components/community/messages/message-external-link.test.ts
@@ -1,0 +1,158 @@
+import React from "react"
+import TestRenderer, { act } from "react-test-renderer"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { toast } from "sonner"
+import {
+  MESSAGE_EXTERNAL_LINK_ERROR,
+  MessageExternalLink,
+  handleMessageExternalLinkClick,
+} from "./message-external-link"
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn() } }))
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function clickEvent(defaultPrevented = false) {
+  return {
+    defaultPrevented,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  }
+}
+
+describe("handleMessageExternalLinkClick", () => {
+  it.each([
+    "http://example.com:8080/path/to/story?source=chat#section",
+    "https://github.com/alookai/alook/pull/598?view=files#diff",
+    "https://alook.ai/blog/native-links?from=message#intro",
+    "https://alook.ai/c/invite/abcdef?from=dm",
+  ])("opens an absolute Tauri HTTP(S) URL exactly once without WebView navigation: %s", async (href) => {
+    const event = clickEvent()
+    const order: string[] = []
+    event.preventDefault.mockImplementation(() => { order.push("prevent") })
+    const openUrl = vi.fn(async () => { order.push("open") })
+    const onError = vi.fn()
+
+    const opening = handleMessageExternalLinkClick(event, href, {
+      tauri: true,
+      openUrl,
+      onError,
+    })
+
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+    expect(event.stopPropagation).toHaveBeenCalledOnce()
+    expect(openUrl).toHaveBeenCalledOnce()
+    expect(openUrl).toHaveBeenCalledWith(href)
+    expect(order).toEqual(["prevent", "open"])
+    await opening
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ["ordinary Web", false, "https://example.com"],
+    ["relative App route", true, "/c/channels/server/channel"],
+    ["mailto", true, "mailto:friend@example.com"],
+    ["tel", true, "tel:+15551234567"],
+    ["invalid URL", true, "not a URL"],
+  ])("leaves %s to its existing browser or App behavior", (_case, tauri, href) => {
+    const event = clickEvent()
+    const openUrl = vi.fn()
+
+    expect(handleMessageExternalLinkClick(event, href, { tauri, openUrl })).toBeNull()
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(event.stopPropagation).not.toHaveBeenCalled()
+    expect(openUrl).not.toHaveBeenCalled()
+  })
+
+  it("respects a caller that already prevented the click", () => {
+    const event = clickEvent(true)
+    const openUrl = vi.fn()
+
+    expect(handleMessageExternalLinkClick(event, "https://example.com", {
+      tauri: true,
+      openUrl,
+    })).toBeNull()
+
+    expect(openUrl).not.toHaveBeenCalled()
+  })
+
+  it("fails closed with one visible error when an old bundle has no opener API", async () => {
+    vi.mocked(toast.error).mockReset()
+    const event = clickEvent()
+
+    await handleMessageExternalLinkClick(event, "https://example.com", {
+      tauri: true,
+      openUrl: null,
+    })
+
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+    expect(toast.error).toHaveBeenCalledOnce()
+    expect(toast.error).toHaveBeenCalledWith(MESSAGE_EXTERNAL_LINK_ERROR)
+  })
+
+  it.each([
+    ["asynchronously", () => Promise.reject(new Error("denied"))],
+    ["synchronously", () => { throw new Error("missing command") }],
+  ])("fails closed with one visible error when opener rejects %s", async (_case, implementation) => {
+    const event = clickEvent()
+    const openUrl = vi.fn(implementation)
+    const onError = vi.fn()
+
+    await handleMessageExternalLinkClick(event, "https://example.com", {
+      tauri: true,
+      openUrl,
+      onError,
+    })
+
+    expect(openUrl).toHaveBeenCalledOnce()
+    expect(onError).toHaveBeenCalledOnce()
+  })
+})
+
+describe("MessageExternalLink", () => {
+  it("preserves anchor attributes and marks the shared external-link surface", () => {
+    let renderer: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(
+        React.createElement(MessageExternalLink, {
+          href: "https://example.com/story",
+          target: "_blank",
+          rel: "noopener noreferrer",
+        }, "Example"),
+      )
+    })
+
+    expect(renderer!.root.findByType("a").props).toMatchObject({
+      href: "https://example.com/story",
+      target: "_blank",
+      rel: "noopener noreferrer",
+      "data-message-external-link": true,
+    })
+  })
+
+  it("uses the registered global Tauri opener from the rendered anchor", async () => {
+    const openUrl = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal("window", { __TAURI__: { opener: { openUrl } } })
+    const event = clickEvent()
+    let renderer: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(
+        React.createElement(MessageExternalLink, {
+          href: "https://example.com/native",
+        }, "Example"),
+      )
+    })
+
+    await act(async () => {
+      renderer!.root.findByType("a").props.onClick(event)
+      await Promise.resolve()
+    })
+
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+    expect(openUrl).toHaveBeenCalledOnce()
+    expect(openUrl).toHaveBeenCalledWith("https://example.com/native")
+  })
+})

--- a/src/web/src/components/community/messages/message-external-link.tsx
+++ b/src/web/src/components/community/messages/message-external-link.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import type { ComponentPropsWithoutRef, MouseEvent } from "react"
+import { isTauri } from "@alook/shared"
+import { toast } from "sonner"
+
+export const MESSAGE_EXTERNAL_LINK_ERROR = "Couldn't open link in your browser"
+
+type OpenUrl = (url: string) => Promise<void>
+type MessageLinkClickEvent = Pick<
+  MouseEvent<HTMLAnchorElement>,
+  "defaultPrevented" | "preventDefault" | "stopPropagation"
+>
+
+type TauriOpenerWindow = Window & {
+  __TAURI__?: {
+    opener?: {
+      openUrl?: OpenUrl
+    }
+  }
+}
+
+function isAbsoluteHttpUrl(href: string | undefined): href is string {
+  if (!href) return false
+  try {
+    const protocol = new URL(href).protocol
+    return protocol === "http:" || protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
+function readTauriOpenUrl(): OpenUrl | null {
+  if (typeof window === "undefined") return null
+  const openUrl = (window as TauriOpenerWindow).__TAURI__?.opener?.openUrl
+  return openUrl ? (url) => openUrl(url) : null
+}
+
+export function handleMessageExternalLinkClick(
+  event: MessageLinkClickEvent,
+  href: string | undefined,
+  options: {
+    tauri?: boolean
+    openUrl?: OpenUrl | null
+    onError?: () => void
+  } = {},
+): Promise<void> | null {
+  const tauri = options.tauri ?? isTauri()
+  if (!tauri || event.defaultPrevented || !isAbsoluteHttpUrl(href)) return null
+
+  event.preventDefault()
+  event.stopPropagation()
+  const onError = options.onError ?? (() => toast.error(MESSAGE_EXTERNAL_LINK_ERROR))
+  const openUrl = options.openUrl === undefined ? readTauriOpenUrl() : options.openUrl
+  if (!openUrl) {
+    onError()
+    return Promise.resolve()
+  }
+
+  try {
+    return Promise.resolve(openUrl(href)).catch(() => {
+      onError()
+    })
+  } catch {
+    onError()
+    return Promise.resolve()
+  }
+}
+
+export function MessageExternalLink({
+  href,
+  onClick,
+  children,
+  ...props
+}: ComponentPropsWithoutRef<"a">) {
+  return (
+    <a
+      {...props}
+      href={href}
+      data-message-external-link
+      onClick={(event) => {
+        onClick?.(event)
+        void handleMessageExternalLinkClick(event, href)
+      }}
+    >
+      {children}
+    </a>
+  )
+}

--- a/src/web/src/components/community/messages/message.render.test.ts
+++ b/src/web/src/components/community/messages/message.render.test.ts
@@ -290,6 +290,37 @@ describe("Message reply content projection", () => {
   })
 })
 
+describe("Message embed links", () => {
+  it("routes author and title URLs through the shared external-link anchor", () => {
+    let renderer: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(makeTree({
+        m: baseMsg({
+          embeds: [{
+            title: "Example story",
+            url: "https://example.com/story?from=embed",
+            author: {
+              name: "Example author",
+              url: "https://example.com/author",
+            },
+          }],
+        }),
+        onOpenThread: vi.fn(),
+      }), { createNodeMock: () => genericMock })
+    })
+
+    const links = renderer!.root.findAllByProps({ "data-message-external-link": true })
+    expect(links).toHaveLength(2)
+    expect(links.map((link) => link.props.href)).toEqual([
+      "https://example.com/author",
+      "https://example.com/story?from=embed",
+    ])
+    expect(links.every((link) => (
+      link.props.target === "_blank" && link.props.rel === "noopener noreferrer"
+    ))).toBe(true)
+  })
+})
+
 describe("Message reaction picker", () => {
   it("opens the non-hover picker and suppresses its Shadow DOM selection click at the row", async () => {
     vi.stubGlobal("window", { getSelection: () => null })

--- a/src/web/src/components/community/messages/message.tsx
+++ b/src/web/src/components/community/messages/message.tsx
@@ -11,6 +11,7 @@ import { ContextMenu, ContextMenuTrigger, ContextMenuContent } from "@/component
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent } from "@/components/ui/dropdown-menu"
 import { Avatar } from "../avatar"
 import { MessageBody } from "./message-body"
+import { MessageExternalLink } from "./message-external-link"
 import { BotApprovalCard } from "../social/bot-approval-card"
 import { EmojiPickerPopover } from "./emoji-picker"
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip"
@@ -556,7 +557,7 @@ function MessageImpl({
                           <span className="grid size-5 place-items-center rounded-full bg-muted text-[9px] font-semibold text-muted-foreground">{avatarInitial(embed.author.name)}</span>
                         )}
                         {embed.author.url ? (
-                          <a href={embed.author.url} target="_blank" rel="noopener noreferrer" className="text-xs font-medium hover:underline">{embed.author.name}</a>
+                          <MessageExternalLink href={embed.author.url} target="_blank" rel="noopener noreferrer" className="text-xs font-medium hover:underline">{embed.author.name}</MessageExternalLink>
                         ) : (
                           <span className="text-xs font-medium">{embed.author.name}</span>
                         )}
@@ -564,7 +565,7 @@ function MessageImpl({
                     )}
                     {embed.provider && <div className="text-xs text-muted-foreground">{embed.provider}</div>}
                     {embed.url ? (
-                      <a href={embed.url} target="_blank" rel="noopener noreferrer" className="mt-1 block font-medium text-primary hover:underline">{embed.title}</a>
+                      <MessageExternalLink href={embed.url} target="_blank" rel="noopener noreferrer" className="mt-1 block font-medium text-primary hover:underline">{embed.title}</MessageExternalLink>
                     ) : (
                       <div className="mt-1 font-medium">{embed.title}</div>
                     )}

--- a/src/web/src/components/community/messages/platform-link-badge.test.ts
+++ b/src/web/src/components/community/messages/platform-link-badge.test.ts
@@ -18,6 +18,7 @@ describe("PlatformLinkBadge", () => {
 
     const link = renderer!.root.findByType("a")
     expect(link.props["data-platform-link"]).toBe("alook")
+    expect(link.props["data-message-external-link"]).toBe(true)
     expect(link.props["aria-label"]).toBe(
       "Alook: https://alook.ai/c/invite/abcdef",
     )
@@ -40,6 +41,7 @@ describe("PlatformLinkBadge", () => {
 
     const link = renderer!.root.findByType("a")
     expect(link.props["data-platform-link"]).toBe("github")
+    expect(link.props["data-message-external-link"]).toBe(true)
     expect(link.props["aria-label"]).toBe("GitHub: https://github.com/alookai/alook/pull/598")
     expect(link.props.target).toBe("_blank")
     expect(renderer!.root.findAllByType("svg")).toHaveLength(1)
@@ -64,6 +66,7 @@ describe("PlatformLinkBadge", () => {
     expect(link.props.className).toContain("platform-link-badge")
     expect(link.props.className).toContain("existing-link")
     expect(link.props["data-platform-link"]).toBe("generic")
+    expect(link.props["data-message-external-link"]).toBe(true)
     expect(link.props["aria-label"]).toBe("Link: https://example.com/story")
     expect(renderer!.root.findAllByType("svg")).toHaveLength(1)
     expect(renderer!.root.findByType("span").children.join("")).toBe("Example story")

--- a/src/web/src/components/community/messages/platform-link-badge.tsx
+++ b/src/web/src/components/community/messages/platform-link-badge.tsx
@@ -13,6 +13,7 @@ import {
 import type { PlatformLinkKind } from "@/lib/community/platform-link"
 import { matchPlatformLink } from "@/lib/community/platform-link"
 import { cn } from "@/lib/utils"
+import { MessageExternalLink } from "./message-external-link"
 
 const ICONS = {
   github: SiGithub,
@@ -39,7 +40,7 @@ export function PlatformLinkBadge({
   const platform = matchPlatformLink(href)
   if (!platform) {
     return (
-      <a
+      <MessageExternalLink
         {...props}
         href={href}
         className={cn("platform-link-badge", className)}
@@ -48,7 +49,7 @@ export function PlatformLinkBadge({
       >
         <Link2 className="platform-link-badge-icon" aria-hidden="true" />
         <span className="platform-link-badge-label">{children}</span>
-      </a>
+      </MessageExternalLink>
     )
   }
 
@@ -69,7 +70,7 @@ export function PlatformLinkBadge({
         return <Icon className="platform-link-badge-icon" aria-hidden="true" />
       })()
   return (
-    <a
+    <MessageExternalLink
       {...props}
       href={href}
       className={cn("platform-link-badge", className)}
@@ -78,6 +79,6 @@ export function PlatformLinkBadge({
     >
       {icon}
       <span className="platform-link-badge-label">{children}</span>
-    </a>
+    </MessageExternalLink>
   )
 }


### PR DESCRIPTION
# Why we need this PR?

Native message links should open in the system browser without navigating the App WebView. The behavior also needs to fail closed when an older or mismatched native bundle has no usable opener API.

## What changed

- Added one shared message external-link anchor for Markdown badges and embed author/title links.
- In Tauri, synchronously prevents HTTP(S) WebView navigation, calls the native opener exactly once, and shows one visible error on missing/rejected opener calls.
- Registered the maintained opener plugin in the common desktop/mobile builder.
- Added production and localhost-development capabilities limited to `opener:allow-open-url` for `http://*` and `https://*` on Linux, macOS, Windows, Android, and iOS.
- Added handler/render regressions and a cross-file capability contract that rejects mailto, tel, path, reveal, shell, and CSP expansion.

## Checklist

- [x] Tests added/updated as needed
- [ ] All CI checks pass (remote Draft checks pending)
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [x] Other: Tauri desktop/iOS/Android shell and capabilities

## Validation

- Focused message-link, Markdown, badge, and embed tests: 60 passed
- Capability/config contract: 41 passed
- Rust warnings-deny tests: 32 passed
- `cargo machete`: passed
- Root typecheck, lint, test, and knip: passed
- Normal pre-commit hooks, including WS and agent-driver boundary checks: passed
