### PR TITLE
feat(web): add message link actions

### DIFF
--- a/src/web/src/components/community/messages/message-external-link.test.ts
+++ b/src/web/src/components/community/messages/message-external-link.test.ts
@@ -122,9 +122,13 @@ describe("handleMessageExternalLinkClick", () => {
 
 describe("messageExternalLinkTargetFromEventTarget", () => {
   it("resolves the exact second marked anchor with its complete live href", () => {
-    const first = { href: "https://example.com/first" }
+    const first = {
+      href: "https://example.com/first",
+      getAttribute: () => "https://example.com/first",
+    }
     const second = {
       href: "https://example.com/second/path?from=message&mode=full#details",
+      getAttribute: () => "https://example.com/second/path?from=message&mode=full#details",
     }
     const target = {
       closest: vi.fn((selector: string) => {
@@ -143,9 +147,21 @@ describe("messageExternalLinkTargetFromEventTarget", () => {
 
   it.each([
     ["non-link", { closest: () => null }],
-    ["relative app route", { closest: () => ({ href: "/c/channels/s1/c1" }) }],
-    ["mailto", { closest: () => ({ href: "mailto:friend@example.com" }) }],
-    ["invalid", { closest: () => ({ href: "not a url" }) }],
+    ["browser-normalized relative app route", {
+      closest: () => ({
+        href: "http://localhost:3000/c/me",
+        getAttribute: () => "/c/me",
+      }),
+    }],
+    ["mailto", {
+      closest: () => ({
+        href: "mailto:friend@example.com",
+        getAttribute: () => "mailto:friend@example.com",
+      }),
+    }],
+    ["invalid", {
+      closest: () => ({ href: "not a url", getAttribute: () => "not a url" }),
+    }],
   ])("rejects a %s target", (_case, target) => {
     expect(messageExternalLinkTargetFromEventTarget(target as unknown as EventTarget)).toBeNull()
   })

--- a/src/web/src/components/community/messages/message-external-link.test.ts
+++ b/src/web/src/components/community/messages/message-external-link.test.ts
@@ -3,14 +3,22 @@ import TestRenderer, { act } from "react-test-renderer"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { toast } from "sonner"
 import {
+  copyMessageExternalLink,
+  MESSAGE_EXTERNAL_LINK_COPY_ERROR,
+  MESSAGE_EXTERNAL_LINK_COPY_SUCCESS,
   MESSAGE_EXTERNAL_LINK_ERROR,
   MessageExternalLink,
   handleMessageExternalLinkClick,
+  messageExternalLinkTargetFromEventTarget,
+  openMessageExternalLink,
 } from "./message-external-link"
 
-vi.mock("sonner", () => ({ toast: { error: vi.fn() } }))
+vi.mock("sonner", () => ({
+  toast: Object.assign(vi.fn(), { error: vi.fn() }),
+}))
 
 afterEach(() => {
+  vi.clearAllMocks()
   vi.unstubAllGlobals()
 })
 
@@ -109,6 +117,102 @@ describe("handleMessageExternalLinkClick", () => {
 
     expect(openUrl).toHaveBeenCalledOnce()
     expect(onError).toHaveBeenCalledOnce()
+  })
+})
+
+describe("messageExternalLinkTargetFromEventTarget", () => {
+  it("resolves the exact second marked anchor with its complete live href", () => {
+    const first = { href: "https://example.com/first" }
+    const second = {
+      href: "https://example.com/second/path?from=message&mode=full#details",
+    }
+    const target = {
+      closest: vi.fn((selector: string) => {
+        expect(selector).toBe("a[data-message-external-link]")
+        return second
+      }),
+    }
+
+    expect(messageExternalLinkTargetFromEventTarget(target as unknown as EventTarget)).toEqual({
+      href: second.href,
+    })
+    expect(messageExternalLinkTargetFromEventTarget({
+      closest: () => first,
+    } as unknown as EventTarget)).toEqual({ href: first.href })
+  })
+
+  it.each([
+    ["non-link", { closest: () => null }],
+    ["relative app route", { closest: () => ({ href: "/c/channels/s1/c1" }) }],
+    ["mailto", { closest: () => ({ href: "mailto:friend@example.com" }) }],
+    ["invalid", { closest: () => ({ href: "not a url" }) }],
+  ])("rejects a %s target", (_case, target) => {
+    expect(messageExternalLinkTargetFromEventTarget(target as unknown as EventTarget)).toBeNull()
+  })
+})
+
+describe("message external-link menu actions", () => {
+  const target = { href: "https://example.com/story?from=message#section" }
+
+  it("copies the exact href and reports visible success", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+
+    await expect(copyMessageExternalLink(target, { writeText })).resolves.toBe(true)
+
+    expect(writeText).toHaveBeenCalledOnce()
+    expect(writeText).toHaveBeenCalledWith(target.href)
+    expect(toast).toHaveBeenCalledWith(MESSAGE_EXTERNAL_LINK_COPY_SUCCESS)
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ["missing", null],
+    ["rejected", vi.fn().mockRejectedValue(new Error("denied"))],
+  ])("reports visible copy failure when clipboard access is %s", async (_case, writeText) => {
+    await expect(copyMessageExternalLink(target, { writeText })).resolves.toBe(false)
+
+    expect(toast.error).toHaveBeenCalledOnce()
+    expect(toast.error).toHaveBeenCalledWith(MESSAGE_EXTERNAL_LINK_COPY_ERROR)
+  })
+
+  it.each([
+    ["a Window proxy", {} as Window],
+    ["the normal null result from an isolated opener", null],
+  ])("opens browser Web exactly once with opener isolation when it returns %s", async (_case, result) => {
+    const openWindow = vi.fn(() => result)
+
+    await openMessageExternalLink(target, { tauri: false, openWindow })
+
+    expect(openWindow).toHaveBeenCalledOnce()
+    expect(openWindow).toHaveBeenCalledWith(
+      target.href,
+      "_blank",
+      "noopener,noreferrer",
+    )
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it("uses the #53 Tauri system-browser opener exactly once", async () => {
+    const openUrl = vi.fn().mockResolvedValue(undefined)
+    const openWindow = vi.fn()
+
+    await openMessageExternalLink(target, { tauri: true, openUrl, openWindow })
+
+    expect(openUrl).toHaveBeenCalledOnce()
+    expect(openUrl).toHaveBeenCalledWith(target.href)
+    expect(openWindow).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ["missing browser API", { tauri: false, openWindow: null }],
+    ["throwing browser API", { tauri: false, openWindow: () => { throw new Error("blocked") } }],
+    ["missing Tauri API", { tauri: true, openUrl: null }],
+    ["rejected Tauri API", { tauri: true, openUrl: vi.fn().mockRejectedValue(new Error("denied")) }],
+  ])("reports visible open failure for %s", async (_case, options) => {
+    await openMessageExternalLink(target, options)
+
+    expect(toast.error).toHaveBeenCalledOnce()
+    expect(toast.error).toHaveBeenCalledWith(MESSAGE_EXTERNAL_LINK_ERROR)
   })
 })
 

--- a/src/web/src/components/community/messages/message-external-link.tsx
+++ b/src/web/src/components/community/messages/message-external-link.tsx
@@ -42,9 +42,15 @@ export function messageExternalLinkTargetFromEventTarget(
   target: EventTarget | null,
 ): MessageExternalLinkTarget | null {
   const anchor = (target as { closest?: (selector: string) => unknown } | null)
-    ?.closest?.("a[data-message-external-link]") as { href?: unknown } | null | undefined
+    ?.closest?.("a[data-message-external-link]") as {
+      href?: unknown
+      getAttribute?: (name: string) => string | null
+    } | null | undefined
+  const authoredHref = anchor?.getAttribute?.("href") ?? undefined
   const href = anchor?.href
-  return typeof href === "string" && isAbsoluteHttpUrl(href) ? { href } : null
+  return isAbsoluteHttpUrl(authoredHref) && typeof href === "string" && isAbsoluteHttpUrl(href)
+    ? { href }
+    : null
 }
 
 function readTauriOpenUrl(): OpenUrl | null {

--- a/src/web/src/components/community/messages/message-external-link.tsx
+++ b/src/web/src/components/community/messages/message-external-link.tsx
@@ -5,8 +5,16 @@ import { isTauri } from "@alook/shared"
 import { toast } from "sonner"
 
 export const MESSAGE_EXTERNAL_LINK_ERROR = "Couldn't open link in your browser"
+export const MESSAGE_EXTERNAL_LINK_COPY_ERROR = "Couldn't copy link"
+export const MESSAGE_EXTERNAL_LINK_COPY_SUCCESS = "Copied to clipboard"
+
+export type MessageExternalLinkTarget = {
+  href: string
+}
 
 type OpenUrl = (url: string) => Promise<void>
+type OpenWindow = (url: string, target: string, features: string) => Window | null
+type WriteText = (text: string) => Promise<void>
 type MessageLinkClickEvent = Pick<
   MouseEvent<HTMLAnchorElement>,
   "defaultPrevented" | "preventDefault" | "stopPropagation"
@@ -30,10 +38,102 @@ function isAbsoluteHttpUrl(href: string | undefined): href is string {
   }
 }
 
+export function messageExternalLinkTargetFromEventTarget(
+  target: EventTarget | null,
+): MessageExternalLinkTarget | null {
+  const anchor = (target as { closest?: (selector: string) => unknown } | null)
+    ?.closest?.("a[data-message-external-link]") as { href?: unknown } | null | undefined
+  const href = anchor?.href
+  return typeof href === "string" && isAbsoluteHttpUrl(href) ? { href } : null
+}
+
 function readTauriOpenUrl(): OpenUrl | null {
   if (typeof window === "undefined") return null
   const openUrl = (window as TauriOpenerWindow).__TAURI__?.opener?.openUrl
   return openUrl ? (url) => openUrl(url) : null
+}
+
+export async function copyMessageExternalLink(
+  target: MessageExternalLinkTarget,
+  options: {
+    writeText?: WriteText | null
+    onSuccess?: () => void
+    onError?: () => void
+  } = {},
+): Promise<boolean> {
+  const onSuccess = options.onSuccess ?? (() => toast(MESSAGE_EXTERNAL_LINK_COPY_SUCCESS))
+  const onError = options.onError ?? (() => toast.error(MESSAGE_EXTERNAL_LINK_COPY_ERROR))
+  const writeText = options.writeText === undefined
+    ? typeof navigator === "undefined"
+      ? null
+      : navigator.clipboard?.writeText.bind(navigator.clipboard) ?? null
+    : options.writeText
+
+  if (!isAbsoluteHttpUrl(target.href) || !writeText) {
+    onError()
+    return false
+  }
+
+  try {
+    await writeText(target.href)
+    onSuccess()
+    return true
+  } catch {
+    onError()
+    return false
+  }
+}
+
+export function openMessageExternalLink(
+  target: MessageExternalLinkTarget,
+  options: {
+    tauri?: boolean
+    openUrl?: OpenUrl | null
+    openWindow?: OpenWindow | null
+    onError?: () => void
+  } = {},
+): Promise<void> {
+  const onError = options.onError ?? (() => toast.error(MESSAGE_EXTERNAL_LINK_ERROR))
+  if (!isAbsoluteHttpUrl(target.href)) {
+    onError()
+    return Promise.resolve()
+  }
+
+  const tauri = options.tauri ?? isTauri()
+  if (tauri) {
+    const openUrl = options.openUrl === undefined ? readTauriOpenUrl() : options.openUrl
+    if (!openUrl) {
+      onError()
+      return Promise.resolve()
+    }
+    try {
+      return Promise.resolve(openUrl(target.href)).catch(() => {
+        onError()
+      })
+    } catch {
+      onError()
+      return Promise.resolve()
+    }
+  }
+
+  const openWindow = options.openWindow === undefined
+    ? typeof window === "undefined"
+      ? null
+      : window.open.bind(window)
+    : options.openWindow
+  if (!openWindow) {
+    onError()
+    return Promise.resolve()
+  }
+  try {
+    // Browsers may return null for a successful `noopener` open because the
+    // opener is deliberately severed, so only a missing/throwing API is a
+    // reliable failure signal here.
+    openWindow(target.href, "_blank", "noopener,noreferrer")
+  } catch {
+    onError()
+  }
+  return Promise.resolve()
 }
 
 export function handleMessageExternalLinkClick(
@@ -50,21 +150,10 @@ export function handleMessageExternalLinkClick(
 
   event.preventDefault()
   event.stopPropagation()
-  const onError = options.onError ?? (() => toast.error(MESSAGE_EXTERNAL_LINK_ERROR))
-  const openUrl = options.openUrl === undefined ? readTauriOpenUrl() : options.openUrl
-  if (!openUrl) {
-    onError()
-    return Promise.resolve()
-  }
-
-  try {
-    return Promise.resolve(openUrl(href)).catch(() => {
-      onError()
-    })
-  } catch {
-    onError()
-    return Promise.resolve()
-  }
+  return openMessageExternalLink(
+    { href },
+    { tauri: true, openUrl: options.openUrl, onError: options.onError },
+  )
 }
 
 export function MessageExternalLink({

--- a/src/web/src/components/community/messages/message-link-surfaces.contract.test.ts
+++ b/src/web/src/components/community/messages/message-link-surfaces.contract.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..")
+const source = (path: string) => readFileSync(resolve(webRoot, path), "utf8")
+
+describe("Community ordinary-link action surface contract", () => {
+  it("routes DM, channel, and thread timeline messages through one Message boundary", () => {
+    for (const path of [
+      "src/app/c/me/[dmId]/page.tsx",
+      "src/components/community/channels/text-channel-surface.tsx",
+      "src/components/community/channels/thread-channel-surface.tsx",
+    ]) {
+      expect(source(path), path).toContain("<MessageList")
+    }
+    expect(source("src/components/community/messages/message-list-row.tsx"))
+      .toContain("<MessageRow")
+    expect(source("src/components/community/messages/message-row.tsx"))
+      .toContain("<Message")
+  })
+
+  it("routes message-context rows through the same MessageRow boundary", () => {
+    const contextSheet = source("src/components/community/messages/message-context-sheet.tsx")
+    expect(contextSheet).toContain("<MessageRow")
+    expect(contextSheet).not.toContain("Copy Link")
+    expect(contextSheet).not.toContain("Open Link")
+  })
+
+  it("keeps gesture target parsing and link-menu labels out of route-specific surfaces", () => {
+    for (const path of [
+      "src/app/c/me/[dmId]/page.tsx",
+      "src/components/community/channels/text-channel-surface.tsx",
+      "src/components/community/channels/thread-channel-surface.tsx",
+      "src/components/community/messages/message-context-sheet.tsx",
+      "src/components/community/messages/message-list-row.tsx",
+      "src/components/community/messages/message-row.tsx",
+    ]) {
+      const text = source(path)
+      expect(text, path).not.toContain("messageExternalLinkTargetFromEventTarget")
+      expect(text, path).not.toContain("Copy Link")
+      expect(text, path).not.toContain("Open Link")
+    }
+
+    const message = source("src/components/community/messages/message.tsx")
+    expect(message).toContain("messageExternalLinkTargetFromEventTarget")
+    expect(message).toContain("onClickCapture")
+    expect(message).toContain("onContextMenuCapture")
+  })
+})

--- a/src/web/src/components/community/messages/message-menu-parity.test.ts
+++ b/src/web/src/components/community/messages/message-menu-parity.test.ts
@@ -16,7 +16,7 @@
  */
 import { describe, it, expect } from "vitest"
 import { messageCanShare } from "./message"
-import { messageMenuItems } from "./message-menu"
+import { messageLinkMenuItems, messageMenuItems } from "./message-menu"
 import type { RenderMsg } from "@/lib/community/models/message"
 
 const msg = (over: Partial<RenderMsg> = {}): RenderMsg =>
@@ -82,5 +82,17 @@ describe("the menu a content message produces on any surface", () => {
       "Reply",
       "Share as Image",
     ])
+  })
+
+  it("keeps the ordinary list intact and exposes the gesture link suffix separately", () => {
+    const linkTarget = { href: "https://example.com/second?mode=full#details" }
+    const suffix = messageLinkMenuItems({
+      linkTarget,
+      onCopyLink: () => {},
+      onOpenLink: () => {},
+    })
+
+    expect(items.map((item) => item.label).at(-1)).toBe("Share as Image")
+    expect(suffix.map((item) => item.label)).toEqual(["Copy Link", "Open Link"])
   })
 })

--- a/src/web/src/components/community/messages/message-menu.test.ts
+++ b/src/web/src/components/community/messages/message-menu.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest"
-import { messageMenuItems, hasMessageMenu } from "./message-menu"
+import { messageLinkMenuItems, messageMenuItems, hasMessageMenu } from "./message-menu"
 
 // The menu is contract-driven: each item appears ONLY when its handler is
 // supplied, so a surface that can't drive an action omits it (no dead entries).
@@ -78,5 +78,28 @@ describe("messageMenuItems", () => {
       onReply: () => {}, onPin: () => {}, onMark: () => {}, onCopy: () => {},
     }).map((it) => it.label)
     expect(labels).toEqual(["Reply", "Pin Message", "Mark", "Copy Text"])
+  })
+})
+
+describe("messageLinkMenuItems", () => {
+  const linkTarget = { href: "https://example.com/second?mode=full#details" }
+
+  it("stays absent unless one exact target and both actions are available", () => {
+    expect(messageLinkMenuItems({})).toEqual([])
+    expect(messageLinkMenuItems({ linkTarget })).toEqual([])
+    expect(messageLinkMenuItems({ linkTarget, onCopyLink: () => {} })).toEqual([])
+  })
+
+  it("appends Copy Link then Open Link and passes the same structured target", () => {
+    const onCopyLink = vi.fn()
+    const onOpenLink = vi.fn()
+    const items = messageLinkMenuItems({ linkTarget, onCopyLink, onOpenLink })
+
+    expect(items.map((item) => item.label)).toEqual(["Copy Link", "Open Link"])
+    expect(items.every((item) => item.icon === undefined)).toBe(true)
+    items[0]?.onClick?.()
+    items[1]?.onClick?.()
+    expect(onCopyLink).toHaveBeenCalledWith(linkTarget)
+    expect(onOpenLink).toHaveBeenCalledWith(linkTarget)
   })
 })

--- a/src/web/src/components/community/messages/message-menu.test.ts
+++ b/src/web/src/components/community/messages/message-menu.test.ts
@@ -96,7 +96,8 @@ describe("messageLinkMenuItems", () => {
     const items = messageLinkMenuItems({ linkTarget, onCopyLink, onOpenLink })
 
     expect(items.map((item) => item.label)).toEqual(["Copy Link", "Open Link"])
-    expect(items.every((item) => item.icon === undefined)).toBe(true)
+    expect(items[0]?.icon).toBeUndefined()
+    expect(items[1]?.icon).toBeDefined()
     items[0]?.onClick?.()
     items[1]?.onClick?.()
     expect(onCopyLink).toHaveBeenCalledWith(linkTarget)

--- a/src/web/src/components/community/messages/message-menu.tsx
+++ b/src/web/src/components/community/messages/message-menu.tsx
@@ -1,6 +1,7 @@
 import { Reply, Pin, Share } from "lucide-react"
-import { ContextMenuItem } from "@/components/ui/context-menu"
-import { DropdownMenuItem } from "@/components/ui/dropdown-menu"
+import { ContextMenuItem, ContextMenuSeparator } from "@/components/ui/context-menu"
+import { DropdownMenuItem, DropdownMenuSeparator } from "@/components/ui/dropdown-menu"
+import type { MessageExternalLinkTarget } from "./message-external-link"
 
 // Shared message-action items, rendered for either a ContextMenu (right-click) or a
 // DropdownMenu (⋯ toolbar). Callbacks are the reusable contract; the preview wires
@@ -60,6 +61,24 @@ export function hasMessageMenu(handlers: Parameters<typeof messageMenuItems>[0])
 
 export type MessageMenuHandlers = Parameters<typeof messageMenuItems>[0]
 
+export type MessageLinkMenuHandlers = {
+  linkTarget?: MessageExternalLinkTarget | null
+  onCopyLink?: (target: MessageExternalLinkTarget) => void
+  onOpenLink?: (target: MessageExternalLinkTarget) => void
+}
+
+export function messageLinkMenuItems({
+  linkTarget,
+  onCopyLink,
+  onOpenLink,
+}: MessageLinkMenuHandlers): Item[] {
+  if (!linkTarget || !onCopyLink || !onOpenLink) return []
+  return [
+    { label: "Copy Link", onClick: () => onCopyLink(linkTarget) },
+    { label: "Open Link", onClick: () => onOpenLink(linkTarget) },
+  ]
+}
+
 // The icon slot: the real icon for high-freq rows, or an equal-width empty
 // placeholder for text-only rows so every label shares one left edge. The menu
 // item's own `gap-2` handles the spacing to the label either way.
@@ -67,12 +86,19 @@ function IconSlot({ icon: Icon }: { icon?: Item["icon"] }) {
   return Icon ? <Icon className="size-4" /> : <span className="size-4" aria-hidden />
 }
 
-export function MessageContextItems(props: MessageMenuHandlers) {
+export function MessageContextItems(props: MessageMenuHandlers & MessageLinkMenuHandlers) {
+  const linkItems = messageLinkMenuItems(props)
   return (
     <>
       {messageMenuItems(props).map((it) => (
         <ContextMenuItem key={it.label} onClick={it.onClick} className={it.danger ? "text-destructive data-highlighted:bg-destructive/10 data-highlighted:text-destructive" : ""}>
           <IconSlot icon={it.icon} /> {it.label}
+        </ContextMenuItem>
+      ))}
+      {linkItems.length > 0 && <ContextMenuSeparator />}
+      {linkItems.map((it) => (
+        <ContextMenuItem key={it.label} onClick={it.onClick}>
+          <IconSlot /> {it.label}
         </ContextMenuItem>
       ))}
     </>
@@ -82,7 +108,8 @@ export function MessageContextItems(props: MessageMenuHandlers) {
 export function MessageDropdownItems({
   touch = false,
   ...props
-}: MessageMenuHandlers & { touch?: boolean }) {
+}: MessageMenuHandlers & MessageLinkMenuHandlers & { touch?: boolean }) {
+  const linkItems = messageLinkMenuItems(props)
   return (
     <>
       {messageMenuItems(props).map((it) => (
@@ -93,6 +120,16 @@ export function MessageDropdownItems({
           className={touch ? "min-h-11" : undefined}
         >
           <IconSlot icon={it.icon} /> {it.label}
+        </DropdownMenuItem>
+      ))}
+      {linkItems.length > 0 && <DropdownMenuSeparator />}
+      {linkItems.map((it) => (
+        <DropdownMenuItem
+          key={it.label}
+          onClick={it.onClick}
+          className={touch ? "min-h-11" : undefined}
+        >
+          <IconSlot /> {it.label}
         </DropdownMenuItem>
       ))}
     </>

--- a/src/web/src/components/community/messages/message-menu.tsx
+++ b/src/web/src/components/community/messages/message-menu.tsx
@@ -1,4 +1,4 @@
-import { Reply, Pin, Share } from "lucide-react"
+import { ExternalLink, Reply, Pin, Share } from "lucide-react"
 import { ContextMenuItem, ContextMenuSeparator } from "@/components/ui/context-menu"
 import { DropdownMenuItem, DropdownMenuSeparator } from "@/components/ui/dropdown-menu"
 import type { MessageExternalLinkTarget } from "./message-external-link"
@@ -9,8 +9,9 @@ import type { MessageExternalLinkTarget } from "./message-external-link"
 type Item = { label: string; icon?: typeof Pin; danger?: boolean; onClick?: () => void }
 
 // Menu design (locked spec, uiux #14 — Gus/Alli, "less is more"): ONE flat list, no
-// sections/divider. Only the HIGH-FREQUENCY actions carry an icon (Reply, Share) —
-// there the icon is a navigation anchor you scan straight to. The low-frequency
+// sections/divider. In the ordinary message-action list, only the HIGH-FREQUENCY
+// actions carry an icon (Reply, Share) — there the icon is a navigation anchor
+// you scan straight to. The low-frequency
 // actions (React / Thread / Pin / Copy) are text only: their labels are
 // self-explanatory, so an icon adds no recognition value, just noise. To keep every
 // label's left edge aligned, the icon-less rows render an icon-width placeholder in
@@ -75,7 +76,7 @@ export function messageLinkMenuItems({
   if (!linkTarget || !onCopyLink || !onOpenLink) return []
   return [
     { label: "Copy Link", onClick: () => onCopyLink(linkTarget) },
-    { label: "Open Link", onClick: () => onOpenLink(linkTarget) },
+    { label: "Open Link", icon: ExternalLink, onClick: () => onOpenLink(linkTarget) },
   ]
 }
 
@@ -98,7 +99,7 @@ export function MessageContextItems(props: MessageMenuHandlers & MessageLinkMenu
       {linkItems.length > 0 && <ContextMenuSeparator />}
       {linkItems.map((it) => (
         <ContextMenuItem key={it.label} onClick={it.onClick}>
-          <IconSlot /> {it.label}
+          <IconSlot icon={it.icon} /> {it.label}
         </ContextMenuItem>
       ))}
     </>
@@ -129,7 +130,7 @@ export function MessageDropdownItems({
           onClick={it.onClick}
           className={touch ? "min-h-11" : undefined}
         >
-          <IconSlot /> {it.label}
+          <IconSlot icon={it.icon} /> {it.label}
         </DropdownMenuItem>
       ))}
     </>

--- a/src/web/src/components/community/messages/message-reactions.test.ts
+++ b/src/web/src/components/community/messages/message-reactions.test.ts
@@ -45,6 +45,7 @@ import {
   MessageReactions,
   reconcileReactionSelection,
   resolveReactionFinalFocus,
+  restoreReactionFocus,
 } from "./message-reactions"
 import { tid } from "@/lib/community/testids"
 
@@ -238,20 +239,23 @@ describe("MessageReactions", () => {
     expect(text).not.toContain("#000")
   })
 
-  it("hands the connected initiating chip to the dialog final-focus contract", () => {
+  it("restores the connected initiating chip after the dialog finishes closing", () => {
     vi.useFakeTimers()
     const { renderer } = renderReactions()
     const chip = renderer.root.findByProps({ "data-testid": tid.reactionChip("message_1", "👍") })
     act(() => chip.props.onPointerDown({ pointerType: "touch", clientX: 10, clientY: 10, stopPropagation: vi.fn() }))
     act(() => vi.advanceTimersByTime(450))
     const content = renderer.root.findByType("mock-dialog-content")
-    expect(content.props.finalFocus()).toBe(buttonNode)
+    expect(content.props.finalFocus).toBe(false)
     const dialog = renderer.root.findByType("mock-dialog")
     act(() => dialog.props.onOpenChange(false))
     expect(buttonNode.focus).not.toHaveBeenCalled()
+    act(() => dialog.props.onOpenChangeComplete(false))
+    expect(buttonNode.focus).toHaveBeenCalledOnce()
+    expect(buttonNode.focus).toHaveBeenCalledWith({ preventScroll: true })
   })
 
-  it("hands the reaction group to the dialog when the initiating chip disappeared", () => {
+  it("restores the reaction group itself when the initiating chip disappeared", () => {
     vi.useFakeTimers()
     const { renderer, onToggleReaction } = renderReactions()
     const chip = renderer.root.findByProps({ "data-testid": tid.reactionChip("message_1", "👍") })
@@ -267,8 +271,10 @@ describe("MessageReactions", () => {
       onToggleReaction,
     })))
     buttonNode.isConnected = false
-    const content = renderer.root.findByType("mock-dialog-content")
-    expect(content.props.finalFocus()).toBe(reactionGroupNode)
+    const dialog = renderer.root.findByType("mock-dialog")
+    act(() => dialog.props.onOpenChangeComplete(false))
+    expect(reactionGroupNode.focus).toHaveBeenCalledOnce()
+    expect(reactionGroupNode.focus).toHaveBeenCalledWith({ preventScroll: true })
   })
 })
 
@@ -296,5 +302,15 @@ describe("resolveReactionFinalFocus", () => {
     expect(resolveReactionFinalFocus(connectedChip, group)).toBe(connectedChip)
     expect(resolveReactionFinalFocus(disconnectedChip, group)).toBe(group)
     expect(resolveReactionFinalFocus(null, group)).toBe(group)
+  })
+})
+
+describe("restoreReactionFocus", () => {
+  it("focuses the exact resolved element without choosing a tabbable child", () => {
+    const focus = vi.fn()
+    const group = { focus } as unknown as HTMLDivElement
+
+    expect(restoreReactionFocus(null, group)).toBe(group)
+    expect(focus).toHaveBeenCalledWith({ preventScroll: true })
   })
 })

--- a/src/web/src/components/community/messages/message-reactions.test.ts
+++ b/src/web/src/components/community/messages/message-reactions.test.ts
@@ -41,7 +41,11 @@ vi.mock("@/components/ui/tooltip", () => ({
   TooltipContent: ({ children }: { children: React.ReactNode }) => React.createElement("span", null, children),
 }))
 
-import { MessageReactions, reconcileReactionSelection } from "./message-reactions"
+import {
+  MessageReactions,
+  reconcileReactionSelection,
+  resolveReactionFinalFocus,
+} from "./message-reactions"
 import { tid } from "@/lib/community/testids"
 
 const buttonNode = {
@@ -234,20 +238,20 @@ describe("MessageReactions", () => {
     expect(text).not.toContain("#000")
   })
 
-  it("restores focus after the dialog close focus handoff", () => {
+  it("hands the connected initiating chip to the dialog final-focus contract", () => {
     vi.useFakeTimers()
     const { renderer } = renderReactions()
     const chip = renderer.root.findByProps({ "data-testid": tid.reactionChip("message_1", "👍") })
     act(() => chip.props.onPointerDown({ pointerType: "touch", clientX: 10, clientY: 10, stopPropagation: vi.fn() }))
     act(() => vi.advanceTimersByTime(450))
+    const content = renderer.root.findByType("mock-dialog-content")
+    expect(content.props.finalFocus()).toBe(buttonNode)
     const dialog = renderer.root.findByType("mock-dialog")
     act(() => dialog.props.onOpenChange(false))
     expect(buttonNode.focus).not.toHaveBeenCalled()
-    act(() => vi.advanceTimersByTime(0))
-    expect(buttonNode.focus).toHaveBeenCalledOnce()
   })
 
-  it("restores focus to the reaction group when the initiating chip disappeared", () => {
+  it("hands the reaction group to the dialog when the initiating chip disappeared", () => {
     vi.useFakeTimers()
     const { renderer, onToggleReaction } = renderReactions()
     const chip = renderer.root.findByProps({ "data-testid": tid.reactionChip("message_1", "👍") })
@@ -263,11 +267,8 @@ describe("MessageReactions", () => {
       onToggleReaction,
     })))
     buttonNode.isConnected = false
-    const dialog = renderer.root.findByType("mock-dialog")
-    act(() => dialog.props.onOpenChange(false))
-    act(() => vi.advanceTimersByTime(0))
-    expect(buttonNode.focus).not.toHaveBeenCalled()
-    expect(reactionGroupNode.focus).toHaveBeenCalledOnce()
+    const content = renderer.root.findByType("mock-dialog-content")
+    expect(content.props.finalFocus()).toBe(reactionGroupNode)
   })
 })
 
@@ -283,5 +284,17 @@ describe("reconcileReactionSelection", () => {
 
   it("closes selection when the final reaction disappears", () => {
     expect(reconcileReactionSelection(["👍"], [], "👍")).toBeNull()
+  })
+})
+
+describe("resolveReactionFinalFocus", () => {
+  it("resolves the connected initiating chip, then the stable reaction group", () => {
+    const connectedChip = { isConnected: true } as HTMLButtonElement
+    const disconnectedChip = { isConnected: false } as HTMLButtonElement
+    const group = {} as HTMLDivElement
+
+    expect(resolveReactionFinalFocus(connectedChip, group)).toBe(connectedChip)
+    expect(resolveReactionFinalFocus(disconnectedChip, group)).toBe(group)
+    expect(resolveReactionFinalFocus(null, group)).toBe(group)
   })
 })

--- a/src/web/src/components/community/messages/message-reactions.tsx
+++ b/src/web/src/components/community/messages/message-reactions.tsx
@@ -187,6 +187,7 @@ function ReactionDetailsDialog({
   reactions,
   selectedEmoji,
   onSelectedEmojiChange,
+  finalFocus,
 }: {
   messageId: string
   authorName: string
@@ -194,6 +195,7 @@ function ReactionDetailsDialog({
   reactions: readonly Reaction[]
   selectedEmoji: string | null
   onSelectedEmojiChange: (emoji: string) => void
+  finalFocus: () => HTMLElement | null
 }) {
   const userIds = useMemo(
     () => reactions.flatMap((reaction) => reaction.userIds ?? []),
@@ -218,6 +220,7 @@ function ReactionDetailsDialog({
   return (
     <DialogContent
       data-testid={tid.reactionDialog(messageId)}
+      finalFocus={finalFocus}
       className="flex max-h-[calc(100dvh-2rem-env(safe-area-inset-top)-env(safe-area-inset-bottom))] flex-col gap-3 overflow-hidden transition-none sm:max-w-sm **:data-[slot=dialog-close]:size-11 **:data-[slot=dialog-close]:transition-none sm:**:data-[slot=dialog-close]:size-7"
     >
       <DialogHeader className="min-w-0 shrink-0">
@@ -294,6 +297,13 @@ function ReactionDetailsDialog({
   )
 }
 
+export function resolveReactionFinalFocus(
+  initiatingChip: HTMLButtonElement | null,
+  reactionGroup: HTMLDivElement | null,
+): HTMLElement | null {
+  return initiatingChip?.isConnected ? initiatingChip : reactionGroup
+}
+
 export function MessageReactions({
   messageId,
   authorName,
@@ -321,11 +331,6 @@ export function MessageReactions({
   const reactionGroupRef = useRef<HTMLDivElement | null>(null)
   const [open, setOpen] = useState(false)
   const [selectedEmoji, setSelectedEmoji] = useState<string | null>(null)
-  const restoreInitiatingFocus = () => {
-    const initiatingChip = initiatingChipRef.current
-    if (initiatingChip?.isConnected !== false) initiatingChip?.focus()
-    else reactionGroupRef.current?.focus()
-  }
 
   useEffect(() => {
     const previous = previousEmojisRef.current
@@ -368,10 +373,7 @@ export function MessageReactions({
 
       <Dialog
         open={open}
-        onOpenChange={(nextOpen) => {
-          setOpen(nextOpen)
-          if (!nextOpen) setTimeout(restoreInitiatingFocus, 0)
-        }}
+        onOpenChange={setOpen}
       >
         {open && (
           <ReactionDetailsDialog
@@ -381,6 +383,10 @@ export function MessageReactions({
             reactions={reactions}
             selectedEmoji={selectedEmoji}
             onSelectedEmojiChange={setSelectedEmoji}
+            finalFocus={() => resolveReactionFinalFocus(
+              initiatingChipRef.current,
+              reactionGroupRef.current,
+            )}
           />
         )}
       </Dialog>

--- a/src/web/src/components/community/messages/message-reactions.tsx
+++ b/src/web/src/components/community/messages/message-reactions.tsx
@@ -181,27 +181,27 @@ function ReactionChip({
 }
 
 function ReactionDetailsDialog({
+  open,
   messageId,
   authorName,
   messagePreview,
   reactions,
   selectedEmoji,
   onSelectedEmojiChange,
-  finalFocus,
 }: {
+  open: boolean
   messageId: string
   authorName: string
   messagePreview: string
   reactions: readonly Reaction[]
   selectedEmoji: string | null
   onSelectedEmojiChange: (emoji: string) => void
-  finalFocus: () => HTMLElement | null
 }) {
   const userIds = useMemo(
     () => reactions.flatMap((reaction) => reaction.userIds ?? []),
     [reactions],
   )
-  const details = useReactionDetails({ messageId, open: true, userIds })
+  const details = useReactionDetails({ messageId, open, userIds })
   const selectedReaction = reactions.find((reaction) => reaction.emoji === selectedEmoji)
   const actors = new Map(details.data?.actors.map((actor) => [actor.userId, actor]))
   const reactionRailKey = reactions.map((reaction) => `${reaction.emoji}\0${reaction.count}`).join("\0")
@@ -220,7 +220,7 @@ function ReactionDetailsDialog({
   return (
     <DialogContent
       data-testid={tid.reactionDialog(messageId)}
-      finalFocus={finalFocus}
+      finalFocus={false}
       className="flex max-h-[calc(100dvh-2rem-env(safe-area-inset-top)-env(safe-area-inset-bottom))] flex-col gap-3 overflow-hidden transition-none sm:max-w-sm **:data-[slot=dialog-close]:size-11 **:data-[slot=dialog-close]:transition-none sm:**:data-[slot=dialog-close]:size-7"
     >
       <DialogHeader className="min-w-0 shrink-0">
@@ -304,6 +304,15 @@ export function resolveReactionFinalFocus(
   return initiatingChip?.isConnected ? initiatingChip : reactionGroup
 }
 
+export function restoreReactionFocus(
+  initiatingChip: HTMLButtonElement | null,
+  reactionGroup: HTMLDivElement | null,
+): HTMLElement | null {
+  const target = resolveReactionFinalFocus(initiatingChip, reactionGroup)
+  target?.focus({ preventScroll: true })
+  return target
+}
+
 export function MessageReactions({
   messageId,
   authorName,
@@ -374,21 +383,21 @@ export function MessageReactions({
       <Dialog
         open={open}
         onOpenChange={setOpen}
+        onOpenChangeComplete={(nextOpen) => {
+          if (!nextOpen) {
+            restoreReactionFocus(initiatingChipRef.current, reactionGroupRef.current)
+          }
+        }}
       >
-        {open && (
-          <ReactionDetailsDialog
-            messageId={messageId}
-            authorName={authorName}
-            messagePreview={messagePreview || "Message"}
-            reactions={reactions}
-            selectedEmoji={selectedEmoji}
-            onSelectedEmojiChange={setSelectedEmoji}
-            finalFocus={() => resolveReactionFinalFocus(
-              initiatingChipRef.current,
-              reactionGroupRef.current,
-            )}
-          />
-        )}
+        <ReactionDetailsDialog
+          open={open}
+          messageId={messageId}
+          authorName={authorName}
+          messagePreview={messagePreview || "Message"}
+          reactions={reactions}
+          selectedEmoji={selectedEmoji}
+          onSelectedEmojiChange={setSelectedEmoji}
+        />
       </Dialog>
     </>
   )

--- a/src/web/src/components/community/messages/message.render.test.ts
+++ b/src/web/src/components/community/messages/message.render.test.ts
@@ -11,6 +11,7 @@ import {
   messageLinkClickUsesMenu,
   messageLinkPointerType,
   selectionBelongsToRow,
+  shouldAdoptDesktopMenuInput,
   shouldActivateMessageOverlays,
   shouldSuppressTouchMenuOpen,
 } from "./message"
@@ -1345,6 +1346,48 @@ describe("Message file attachment", () => {
 })
 
 describe("Message lazy overlays", () => {
+  it("does not swap menu shells when portal close reveals the pointer over restored focus", () => {
+    const focused = {} as Element
+    const row = { contains: vi.fn((target: Node | null) => target === focused) }
+
+    expect(shouldAdoptDesktopMenuInput("mouse", row, focused)).toBe(false)
+    expect(shouldAdoptDesktopMenuInput("mouse", row, null)).toBe(true)
+    expect(shouldAdoptDesktopMenuInput("touch", row, null)).toBe(false)
+  })
+
+  it("keeps coarse swipe reply available after the row sees mouse input", () => {
+    let renderer: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(
+        makeTree({
+          m: baseMsg(),
+          hoverCapable: false,
+          onOpenThread: vi.fn(),
+          onReply: vi.fn(),
+        }),
+        { createNodeMock: () => genericMock },
+      )
+    })
+
+    let row = renderer!.root.find(
+      (node) => typeof node.props.className === "string"
+        && node.props.className.includes("group relative -mx-2"),
+    )
+    act(() => row.props.onPointerEnter({
+      target: { closest: vi.fn(() => null) },
+      currentTarget: genericMock,
+      nativeEvent: { type: "pointerenter", pointerType: "mouse" },
+    }))
+    row = renderer!.root.find(
+      (node) => typeof node.props.className === "string"
+        && node.props.className.includes("group relative -mx-2"),
+    )
+
+    expect(row.props.onPointerDown).toBeTypeOf("function")
+    expect(row.props.onPointerMove).toBeTypeOf("function")
+    expect(row.props.onPointerUp).toBeTypeOf("function")
+  })
+
   it("does not remount the row when the pointer enters an author button", () => {
     const interactiveTarget = { closest: vi.fn(() => ({})) }
     const rowTarget = { closest: vi.fn(() => null) }

--- a/src/web/src/components/community/messages/message.render.test.ts
+++ b/src/web/src/components/community/messages/message.render.test.ts
@@ -349,10 +349,12 @@ describe("Message embed links", () => {
 
 describe("Message ordinary-link gesture ownership", () => {
   const secondHref = "https://example.com/second/path?from=message&mode=full#details"
+  const linkAnchor = { href: secondHref, getAttribute: () => secondHref }
   const linkEventTarget = {
-    closest: (selector: string) => selector === "a[data-message-external-link]"
-      ? { href: secondHref }
-      : null,
+    closest: (selector: string) => (
+      selector === "a[data-message-external-link]"
+      || selector === "button, a, input, textarea, select, [role=button]"
+    ) ? linkAnchor : null,
   }
   const findRow = (renderer: TestRenderer.ReactTestRenderer) => renderer.root.find(
     (node) => typeof node.props.className === "string"
@@ -381,6 +383,12 @@ describe("Message ordinary-link gesture ownership", () => {
     })).toBe(true)
     expect(messageLinkClickUsesMenu({
       clickPointerType: null, capturedPointerType: null, hoverCapable: true,
+    })).toBe(false)
+    expect(messageLinkClickUsesMenu({
+      clickPointerType: null,
+      capturedPointerType: null,
+      hoverCapable: false,
+      desktopInputSeen: true,
     })).toBe(false)
   })
 
@@ -422,7 +430,9 @@ describe("Message ordinary-link gesture ownership", () => {
     expect(renderer!.root.findAllByProps({ "data-slot": "dropdown-menu-separator" })).toHaveLength(0)
   })
 
-  it("switches a touch-default fallback to the desktop menu for keyboard input", async () => {
+  it("keeps keyboard Enter direct on a touch-default fallback", async () => {
+    const openUrl = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal("window", { __TAURI__: { opener: { openUrl } } })
     let renderer: TestRenderer.ReactTestRenderer
     await act(async () => {
       renderer = TestRenderer.create(makeTree({
@@ -432,14 +442,36 @@ describe("Message ordinary-link gesture ownership", () => {
         onCopy: vi.fn(),
       }), { createNodeMock: () => genericMock })
     })
-    let row = findRow(renderer!)
+    const row = findRow(renderer!)
     act(() => row.props.onKeyDownCapture({
-      key: "ContextMenu",
-      target: { closest: () => null },
+      key: "Enter",
+      target: linkEventTarget,
     }))
-    row = findRow(renderer!)
 
-    expect(row.props["data-slot"]).toBe("context-menu-trigger")
+    const anchor = renderer!.root.findAllByType("a")
+      .find((node) => node.props.href === secondHref)
+    expect(anchor).toBeDefined()
+    const click = {
+      button: 0,
+      clientX: 0,
+      clientY: 0,
+      defaultPrevented: false,
+      target: linkEventTarget,
+      nativeEvent: { type: "click" },
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    }
+    await act(async () => {
+      row.props.onClickCapture(click)
+      anchor!.props.onClick(click)
+      await Promise.resolve()
+    })
+
+    expect(click.preventDefault).toHaveBeenCalledOnce()
+    expect(click.stopPropagation).toHaveBeenCalledOnce()
+    expect(openUrl).toHaveBeenCalledOnce()
+    expect(openUrl).toHaveBeenCalledWith(secondHref)
+    expect(renderer!.root.findAllByProps({ "data-slot": "dropdown-menu-separator" })).toHaveLength(0)
   })
 
   it("opens the existing menu first for a real touch tap on a hover-capable hybrid", async () => {
@@ -520,7 +552,7 @@ describe("Message ordinary-link gesture ownership", () => {
     })
     let row = findRow(renderer!)
     act(() => row.props.onPointerEnter({
-      target: { closest: () => null },
+      target: linkEventTarget,
       nativeEvent: { type: "pointerenter", pointerType: "mouse" },
     }))
     row = findRow(renderer!)

--- a/src/web/src/components/community/messages/message.render.test.ts
+++ b/src/web/src/components/community/messages/message.render.test.ts
@@ -7,6 +7,7 @@ import {
   createMessageMenuPointAnchor,
   Message,
   messageCanShare,
+  messageEventBelongsToRow,
   messageLinkClickUsesMenu,
   messageLinkPointerType,
   selectionBelongsToRow,
@@ -140,6 +141,40 @@ vi.mock("@/components/ui/dropdown-menu", async (importOriginal) => {
       }),
   }
 })
+
+vi.mock("@/components/ui/dialog", async () => {
+  const ReactModule = await import("react")
+  const component = (type: string, slot: string) => ({
+    children,
+    ...props
+  }: {
+    children?: React.ReactNode
+    [key: string]: unknown
+  }) => ReactModule.createElement(type, { ...props, "data-slot": slot }, children)
+  return {
+    Dialog: component("mock-dialog", "dialog"),
+    DialogContent: component("mock-dialog-content", "dialog-content"),
+    DialogDescription: component("mock-dialog-description", "dialog-description"),
+    DialogHeader: component("mock-dialog-header", "dialog-header"),
+    DialogTitle: component("mock-dialog-title", "dialog-title"),
+  }
+})
+
+vi.mock("@/components/ui/tabs", async () => {
+  const ReactModule = await import("react")
+  return {
+    Tabs: ({ children, ...props }: { children?: React.ReactNode }) =>
+      ReactModule.createElement("mock-tabs", props, children),
+    TabsList: ({ children, ...props }: { children?: React.ReactNode }) =>
+      ReactModule.createElement("mock-tabs-list", props, children),
+    TabsTrigger: ({ children, ...props }: { children?: React.ReactNode }) =>
+      ReactModule.createElement("button", { ...props, "data-slot": "tabs-trigger" }, children),
+  }
+})
+
+vi.mock("@/hooks/community/use-reaction-details", () => ({
+  useReactionDetails: () => ({ data: { actors: [] }, isLoading: false }),
+}))
 
 // WS3 render-behavior tests (see plans/community-switch-perf-optimization.md):
 // - the custom memo comparator bails out despite the per-render `m` clone,
@@ -362,6 +397,12 @@ describe("Message ordinary-link gesture ownership", () => {
   )
 
   it("derives actual touch/mouse modality before using hover capability as fallback", () => {
+    const ownedTarget = {} as EventTarget
+    const portalTarget = {} as EventTarget
+    const rowOwner = { contains: (target: Node | null) => target === ownedTarget }
+    expect(messageEventBelongsToRow(ownedTarget, rowOwner)).toBe(true)
+    expect(messageEventBelongsToRow(portalTarget, rowOwner)).toBe(false)
+
     expect(messageLinkPointerType({ type: "click", pointerType: "touch" })).toBe("touch")
     expect(messageLinkPointerType({
       type: "click",
@@ -575,6 +616,106 @@ describe("Message ordinary-link gesture ownership", () => {
   })
 })
 
+describe("Message portal event ownership", () => {
+  it("keeps a reaction dialog mounted and ignores its pointer, click, and swipe events", async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal("window", { getSelection: () => null })
+    vi.stubGlobal("navigator", { vibrate: vi.fn() })
+    const onReply = vi.fn()
+    let renderer: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(makeTree({
+        m: baseMsg({
+          content: "portal ownership",
+          reactions: [{ emoji: "🔥", count: 1, me: false, userIds: ["u2"] }],
+        }),
+        hoverCapable: false,
+        onOpenThread: vi.fn(),
+        onCopy: vi.fn(),
+        onReply,
+        onToggleReaction: vi.fn(),
+      }), { createNodeMock: () => genericMock })
+    })
+
+    const chip = renderer!.root.findAllByType("button")
+      .find((button) => textContent(button).includes("🔥") && button.props.onPointerDown)
+    expect(chip).toBeDefined()
+    act(() => chip!.props.onPointerDown({
+      pointerType: "touch",
+      clientX: 20,
+      clientY: 20,
+      stopPropagation: vi.fn(),
+    }))
+    await act(async () => {
+      vi.advanceTimersByTime(451)
+      await Promise.resolve()
+    })
+    expect(renderer!.root.findAllByType("mock-dialog-content")).toHaveLength(1)
+
+    const row = renderer!.root.find(
+      (node) => typeof node.props.className === "string"
+        && node.props.className.includes("group relative -mx-2"),
+    )
+    const portalTarget = { closest: () => null, matches: () => false }
+    const rowElement = {
+      contains: (target: unknown) => target !== portalTarget,
+      setPointerCapture: vi.fn(),
+    }
+    const preventDefault = vi.fn()
+    const stopPropagation = vi.fn()
+
+    act(() => row.props.onPointerEnter({
+      target: portalTarget,
+      currentTarget: rowElement,
+      nativeEvent: { type: "pointerenter", pointerType: "mouse" },
+    }))
+    act(() => row.props.onClickCapture({
+      target: portalTarget,
+      currentTarget: rowElement,
+      nativeEvent: { type: "click" },
+      preventDefault,
+      stopPropagation,
+    }))
+    act(() => row.props.onClick({
+      clientX: 25,
+      clientY: 25,
+      target: portalTarget,
+      currentTarget: rowElement,
+      nativeEvent: { composedPath: () => [portalTarget] },
+    }))
+    act(() => row.props.onPointerDown({
+      pointerType: "touch",
+      pointerId: 77,
+      clientX: 20,
+      clientY: 20,
+      target: portalTarget,
+      currentTarget: rowElement,
+    }))
+    act(() => row.props.onPointerMove({
+      pointerType: "touch",
+      pointerId: 77,
+      clientX: 92,
+      clientY: 22,
+      target: portalTarget,
+      currentTarget: rowElement,
+      preventDefault,
+    }))
+    act(() => row.props.onPointerUp({
+      pointerType: "touch",
+      clientX: 92,
+      clientY: 22,
+      target: portalTarget,
+      currentTarget: rowElement,
+    }))
+
+    expect(renderer!.root.findAllByType("mock-dialog-content")).toHaveLength(1)
+    expect(renderer!.root.findByType("mock-dropdown-menu").props.open).toBe(false)
+    expect(onReply).not.toHaveBeenCalled()
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(stopPropagation).not.toHaveBeenCalled()
+  })
+})
+
 describe("Message reaction picker", () => {
   it("opens the non-hover picker and suppresses its Shadow DOM selection click at the row", async () => {
     vi.stubGlobal("window", { getSelection: () => null })
@@ -737,18 +878,24 @@ describe("Message touch action menu", () => {
       (node) => typeof node.props.className === "string"
         && node.props.className.includes("group relative -mx-2"),
     )
-    const currentTarget = { contains: () => false, setPointerCapture: vi.fn() }
+    const ownedTarget = { closest: () => null }
+    const currentTarget = {
+      contains: (target: unknown) => target === ownedTarget,
+      setPointerCapture: vi.fn(),
+    }
     act(() => row.props.onPointerDown({
       pointerType: "touch", clientX: 80, clientY: 100,
-      target: { closest: () => null }, currentTarget,
+      target: ownedTarget, currentTarget,
     }))
     act(() => row.props.onPointerMove({
       pointerType: "touch", pointerId: 1, clientX: 148, clientY: 102,
-      currentTarget, preventDefault: vi.fn(),
+      target: ownedTarget, currentTarget, preventDefault: vi.fn(),
     }))
     expect(renderer!.root.findByProps({ "data-mobile-reply-affordance": true }).props)
       .toMatchObject({ "data-threshold-crossed": true })
-    act(() => row.props.onPointerUp({ pointerType: "touch" }))
+    act(() => row.props.onPointerUp({
+      pointerType: "touch", target: ownedTarget, currentTarget,
+    }))
     expect(onReply).toHaveBeenCalledOnce()
     expect(vibrate).toHaveBeenCalledOnce()
     expect(currentTarget.setPointerCapture).toHaveBeenCalledWith(1)
@@ -770,16 +917,22 @@ describe("Message touch action menu", () => {
       (node) => typeof node.props.className === "string"
         && node.props.className.includes("group relative -mx-2"),
     )
-    const currentTarget = { contains: () => false, setPointerCapture: vi.fn() }
+    const ownedTarget = { closest: () => null }
+    const currentTarget = {
+      contains: (target: unknown) => target === ownedTarget,
+      setPointerCapture: vi.fn(),
+    }
     act(() => row.props.onPointerDown({
       pointerType: "touch", clientX: 80, clientY: 100,
-      target: { closest: () => null }, currentTarget,
+      target: ownedTarget, currentTarget,
     }))
     act(() => row.props.onPointerMove({
       pointerType: "touch", pointerId: 1, clientX: 86, clientY: 130,
-      currentTarget, preventDefault: vi.fn(),
+      target: ownedTarget, currentTarget, preventDefault: vi.fn(),
     }))
-    act(() => row.props.onPointerUp({ pointerType: "touch" }))
+    act(() => row.props.onPointerUp({
+      pointerType: "touch", target: ownedTarget, currentTarget,
+    }))
     expect(onReply).not.toHaveBeenCalled()
     expect(vibrate).not.toHaveBeenCalled()
   })
@@ -801,13 +954,14 @@ describe("Message touch action menu", () => {
       (node) => typeof node.props.className === "string"
         && node.props.className.includes("group relative -mx-2"),
     )
+    const ownedTarget = { closest: () => null }
     const currentTarget = {
-      contains: (node: unknown) => node === selectedNode,
+      contains: (node: unknown) => node === ownedTarget || node === selectedNode,
       setPointerCapture: vi.fn(),
     }
     act(() => row.props.onPointerDown({
       pointerType: "touch", clientX: 80, clientY: 100,
-      target: { closest: () => null }, currentTarget,
+      target: ownedTarget, currentTarget,
     }))
     selection = {
       isCollapsed: false,
@@ -816,9 +970,11 @@ describe("Message touch action menu", () => {
     }
     act(() => row.props.onPointerMove({
       pointerType: "touch", pointerId: 1, clientX: 150, clientY: 102,
-      currentTarget, preventDefault: vi.fn(),
+      target: ownedTarget, currentTarget, preventDefault: vi.fn(),
     }))
-    act(() => row.props.onPointerUp({ pointerType: "touch" }))
+    act(() => row.props.onPointerUp({
+      pointerType: "touch", target: ownedTarget, currentTarget,
+    }))
     expect(onReply).not.toHaveBeenCalled()
     expect(vibrate).not.toHaveBeenCalled()
     expect(currentTarget.setPointerCapture).not.toHaveBeenCalled()
@@ -952,12 +1108,16 @@ describe("Message touch action menu", () => {
       (node) => typeof node.props.className === "string"
         && node.props.className.includes("group relative -mx-2"),
     )
+    const ownedTarget = { closest: () => null }
+    const currentTarget = {
+      contains: (target: unknown) => target === ownedTarget,
+    }
     await act(async () => {
       row.props.onClick({
         clientX: 271,
         clientY: 603,
-        currentTarget: { contains: () => false },
-        target: { closest: () => null },
+        currentTarget,
+        target: ownedTarget,
       })
     })
 

--- a/src/web/src/components/community/messages/message.render.test.ts
+++ b/src/web/src/components/community/messages/message.render.test.ts
@@ -7,6 +7,8 @@ import {
   createMessageMenuPointAnchor,
   Message,
   messageCanShare,
+  messageLinkClickUsesMenu,
+  messageLinkPointerType,
   selectionBelongsToRow,
   shouldActivateMessageOverlays,
   shouldSuppressTouchMenuOpen,
@@ -67,8 +69,8 @@ vi.mock("@/components/ui/tooltip", async () => {
 vi.mock("@/components/ui/context-menu", async () => {
   const ReactModule = await import("react")
   return {
-    ContextMenu: ({ children }: { children: React.ReactNode }) =>
-      ReactModule.createElement("mock-context-menu", null, children),
+    ContextMenu: ({ children, ...props }: { children: React.ReactNode }) =>
+      ReactModule.createElement("mock-context-menu", props, children),
     ContextMenuTrigger: ({
       render,
       ...props
@@ -76,6 +78,7 @@ vi.mock("@/components/ui/context-menu", async () => {
       render: React.ReactElement
     }) => ReactModule.cloneElement(render, {
       ...props,
+      className: [render.props.className, props.className].filter(Boolean).join(" "),
       "data-slot": "context-menu-trigger",
     } as React.HTMLAttributes<HTMLElement>),
     ContextMenuContent: ({ children }: { children: React.ReactNode }) =>
@@ -86,6 +89,11 @@ vi.mock("@/components/ui/context-menu", async () => {
     }: {
       children: React.ReactNode
     }) => ReactModule.createElement("button", { ...props, "data-slot": "context-menu-item" }, children),
+    ContextMenuSeparator: (props: Record<string, unknown>) =>
+      ReactModule.createElement("mock-context-menu-separator", {
+        ...props,
+        "data-slot": "context-menu-separator",
+      }),
   }
 })
 
@@ -94,6 +102,19 @@ vi.mock("@/components/ui/dropdown-menu", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/components/ui/dropdown-menu")>()
   return {
     ...actual,
+    DropdownMenu: ({ children, ...props }: { children: React.ReactNode }) =>
+      ReactModule.createElement("mock-dropdown-menu", props, children),
+    DropdownMenuTrigger: ({
+      render,
+      children,
+      ...props
+    }: {
+      render: React.ReactElement
+      children?: React.ReactNode
+    }) => ReactModule.cloneElement(render, {
+      ...props,
+      "data-slot": "dropdown-menu-trigger",
+    } as React.HTMLAttributes<HTMLElement>, children ?? render.props.children),
     DropdownMenuContent: ({
       children,
       ...props
@@ -112,6 +133,11 @@ vi.mock("@/components/ui/dropdown-menu", async (importOriginal) => {
       children: React.ReactNode
       [key: string]: unknown
     }) => ReactModule.createElement("button", { ...props, "data-slot": "dropdown-menu-item" }, children),
+    DropdownMenuSeparator: (props: Record<string, unknown>) =>
+      ReactModule.createElement("mock-dropdown-menu-separator", {
+        ...props,
+        "data-slot": "dropdown-menu-separator",
+      }),
   }
 })
 
@@ -318,6 +344,202 @@ describe("Message embed links", () => {
     expect(links.every((link) => (
       link.props.target === "_blank" && link.props.rel === "noopener noreferrer"
     ))).toBe(true)
+  })
+})
+
+describe("Message ordinary-link gesture ownership", () => {
+  const secondHref = "https://example.com/second/path?from=message&mode=full#details"
+  const linkEventTarget = {
+    closest: (selector: string) => selector === "a[data-message-external-link]"
+      ? { href: secondHref }
+      : null,
+  }
+  const findRow = (renderer: TestRenderer.ReactTestRenderer) => renderer.root.find(
+    (node) => typeof node.props.className === "string"
+      && node.props.className.includes("group relative -mx-2"),
+  )
+
+  it("derives actual touch/mouse modality before using hover capability as fallback", () => {
+    expect(messageLinkPointerType({ type: "click", pointerType: "touch" })).toBe("touch")
+    expect(messageLinkPointerType({
+      type: "click",
+      sourceCapabilities: { firesTouchEvents: true },
+    })).toBe("touch")
+    expect(messageLinkPointerType({ type: "click" })).toBeNull()
+
+    expect(messageLinkClickUsesMenu({
+      clickPointerType: "touch", capturedPointerType: "mouse", hoverCapable: true,
+    })).toBe(true)
+    expect(messageLinkClickUsesMenu({
+      clickPointerType: null, capturedPointerType: "pen", hoverCapable: true,
+    })).toBe(true)
+    expect(messageLinkClickUsesMenu({
+      clickPointerType: null, capturedPointerType: "mouse", hoverCapable: false,
+    })).toBe(false)
+    expect(messageLinkClickUsesMenu({
+      clickPointerType: null, capturedPointerType: null, hoverCapable: false,
+    })).toBe(true)
+    expect(messageLinkClickUsesMenu({
+      clickPointerType: null, capturedPointerType: null, hoverCapable: true,
+    })).toBe(false)
+  })
+
+  it("keeps mouse primary click direct on a touch-default device", async () => {
+    let renderer: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(makeTree({
+        m: baseMsg({ content: `first https://example.com/first second ${secondHref}` }),
+        hoverCapable: false,
+        onOpenThread: vi.fn(),
+        onCopy: vi.fn(),
+      }), { createNodeMock: () => genericMock })
+    })
+    let row = findRow(renderer!)
+    act(() => row.props.onPointerEnter({
+      target: { closest: () => null },
+      nativeEvent: { type: "pointerenter", pointerType: "mouse" },
+    }))
+    row = findRow(renderer!)
+    expect(row.props["data-slot"]).toBe("context-menu-trigger")
+    act(() => row.props.onPointerDownCapture({
+      button: 0,
+      target: linkEventTarget,
+      nativeEvent: { type: "pointerdown", pointerType: "mouse" },
+    }))
+    const preventDefault = vi.fn()
+    const stopPropagation = vi.fn()
+    act(() => row.props.onClickCapture({
+      clientX: 120,
+      clientY: 240,
+      target: linkEventTarget,
+      nativeEvent: { type: "click" },
+      preventDefault,
+      stopPropagation,
+    }))
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(stopPropagation).not.toHaveBeenCalled()
+    expect(renderer!.root.findAllByProps({ "data-slot": "dropdown-menu-separator" })).toHaveLength(0)
+  })
+
+  it("switches a touch-default fallback to the desktop menu for keyboard input", async () => {
+    let renderer: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(makeTree({
+        m: baseMsg({ content: secondHref }),
+        hoverCapable: false,
+        onOpenThread: vi.fn(),
+        onCopy: vi.fn(),
+      }), { createNodeMock: () => genericMock })
+    })
+    let row = findRow(renderer!)
+    act(() => row.props.onKeyDownCapture({
+      key: "ContextMenu",
+      target: { closest: () => null },
+    }))
+    row = findRow(renderer!)
+
+    expect(row.props["data-slot"]).toBe("context-menu-trigger")
+  })
+
+  it("opens the existing menu first for a real touch tap on a hover-capable hybrid", async () => {
+    const openWindow = vi.fn(() => ({} as Window))
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal("window", { open: openWindow })
+    vi.stubGlobal("navigator", { clipboard: { writeText } })
+    let renderer: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(makeTree({
+        m: baseMsg({ content: `first https://example.com/first second ${secondHref}` }),
+        hoverCapable: true,
+        onOpenThread: vi.fn(),
+        onCopy: vi.fn(),
+        onShareSingle: vi.fn(),
+      }), { createNodeMock: () => genericMock })
+    })
+    const row = findRow(renderer!)
+    act(() => row.props.onPointerDownCapture({
+      button: 0,
+      target: linkEventTarget,
+      nativeEvent: { type: "pointerdown", pointerType: "touch" },
+    }))
+    const preventDefault = vi.fn()
+    const stopPropagation = vi.fn()
+    await act(async () => {
+      row.props.onClickCapture({
+        clientX: 271,
+        clientY: 603,
+        target: linkEventTarget,
+        nativeEvent: { type: "click" },
+        preventDefault,
+        stopPropagation,
+      })
+    })
+
+    expect(preventDefault).toHaveBeenCalledOnce()
+    expect(stopPropagation).toHaveBeenCalledOnce()
+    const items = renderer!.root.findAllByProps({ "data-slot": "dropdown-menu-item" })
+    const labels = items.map((item) => textContent(item).trim())
+    expect(labels.slice(-3)).toEqual(["Share as Image", "Copy Link", "Open Link"])
+    expect(renderer!.root.findAllByProps({ "data-slot": "dropdown-menu-separator" })).toHaveLength(1)
+    const positioner = renderer!.root.find(
+      (node) => node.props.positionMethod === "fixed" && node.props.anchor,
+    )
+    expect(positioner.props.anchor.getBoundingClientRect()).toMatchObject({
+      x: 271,
+      y: 603,
+    })
+
+    await act(async () => {
+      items.find((item) => textContent(item).trim() === "Copy Link")?.props.onClick()
+      await Promise.resolve()
+    })
+    expect(writeText).toHaveBeenCalledWith(secondHref)
+    expect(openWindow).not.toHaveBeenCalled()
+
+    await act(async () => {
+      items.find((item) => textContent(item).trim() === "Open Link")?.props.onClick()
+      await Promise.resolve()
+    })
+    expect(openWindow).toHaveBeenCalledOnce()
+    expect(openWindow).toHaveBeenCalledWith(secondHref, "_blank", "noopener,noreferrer")
+  })
+
+  it("adds the link suffix only for the exact desktop secondary-click target and clears it", async () => {
+    const openWindow = vi.fn()
+    vi.stubGlobal("window", { open: openWindow })
+    let renderer: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(makeTree({
+        m: baseMsg({ content: `first https://example.com/first second ${secondHref}` }),
+        hoverCapable: false,
+        onOpenThread: vi.fn(),
+        onCopy: vi.fn(),
+        onShareSingle: vi.fn(),
+      }), { createNodeMock: () => genericMock })
+    })
+    let row = findRow(renderer!)
+    act(() => row.props.onPointerEnter({
+      target: { closest: () => null },
+      nativeEvent: { type: "pointerenter", pointerType: "mouse" },
+    }))
+    row = findRow(renderer!)
+    act(() => row.props.onContextMenuCapture({ target: linkEventTarget }))
+
+    let items = renderer!.root.findAllByProps({ "data-slot": "context-menu-item" })
+    expect(items.map((item) => textContent(item).trim()).slice(-3)).toEqual(["Share as Image", "Copy Link", "Open Link"])
+    expect(renderer!.root.findAllByProps({ "data-slot": "context-menu-separator" })).toHaveLength(1)
+    expect(openWindow).not.toHaveBeenCalled()
+
+    const contextMenu = renderer!.root.findByType("mock-context-menu")
+    act(() => contextMenu.props.onOpenChange(false))
+    items = renderer!.root.findAllByProps({ "data-slot": "context-menu-item" })
+    expect(items.map((item) => textContent(item).trim())).not.toContain("Copy Link")
+    expect(items.map((item) => textContent(item).trim())).not.toContain("Open Link")
+
+    row = findRow(renderer!)
+    act(() => row.props.onContextMenuCapture({ target: { closest: () => null } }))
+    expect(renderer!.root.findAllByProps({ "data-slot": "context-menu-separator" })).toHaveLength(0)
   })
 })
 
@@ -799,7 +1021,7 @@ describe("Message desktop text selection", () => {
     expect(selectionBelongsToRow(null, rowElement)).toBe(false)
   })
 
-  it("delegates desktop selection contextmenu policy to the authenticated boundary", () => {
+  it("observes the desktop context target without taking over authenticated contextmenu policy", () => {
     let renderer: TestRenderer.ReactTestRenderer
     act(() => {
       renderer = TestRenderer.create(makeTree({
@@ -814,7 +1036,15 @@ describe("Message desktop text selection", () => {
         && node.props.className.includes("group relative -mx-2"),
     )
 
-    expect(row.props.onContextMenuCapture).toBeUndefined()
+    const preventDefault = vi.fn()
+    const stopPropagation = vi.fn()
+    act(() => row.props.onContextMenuCapture({
+      target: { closest: () => null },
+      preventDefault,
+      stopPropagation,
+    }))
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(stopPropagation).not.toHaveBeenCalled()
     act(() => renderer!.unmount())
   })
 })

--- a/src/web/src/components/community/messages/message.tsx
+++ b/src/web/src/components/community/messages/message.tsx
@@ -129,15 +129,17 @@ export function messageLinkClickUsesMenu({
   clickPointerType,
   capturedPointerType,
   hoverCapable,
+  desktopInputSeen = false,
 }: {
   clickPointerType: string | null
   capturedPointerType: string | null
   hoverCapable: boolean
+  desktopInputSeen?: boolean
 }): boolean {
   const pointerType = clickPointerType ?? capturedPointerType
   if (pointerType === "touch" || pointerType === "pen") return true
   if (pointerType === "mouse") return false
-  return !hoverCapable
+  return !(hoverCapable || desktopInputSeen)
 }
 
 function MessageImpl({
@@ -220,6 +222,7 @@ function MessageImpl({
     href: string
     pointerType: string | null
   } | null>(null)
+  const keyboardLinkActivationRef = useRef(false)
   const touchStartedAt = useRef<number | null>(null)
   const suppressLongPressClick = useRef(false)
   const swipeGestureRef = useRef<MobileReplyGesture | null>(null)
@@ -288,12 +291,21 @@ function MessageImpl({
         if (shouldActivateMessageOverlays(event.target)) setActivated(true)
       }
     : undefined
+  const activateLinkOrOverlays = interactive && !activated
+    ? (event: React.SyntheticEvent<HTMLElement>) => {
+        if (messageExternalLinkTargetFromEventTarget(event.target)) {
+          setActivated(true)
+        } else {
+          activateOverlays?.(event)
+        }
+      }
+    : undefined
   const activate = interactive
     ? (event: React.PointerEvent<HTMLElement>) => {
         const pointerType = messageLinkPointerType(event.nativeEvent)
         if (pointerType === "mouse") {
           setDesktopMenuInputSeen(true)
-          activateOverlays?.(event)
+          activateLinkOrOverlays?.(event)
         } else if (hoverCapable) {
           activateOverlays?.(event)
         }
@@ -301,8 +313,20 @@ function MessageImpl({
     : undefined
   const activateFromKeyboard = interactive
     ? (event: React.KeyboardEvent<HTMLElement>) => {
+        if (
+          (event.key === "Enter" || event.key === " ")
+          && !shouldActivateMessageOverlays(event.target)
+        ) {
+          // Keep nested controls mounted so the browser can dispatch their
+          // synthesized click after keydown. For an ordinary external link,
+          // the capture handler consumes this modality ref and leaves the
+          // click direct; relative/in-app controls remain untouched too.
+          keyboardLinkActivationRef.current = !!messageExternalLinkTargetFromEventTarget(event.target)
+          return
+        }
+        keyboardLinkActivationRef.current = false
         setDesktopMenuInputSeen(true)
-        activateOverlays?.(event)
+        activateLinkOrOverlays?.(event)
       }
     : undefined
   // In select mode (multi-share), the whole row is a big toggle target and gets
@@ -347,6 +371,7 @@ function MessageImpl({
       onPointerEnter={activate}
       onPointerDownCapture={interactive
         ? (event) => {
+            keyboardLinkActivationRef.current = false
             const target = messageExternalLinkTargetFromEventTarget(event.target)
             linkPointerRef.current = target && event.button === 0
               ? { href: target.href, pointerType: messageLinkPointerType(event.nativeEvent) }
@@ -472,16 +497,20 @@ function MessageImpl({
             const target = messageExternalLinkTargetFromEventTarget(event.target)
             if (!target) {
               linkPointerRef.current = null
+              keyboardLinkActivationRef.current = false
               return
             }
             const capturedPointer = linkPointerRef.current?.href === target.href
               ? linkPointerRef.current.pointerType
               : null
             linkPointerRef.current = null
+            const keyboardInputSeen = keyboardLinkActivationRef.current
+            keyboardLinkActivationRef.current = false
             if (!messageLinkClickUsesMenu({
               clickPointerType: messageLinkPointerType(event.nativeEvent),
               capturedPointerType: capturedPointer,
               hoverCapable,
+              desktopInputSeen: desktopMenuInputSeen || keyboardInputSeen,
             })) return
 
             event.preventDefault()

--- a/src/web/src/components/community/messages/message.tsx
+++ b/src/web/src/components/community/messages/message.tsx
@@ -11,7 +11,13 @@ import { ContextMenu, ContextMenuTrigger, ContextMenuContent } from "@/component
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent } from "@/components/ui/dropdown-menu"
 import { Avatar } from "../avatar"
 import { MessageBody } from "./message-body"
-import { MessageExternalLink } from "./message-external-link"
+import {
+  copyMessageExternalLink,
+  messageExternalLinkTargetFromEventTarget,
+  MessageExternalLink,
+  openMessageExternalLink,
+  type MessageExternalLinkTarget,
+} from "./message-external-link"
 import { BotApprovalCard } from "../social/bot-approval-card"
 import { EmojiPickerPopover } from "./emoji-picker"
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip"
@@ -107,6 +113,33 @@ export function createMessageMenuPointAnchor(clientX: number, clientY: number) {
   return { getBoundingClientRect: () => rect }
 }
 
+export function messageLinkPointerType(
+  event: Pick<Event, "type"> & {
+    pointerType?: unknown
+    sourceCapabilities?: { firesTouchEvents?: boolean } | null
+  } | null | undefined,
+): string | null {
+  if (!event) return null
+  if (typeof event.pointerType === "string" && event.pointerType) return event.pointerType
+  if (event.sourceCapabilities?.firesTouchEvents) return "touch"
+  return null
+}
+
+export function messageLinkClickUsesMenu({
+  clickPointerType,
+  capturedPointerType,
+  hoverCapable,
+}: {
+  clickPointerType: string | null
+  capturedPointerType: string | null
+  hoverCapable: boolean
+}): boolean {
+  const pointerType = clickPointerType ?? capturedPointerType
+  if (pointerType === "touch" || pointerType === "pen") return true
+  if (pointerType === "mouse") return false
+  return !hoverCapable
+}
+
 function MessageImpl({
   m, compact, pinned, onOpenThread, onOpenProfile, onJumpReply,
   onToggleReaction, onReact, onReply, onMentionAuthor, onPin, onMark, onCreateThread, onCopy, onEdit, onRetry, onDismiss,
@@ -181,6 +214,12 @@ function MessageImpl({
   // the browser so message text keeps native selection/copy behavior.
   const [touchMenuOpen, setTouchMenuOpen] = useState(false)
   const [touchMenuAnchor, setTouchMenuAnchor] = useState<ReturnType<typeof createMessageMenuPointAnchor> | null>(null)
+  const [linkTarget, setLinkTarget] = useState<MessageExternalLinkTarget | null>(null)
+  const [desktopMenuInputSeen, setDesktopMenuInputSeen] = useState(false)
+  const linkPointerRef = useRef<{
+    href: string
+    pointerType: string | null
+  } | null>(null)
   const touchStartedAt = useRef<number | null>(null)
   const suppressLongPressClick = useRef(false)
   const swipeGestureRef = useRef<MobileReplyGesture | null>(null)
@@ -231,12 +270,39 @@ function MessageImpl({
     // (context-sheet). Undefined only when the surface wired NEITHER.
     onShare: canShare ? (onEnterSelect ?? onShareSingle) : undefined,
   }
+  const linkMenuHandlers = {
+    linkTarget,
+    onCopyLink: (target: MessageExternalLinkTarget) => {
+      void copyMessageExternalLink(target)
+    },
+    onOpenLink: (target: MessageExternalLinkTarget) => {
+      void openMessageExternalLink(target)
+    },
+  }
   const showMenu = hasMessageMenu(menuHandlers)
   const interactive = !compact && !m.failed && showMenu
-  const swipeReplyEnabled = interactive && !hoverCapable && !selectMode && !!onReply
-  const activate = interactive && hoverCapable && !activated
+  const touchFallbackActive = !desktopMenuInputSeen && !hoverCapable
+  const swipeReplyEnabled = interactive && touchFallbackActive && !selectMode && !!onReply
+  const activateOverlays = interactive && !activated
     ? (event: React.SyntheticEvent<HTMLElement>) => {
         if (shouldActivateMessageOverlays(event.target)) setActivated(true)
+      }
+    : undefined
+  const activate = interactive
+    ? (event: React.PointerEvent<HTMLElement>) => {
+        const pointerType = messageLinkPointerType(event.nativeEvent)
+        if (pointerType === "mouse") {
+          setDesktopMenuInputSeen(true)
+          activateOverlays?.(event)
+        } else if (hoverCapable) {
+          activateOverlays?.(event)
+        }
+      }
+    : undefined
+  const activateFromKeyboard = interactive
+    ? (event: React.KeyboardEvent<HTMLElement>) => {
+        setDesktopMenuInputSeen(true)
+        activateOverlays?.(event)
       }
     : undefined
   // In select mode (multi-share), the whole row is a big toggle target and gets
@@ -279,6 +345,19 @@ function MessageImpl({
         ? { transform: `translate3d(${swipeVisual.offset}px, 0, 0)` }
         : undefined}
       onPointerEnter={activate}
+      onPointerDownCapture={interactive
+        ? (event) => {
+            const target = messageExternalLinkTargetFromEventTarget(event.target)
+            linkPointerRef.current = target && event.button === 0
+              ? { href: target.href, pointerType: messageLinkPointerType(event.nativeEvent) }
+              : null
+          }
+        : undefined}
+      onPointerCancelCapture={interactive
+        ? () => {
+            linkPointerRef.current = null
+          }
+        : undefined}
       onPointerDown={swipeReplyEnabled
         ? (event) => {
             if (event.pointerType !== "touch") return
@@ -336,15 +415,15 @@ function MessageImpl({
             setSwipeVisual({ offset: 0, active: false, crossed: false })
           }
         : undefined}
-      onFocusCapture={activate}
-      onKeyDownCapture={activate}
-      onTouchStart={interactive && !hoverCapable
+      onFocusCapture={hoverCapable ? activateOverlays : undefined}
+      onKeyDownCapture={activateFromKeyboard}
+      onTouchStart={interactive && touchFallbackActive
           ? () => {
             touchStartedAt.current = performance.now()
             suppressLongPressClick.current = false
           }
         : undefined}
-      onTouchEnd={interactive && !hoverCapable
+      onTouchEnd={interactive && touchFallbackActive
         ? () => {
             const startedAt = touchStartedAt.current
             suppressLongPressClick.current = suppressLongPressClick.current || (
@@ -353,7 +432,7 @@ function MessageImpl({
             touchStartedAt.current = null
           }
         : undefined}
-      onTouchCancel={interactive && !hoverCapable
+      onTouchCancel={interactive && touchFallbackActive
           ? () => {
             touchStartedAt.current = null
             suppressLongPressClick.current = true
@@ -361,7 +440,7 @@ function MessageImpl({
         : undefined}
       onClick={selectable
         ? onToggleSelect
-        : interactive && !hoverCapable
+        : interactive && touchFallbackActive
           ? (event) => {
             const selection = window.getSelection()
             const selectionInsideRow = selectionBelongsToRow(selection, event.currentTarget)
@@ -386,6 +465,35 @@ function MessageImpl({
               setTouchMenuAnchor(createMessageMenuPointAnchor(event.clientX, event.clientY))
               setTouchMenuOpen(true)
             }
+          }
+        : undefined}
+      onClickCapture={interactive
+        ? (event) => {
+            const target = messageExternalLinkTargetFromEventTarget(event.target)
+            if (!target) {
+              linkPointerRef.current = null
+              return
+            }
+            const capturedPointer = linkPointerRef.current?.href === target.href
+              ? linkPointerRef.current.pointerType
+              : null
+            linkPointerRef.current = null
+            if (!messageLinkClickUsesMenu({
+              clickPointerType: messageLinkPointerType(event.nativeEvent),
+              capturedPointerType: capturedPointer,
+              hoverCapable,
+            })) return
+
+            event.preventDefault()
+            event.stopPropagation()
+            setLinkTarget(target)
+            setTouchMenuAnchor(createMessageMenuPointAnchor(event.clientX, event.clientY))
+            setTouchMenuOpen(true)
+          }
+        : undefined}
+      onContextMenuCapture={interactive
+        ? (event) => {
+            setLinkTarget(messageExternalLinkTargetFromEventTarget(event.target))
           }
         : undefined}
     >
@@ -661,9 +769,15 @@ function MessageImpl({
   // Coarse/touch input: tap opens the existing dropdown menu. Deliberately do
   // not mount ContextMenuTrigger here — its long-press gesture competes with
   // native message-text selection on iOS/Android.
-  if (!hoverCapable) {
+  if (touchFallbackActive || touchMenuOpen) {
     return (
-      <DropdownMenu open={touchMenuOpen} onOpenChange={setTouchMenuOpen}>
+      <DropdownMenu
+        open={touchMenuOpen}
+        onOpenChange={(open) => {
+          setTouchMenuOpen(open)
+          if (!open) setLinkTarget(null)
+        }}
+      >
         <div className="relative">
           {swipeReplyEnabled && (
             <div
@@ -697,7 +811,7 @@ function MessageImpl({
           collisionAvoidance={{ side: "flip", align: "shift", fallbackAxisSide: "none" }}
           className="w-48 select-none"
         >
-          <MessageDropdownItems {...menuHandlers} touch />
+          <MessageDropdownItems {...menuHandlers} {...linkMenuHandlers} touch />
         </DropdownMenuContent>
       </DropdownMenu>
     )
@@ -713,10 +827,15 @@ function MessageImpl({
   // In select mode the row is a toggle target — no context menu / toolbar.
   if (!activated) return row
   return (
-    <ContextMenu onOpenChange={setContextOpen}>
+    <ContextMenu
+      onOpenChange={(open) => {
+        setContextOpen(open)
+        if (!open) setLinkTarget(null)
+      }}
+    >
       <ContextMenuTrigger className="select-text" render={row} />
       <ContextMenuContent className="w-48">
-        <MessageContextItems {...menuHandlers} />
+        <MessageContextItems {...menuHandlers} {...linkMenuHandlers} />
       </ContextMenuContent>
     </ContextMenu>
   )

--- a/src/web/src/components/community/messages/message.tsx
+++ b/src/web/src/components/community/messages/message.tsx
@@ -65,6 +65,17 @@ export function shouldActivateMessageOverlays(target: EventTarget | null): boole
   return !element?.closest?.("button, a, input, textarea, select, [role=button]")
 }
 
+export function messageEventBelongsToRow(
+  target: EventTarget | null,
+  row: { contains?: (target: Node | null) => boolean } | null,
+): boolean {
+  // React portal events follow the component tree, so they can reach the
+  // message row even though their DOM target lives in an overlay elsewhere.
+  // Real row elements always expose `contains`; the fallback keeps lightweight
+  // non-DOM event doubles compatible with these pure render tests.
+  return typeof row?.contains !== "function" || row.contains(target as Node | null)
+}
+
 export function shouldSuppressTouchMenuOpen({
   nestedControl,
   selectionInsideRow,
@@ -302,6 +313,7 @@ function MessageImpl({
     : undefined
   const activate = interactive
     ? (event: React.PointerEvent<HTMLElement>) => {
+        if (!messageEventBelongsToRow(event.target, event.currentTarget)) return
         const pointerType = messageLinkPointerType(event.nativeEvent)
         if (pointerType === "mouse") {
           setDesktopMenuInputSeen(true)
@@ -313,6 +325,7 @@ function MessageImpl({
     : undefined
   const activateFromKeyboard = interactive
     ? (event: React.KeyboardEvent<HTMLElement>) => {
+        if (!messageEventBelongsToRow(event.target, event.currentTarget)) return
         if (
           (event.key === "Enter" || event.key === " ")
           && !shouldActivateMessageOverlays(event.target)
@@ -371,6 +384,7 @@ function MessageImpl({
       onPointerEnter={activate}
       onPointerDownCapture={interactive
         ? (event) => {
+            if (!messageEventBelongsToRow(event.target, event.currentTarget)) return
             keyboardLinkActivationRef.current = false
             const target = messageExternalLinkTargetFromEventTarget(event.target)
             linkPointerRef.current = target && event.button === 0
@@ -379,12 +393,14 @@ function MessageImpl({
           }
         : undefined}
       onPointerCancelCapture={interactive
-        ? () => {
+        ? (event) => {
+            if (!messageEventBelongsToRow(event.target, event.currentTarget)) return
             linkPointerRef.current = null
           }
         : undefined}
       onPointerDown={swipeReplyEnabled
         ? (event) => {
+            if (!messageEventBelongsToRow(event.target, event.currentTarget)) return
             if (event.pointerType !== "touch") return
             const nested = (event.target as Element).closest?.(
               "button, a, input, textarea, select, [role=button]",
@@ -398,6 +414,7 @@ function MessageImpl({
         : undefined}
       onPointerMove={swipeReplyEnabled
         ? (event) => {
+            if (!messageEventBelongsToRow(event.target, event.currentTarget)) return
             const current = swipeGestureRef.current
             if (!current || event.pointerType !== "touch") return
             if (selectionBelongsToRow(window.getSelection(), event.currentTarget)) {
@@ -423,6 +440,7 @@ function MessageImpl({
         : undefined}
       onPointerUp={swipeReplyEnabled
         ? (event) => {
+            if (!messageEventBelongsToRow(event.target, event.currentTarget)) return
             const gesture = swipeGestureRef.current
             if (!gesture || event.pointerType !== "touch") return
             const commit = shouldCommitMobileReply(gesture)
@@ -434,22 +452,29 @@ function MessageImpl({
           }
         : undefined}
       onPointerCancel={swipeReplyEnabled
-        ? () => {
+        ? (event) => {
+            if (!messageEventBelongsToRow(event.target, event.currentTarget)) return
             swipeGestureRef.current = null
             suppressLongPressClick.current = true
             setSwipeVisual({ offset: 0, active: false, crossed: false })
           }
         : undefined}
-      onFocusCapture={hoverCapable ? activateOverlays : undefined}
+      onFocusCapture={hoverCapable
+        ? (event) => {
+            if (messageEventBelongsToRow(event.target, event.currentTarget)) activateOverlays?.(event)
+          }
+        : undefined}
       onKeyDownCapture={activateFromKeyboard}
       onTouchStart={interactive && touchFallbackActive
-          ? () => {
+          ? (event) => {
+            if (!messageEventBelongsToRow(event.target, event.currentTarget)) return
             touchStartedAt.current = performance.now()
             suppressLongPressClick.current = false
           }
         : undefined}
       onTouchEnd={interactive && touchFallbackActive
-        ? () => {
+        ? (event) => {
+            if (!messageEventBelongsToRow(event.target, event.currentTarget)) return
             const startedAt = touchStartedAt.current
             suppressLongPressClick.current = suppressLongPressClick.current || (
               startedAt !== null && performance.now() - startedAt >= 500
@@ -458,15 +483,19 @@ function MessageImpl({
           }
         : undefined}
       onTouchCancel={interactive && touchFallbackActive
-          ? () => {
+          ? (event) => {
+            if (!messageEventBelongsToRow(event.target, event.currentTarget)) return
             touchStartedAt.current = null
             suppressLongPressClick.current = true
           }
         : undefined}
       onClick={selectable
-        ? onToggleSelect
+        ? (event) => {
+            if (messageEventBelongsToRow(event.target, event.currentTarget)) onToggleSelect?.()
+          }
         : interactive && touchFallbackActive
           ? (event) => {
+            if (!messageEventBelongsToRow(event.target, event.currentTarget)) return
             const selection = window.getSelection()
             const selectionInsideRow = selectionBelongsToRow(selection, event.currentTarget)
             const controlSelector = "button, a, input, textarea, select, [role=button]"
@@ -494,6 +523,7 @@ function MessageImpl({
         : undefined}
       onClickCapture={interactive
         ? (event) => {
+            if (!messageEventBelongsToRow(event.target, event.currentTarget)) return
             const target = messageExternalLinkTargetFromEventTarget(event.target)
             if (!target) {
               linkPointerRef.current = null
@@ -522,6 +552,7 @@ function MessageImpl({
         : undefined}
       onContextMenuCapture={interactive
         ? (event) => {
+            if (!messageEventBelongsToRow(event.target, event.currentTarget)) return
             setLinkTarget(messageExternalLinkTargetFromEventTarget(event.target))
           }
         : undefined}

--- a/src/web/src/components/community/messages/message.tsx
+++ b/src/web/src/components/community/messages/message.tsx
@@ -76,6 +76,15 @@ export function messageEventBelongsToRow(
   return typeof row?.contains !== "function" || row.contains(target as Node | null)
 }
 
+export function shouldAdoptDesktopMenuInput(
+  pointerType: string | null,
+  row: { contains?: (target: Node | null) => boolean } | null,
+  activeElement: Element | null,
+): boolean {
+  if (pointerType !== "mouse") return false
+  return typeof row?.contains !== "function" || !row.contains(activeElement)
+}
+
 export function shouldSuppressTouchMenuOpen({
   nestedControl,
   selectionInsideRow,
@@ -295,8 +304,11 @@ function MessageImpl({
   }
   const showMenu = hasMessageMenu(menuHandlers)
   const interactive = !compact && !m.failed && showMenu
-  const touchFallbackActive = !desktopMenuInputSeen && !hoverCapable
-  const swipeReplyEnabled = interactive && touchFallbackActive && !selectMode && !!onReply
+  const touchInputCapable = !hoverCapable
+  const touchFallbackActive = !desktopMenuInputSeen && touchInputCapable
+  // A hybrid device can alternate between mouse and touch. Switching the menu
+  // shell after a mouse gesture must not remove the row's touch swipe handler.
+  const swipeReplyEnabled = interactive && touchInputCapable && !selectMode && !!onReply
   const activateOverlays = interactive && !activated
     ? (event: React.SyntheticEvent<HTMLElement>) => {
         if (shouldActivateMessageOverlays(event.target)) setActivated(true)
@@ -316,7 +328,13 @@ function MessageImpl({
         if (!messageEventBelongsToRow(event.target, event.currentTarget)) return
         const pointerType = messageLinkPointerType(event.nativeEvent)
         if (pointerType === "mouse") {
-          setDesktopMenuInputSeen(true)
+          // Closing a portal can reveal the stationary mouse over this row and
+          // synthesize pointerenter. Do not swap menu shells underneath a focus
+          // target that was just restored into the row.
+          const activeElement = typeof document === "undefined" ? null : document.activeElement
+          if (shouldAdoptDesktopMenuInput(pointerType, event.currentTarget, activeElement)) {
+            setDesktopMenuInputSeen(true)
+          }
           activateLinkOrOverlays?.(event)
         } else if (hoverCapable) {
           activateOverlays?.(event)

--- a/src/web/src/test/e2e-ui/39-mobile-message-interactions.spec.ts
+++ b/src/web/src/test/e2e-ui/39-mobile-message-interactions.spec.ts
@@ -356,8 +356,11 @@ test("mobile reply, avatar mention, and typing rail keep exact backend and WS id
   await expect(alice.page.getByTestId(tid.profileCard)).toBeHidden()
   await dispatchCancelledAvatarPress(channelAvatar, "cancel")
   await expect(alice.page.getByTestId(tid.profileCard)).toBeHidden()
-  await channelAvatar.click()
-  await expect(alice.page.getByTestId(tid.profileCard)).toBeVisible()
+  const profileCard = alice.page.getByTestId(tid.profileCard)
+  await expect(async () => {
+    await channelAvatar.click({ timeout: 5_000 })
+    await expect(profileCard).toBeVisible({ timeout: 5_000 })
+  }).toPass({ timeout: 30_000 })
   const mobileProfileSheet = alice.page.locator('[data-slot="sheet-content"][data-side="bottom"]')
   await expect(mobileProfileSheet).toHaveCSS("border-top-width", "0px")
   await alice.page.keyboard.press("Escape")

--- a/src/web/src/test/e2e-ui/44-mobile-reaction-details.spec.ts
+++ b/src/web/src/test/e2e-ui/44-mobile-reaction-details.spec.ts
@@ -182,6 +182,9 @@ test.describe.serial("mobile reaction details", () => {
     expect(mutationRequests).toHaveLength(0)
     await alice.page.getByRole("button", { name: "Close" }).click()
     await expect(fire).toBeFocused()
+    await expect.poll(() => alice.page.evaluate(() => (
+      document.activeElement?.getAttribute("data-testid") ?? null
+    ))).toBe(tid.reactionChip(messageId, "🔥"))
 
     const thumb = alice.page.getByTestId(tid.reactionChip(messageId, "👍"))
     const toggleResponse = alice.page.waitForResponse((response) => (
@@ -403,5 +406,8 @@ test.describe.serial("mobile reaction details", () => {
       body: await alice.page.screenshot(),
       contentType: "image/png",
     })
+    const reactionGroup = alice.page.getByTestId(tid.reactionGroup(emptyMessageId))
+    await alice.page.getByRole("button", { name: "Close" }).click()
+    await expect(reactionGroup).toBeFocused()
   })
 })

--- a/src/web/src/test/e2e-ui/44-mobile-reaction-details.spec.ts
+++ b/src/web/src/test/e2e-ui/44-mobile-reaction-details.spec.ts
@@ -15,6 +15,9 @@ import { tid } from "./_fixtures/testids"
 
 const HOVER_QUERY = "(hover: hover) and (pointer: fine)"
 const OVERFLOW_EMOJIS = ["👍", "🔥", "🎉", "✅", "🚀", "👀", "❤️", "😂", "🤔"] as const
+// Keep explicit scheduling headroom beyond the product's hold threshold. An
+// exact-boundary wait lets CI dispatch pointerup before the page timer runs.
+const REACTION_HOLD_WAIT_MS = 700
 
 async function installInputCapability(page: Page, hoverCapable: boolean) {
   await page.addInitScript(({ query, matches }) => {
@@ -40,7 +43,7 @@ async function holdReaction(page: Page, chip: Locator, pointerId = 41) {
   const point = { x: box.x + box.width / 2, y: box.y + box.height / 2 }
   const pointer = { pointerType: "touch", pointerId, isPrimary: true, button: 0 }
   await chip.dispatchEvent("pointerdown", { ...pointer, clientX: point.x, clientY: point.y })
-  await page.waitForTimeout(500)
+  await page.waitForTimeout(REACTION_HOLD_WAIT_MS)
   await chip.dispatchEvent("pointerup", { ...pointer, clientX: point.x, clientY: point.y })
   await chip.dispatchEvent("click", point)
 }


### PR DESCRIPTION
# Why we need this PR?
> Ordinary user-authored links need precise Copy Link and Open Link actions without breaking direct desktop navigation or existing message menus.

## What changed
- Resolve the exact ordinary HTTP(S) anchor under each gesture, preserving its full query and fragment.
- Append Copy Link and Open Link to the existing desktop context menu and touch menu while preserving current actions and order.
- Use actual mouse, touch, pen, or keyboard input before the hover-capability fallback, including hybrid and narrow-desktop behavior.
- Reuse the existing Tauri system-browser opener, keep browser opening isolated, and show clipboard/opener success or failure feedback.
- Cover the shared DM, channel, thread, and message-context boundary without route-specific parsing or duplicate menus.

## Checklist
- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...

## Local verification
- Focused message-link suite: 86 tests passed.
- Full web suite: 727 files / 6,468 tests passed.
- Normal commit hooks: typecheck, lint, full repository tests, typegrep, and Knip passed.
