### PR TITLE
fix(web): move forum archive to row action

### DIFF
--- a/src/web/src/components/community/channels/forum-view.test.ts
+++ b/src/web/src/components/community/channels/forum-view.test.ts
@@ -7,6 +7,7 @@ import {
   ForumViewSkeleton,
   forumTagScrollFades,
   shouldActivateForumRow,
+  toggleForumArchivedStatus,
 } from "./forum-view"
 import { tid } from "@/lib/community/testids"
 import type { ForumThread } from "@/lib/community/models/message"
@@ -102,7 +103,7 @@ function renderWithDelete(
 
 function renderWithActions(
   post: ForumThread,
-  opts: { canEdit?: boolean; canDelete?: boolean } = {},
+  opts: { canEdit?: boolean; canDelete?: boolean; savingTagsFor?: string | null } = {},
 ): string {
   return renderToStaticMarkup(
     createElement(ForumView, {
@@ -114,6 +115,7 @@ function renderWithActions(
       onOpenPost: () => {},
       onEditPostTags: () => {},
       canEditPostTags: () => opts.canEdit ?? true,
+      savingTagsFor: opts.savingTagsFor ?? null,
       onDeletePost: () => {},
       canDeletePost: () => opts.canDelete ?? true,
     }),
@@ -207,6 +209,16 @@ describe("ForumView post card header", () => {
     expect(html).toContain("Show 2 more tags")
     expect(html).toContain(">+2<")
   })
+
+  it("keeps the reserved archived state out of the ordinary row tag summary", () => {
+    const html = render([makePost({ tags: ["alpha", "archived", "beta"] })])
+    expect(html).toContain("#alpha")
+    expect(html).toContain("#beta")
+    expect(html).not.toContain("#archived")
+
+    const archivedOnly = render([makePost({ tags: ["archived"] })])
+    expect(archivedOnly.match(/aria-hidden="true">·<\/span>/g)).toHaveLength(1)
+  })
 })
 
 describe("ForumView post delete button", () => {
@@ -246,14 +258,18 @@ describe("ForumView post delete button", () => {
 })
 
 describe("ForumView responsive post actions", () => {
-  it("keeps authorized actions visible and touch-safe on mobile, then progressive on desktop", () => {
+  it("orders tag, archive, and delete actions with responsive geometry", () => {
     const html = renderWithActions(makePost({ parentSeq: 3 }))
     const tagIndex = html.indexOf(tid.forumThreadTagBtn("p1"))
+    const archiveIndex = html.indexOf(tid.forumThreadArchiveBtn("p1"))
     const deleteIndex = html.indexOf(tid.forumThreadDeleteBtn("p1"))
     const tagButton = html.slice(Math.max(0, tagIndex - 500), tagIndex + 500)
+    const archiveButton = html.slice(Math.max(0, archiveIndex - 500), archiveIndex + 500)
     const deleteButton = html.slice(Math.max(0, deleteIndex - 500), deleteIndex + 500)
 
-    for (const button of [tagButton, deleteButton]) {
+    expect(tagIndex).toBeLessThan(archiveIndex)
+    expect(archiveIndex).toBeLessThan(deleteIndex)
+    for (const button of [tagButton, archiveButton, deleteButton]) {
       expect(button).toContain("size-8")
       expect(button).toContain("opacity-100")
       expect(button).toContain("sm:size-6")
@@ -262,21 +278,53 @@ describe("ForumView responsive post actions", () => {
       expect(button).toContain("sm:group-hover/card:opacity-100")
     }
     expect(tagButton).toContain("sm:data-popup-open:opacity-100")
+    expect(archiveButton).toContain('aria-label="Archive post"')
+    expect(archiveButton).toContain('aria-pressed="false"')
+    expect(archiveButton).toContain("disabled:opacity-50")
     expect(deleteButton).toContain("disabled:opacity-50")
-    expect(html).toContain("min-h-8 pr-16 sm:min-h-0")
+    expect(html).toContain("min-h-8 pr-28 sm:min-h-0 sm:pr-22")
     expect(html).toContain("relative line-clamp-2 w-full min-w-0 max-w-full wrap-break-word")
     expect(html).toContain(tid.forumThreadTitle("p1"))
     expect(html).toContain(tid.forumThreadTitleText("p1"))
     expect(html).toContain(tid.forumThreadSeq("p1"))
   })
 
+  it("expresses unarchive state and disables the row action while its tag update is pending", () => {
+    const html = renderWithActions(makePost({ tags: ["bug", "archived"] }), {
+      savingTagsFor: "p1",
+    })
+    const archiveIndex = html.indexOf(tid.forumThreadArchiveBtn("p1"))
+    const archiveButton = html.slice(Math.max(0, archiveIndex - 300), archiveIndex + 450)
+
+    expect(archiveButton).toContain('aria-label="Unarchive post"')
+    expect(archiveButton).toContain('aria-pressed="true"')
+    expect(archiveButton).toContain("disabled")
+  })
+
+  it("preserves ordinary tags when toggling the reserved archived status", () => {
+    expect(toggleForumArchivedStatus(["bug", "design"]))
+      .toEqual(["bug", "design", "archived"])
+    expect(toggleForumArchivedStatus(["bug", "archived", "design"]))
+      .toEqual(["bug", "design"])
+  })
+
   it("does not render actions or reserve mobile header space without permission", () => {
     const html = renderWithActions(makePost(), { canEdit: false, canDelete: false })
 
     expect(html).not.toContain(tid.forumThreadTagBtn("p1"))
+    expect(html).not.toContain(tid.forumThreadArchiveBtn("p1"))
     expect(html).not.toContain(tid.forumThreadDeleteBtn("p1"))
-    expect(html).not.toContain("min-h-8 pr-16 sm:min-h-0")
-    expect(html).toContain("sm:pr-14 pr-0")
+    expect(html).not.toContain("min-h-8")
+    expect(html).toContain("pr-0")
+  })
+
+  it("does not expose the archive action when the user may only delete", () => {
+    const html = renderWithActions(makePost(), { canEdit: false, canDelete: true })
+
+    expect(html).not.toContain(tid.forumThreadTagBtn("p1"))
+    expect(html).not.toContain(tid.forumThreadArchiveBtn("p1"))
+    expect(html).toContain(tid.forumThreadDeleteBtn("p1"))
+    expect(html).toContain("min-h-8 pr-12 sm:min-h-0 sm:pr-8")
   })
 })
 

--- a/src/web/src/components/community/channels/forum-view.tsx
+++ b/src/web/src/components/community/channels/forum-view.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useLayoutEffect, useRef, useState } from "react"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import { COMMUNITY_VIRTUALIZER_REACT_OPTIONS } from "@/hooks/community/virtualizer-react-options"
-import { MessagesSquare, ListChevronsUpDown, Plus, Tag, Trash2 } from "lucide-react"
+import { Archive, ArchiveRestore, MessagesSquare, ListChevronsUpDown, Plus, Tag, Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { formatRelativeTime } from "@/lib/community/format-time"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -45,8 +45,9 @@ export function shouldActivateForumRow(event: {
 export const forumTagScrollFades = horizontalOverflowFades
 
 function ForumTagSummary({ tags }: { tags: string[] }) {
-  const shown = tags.slice(0, MAX_VISIBLE_TAGS)
-  const hidden = tags.slice(MAX_VISIBLE_TAGS)
+  const ordinaryTags = tags.filter((tag) => tag !== FORUM_ARCHIVE_TAG)
+  const shown = ordinaryTags.slice(0, MAX_VISIBLE_TAGS)
+  const hidden = ordinaryTags.slice(MAX_VISIBLE_TAGS)
   if (shown.length === 0) return null
 
   return (
@@ -76,7 +77,7 @@ function ForumTagSummary({ tags }: { tags: string[] }) {
             className="flex w-52 flex-wrap gap-1.5 p-2"
             onClick={(event) => event.stopPropagation()}
           >
-            {tags.map((tag) => (
+            {ordinaryTags.map((tag) => (
               <span key={tag} className="rounded-md bg-muted px-1.5 py-1 text-xs text-muted-foreground">#{tag}</span>
             ))}
           </PopoverContent>
@@ -84,6 +85,13 @@ function ForumTagSummary({ tags }: { tags: string[] }) {
       )}
     </div>
   )
+}
+
+export function toggleForumArchivedStatus(tags: string[]): string[] {
+  const ordinaryTags = tags.filter((tag) => tag !== FORUM_ARCHIVE_TAG)
+  return tags.includes(FORUM_ARCHIVE_TAG)
+    ? ordinaryTags
+    : [...ordinaryTags, FORUM_ARCHIVE_TAG]
 }
 
 function ForumPostTitle({ name, postId, seq }: { name: string; postId: string; seq?: number }) {
@@ -370,6 +378,10 @@ export function ForumView({
               renderItem={(p, index) => {
               const canEdit = !!onEditPostTags && (canEditPostTags?.(p) ?? false)
               const canDelete = !!onDeletePost && (canDeletePost?.(p) ?? false)
+              const archived = p.tags.includes(FORUM_ARCHIVE_TAG)
+              const hasOrdinaryTags = p.tags.some((postTag) => postTag !== FORUM_ARCHIVE_TAG)
+              const savingTags = savingTagsFor === p.id
+              const actionCount = (canEdit ? 2 : 0) + (canDelete ? 1 : 0)
               const author = readCommunityProfile(
                 profilesByUserId.get(p.authorId),
                 p.authorId,
@@ -422,6 +434,26 @@ export function ForumView({
                           onSave={(tags) => onEditPostTags?.(p.id, tags)}
                         />
                       )}
+                      {canEdit && (
+                        <button
+                          type="button"
+                          data-testid={tid.forumThreadArchiveBtn(p.id)}
+                          disabled={savingTags}
+                          onClick={(event) => {
+                            event.stopPropagation()
+                            void Promise.resolve(
+                              onEditPostTags?.(p.id, toggleForumArchivedStatus(p.tags)),
+                            ).catch(() => undefined)
+                          }}
+                          className="grid size-8 shrink-0 place-items-center rounded-md text-muted-foreground opacity-100 transition-opacity hover:bg-accent hover:text-foreground sm:size-6 sm:opacity-0 sm:focus-visible:opacity-100 sm:group-hover/card:opacity-100 disabled:cursor-not-allowed disabled:opacity-50"
+                          aria-label={archived ? "Unarchive post" : "Archive post"}
+                          aria-pressed={archived}
+                        >
+                          {archived
+                            ? <ArchiveRestore aria-hidden="true" className="size-4" />
+                            : <Archive aria-hidden="true" className="size-4" />}
+                        </button>
+                      )}
                       {canDelete && (
                       <button
                         type="button"
@@ -438,8 +470,10 @@ export function ForumView({
                   )}
 
                   <div className={cn(
-                    "sm:pr-14",
-                    canEdit || canDelete ? "min-h-8 pr-16 sm:min-h-0" : "pr-0",
+                    actionCount === 3 && "min-h-8 pr-28 sm:min-h-0 sm:pr-22",
+                    actionCount === 2 && "min-h-8 pr-20 sm:min-h-0 sm:pr-16",
+                    actionCount === 1 && "min-h-8 pr-12 sm:min-h-0 sm:pr-8",
+                    actionCount === 0 && "pr-0",
                   )}>
                     <ForumPostTitle name={p.name} postId={p.id} seq={p.parentSeq} />
                   </div>
@@ -449,7 +483,7 @@ export function ForumView({
                     <span className="shrink-0 font-medium text-foreground" suppressHydrationWarning>{author.name}</span>
                     <span className="shrink-0" aria-hidden>·</span>
                     <span className="shrink-0" suppressHydrationWarning>{formatRelativeTime(p.lastMessageAt)}</span>
-                    {p.tags.length > 0 && <span className="shrink-0 max-sm:hidden" aria-hidden>·</span>}
+                    {hasOrdinaryTags && <span className="shrink-0 max-sm:hidden" aria-hidden>·</span>}
                     <ForumTagSummary tags={p.tags} />
                     <span className="ml-auto flex shrink-0 items-center gap-2">
                       {others.length > 0 && (

--- a/src/web/src/components/community/channels/post-tag-dialog.test.ts
+++ b/src/web/src/components/community/channels/post-tag-dialog.test.ts
@@ -112,6 +112,10 @@ function tagButton(root: ReactTestInstance, tag: string): ReactTestInstance {
   return byTestId(root, tid.forumTagDialogChip(tag))
 }
 
+function archivedButton(root: ReactTestInstance): ReactTestInstance {
+  return byTestId(root, tid.forumTagDialogArchived)
+}
+
 function input(root: ReactTestInstance): ReactTestInstance {
   return byTestId(root, tid.forumTagDialogInput)
 }
@@ -151,21 +155,56 @@ describe("PostTagDialog responsive session", () => {
     expect(byTestId(renderer.root, "trigger")).toBeTruthy()
   })
 
-  it("keeps Archived outside the ordinary quota and preserves desktop close-save", () => {
+  it("renders Archived as a quota-exempt ghost status and preserves ordinary tags on save", () => {
     const current = Array.from({ length: MAX_FORUM_TAGS_PER_POST }, (_, index) => `tag-${index + 1}`)
     const onSave = vi.fn()
-    const { renderer } = renderDialog({ current, allTags: [...current, "replacement"], onSave })
+    const { renderer } = renderDialog({
+      current,
+      allTags: [...current, "replacement", FORUM_ARCHIVE_TAG],
+      onSave,
+    })
     setOpen(renderer.root, true)
 
-    expect(tagButton(renderer.root, FORUM_ARCHIVE_TAG).props.disabled).toBe(false)
+    const archived = archivedButton(renderer.root)
+    expect(archived.props.variant).toBe("ghost")
+    expect(archived.props["aria-pressed"]).toBe(false)
+    expect(archived.props["aria-label"]).toBe("Add Archived status")
+    expect(String(archived.props.className)).toContain("text-muted-foreground")
+    expect(renderer.root.findAllByProps({
+      "data-testid": tid.forumTagDialogChip(FORUM_ARCHIVE_TAG),
+    })).toHaveLength(0)
+    expect(archived.props.disabled).toBe(false)
     expect(tagButton(renderer.root, "replacement").props.disabled).toBe(true)
     expect(input(renderer.root).props.disabled).toBe(true)
-    act(() => tagButton(renderer.root, FORUM_ARCHIVE_TAG).props.onClick())
+    act(() => archived.props.onClick())
+    expect(archivedButton(renderer.root).props["aria-pressed"]).toBe(true)
+    for (const tag of current) {
+      expect(tagButton(renderer.root, tag).props["aria-label"]).toBe(`Remove tag ${tag}`)
+    }
     setOpen(renderer.root, false)
 
     expect(onSave).toHaveBeenCalledOnce()
     expect(onSave).toHaveBeenCalledWith([...current, FORUM_ARCHIVE_TAG])
     expect(shell(renderer.root).props.open).toBe(false)
+  })
+
+  it("removes only Archived and restores every ordinary tag", () => {
+    const onSave = vi.fn()
+    const { renderer } = renderDialog({
+      current: ["bug", FORUM_ARCHIVE_TAG, "design"],
+      allTags: ["bug", "design"],
+      onSave,
+    })
+    setOpen(renderer.root, true)
+
+    expect(archivedButton(renderer.root).props["aria-pressed"]).toBe(true)
+    act(() => archivedButton(renderer.root).props.onClick())
+    expect(archivedButton(renderer.root).props["aria-pressed"]).toBe(false)
+    expect(tagButton(renderer.root, "bug").props["aria-label"]).toBe("Remove tag bug")
+    expect(tagButton(renderer.root, "design").props["aria-label"]).toBe("Remove tag design")
+    setOpen(renderer.root, false)
+
+    expect(onSave).toHaveBeenCalledWith(["bug", "design"])
   })
 
   it("normalizes Enter additions, rejects duplicates, and ignores IME or Shift+Enter", () => {
@@ -191,12 +230,27 @@ describe("PostTagDialog responsive session", () => {
     expect(onSave).not.toHaveBeenCalled()
   })
 
+  it("keeps the reserved Archived value out of the ordinary tag input", () => {
+    mocks.breakpoint = "mobile"
+    const { renderer } = renderDialog({ allTags: [FORUM_ARCHIVE_TAG] })
+    setOpen(renderer.root, true)
+
+    setDraft(renderer.root, FORUM_ARCHIVE_TAG)
+    pressEnter(renderer.root)
+
+    expect(input(renderer.root).props.value).toBe("")
+    expect(archivedButton(renderer.root).props["aria-pressed"]).toBe(false)
+    expect(renderer.root.findAllByProps({
+      "data-testid": tid.forumTagDialogChip(FORUM_ARCHIVE_TAG),
+    })).toHaveLength(0)
+  })
+
   it.each(["implicit", "close"])("discards a changed mobile session via %s dismissal", (dismissal) => {
     mocks.breakpoint = "mobile"
     const onSave = vi.fn()
     const { renderer } = renderDialog({ current: ["existing"], onSave })
     setOpen(renderer.root, true)
-    act(() => tagButton(renderer.root, FORUM_ARCHIVE_TAG).props.onClick())
+    act(() => archivedButton(renderer.root).props.onClick())
 
     if (dismissal === "implicit") setOpen(renderer.root, false)
     else {
@@ -206,7 +260,7 @@ describe("PostTagDialog responsive session", () => {
     expect(onSave).not.toHaveBeenCalled()
     expect(shell(renderer.root).props.open).toBe(false)
     setOpen(renderer.root, true)
-    expect(tagButton(renderer.root, FORUM_ARCHIVE_TAG).props["aria-label"]).toBe("Add tag archived")
+    expect(archivedButton(renderer.root).props["aria-label"]).toBe("Add Archived status")
   })
 
   it("closes a clean mobile session without saving", () => {
@@ -225,7 +279,7 @@ describe("PostTagDialog responsive session", () => {
     const onSave = vi.fn(() => pending.promise)
     const { renderer } = renderDialog({ onSave })
     setOpen(renderer.root, true)
-    act(() => tagButton(renderer.root, FORUM_ARCHIVE_TAG).props.onClick())
+    act(() => archivedButton(renderer.root).props.onClick())
 
     await act(async () => {
       byTestId(renderer.root, tid.forumTagDialogSave).props.onClick()
@@ -252,7 +306,7 @@ describe("PostTagDialog responsive session", () => {
       .mockResolvedValueOnce(undefined)
     const { renderer } = renderDialog({ onSave })
     setOpen(renderer.root, true)
-    act(() => tagButton(renderer.root, FORUM_ARCHIVE_TAG).props.onClick())
+    act(() => archivedButton(renderer.root).props.onClick())
     setDraft(renderer.root, "raw-draft")
 
     await act(async () => {
@@ -262,7 +316,7 @@ describe("PostTagDialog responsive session", () => {
     })
     expect(shell(renderer.root).props.open).toBe(true)
     expect(input(renderer.root).props.value).toBe("raw-draft")
-    expect(tagButton(renderer.root, FORUM_ARCHIVE_TAG).props["aria-label"]).toBe("Remove tag archived")
+    expect(archivedButton(renderer.root).props["aria-label"]).toBe("Remove Archived status")
     expect(byTestId(renderer.root, tid.forumTagDialogSave).props.disabled).toBe(false)
 
     await act(async () => {
@@ -279,13 +333,13 @@ describe("PostTagDialog responsive session", () => {
     const onSave = vi.fn()
     const rendered = renderDialog({ onSave })
     setOpen(rendered.renderer.root, true)
-    act(() => tagButton(rendered.renderer.root, FORUM_ARCHIVE_TAG).props.onClick())
+    act(() => archivedButton(rendered.renderer.root).props.onClick())
     setDraft(rendered.renderer.root, "unfinished")
 
     switchBreakpoint(rendered, "desktop")
     expect(rendered.renderer.root.findByType("mock-popover").props.open).toBe(true)
     expect(input(rendered.renderer.root).props.value).toBe("unfinished")
-    expect(tagButton(rendered.renderer.root, FORUM_ARCHIVE_TAG).props["aria-label"]).toBe("Remove tag archived")
+    expect(archivedButton(rendered.renderer.root).props["aria-label"]).toBe("Remove Archived status")
     expect(onSave).not.toHaveBeenCalled()
 
     setOpen(rendered.renderer.root, false)
@@ -297,13 +351,13 @@ describe("PostTagDialog responsive session", () => {
     const onSave = vi.fn()
     const rendered = renderDialog({ onSave })
     setOpen(rendered.renderer.root, true)
-    act(() => tagButton(rendered.renderer.root, FORUM_ARCHIVE_TAG).props.onClick())
+    act(() => archivedButton(rendered.renderer.root).props.onClick())
     setDraft(rendered.renderer.root, "unfinished")
 
     switchBreakpoint(rendered, "mobile")
     expect(rendered.renderer.root.findByType("mock-dialog").props.open).toBe(true)
     expect(input(rendered.renderer.root).props.value).toBe("unfinished")
-    expect(tagButton(rendered.renderer.root, FORUM_ARCHIVE_TAG).props["aria-label"]).toBe("Remove tag archived")
+    expect(archivedButton(rendered.renderer.root).props["aria-label"]).toBe("Remove Archived status")
     expect(onSave).not.toHaveBeenCalled()
 
     setOpen(rendered.renderer.root, false)
@@ -317,7 +371,7 @@ describe("PostTagDialog responsive session", () => {
     const onSave = vi.fn(() => pending.promise)
     const rendered = renderDialog({ onSave })
     setOpen(rendered.renderer.root, true)
-    act(() => tagButton(rendered.renderer.root, FORUM_ARCHIVE_TAG).props.onClick())
+    act(() => archivedButton(rendered.renderer.root).props.onClick())
     const staleMobileClose = rendered.renderer.root.findByType("mock-dialog").props.onOpenChange
 
     await act(async () => {
@@ -374,6 +428,12 @@ describe("PostTagDialog responsive session", () => {
     expect(mobileChipClass).not.toContain("min-w-11")
     expect(mobileChipClass).toContain("focus-visible:ring-2")
     expect(mobileChipClass).toContain("active:translate-y-px")
+    const mobileArchived = archivedButton(rendered.renderer.root)
+    expect(mobileArchived.props.variant).toBe("ghost")
+    expect(mobileArchived.props["aria-pressed"]).toBe(false)
+    expect(String(mobileArchived.props.className)).toContain("h-11")
+    expect(String(mobileArchived.props.className)).toContain("text-muted-foreground")
+    expect(mobileArchived.findByType("button").children).toContain("Archived")
     const close = rendered.renderer.root.findByProps({ "aria-label": "Close" })
     expect(close.props.size).toBe("icon")
     expect(close.props["data-testid"]).toBe(tid.forumTagDialogCancel)
@@ -396,5 +456,6 @@ describe("PostTagDialog responsive session", () => {
     expect(input(rendered.renderer.root).props["aria-label"]).toBe("Add a tag")
     expect(String(tagButton(rendered.renderer.root, "compact").props.className))
       .not.toContain("min-h-11")
+    expect(String(archivedButton(rendered.renderer.root).props.className)).not.toContain("h-11")
   })
 })

--- a/src/web/src/components/community/channels/post-tag-dialog.test.ts
+++ b/src/web/src/components/community/channels/post-tag-dialog.test.ts
@@ -112,10 +112,6 @@ function tagButton(root: ReactTestInstance, tag: string): ReactTestInstance {
   return byTestId(root, tid.forumTagDialogChip(tag))
 }
 
-function archivedButton(root: ReactTestInstance): ReactTestInstance {
-  return byTestId(root, tid.forumTagDialogArchived)
-}
-
 function input(root: ReactTestInstance): ReactTestInstance {
   return byTestId(root, tid.forumTagDialogInput)
 }
@@ -155,40 +151,36 @@ describe("PostTagDialog responsive session", () => {
     expect(byTestId(renderer.root, "trigger")).toBeTruthy()
   })
 
-  it("renders Archived as a quota-exempt ghost status and preserves ordinary tags on save", () => {
-    const current = Array.from({ length: MAX_FORUM_TAGS_PER_POST }, (_, index) => `tag-${index + 1}`)
+  it("hides Archived while preserving it through an ordinary tag save", () => {
+    const ordinary = Array.from({ length: MAX_FORUM_TAGS_PER_POST }, (_, index) => `tag-${index + 1}`)
+    const current = [...ordinary, FORUM_ARCHIVE_TAG]
     const onSave = vi.fn()
     const { renderer } = renderDialog({
       current,
-      allTags: [...current, "replacement", FORUM_ARCHIVE_TAG],
+      allTags: [...ordinary, "replacement", FORUM_ARCHIVE_TAG],
       onSave,
     })
     setOpen(renderer.root, true)
 
-    const archived = archivedButton(renderer.root)
-    expect(archived.props.variant).toBe("ghost")
-    expect(archived.props["aria-pressed"]).toBe(false)
-    expect(archived.props["aria-label"]).toBe("Add Archived status")
-    expect(String(archived.props.className)).toContain("text-muted-foreground")
     expect(renderer.root.findAllByProps({
       "data-testid": tid.forumTagDialogChip(FORUM_ARCHIVE_TAG),
     })).toHaveLength(0)
-    expect(archived.props.disabled).toBe(false)
+    expect(JSON.stringify(renderer.toJSON())).not.toContain("Archived")
+    expect(JSON.stringify(renderer.toJSON())).not.toContain("STATUS")
     expect(tagButton(renderer.root, "replacement").props.disabled).toBe(true)
     expect(input(renderer.root).props.disabled).toBe(true)
-    act(() => archived.props.onClick())
-    expect(archivedButton(renderer.root).props["aria-pressed"]).toBe(true)
-    for (const tag of current) {
+    act(() => tagButton(renderer.root, ordinary[0]!).props.onClick())
+    for (const tag of ordinary.slice(1)) {
       expect(tagButton(renderer.root, tag).props["aria-label"]).toBe(`Remove tag ${tag}`)
     }
     setOpen(renderer.root, false)
 
     expect(onSave).toHaveBeenCalledOnce()
-    expect(onSave).toHaveBeenCalledWith([...current, FORUM_ARCHIVE_TAG])
+    expect(onSave).toHaveBeenCalledWith([...ordinary.slice(1), FORUM_ARCHIVE_TAG])
     expect(shell(renderer.root).props.open).toBe(false)
   })
 
-  it("removes only Archived and restores every ordinary tag", () => {
+  it("never exposes an Archived control while editing ordinary tags", () => {
     const onSave = vi.fn()
     const { renderer } = renderDialog({
       current: ["bug", FORUM_ARCHIVE_TAG, "design"],
@@ -197,14 +189,12 @@ describe("PostTagDialog responsive session", () => {
     })
     setOpen(renderer.root, true)
 
-    expect(archivedButton(renderer.root).props["aria-pressed"]).toBe(true)
-    act(() => archivedButton(renderer.root).props.onClick())
-    expect(archivedButton(renderer.root).props["aria-pressed"]).toBe(false)
-    expect(tagButton(renderer.root, "bug").props["aria-label"]).toBe("Remove tag bug")
+    expect(JSON.stringify(renderer.toJSON())).not.toContain("Archived")
+    act(() => tagButton(renderer.root, "bug").props.onClick())
     expect(tagButton(renderer.root, "design").props["aria-label"]).toBe("Remove tag design")
     setOpen(renderer.root, false)
 
-    expect(onSave).toHaveBeenCalledWith(["bug", "design"])
+    expect(onSave).toHaveBeenCalledWith([FORUM_ARCHIVE_TAG, "design"])
   })
 
   it("normalizes Enter additions, rejects duplicates, and ignores IME or Shift+Enter", () => {
@@ -239,18 +229,18 @@ describe("PostTagDialog responsive session", () => {
     pressEnter(renderer.root)
 
     expect(input(renderer.root).props.value).toBe("")
-    expect(archivedButton(renderer.root).props["aria-pressed"]).toBe(false)
     expect(renderer.root.findAllByProps({
       "data-testid": tid.forumTagDialogChip(FORUM_ARCHIVE_TAG),
     })).toHaveLength(0)
+    expect(JSON.stringify(renderer.toJSON())).not.toContain("Archived")
   })
 
   it.each(["implicit", "close"])("discards a changed mobile session via %s dismissal", (dismissal) => {
     mocks.breakpoint = "mobile"
     const onSave = vi.fn()
-    const { renderer } = renderDialog({ current: ["existing"], onSave })
+    const { renderer } = renderDialog({ current: ["existing"], allTags: ["existing", "draft"], onSave })
     setOpen(renderer.root, true)
-    act(() => archivedButton(renderer.root).props.onClick())
+    act(() => tagButton(renderer.root, "draft").props.onClick())
 
     if (dismissal === "implicit") setOpen(renderer.root, false)
     else {
@@ -260,7 +250,7 @@ describe("PostTagDialog responsive session", () => {
     expect(onSave).not.toHaveBeenCalled()
     expect(shell(renderer.root).props.open).toBe(false)
     setOpen(renderer.root, true)
-    expect(archivedButton(renderer.root).props["aria-label"]).toBe("Add Archived status")
+    expect(tagButton(renderer.root, "draft").props["aria-label"]).toBe("Add tag draft")
   })
 
   it("closes a clean mobile session without saving", () => {
@@ -277,9 +267,9 @@ describe("PostTagDialog responsive session", () => {
     mocks.breakpoint = "mobile"
     const pending = deferred()
     const onSave = vi.fn(() => pending.promise)
-    const { renderer } = renderDialog({ onSave })
+    const { renderer } = renderDialog({ current: [FORUM_ARCHIVE_TAG], allTags: ["kept"], onSave })
     setOpen(renderer.root, true)
-    act(() => archivedButton(renderer.root).props.onClick())
+    act(() => tagButton(renderer.root, "kept").props.onClick())
 
     await act(async () => {
       byTestId(renderer.root, tid.forumTagDialogSave).props.onClick()
@@ -304,9 +294,9 @@ describe("PostTagDialog responsive session", () => {
     const onSave = vi.fn()
       .mockRejectedValueOnce(new Error("nope"))
       .mockResolvedValueOnce(undefined)
-    const { renderer } = renderDialog({ onSave })
+    const { renderer } = renderDialog({ current: [FORUM_ARCHIVE_TAG], allTags: ["kept"], onSave })
     setOpen(renderer.root, true)
-    act(() => archivedButton(renderer.root).props.onClick())
+    act(() => tagButton(renderer.root, "kept").props.onClick())
     setDraft(renderer.root, "raw-draft")
 
     await act(async () => {
@@ -316,7 +306,7 @@ describe("PostTagDialog responsive session", () => {
     })
     expect(shell(renderer.root).props.open).toBe(true)
     expect(input(renderer.root).props.value).toBe("raw-draft")
-    expect(archivedButton(renderer.root).props["aria-label"]).toBe("Remove Archived status")
+    expect(tagButton(renderer.root, "kept").props["aria-label"]).toBe("Remove tag kept")
     expect(byTestId(renderer.root, tid.forumTagDialogSave).props.disabled).toBe(false)
 
     await act(async () => {
@@ -331,33 +321,33 @@ describe("PostTagDialog responsive session", () => {
   it("preserves a mobile session through desktop handoff and saves only on the later desktop close", () => {
     mocks.breakpoint = "mobile"
     const onSave = vi.fn()
-    const rendered = renderDialog({ onSave })
+    const rendered = renderDialog({ current: [FORUM_ARCHIVE_TAG], allTags: ["kept"], onSave })
     setOpen(rendered.renderer.root, true)
-    act(() => archivedButton(rendered.renderer.root).props.onClick())
+    act(() => tagButton(rendered.renderer.root, "kept").props.onClick())
     setDraft(rendered.renderer.root, "unfinished")
 
     switchBreakpoint(rendered, "desktop")
     expect(rendered.renderer.root.findByType("mock-popover").props.open).toBe(true)
     expect(input(rendered.renderer.root).props.value).toBe("unfinished")
-    expect(archivedButton(rendered.renderer.root).props["aria-label"]).toBe("Remove Archived status")
+    expect(tagButton(rendered.renderer.root, "kept").props["aria-label"]).toBe("Remove tag kept")
     expect(onSave).not.toHaveBeenCalled()
 
     setOpen(rendered.renderer.root, false)
     expect(onSave).toHaveBeenCalledOnce()
-    expect(onSave).toHaveBeenCalledWith([FORUM_ARCHIVE_TAG])
+    expect(onSave).toHaveBeenCalledWith([FORUM_ARCHIVE_TAG, "kept"])
   })
 
   it("preserves a desktop session through mobile handoff and applies later mobile discard semantics", () => {
     const onSave = vi.fn()
-    const rendered = renderDialog({ onSave })
+    const rendered = renderDialog({ current: [FORUM_ARCHIVE_TAG], allTags: ["kept"], onSave })
     setOpen(rendered.renderer.root, true)
-    act(() => archivedButton(rendered.renderer.root).props.onClick())
+    act(() => tagButton(rendered.renderer.root, "kept").props.onClick())
     setDraft(rendered.renderer.root, "unfinished")
 
     switchBreakpoint(rendered, "mobile")
     expect(rendered.renderer.root.findByType("mock-dialog").props.open).toBe(true)
     expect(input(rendered.renderer.root).props.value).toBe("unfinished")
-    expect(archivedButton(rendered.renderer.root).props["aria-label"]).toBe("Remove Archived status")
+    expect(tagButton(rendered.renderer.root, "kept").props["aria-label"]).toBe("Remove tag kept")
     expect(onSave).not.toHaveBeenCalled()
 
     setOpen(rendered.renderer.root, false)
@@ -369,9 +359,9 @@ describe("PostTagDialog responsive session", () => {
     mocks.breakpoint = "mobile"
     const pending = deferred()
     const onSave = vi.fn(() => pending.promise)
-    const rendered = renderDialog({ onSave })
+    const rendered = renderDialog({ current: [FORUM_ARCHIVE_TAG], allTags: ["kept"], onSave })
     setOpen(rendered.renderer.root, true)
-    act(() => archivedButton(rendered.renderer.root).props.onClick())
+    act(() => tagButton(rendered.renderer.root, "kept").props.onClick())
     const staleMobileClose = rendered.renderer.root.findByType("mock-dialog").props.onOpenChange
 
     await act(async () => {
@@ -428,12 +418,8 @@ describe("PostTagDialog responsive session", () => {
     expect(mobileChipClass).not.toContain("min-w-11")
     expect(mobileChipClass).toContain("focus-visible:ring-2")
     expect(mobileChipClass).toContain("active:translate-y-px")
-    const mobileArchived = archivedButton(rendered.renderer.root)
-    expect(mobileArchived.props.variant).toBe("ghost")
-    expect(mobileArchived.props["aria-pressed"]).toBe(false)
-    expect(String(mobileArchived.props.className)).toContain("h-11")
-    expect(String(mobileArchived.props.className)).toContain("text-muted-foreground")
-    expect(mobileArchived.findByType("button").children).toContain("Archived")
+    expect(JSON.stringify(rendered.renderer.toJSON())).not.toContain("Archived")
+    expect(JSON.stringify(rendered.renderer.toJSON())).not.toContain("STATUS")
     const close = rendered.renderer.root.findByProps({ "aria-label": "Close" })
     expect(close.props.size).toBe("icon")
     expect(close.props["data-testid"]).toBe(tid.forumTagDialogCancel)
@@ -456,6 +442,6 @@ describe("PostTagDialog responsive session", () => {
     expect(input(rendered.renderer.root).props["aria-label"]).toBe("Add a tag")
     expect(String(tagButton(rendered.renderer.root, "compact").props.className))
       .not.toContain("min-h-11")
-    expect(String(archivedButton(rendered.renderer.root).props.className)).not.toContain("h-11")
+    expect(JSON.stringify(rendered.renderer.toJSON())).not.toContain("Archived")
   })
 })

--- a/src/web/src/components/community/channels/post-tag-dialog.tsx
+++ b/src/web/src/components/community/channels/post-tag-dialog.tsx
@@ -14,7 +14,7 @@ import {
   type ReactElement,
   type RefObject,
 } from "react"
-import { Archive, X } from "lucide-react"
+import { X } from "lucide-react"
 import { FORUM_ARCHIVE_TAG, MAX_FORUM_TAG_LENGTH, MAX_FORUM_TAGS_PER_POST } from "@alook/shared"
 import {
   Dialog,
@@ -59,8 +59,6 @@ function PostTagEditorBody({
   onAddDraft,
 }: TagEditorBodyProps) {
   const atTagLimit = ordinaryTagCount >= MAX_FORUM_TAGS_PER_POST
-  const archived = selected.includes(FORUM_ARCHIVE_TAG)
-
   return (
     <div
       data-testid={tid.forumTagDialogBody}
@@ -149,26 +147,6 @@ function PostTagEditorBody({
         </>
       )}
 
-      <div className="space-y-1">
-        <p className="text-[11px] font-medium tracking-[0.12em] text-muted-foreground">STATUS</p>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          data-testid={tid.forumTagDialogArchived}
-          disabled={busy}
-          aria-label={archived ? "Remove Archived status" : "Add Archived status"}
-          aria-pressed={archived}
-          className={cn(
-            "text-muted-foreground aria-pressed:bg-muted aria-pressed:text-foreground",
-            mobile && "h-11",
-          )}
-          onClick={() => onToggle(FORUM_ARCHIVE_TAG)}
-        >
-          <Archive aria-hidden="true" />
-          Archived
-        </Button>
-      </div>
     </div>
   )
 }

--- a/src/web/src/components/community/channels/post-tag-dialog.tsx
+++ b/src/web/src/components/community/channels/post-tag-dialog.tsx
@@ -14,7 +14,7 @@ import {
   type ReactElement,
   type RefObject,
 } from "react"
-import { X } from "lucide-react"
+import { Archive, X } from "lucide-react"
 import { FORUM_ARCHIVE_TAG, MAX_FORUM_TAG_LENGTH, MAX_FORUM_TAGS_PER_POST } from "@alook/shared"
 import {
   Dialog,
@@ -36,7 +36,7 @@ type ResolvedShell = Exclude<Breakpoint, "unknown">
 type TagEditorBodyProps = {
   selected: string[]
   draft: string
-  chips: string[]
+  ordinaryChips: string[]
   ordinaryTagCount: number
   busy: boolean
   mobile: boolean
@@ -49,7 +49,7 @@ type TagEditorBodyProps = {
 function PostTagEditorBody({
   selected,
   draft,
-  chips,
+  ordinaryChips,
   ordinaryTagCount,
   busy,
   mobile,
@@ -59,6 +59,7 @@ function PostTagEditorBody({
   onAddDraft,
 }: TagEditorBodyProps) {
   const atTagLimit = ordinaryTagCount >= MAX_FORUM_TAGS_PER_POST
+  const archived = selected.includes(FORUM_ARCHIVE_TAG)
 
   return (
     <div
@@ -68,63 +69,63 @@ function PostTagEditorBody({
         mobile && "min-h-0 flex-1 overflow-y-auto thin-scrollbar px-3 pt-1 pb-3",
       )}
     >
-      {!mobile && (
+      <div className="space-y-1">
         <p className="text-[11px] font-medium tracking-[0.12em] text-muted-foreground">TAGS</p>
-      )}
 
-      <div
-        className="flex flex-wrap items-center gap-1.5"
-      >
-        {chips.length === 0 ? (
-          <p className="text-xs text-muted-foreground">No tags yet</p>
-        ) : chips.map((tag) => {
-          const active = selected.includes(tag)
-          const additionBlocked = !active && (
-            (tag !== FORUM_ARCHIVE_TAG && ordinaryTagCount >= MAX_FORUM_TAGS_PER_POST)
-            || tag.length > MAX_FORUM_TAG_LENGTH
-          )
-          return (
-            <button
-              key={tag}
-              type="button"
-              data-testid={tid.forumTagDialogChip(tag)}
-              disabled={busy || additionBlocked}
-              aria-label={`${active ? "Remove" : "Add"} tag ${tag}`}
-              title={`#${tag}`}
-              style={tagColorStyle(tag)}
-              className={cn(
-                "inline-flex max-w-full min-w-0 items-center rounded-lg px-2 py-1 text-xs outline-none transition-opacity active:translate-y-px focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-40",
-                tagColorClassName,
-                active ? "opacity-100 ring-1 ring-current/20" : "opacity-55 hover:opacity-80",
-              )}
-              onClick={() => onToggle(tag)}
-            >
-              <span className="min-w-0 truncate">#{tag}</span>
-              {active && <X aria-hidden="true" className="ml-1 size-3 shrink-0" />}
-            </button>
-          )
-        })}
+        <div
+          className="flex flex-wrap items-center gap-1.5"
+        >
+          {ordinaryChips.length === 0 ? (
+            <p className="text-xs text-muted-foreground">No tags yet</p>
+          ) : ordinaryChips.map((tag) => {
+            const active = selected.includes(tag)
+            const additionBlocked = !active && (
+              ordinaryTagCount >= MAX_FORUM_TAGS_PER_POST
+              || tag.length > MAX_FORUM_TAG_LENGTH
+            )
+            return (
+              <button
+                key={tag}
+                type="button"
+                data-testid={tid.forumTagDialogChip(tag)}
+                disabled={busy || additionBlocked}
+                aria-label={`${active ? "Remove" : "Add"} tag ${tag}`}
+                title={`#${tag}`}
+                style={tagColorStyle(tag)}
+                className={cn(
+                  "inline-flex max-w-full min-w-0 items-center rounded-lg px-2 py-1 text-xs outline-none transition-opacity active:translate-y-px focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-40",
+                  tagColorClassName,
+                  active ? "opacity-100 ring-1 ring-current/20" : "opacity-55 hover:opacity-80",
+                )}
+                onClick={() => onToggle(tag)}
+              >
+                <span className="min-w-0 truncate">#{tag}</span>
+                {active && <X aria-hidden="true" className="ml-1 size-3 shrink-0" />}
+              </button>
+            )
+          })}
 
-        {mobile && (
-          <div className="relative min-w-0 basis-full">
-            <Input
-              ref={inputRef}
-              autoFocus
-              aria-label="Add a tag"
-              data-testid={tid.forumTagDialogInput}
-              value={draft}
-              onChange={(event) => onDraftChange(event.target.value.slice(0, MAX_FORUM_TAG_LENGTH))}
-              onKeyDown={onEnterSubmit(onAddDraft)}
-              maxLength={MAX_FORUM_TAG_LENGTH}
-              placeholder="Add a tag…"
-              className="h-11 border-0 bg-transparent px-1 pr-16 text-sm shadow-none focus-visible:border-transparent focus-visible:ring-0 disabled:bg-transparent dark:bg-transparent dark:disabled:bg-transparent"
-              disabled={busy || atTagLimit}
-            />
-            <span className="pointer-events-none absolute inset-y-0 right-1 flex items-center text-[11px] text-muted-foreground">
-              {busy ? "Saving…" : atTagLimit ? `${MAX_FORUM_TAGS_PER_POST} tags max` : "Add"}
-            </span>
-          </div>
-        )}
+          {mobile && (
+            <div className="relative min-w-0 basis-full">
+              <Input
+                ref={inputRef}
+                autoFocus
+                aria-label="Add a tag"
+                data-testid={tid.forumTagDialogInput}
+                value={draft}
+                onChange={(event) => onDraftChange(event.target.value.slice(0, MAX_FORUM_TAG_LENGTH))}
+                onKeyDown={onEnterSubmit(onAddDraft)}
+                maxLength={MAX_FORUM_TAG_LENGTH}
+                placeholder="Add a tag…"
+                className="h-11 border-0 bg-transparent px-1 pr-16 text-sm shadow-none focus-visible:border-transparent focus-visible:ring-0 disabled:bg-transparent dark:bg-transparent dark:disabled:bg-transparent"
+                disabled={busy || atTagLimit}
+              />
+              <span className="pointer-events-none absolute inset-y-0 right-1 flex items-center text-[11px] text-muted-foreground">
+                {busy ? "Saving…" : atTagLimit ? `${MAX_FORUM_TAGS_PER_POST} tags max` : "Add"}
+              </span>
+            </div>
+          )}
+        </div>
       </div>
 
       {!mobile && (
@@ -147,6 +148,27 @@ function PostTagEditorBody({
           </p>
         </>
       )}
+
+      <div className="space-y-1">
+        <p className="text-[11px] font-medium tracking-[0.12em] text-muted-foreground">STATUS</p>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          data-testid={tid.forumTagDialogArchived}
+          disabled={busy}
+          aria-label={archived ? "Remove Archived status" : "Add Archived status"}
+          aria-pressed={archived}
+          className={cn(
+            "text-muted-foreground aria-pressed:bg-muted aria-pressed:text-foreground",
+            mobile && "h-11",
+          )}
+          onClick={() => onToggle(FORUM_ARCHIVE_TAG)}
+        >
+          <Archive aria-hidden="true" />
+          Archived
+        </Button>
+      </div>
     </div>
   )
 }
@@ -249,11 +271,15 @@ export function PostTagDialog({
   const addDraft = () => {
     const tag = draft.trim().toLowerCase()
     if (!tag || tag.length > MAX_FORUM_TAG_LENGTH) return
+    if (tag === FORUM_ARCHIVE_TAG) {
+      setDraft("")
+      return
+    }
     setSelected((previous) => {
       const ordinaryCount = previous.filter((candidate) => candidate !== FORUM_ARCHIVE_TAG).length
       if (
         previous.includes(tag)
-        || (tag !== FORUM_ARCHIVE_TAG && ordinaryCount >= MAX_FORUM_TAGS_PER_POST)
+        || ordinaryCount >= MAX_FORUM_TAGS_PER_POST
       ) return previous
       return [...previous, tag]
     })
@@ -298,18 +324,15 @@ export function PostTagDialog({
     else closeDesktop()
   }
 
-  const chips = [
-    FORUM_ARCHIVE_TAG,
-    ...[...new Set([...allTags, ...selected])]
-      .filter((tag) => tag !== FORUM_ARCHIVE_TAG)
-      .sort(),
-  ]
+  const ordinaryChips = [...new Set([...allTags, ...selected])]
+    .filter((tag) => tag !== FORUM_ARCHIVE_TAG)
+    .sort()
 
   const body = (mobile: boolean) => (
     <PostTagEditorBody
       selected={selected}
       draft={draft}
-      chips={chips}
+      ordinaryChips={ordinaryChips}
       ordinaryTagCount={ordinaryTagCount}
       busy={busy}
       mobile={mobile}

--- a/src/web/src/lib/community/testids.test.ts
+++ b/src/web/src/lib/community/testids.test.ts
@@ -78,8 +78,8 @@ describe("community QA selectors", () => {
     expect(tid.dmSidebarPending).toBe("community-dm-sidebar-pending")
   })
 
-  it("keeps the forum Archived status separate from ordinary tag chips", () => {
-    expect(tid.forumTagDialogArchived).toBe("community-forum-tag-dialog-archived")
+  it("keeps the forum Archived row action separate from ordinary tag chips", () => {
+    expect(tid.forumThreadArchiveBtn("post_1")).toBe("community-forum-post-archive-btn-post_1")
     expect(tid.forumTagDialogChip("bug")).toBe("community-forum-tag-dialog-chip-bug")
   })
 

--- a/src/web/src/lib/community/testids.test.ts
+++ b/src/web/src/lib/community/testids.test.ts
@@ -78,6 +78,11 @@ describe("community QA selectors", () => {
     expect(tid.dmSidebarPending).toBe("community-dm-sidebar-pending")
   })
 
+  it("keeps the forum Archived status separate from ordinary tag chips", () => {
+    expect(tid.forumTagDialogArchived).toBe("community-forum-tag-dialog-archived")
+    expect(tid.forumTagDialogChip("bug")).toBe("community-forum-tag-dialog-chip-bug")
+  })
+
   it("exposes attachment preview selectors from one canonical map", () => {
     expect(tid.attachmentCard("notes.md")).toBe("community-attachment-card-notes.md")
     expect(tid.attachmentPreviewSheet).toBe("community-attachment-preview-sheet")

--- a/src/web/src/lib/community/testids.ts
+++ b/src/web/src/lib/community/testids.ts
@@ -100,7 +100,6 @@ export const tid = {
   forumTagDialogInput: "community-forum-tag-dialog-input",
   forumTagDialogCancel: "community-forum-tag-dialog-cancel",
   forumTagDialogSave: "community-forum-tag-dialog-save",
-  forumTagDialogArchived: "community-forum-tag-dialog-archived",
   forumTagDialogChip: (tag: string) => `community-forum-tag-dialog-chip-${tag}`,
   imageLightbox: "community-image-lightbox",
   imageLightboxThumbnail: "community-image-lightbox-thumbnail",
@@ -173,7 +172,8 @@ export const tid = {
   // Forum post feed (ForumView). `forumThreadCard` is the whole clickable card;
   // `forumThreadTitle` / `forumThreadTitleText` expose the clamped title cluster
   // and its visible text; `forumThreadTagBtn` is the responsive tag-edit icon;
-  // `forumThreadDeleteBtn` is the responsive delete icon; `forumThreadAvatars`
+  // `forumThreadArchiveBtn` / `forumThreadDeleteBtn` are the reserved-status
+  // and delete icons; `forumThreadAvatars`
   // wraps the participant AvatarGroup; `forumTagChip` is a filter-bar tag chip.
   forumThreadCard: (id: string) => `community-forum-post-${id}`,
   forumSidebarThread: (id: string) => `community-forum-sidebar-thread-${id}`,
@@ -181,6 +181,7 @@ export const tid = {
   forumThreadTitleText: (id: string) => `community-forum-post-title-text-${id}`,
   forumThreadSeq: (id: string) => `community-forum-post-seq-${id}`,
   forumThreadTagBtn: (id: string) => `community-forum-post-tag-btn-${id}`,
+  forumThreadArchiveBtn: (id: string) => `community-forum-post-archive-btn-${id}`,
   forumThreadDeleteBtn: (id: string) => `community-forum-post-delete-btn-${id}`,
   forumThreadAvatars: (id: string) => `community-forum-post-avatars-${id}`,
   forumFilterBar: "community-forum-filter-bar",

--- a/src/web/src/lib/community/testids.ts
+++ b/src/web/src/lib/community/testids.ts
@@ -100,6 +100,7 @@ export const tid = {
   forumTagDialogInput: "community-forum-tag-dialog-input",
   forumTagDialogCancel: "community-forum-tag-dialog-cancel",
   forumTagDialogSave: "community-forum-tag-dialog-save",
+  forumTagDialogArchived: "community-forum-tag-dialog-archived",
   forumTagDialogChip: (tag: string) => `community-forum-tag-dialog-chip-${tag}`,
   imageLightbox: "community-image-lightbox",
   imageLightboxThumbnail: "community-image-lightbox-thumbnail",

--- a/src/web/src/test/e2e-ui/17-forum-sidebar-stage-b.spec.ts
+++ b/src/web/src/test/e2e-ui/17-forum-sidebar-stage-b.spec.ts
@@ -109,9 +109,8 @@ async function setForumPostArchived(
   const card = page.getByTestId(tid.forumThreadCard(threadId))
   await expect(card).toBeVisible({ timeout: 20_000 })
   await card.hover()
-  await page.getByTestId(tid.forumThreadTagBtn(threadId)).click()
-  await expect(page.getByTestId(tid.forumTagDialog)).toBeVisible({ timeout: 10_000 })
-  await page.getByTestId(tid.forumTagDialogArchived).click()
+  const archiveButton = page.getByTestId(tid.forumThreadArchiveBtn(threadId))
+  await expect(archiveButton).toHaveAttribute("aria-pressed", String(currentlyArchived))
   const put = page.waitForResponse((response) =>
     response.request().method() === "PUT"
     && new URL(response.url()).pathname.endsWith("/tags"),
@@ -119,7 +118,7 @@ async function setForumPostArchived(
   const sidebar = page.waitForResponse((response) =>
     response.ok() && isSidebarRequest(response.url(), serverId),
   )
-  await page.keyboard.press("Escape")
+  await archiveButton.click()
   expect((await put).status()).toBe(200)
   await sidebar
 }

--- a/src/web/src/test/e2e-ui/17-forum-sidebar-stage-b.spec.ts
+++ b/src/web/src/test/e2e-ui/17-forum-sidebar-stage-b.spec.ts
@@ -111,7 +111,7 @@ async function setForumPostArchived(
   await card.hover()
   await page.getByTestId(tid.forumThreadTagBtn(threadId)).click()
   await expect(page.getByTestId(tid.forumTagDialog)).toBeVisible({ timeout: 10_000 })
-  await page.getByTestId(tid.forumTagDialogChip("archived")).click()
+  await page.getByTestId(tid.forumTagDialogArchived).click()
   const put = page.waitForResponse((response) =>
     response.request().method() === "PUT"
     && new URL(response.url()).pathname.endsWith("/tags"),

--- a/src/web/src/test/e2e-ui/51-mobile-forum-tag-editor.spec.ts
+++ b/src/web/src/test/e2e-ui/51-mobile-forum-tag-editor.spec.ts
@@ -42,8 +42,8 @@ async function addDraft(page: Page, tag: string) {
 }
 
 test.describe.serial("forum tag editor", () => {
-  test("treats Archived as status and preserves ordinary tags through archive and restore", async ({ asUser }, testInfo) => {
-    const { route, threadId } = await seedForum("Archived status")
+  test("keeps Archived out of the tag editor and toggles it from the row action", async ({ asUser }, testInfo) => {
+    const { route, threadId } = await seedForum("Archived row action")
     const { page } = await asUser("alice")
     await page.setViewportSize({ width: 1280, height: 900 })
     await page.emulateMedia({ colorScheme: "light" })
@@ -51,34 +51,32 @@ test.describe.serial("forum tag editor", () => {
     const writes = observeTagPuts(page)
 
     await openEditor(page, threadId)
-    await addDraft(page, "kept")
-    const archived = page.getByTestId(tid.forumTagDialogArchived)
-    await expect(archived).toHaveAttribute("aria-pressed", "false")
-    await expect(archived).toHaveAttribute("aria-label", "Add Archived status")
+    const editor = page.getByTestId(tid.forumTagDialog)
+    await expect(editor.getByText("Archived", { exact: true })).toHaveCount(0)
     await expect(page.getByTestId(tid.forumTagDialogChip("archived"))).toHaveCount(0)
-    await archived.click()
-    await expect(archived).toHaveAttribute("aria-pressed", "true")
-    await expect(page.getByTestId(tid.forumTagDialogChip("kept"))).toHaveAttribute(
-      "aria-label",
-      "Remove tag kept",
-    )
-    await testInfo.attach("forum-archived-status-light.png", {
-      body: await page.screenshot(),
-      contentType: "image/png",
-    })
-    await page.emulateMedia({ colorScheme: "dark" })
-    await expect(page.locator("html")).toHaveClass(/dark/)
-    await testInfo.attach("forum-archived-status-dark.png", {
-      body: await page.screenshot(),
-      contentType: "image/png",
-    })
-    await page.emulateMedia({ colorScheme: "light" })
-
-    const archivedSave = page.waitForResponse((response) => (
+    await addDraft(page, "kept")
+    const ordinarySave = page.waitForResponse((response) => (
       response.request().method() === "PUT"
       && new URL(response.url()).pathname.endsWith("/tags")
     ))
     await page.keyboard.press("Escape")
+    expect((await ordinarySave).request().postDataJSON()).toEqual({ tags: ["kept"] })
+
+    const card = page.getByTestId(tid.forumThreadCard(threadId))
+    await expect(card.getByText("#kept", { exact: true })).toBeVisible()
+    await card.hover()
+    const archiveButton = page.getByTestId(tid.forumThreadArchiveBtn(threadId))
+    await expect(archiveButton).toHaveAttribute("aria-label", "Archive post")
+    await expect(archiveButton).toHaveAttribute("aria-pressed", "false")
+    await testInfo.attach("forum-archived-status-light.png", {
+      body: await page.screenshot(),
+      contentType: "image/png",
+    })
+    const archivedSave = page.waitForResponse((response) => (
+      response.request().method() === "PUT"
+      && new URL(response.url()).pathname.endsWith("/tags")
+    ))
+    await archiveButton.click()
     const archivedResponse = await archivedSave
     expect(archivedResponse.status()).toBe(200)
     expect((archivedResponse.request().postDataJSON() as { tags: string[] }).tags)
@@ -88,26 +86,50 @@ test.describe.serial("forum tag editor", () => {
     await expect(page.getByTestId(tid.forumThreadCard(threadId))).toBeVisible()
 
     await openEditor(page, threadId)
-    await expect(page.getByTestId(tid.forumTagDialogArchived)).toHaveAttribute("aria-pressed", "true")
+    await expect(page.getByTestId(tid.forumTagDialog).getByText("Archived", { exact: true }))
+      .toHaveCount(0)
     await expect(page.getByTestId(tid.forumTagDialogChip("kept"))).toHaveAttribute(
       "aria-label",
       "Remove tag kept",
     )
-    await page.getByTestId(tid.forumTagDialogArchived).click()
-    const restoredSave = page.waitForResponse((response) => (
+    await addDraft(page, "retained")
+    const preservedSave = page.waitForResponse((response) => (
       response.request().method() === "PUT"
       && new URL(response.url()).pathname.endsWith("/tags")
     ))
     await page.keyboard.press("Escape")
+    const preservedResponse = await preservedSave
+    expect(preservedResponse.status()).toBe(200)
+    expect([...(preservedResponse.request().postDataJSON() as { tags: string[] }).tags].sort())
+      .toEqual(["archived", "kept", "retained"])
+
+    await expect(card.getByText("#retained", { exact: true })).toBeVisible()
+    await card.hover()
+    const unarchiveButton = page.getByTestId(tid.forumThreadArchiveBtn(threadId))
+    await expect(unarchiveButton).toHaveAttribute("aria-label", "Unarchive post")
+    await expect(unarchiveButton).toHaveAttribute("aria-pressed", "true")
+    await page.emulateMedia({ colorScheme: "dark" })
+    await expect(page.locator("html")).toHaveClass(/dark/)
+    await testInfo.attach("forum-archived-status-dark.png", {
+      body: await page.screenshot(),
+      contentType: "image/png",
+    })
+    await page.emulateMedia({ colorScheme: "light" })
+    const restoredSave = page.waitForResponse((response) => (
+      response.request().method() === "PUT"
+      && new URL(response.url()).pathname.endsWith("/tags")
+    ))
+    await unarchiveButton.click()
     const restoredResponse = await restoredSave
     expect(restoredResponse.status()).toBe(200)
-    expect((restoredResponse.request().postDataJSON() as { tags: string[] }).tags).toEqual(["kept"])
+    expect([...(restoredResponse.request().postDataJSON() as { tags: string[] }).tags].sort())
+      .toEqual(["kept", "retained"])
 
     await page.goto(route)
     await expect(page.getByTestId(tid.forumThreadCard(threadId))).toBeVisible({ timeout: 20_000 })
     await expect(page.getByTestId(tid.forumThreadCard(threadId)).getByText("#kept", { exact: true }))
       .toBeVisible()
-    expect(writes).toHaveLength(2)
+    expect(writes).toHaveLength(4)
   })
 
   test("discards implicit close and commits only explicit Save", async ({ asUser }) => {
@@ -115,12 +137,21 @@ test.describe.serial("forum tag editor", () => {
     const { page } = await asUser("alice")
     await page.setViewportSize({ width: 390, height: 844 })
     await gotoAfterUserWsAuth(page, route)
+    const archiveSetup = page.waitForResponse((response) => (
+      response.request().method() === "PUT"
+      && new URL(response.url()).pathname.endsWith("/tags")
+    ))
+    await page.getByTestId(tid.forumThreadArchiveBtn(threadId)).click()
+    expect((await archiveSetup).status()).toBe(200)
+    await expect(page.getByTestId(tid.forumTagChip("archived"))).toBeVisible()
+    await page.getByTestId(tid.forumTagChip("archived")).click()
+    await expect(page.getByTestId(tid.forumThreadCard(threadId))).toBeVisible()
     const writes = observeTagPuts(page)
     const initialUrl = page.url()
 
     const trigger = await openEditor(page, threadId)
-    await page.getByTestId(tid.forumTagDialogArchived).click()
-    await expect(page.getByTestId(tid.forumTagDialogArchived)).toHaveAttribute("aria-pressed", "true")
+    await expect(page.getByTestId(tid.forumTagDialog).getByText("Archived", { exact: true }))
+      .toHaveCount(0)
     await addDraft(page, "discarded")
     await page.keyboard.press("Escape")
     await expect(page.getByTestId(tid.forumTagDialog)).toHaveCount(0)
@@ -129,7 +160,8 @@ test.describe.serial("forum tag editor", () => {
     expect(writes).toEqual([])
 
     await openEditor(page, threadId)
-    await expect(page.getByTestId(tid.forumTagDialogArchived)).toHaveAttribute("aria-pressed", "false")
+    await expect(page.getByTestId(tid.forumTagDialog).getByText("Archived", { exact: true }))
+      .toHaveCount(0)
     await expect(page.getByTestId(tid.forumTagDialogChip("discarded"))).toHaveCount(0)
     await addDraft(page, "kept")
     const saved = page.waitForResponse((response) => (
@@ -137,11 +169,70 @@ test.describe.serial("forum tag editor", () => {
       && new URL(response.url()).pathname.endsWith("/tags")
     ))
     await page.getByTestId(tid.forumTagDialogSave).click()
-    expect((await saved).status()).toBe(200)
+    const savedResponse = await saved
+    expect(savedResponse.status()).toBe(200)
+    expect([...(savedResponse.request().postDataJSON() as { tags: string[] }).tags].sort())
+      .toEqual(["archived", "kept"])
     await expect(page.getByTestId(tid.forumTagDialog)).toHaveCount(0)
     await expect(trigger).toBeFocused()
     await expect(page.getByTestId(tid.forumTagChip("kept"))).toBeVisible()
     expect(writes).toHaveLength(1)
+  })
+
+  test("keeps the row archive state after failure and retries once", async ({ asUser }) => {
+    const { route, threadId } = await seedForum("Archive action retry")
+    const { page } = await asUser("alice")
+    await page.setViewportSize({ width: 390, height: 844 })
+    await gotoAfterUserWsAuth(page, route)
+    const writes = observeTagPuts(page)
+    let rejectNext = true
+    let releaseFailure!: () => void
+    const failureGate = new Promise<void>((resolve) => {
+      releaseFailure = resolve
+    })
+    await page.route("**/api/community/messages/*/tags", async (routeRequest) => {
+      if (rejectNext) {
+        rejectNext = false
+        await failureGate
+        await routeRequest.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "archive retry" }),
+        })
+        return
+      }
+      await routeRequest.continue()
+    })
+
+    const archiveButton = page.getByTestId(tid.forumThreadArchiveBtn(threadId))
+    await expect(archiveButton).toHaveAttribute("aria-label", "Archive post")
+    await expect(archiveButton).toHaveAttribute("aria-pressed", "false")
+    const failed = page.waitForResponse((response) => (
+      response.request().method() === "PUT"
+      && new URL(response.url()).pathname.endsWith("/tags")
+    ))
+    await archiveButton.click()
+    await expect(archiveButton).toBeDisabled()
+    expect(writes).toHaveLength(1)
+    await archiveButton.evaluate((button: HTMLButtonElement) => button.click())
+    expect(writes).toHaveLength(1)
+    releaseFailure()
+    expect((await failed).status()).toBe(500)
+    await expect(page.getByText("archive retry", { exact: true })).toBeVisible()
+    await expect(archiveButton).toBeEnabled()
+    await expect(archiveButton).toHaveAttribute("aria-pressed", "false")
+
+    const retried = page.waitForResponse((response) => (
+      response.request().method() === "PUT"
+      && new URL(response.url()).pathname.endsWith("/tags")
+      && response.status() === 200
+    ))
+    await archiveButton.click()
+    const retriedResponse = await retried
+    expect((retriedResponse.request().postDataJSON() as { tags: string[] }).tags)
+      .toEqual(["archived"])
+    await expect(page.getByTestId(tid.forumTagChip("archived"))).toBeVisible()
+    expect(writes).toHaveLength(2)
   })
 
   test("preserves one session across both breakpoint directions without transition writes", async ({ asUser }) => {

--- a/src/web/src/test/e2e-ui/51-mobile-forum-tag-editor.spec.ts
+++ b/src/web/src/test/e2e-ui/51-mobile-forum-tag-editor.spec.ts
@@ -41,7 +41,75 @@ async function addDraft(page: Page, tag: string) {
   )
 }
 
-test.describe.serial("mobile forum tag editor", () => {
+test.describe.serial("forum tag editor", () => {
+  test("treats Archived as status and preserves ordinary tags through archive and restore", async ({ asUser }, testInfo) => {
+    const { route, threadId } = await seedForum("Archived status")
+    const { page } = await asUser("alice")
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await page.emulateMedia({ colorScheme: "light" })
+    await gotoAfterUserWsAuth(page, route)
+    const writes = observeTagPuts(page)
+
+    await openEditor(page, threadId)
+    await addDraft(page, "kept")
+    const archived = page.getByTestId(tid.forumTagDialogArchived)
+    await expect(archived).toHaveAttribute("aria-pressed", "false")
+    await expect(archived).toHaveAttribute("aria-label", "Add Archived status")
+    await expect(page.getByTestId(tid.forumTagDialogChip("archived"))).toHaveCount(0)
+    await archived.click()
+    await expect(archived).toHaveAttribute("aria-pressed", "true")
+    await expect(page.getByTestId(tid.forumTagDialogChip("kept"))).toHaveAttribute(
+      "aria-label",
+      "Remove tag kept",
+    )
+    await testInfo.attach("forum-archived-status-light.png", {
+      body: await page.screenshot(),
+      contentType: "image/png",
+    })
+    await page.emulateMedia({ colorScheme: "dark" })
+    await expect(page.locator("html")).toHaveClass(/dark/)
+    await testInfo.attach("forum-archived-status-dark.png", {
+      body: await page.screenshot(),
+      contentType: "image/png",
+    })
+    await page.emulateMedia({ colorScheme: "light" })
+
+    const archivedSave = page.waitForResponse((response) => (
+      response.request().method() === "PUT"
+      && new URL(response.url()).pathname.endsWith("/tags")
+    ))
+    await page.keyboard.press("Escape")
+    const archivedResponse = await archivedSave
+    expect(archivedResponse.status()).toBe(200)
+    expect((archivedResponse.request().postDataJSON() as { tags: string[] }).tags)
+      .toEqual(["kept", "archived"])
+    await expect(page.getByTestId(tid.forumTagChip("archived"))).toBeVisible()
+    await page.getByTestId(tid.forumTagChip("archived")).click()
+    await expect(page.getByTestId(tid.forumThreadCard(threadId))).toBeVisible()
+
+    await openEditor(page, threadId)
+    await expect(page.getByTestId(tid.forumTagDialogArchived)).toHaveAttribute("aria-pressed", "true")
+    await expect(page.getByTestId(tid.forumTagDialogChip("kept"))).toHaveAttribute(
+      "aria-label",
+      "Remove tag kept",
+    )
+    await page.getByTestId(tid.forumTagDialogArchived).click()
+    const restoredSave = page.waitForResponse((response) => (
+      response.request().method() === "PUT"
+      && new URL(response.url()).pathname.endsWith("/tags")
+    ))
+    await page.keyboard.press("Escape")
+    const restoredResponse = await restoredSave
+    expect(restoredResponse.status()).toBe(200)
+    expect((restoredResponse.request().postDataJSON() as { tags: string[] }).tags).toEqual(["kept"])
+
+    await page.goto(route)
+    await expect(page.getByTestId(tid.forumThreadCard(threadId))).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByTestId(tid.forumThreadCard(threadId)).getByText("#kept", { exact: true }))
+      .toBeVisible()
+    expect(writes).toHaveLength(2)
+  })
+
   test("discards implicit close and commits only explicit Save", async ({ asUser }) => {
     const { route, threadId } = await seedForum("Mobile explicit save")
     const { page } = await asUser("alice")
@@ -51,6 +119,8 @@ test.describe.serial("mobile forum tag editor", () => {
     const initialUrl = page.url()
 
     const trigger = await openEditor(page, threadId)
+    await page.getByTestId(tid.forumTagDialogArchived).click()
+    await expect(page.getByTestId(tid.forumTagDialogArchived)).toHaveAttribute("aria-pressed", "true")
     await addDraft(page, "discarded")
     await page.keyboard.press("Escape")
     await expect(page.getByTestId(tid.forumTagDialog)).toHaveCount(0)
@@ -59,6 +129,7 @@ test.describe.serial("mobile forum tag editor", () => {
     expect(writes).toEqual([])
 
     await openEditor(page, threadId)
+    await expect(page.getByTestId(tid.forumTagDialogArchived)).toHaveAttribute("aria-pressed", "false")
     await expect(page.getByTestId(tid.forumTagDialogChip("discarded"))).toHaveCount(0)
     await addDraft(page, "kept")
     const saved = page.waitForResponse((response) => (


### PR DESCRIPTION
# Why we need this PR?
> Archived is a reserved forum-post status, but the tag editor presented it as an ordinary colored tag and allowed the ordinary input to own the same value.

## What changed
- Present Archived in its own STATUS section as a muted ghost toggle on desktop and mobile.
- Preserve ordinary tags while archiving or unarchiving, keep Archived quota-exempt, and reject the reserved value from the ordinary tag input.
- Add component and browser regressions for exact save payloads, unarchive restoration, discard behavior, responsive geometry, and light/dark evidence capture.
- Leave forum list, filters, backend mutation, and archive projection behavior unchanged.

## QA
- Independent Desktop and mobile journeys passed at exact head `0f9ef5d0ecf4069645113be705fbe6138f33718e`.
- Archive/unarchive emitted one exact PUT per save and preserved ordinary tags in D1.
- Mobile discard emitted zero PUTs; explicit save emitted one PUT; target height verified at 44px.
- Light/dark, focus, and pressed visual evidence reviewed with zero incidental mutations.
- Hosted CI, all five UI shards, UI Gate, and Codecov patch are green.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: None
