### PR TITLE
fix: audit daemon-accepted Stop commands

### DIFF
--- a/src/daemon/src/daemon/createDaemon.ts
+++ b/src/daemon/src/daemon/createDaemon.ts
@@ -493,6 +493,7 @@ export async function createDaemon(opts: CreateDaemonOptions): Promise<RunningDa
         }
       | { kind: "tool_call"; payload: { name: string; target?: string } }
       | { kind: "thinking"; payload: { text: string; truncated: boolean; chars: number } }
+      | { kind: "turn_interrupt"; payload: { status: "accepted" } }
       | { kind: "session_reset"; payload: { trigger: "idle_timeout" } }
       | {
           kind: "error";

--- a/src/daemon/src/manager/managerRuntime.test.ts
+++ b/src/daemon/src/manager/managerRuntime.test.ts
@@ -336,6 +336,19 @@ describe("AgentProcessManager — running-turn interrupt", () => {
 
     expect(onBotAuditEvent).not.toHaveBeenCalled();
   });
+
+  it("keeps an accepted interrupt successful when the audit observer throws", async () => {
+    const onBotAuditEvent = vi.fn(() => {
+      throw new Error("audit unavailable");
+    });
+    const { mgr } = makeManager({ onBotAuditEvent });
+    const session = fakeSession("interrupt-session");
+    session.interrupt = vi.fn(async ({ requestId }) => ({ status: "accepted", requestId, turnId: "turn_1" }));
+    (mgr as unknown as { sessions: Map<string, TestAgentSession> }).sessions.set("a1", session);
+
+    await expect(mgr.interrupt("a1")).resolves.toBeUndefined();
+    expect(onBotAuditEvent).toHaveBeenCalledOnce();
+  });
 });
 
 function exactTimelineLifecycleStub() {

--- a/src/daemon/src/manager/managerRuntime.test.ts
+++ b/src/daemon/src/manager/managerRuntime.test.ts
@@ -304,8 +304,9 @@ function makeManager(opts: { logger?: Logger; tickIntervalMs?: number; idleTimeo
 }
 
 describe("AgentProcessManager — running-turn interrupt", () => {
-  it("interrupts the current session without deleting it", async () => {
-    const { mgr } = makeManager();
+  it("audits a daemon-accepted interrupt without deleting the session", async () => {
+    const onBotAuditEvent = vi.fn();
+    const { mgr } = makeManager({ onBotAuditEvent });
     const session = fakeSession("interrupt-session");
     session.interrupt = vi.fn(async ({ requestId }) => ({ status: "accepted", requestId, turnId: "turn_1" }));
     (mgr as unknown as { sessions: Map<string, TestAgentSession> }).sessions.set("a1", session);
@@ -317,6 +318,23 @@ describe("AgentProcessManager — running-turn interrupt", () => {
       reason: "owner_request",
     });
     expect((mgr as unknown as { sessions: Map<string, TestAgentSession> }).sessions.get("a1")).toBe(session);
+    expect(onBotAuditEvent).toHaveBeenCalledWith(
+      "a1",
+      { kind: "turn_interrupt", payload: { status: "accepted" } },
+      { sessionId: null, launchId: null },
+    );
+  });
+
+  it.each(["not_running", "closed"] as const)("does not audit a %s interrupt as successful", async (status) => {
+    const onBotAuditEvent = vi.fn();
+    const { mgr } = makeManager({ onBotAuditEvent });
+    const session = fakeSession("interrupt-session");
+    session.interrupt = vi.fn(async () => ({ status }));
+    (mgr as unknown as { sessions: Map<string, TestAgentSession> }).sessions.set("a1", session);
+
+    await mgr.interrupt("a1");
+
+    expect(onBotAuditEvent).not.toHaveBeenCalled();
   });
 });
 

--- a/src/daemon/src/manager/managerRuntime.test.ts
+++ b/src/daemon/src/manager/managerRuntime.test.ts
@@ -338,16 +338,18 @@ describe("AgentProcessManager — running-turn interrupt", () => {
   });
 
   it("keeps an accepted interrupt successful when the audit observer throws", async () => {
+    const logger = stubLogger();
     const onBotAuditEvent = vi.fn(() => {
       throw new Error("audit unavailable");
     });
-    const { mgr } = makeManager({ onBotAuditEvent });
+    const { mgr } = makeManager({ logger, onBotAuditEvent });
     const session = fakeSession("interrupt-session");
     session.interrupt = vi.fn(async ({ requestId }) => ({ status: "accepted", requestId, turnId: "turn_1" }));
     (mgr as unknown as { sessions: Map<string, TestAgentSession> }).sessions.set("a1", session);
 
     await expect(mgr.interrupt("a1")).resolves.toBeUndefined();
     expect(onBotAuditEvent).toHaveBeenCalledOnce();
+    expect(logger.calls.debug.map(([message]) => message)).toContain("audit emit failed (turn interrupt)");
   });
 });
 

--- a/src/daemon/src/manager/managerRuntime.ts
+++ b/src/daemon/src/manager/managerRuntime.ts
@@ -238,6 +238,7 @@ export interface ManagerRuntimeOpts {
     event:
       | { kind: "tool_call"; payload: { name: string; target?: string } }
       | { kind: "thinking"; payload: { text: string; truncated: boolean; chars: number } }
+      | { kind: "turn_interrupt"; payload: { status: "accepted" } }
       | { kind: "session_reset"; payload: { trigger: "idle_timeout" } }
       | {
           kind: "error";
@@ -842,7 +843,22 @@ export class AgentProcessManager {
   async interrupt(agentId: string): Promise<void> {
     const session = this.sessions.get(agentId);
     if (!session) return;
-    await session.interrupt({ requestId: randomUUID(), reason: "owner_request" });
+    const result = await session.interrupt({ requestId: randomUUID(), reason: "owner_request" });
+    if (result.status !== "accepted") return;
+    this.log.info("agent turn interrupt accepted", {
+      agentId,
+      sessionInstanceId: session.sessionInstanceId,
+      turnId: result.turnId,
+    });
+    try {
+      this.opts.onBotAuditEvent?.(
+        agentId,
+        { kind: "turn_interrupt", payload: { status: "accepted" } },
+        this.auditContext(agentId),
+      );
+    } catch (err) {
+      this.log.debug("audit emit failed (turn interrupt)", { agentId, err: String(err) });
+    }
   }
   async stopAll(): Promise<void> {
     if (this.tickTimer) {

--- a/src/shared/src/community-cli-contract.ts
+++ b/src/shared/src/community-cli-contract.ts
@@ -947,6 +947,7 @@ export type BotAuditEventPayload =
     }
   | { kind: "tool_call"; payload: { name: string; target?: string } }
   | { kind: "thinking"; payload: { text: string; truncated: boolean; chars: number } }
+  | { kind: "turn_interrupt"; payload: { status: "accepted" } }
   | {
       kind: "wake_trigger";
       payload: {

--- a/src/shared/src/community-ws-events.ts
+++ b/src/shared/src/community-ws-events.ts
@@ -465,7 +465,7 @@ const communityBotAuditEventSchema = z.strictObject({
   type: z.literal("community:bot.audit_event"),
   botId: string,
   id: string,
-  kind: z.enum(["cli_invocation", "tool_call", "thinking", "wake_trigger", "session_reset", "nap", "model_changed", "provider_changed", "error"]),
+  kind: z.enum(["cli_invocation", "tool_call", "thinking", "turn_interrupt", "wake_trigger", "session_reset", "nap", "model_changed", "provider_changed", "error"]),
   payload: z.unknown(),
   sessionId: nullableString.optional(),
   launchId: nullableString.optional(),

--- a/src/shared/src/db/queries/community/bot-audit-log.ts
+++ b/src/shared/src/db/queries/community/bot-audit-log.ts
@@ -31,7 +31,7 @@ export type BotActivityEventInput = {
   botId: string;
   sessionId?: string | null;
   launchId?: string | null;
-  kind: "cli_invocation" | "tool_call" | "thinking" | "wake_trigger" | "session_reset" | "nap" | "model_changed" | "provider_changed" | "error";
+  kind: "cli_invocation" | "tool_call" | "thinking" | "turn_interrupt" | "wake_trigger" | "session_reset" | "nap" | "model_changed" | "provider_changed" | "error";
   payload: string;
   createdAt?: string;
 };

--- a/src/shared/src/index.ts
+++ b/src/shared/src/index.ts
@@ -319,6 +319,7 @@ export {
   AuditLogCliInvocationPayloadSchema,
   AuditLogToolCallPayloadSchema,
   AuditLogThinkingPayloadSchema,
+  AuditLogTurnInterruptPayloadSchema,
   AuditLogWakeTriggerPayloadSchema,
   AuditLogModelChangedPayloadSchema,
   AuditLogProviderChangedPayloadSchema,

--- a/src/shared/src/schemas.ts
+++ b/src/shared/src/schemas.ts
@@ -1493,6 +1493,10 @@ export const AuditLogThinkingPayloadSchema = z.object({
   truncated: z.boolean(),
   chars: z.number().int().nonnegative(),
 });
+export const AuditLogTurnInterruptPayloadSchema = z.object({
+  status: z.literal("accepted"),
+});
+export type AuditLogTurnInterruptPayload = z.infer<typeof AuditLogTurnInterruptPayloadSchema>;
 /**
  * `wake_trigger` — one row per wake we ATTEMPTED to deliver. Written from
  * `buildUnreadWakeCommand` right before the `HostCommand` is returned to the
@@ -1582,6 +1586,7 @@ export const BotAuditEventSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("cli_invocation"), payload: AuditLogCliInvocationPayloadSchema }),
   z.object({ kind: z.literal("tool_call"), payload: AuditLogToolCallPayloadSchema }),
   z.object({ kind: z.literal("thinking"), payload: AuditLogThinkingPayloadSchema }),
+  z.object({ kind: z.literal("turn_interrupt"), payload: AuditLogTurnInterruptPayloadSchema }),
   z.object({ kind: z.literal("wake_trigger"), payload: AuditLogWakeTriggerPayloadSchema }),
   z.object({ kind: z.literal("session_reset"), payload: AuditLogSessionResetPayloadSchema }),
   z.object({ kind: z.literal("nap"), payload: AuditLogNapPayloadSchema }),
@@ -1595,6 +1600,7 @@ export const BotAuditEventKindSchema = z.enum([
   "cli_invocation",
   "tool_call",
   "thinking",
+  "turn_interrupt",
   "wake_trigger",
   "session_reset",
   "nap",

--- a/src/shared/test/community-ws-events.contract.test.ts
+++ b/src/shared/test/community-ws-events.contract.test.ts
@@ -84,6 +84,15 @@ describe("Community browser event runtime contract", () => {
     }
   })
 
+  it("accepts daemon-accepted turn interrupts as live bot audit events", () => {
+    const event = {
+      ...communityWsEventFixtures["community:bot.audit_event"],
+      kind: "turn_interrupt",
+      payload: { status: "accepted" },
+    }
+    expect(decodeCommunityBrowserEvent(event)).toEqual({ ok: true, event })
+  })
+
   it("rejects one required-field corruption for every event", () => {
     for (const fixture of fixtures) {
       const corrupted = withoutPath(fixture, requiredFixturePaths[fixture.type])

--- a/src/shared/test/queries/community-bot-audit-log.test.ts
+++ b/src/shared/test/queries/community-bot-audit-log.test.ts
@@ -291,6 +291,17 @@ describe("listOwnedBotActivityEvents", () => {
 })
 
 describe("BotAuditEventSchema — payload discriminated union", () => {
+  it("accepts only an accepted daemon turn interrupt receipt", () => {
+    expect(BotAuditEventSchema.safeParse({
+      kind: "turn_interrupt",
+      payload: { status: "accepted" },
+    }).success).toBe(true);
+    expect(BotAuditEventSchema.safeParse({
+      kind: "turn_interrupt",
+      payload: { status: "stopped" },
+    }).success).toBe(false);
+  });
+
   it("accepts a cli_invocation payload", () => {
     const r = BotAuditEventSchema.safeParse({
       kind: "cli_invocation",

--- a/src/web/src/components/community/bots/bot-activity-row.test.ts
+++ b/src/web/src/components/community/bots/bot-activity-row.test.ts
@@ -90,6 +90,22 @@ describe("BotActivityRow — concrete command copy", () => {
   })
 })
 
+describe("BotActivityRow — turn_interrupt", () => {
+  it("states daemon acceptance without claiming the turn is already idle", () => {
+    const renderer = render({
+      id: "e-stop",
+      kind: "turn_interrupt",
+      payload: { status: "accepted" },
+      sessionId: "session-1",
+      launchId: "launch-1",
+      createdAt: "2026-09-01T14:00:00.000Z",
+    })
+    const text = rowText(renderer, "bot-activity-event-turn_interrupt")
+    expect(text).toContain("Stop accepted by daemon")
+    expect(text).toContain("waiting for the active turn to become idle")
+  })
+})
+
 describe("BotActivityRow — provider_changed", () => {
   function providerRowText(renderer: TestRenderer.ReactTestRenderer): string {
     return rowText(renderer, "bot-activity-event-provider_changed")

--- a/src/web/src/components/community/bots/bot-activity-row.tsx
+++ b/src/web/src/components/community/bots/bot-activity-row.tsx
@@ -59,6 +59,7 @@ function KindTag({ kind }: { kind: AuditKind }) {
 function kindMeta(kind: AuditKind): { label: string; tone: string } {
   if (kind === "cli_invocation") return { label: "daemon", tone: "text-foreground/70" }
   if (kind === "tool_call") return { label: "tool", tone: "text-muted-foreground" }
+  if (kind === "turn_interrupt") return { label: "stop", tone: "text-foreground/70" }
   if (kind === "wake_trigger") return { label: "wake", tone: "text-foreground/70" }
   if (kind === "session_reset") return { label: "reset", tone: "text-foreground/70" }
   if (kind === "nap") return { label: "nap", tone: "text-foreground/70" }
@@ -104,6 +105,19 @@ function RowBody({
       )
     }
     return <span className="font-mono text-[13px] text-foreground">{name}</span>
+  }
+  if (event.kind === "turn_interrupt") {
+    return (
+      <div
+        data-testid="bot-activity-event-turn_interrupt"
+        className="truncate font-mono text-[13px] text-foreground"
+      >
+        <span>Stop accepted by daemon</span>{" "}
+        <span className="text-muted-foreground">
+          — waiting for the active turn to become idle.
+        </span>
+      </div>
+    )
   }
   if (event.kind === "session_reset") {
     return (

--- a/src/web/src/hooks/community/community-ws/presence-machine-events.test.ts
+++ b/src/web/src/hooks/community/community-ws/presence-machine-events.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type {
+  CommunityBotAuditEvent,
   CommunityMachineCreated,
   CommunityMachineStatus,
   CommunityPresenceUpdate,
@@ -96,6 +97,35 @@ describe("useCommunityWs — status.update → Zustand store, no cache", () => {
     })
     // No cache touched.
     expect(spy).not.toHaveBeenCalled()
+  })
+})
+
+describe("useCommunityWs — bot audit events", () => {
+  it("accepts and stores a live daemon-accepted turn interrupt", async () => {
+    await mountHook()
+    const event: CommunityBotAuditEvent = {
+      type: "community:bot.audit_event",
+      botId: "bot_stop",
+      id: "audit_stop",
+      kind: "turn_interrupt",
+      payload: { status: "accepted" },
+      sessionId: "session_1",
+      launchId: "launch_1",
+      createdAt: "2026-09-01T15:00:00.000Z",
+    }
+
+    capturedOnMessage!(event)
+
+    const { useCommunityWsStore } = await import("@/stores/community/ws")
+    expect(useCommunityWsStore.getState().botAuditEvents.get("bot_stop")).toEqual([{
+      id: "audit_stop",
+      botId: "bot_stop",
+      kind: "turn_interrupt",
+      payload: { status: "accepted" },
+      sessionId: "session_1",
+      launchId: "launch_1",
+      createdAt: "2026-09-01T15:00:00.000Z",
+    }])
   })
 })
 

--- a/src/web/src/hooks/community/use-bot-audit-log.ts
+++ b/src/web/src/hooks/community/use-bot-audit-log.ts
@@ -10,7 +10,7 @@ import { apiFetch } from "@/lib/api/client"
 import { communityKeys } from "@/lib/query-keys"
 import { useBotAuditEventsForBot } from "@/stores/community/ws"
 
-export type AuditKind = "cli_invocation" | "tool_call" | "thinking" | "wake_trigger" | "session_reset" | "nap" | "model_changed" | "provider_changed" | "error"
+export type AuditKind = "cli_invocation" | "tool_call" | "thinking" | "turn_interrupt" | "wake_trigger" | "session_reset" | "nap" | "model_changed" | "provider_changed" | "error"
 
 export type AuditEvent = {
   id: string

--- a/src/web/src/lib/community/audit-event-summary.test.ts
+++ b/src/web/src/lib/community/audit-event-summary.test.ts
@@ -8,6 +8,7 @@ describe("summarizeAuditEvent", () => {
       "cli_invocation",
       "tool_call",
       "thinking",
+      "turn_interrupt",
       "wake_trigger",
       "session_reset",
       "nap",

--- a/src/web/src/lib/community/audit-event-summary.ts
+++ b/src/web/src/lib/community/audit-event-summary.ts
@@ -4,6 +4,7 @@ const SUMMARY_BY_KIND: Record<AuditKind, string> = {
   cli_invocation: "alook command",
   tool_call: "tool",
   thinking: "Updated its reasoning",
+  turn_interrupt: "Stop accepted by daemon",
   wake_trigger: "Woke for a new message",
   session_reset: "Session reset requested",
   nap: "Started a fresh session",

--- a/src/web/src/lib/community/audit-log-payload.test.ts
+++ b/src/web/src/lib/community/audit-log-payload.test.ts
@@ -38,6 +38,12 @@ describe("parseAuditLogPayload", () => {
     )
     expect(p).toEqual({ text: "hmm", truncated: false, chars: 3 })
   })
+  it("parses only daemon-accepted turn_interrupt payloads", () => {
+    expect(parseAuditLogPayload("turn_interrupt", JSON.stringify({ status: "accepted" }))).toEqual({
+      status: "accepted",
+    })
+    expect(parseAuditLogPayload("turn_interrupt", JSON.stringify({ status: "stopped" }))).toBe(null)
+  })
   it("parses a well-shaped wake_trigger payload", () => {
     const payload = {
       messageId: "m_1",

--- a/src/web/src/lib/community/audit-log-payload.ts
+++ b/src/web/src/lib/community/audit-log-payload.ts
@@ -2,6 +2,7 @@ import {
   AuditLogCliInvocationPayloadSchema,
   AuditLogToolCallPayloadSchema,
   AuditLogThinkingPayloadSchema,
+  AuditLogTurnInterruptPayloadSchema,
   AuditLogWakeTriggerPayloadSchema,
   AuditLogModelChangedPayloadSchema,
   AuditLogProviderChangedPayloadSchema,
@@ -37,6 +38,10 @@ export function parseAuditLogPayload(
     }
     case "thinking": {
       const r = AuditLogThinkingPayloadSchema.safeParse(json)
+      return r.success ? r.data : null
+    }
+    case "turn_interrupt": {
+      const r = AuditLogTurnInterruptPayloadSchema.safeParse(json)
       return r.success ? r.data : null
     }
     case "wake_trigger": {

--- a/src/web/src/stores/community/ws.ts
+++ b/src/web/src/stores/community/ws.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import { create } from "zustand"
+import type { CommunityBotAuditEvent } from "@alook/shared"
 import type {
   CommunityProfile,
   CommunityProfilePatch,
@@ -50,7 +51,7 @@ export const BOT_AUDIT_RING_MAX = 200
 export type BotAuditEventEntry = {
   id: string
   botId: string
-  kind: "cli_invocation" | "tool_call" | "thinking" | "wake_trigger" | "session_reset" | "nap" | "model_changed" | "provider_changed" | "error"
+  kind: CommunityBotAuditEvent["kind"]
   payload: unknown
   sessionId?: string | null
   launchId?: string | null

--- a/src/ws-do/src/ws-durable/machine-telemetry.test.ts
+++ b/src/ws-do/src/ws-durable/machine-telemetry.test.ts
@@ -871,6 +871,51 @@ describe("WebSocketDurableObject", () => {
         mockStubFetch.mockClear()
       })
 
+      it("persists a daemon-accepted turn interrupt", async () => {
+        const { durable, store } = createDO()
+        store.set("community-machine-identity", {
+          userId: "u_1",
+          machineId: "cm_1",
+          credentialHash: "0".repeat(64),
+        })
+        mockGetBotBindingWithOwner.mockResolvedValue({
+          machineId: "cm_1",
+          ownerUserId: "owner_1",
+          runtime: "codex",
+          name: "Bot",
+          discriminator: "0007",
+        })
+        mockInsertBotActivityEventAndPrune.mockResolvedValue({
+          id: "bae_stop",
+          createdAt: "2026-09-01T15:00:00.000Z",
+        })
+        const ws = createMockWebSocket()
+        ws.serializeAttachment({
+          type: "community-machine",
+          machineId: "cm_1",
+          userId: "u_1",
+          authenticated: true,
+        })
+
+        await durable.webSocketMessage(ws as any, JSON.stringify({
+          type: "bot_audit_event",
+          agentId: "bot_1",
+          sessionId: "s_1",
+          launchId: "l_1",
+          event: { kind: "turn_interrupt", payload: { status: "accepted" } },
+        }))
+
+        expect(mockInsertBotActivityEventAndPrune).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            botId: "bot_1",
+            kind: "turn_interrupt",
+            payload: JSON.stringify({ status: "accepted" }),
+          }),
+          [],
+        )
+      })
+
       it("preserves the durable completion time when a reset is replayed two hours late", async () => {
         const { durable, store } = createDO()
         store.set("community-machine-identity", {

--- a/src/ws-do/src/ws-durable/test-harness.ts
+++ b/src/ws-do/src/ws-durable/test-harness.ts
@@ -270,6 +270,7 @@ vi.mock("@alook/shared", async () => {
       else if (kind === "tool_call") ok = typeof payload.name === "string"
       else if (kind === "thinking")
         ok = typeof payload.text === "string" && typeof payload.truncated === "boolean" && typeof payload.chars === "number"
+      else if (kind === "turn_interrupt") ok = payload.status === "accepted"
       else if (kind === "session_reset")
         ok = payload.trigger === "single" || payload.trigger === "reset_all" || payload.trigger === "idle_timeout"
       if (kind === "session_reset" && payload.trigger === "idle_timeout") {


### PR DESCRIPTION
## Summary
- emit a `turn_interrupt` audit event only after the daemon manager receives an `accepted` interrupt result
- do not record `not_running`, `closed`, or failed interrupts as successful
- render the event honestly as “Stop accepted by daemon” while explicitly waiting for the active turn to become idle
- persist and query the new event across the shared contract, WS durable object, and web audit UI

Alook issue: `/Alook#5620/gus-issues/#84`

## Validation
- full repository typecheck: 11/11 packages passed
- full repository lint: 5/5 tasks passed
- full repository test: 6442/6443 passed; the only failure was an unrelated `cdn.jsdelivr.net` TLS reset in the OG emoji test
- isolated retry of the flaky OG image suite: 6/6 passed
- targeted daemon, shared, web, and WS-DO tests passed
- `git diff --check` passed
