### PR TITLE
fix(web): remove mobile inbox chrome

### DIFF
--- a/src/web/src/components/community/shell/community-inbox-surface.test.ts
+++ b/src/web/src/components/community/shell/community-inbox-surface.test.ts
@@ -11,7 +11,6 @@ vi.mock("@/components/ui/popover", () => {
     }
   return {
     Popover: pass("popover-root"),
-    PopoverBackdrop: pass("popover-backdrop"),
     PopoverContent: pass("popover-content"),
     PopoverPopup: pass("popover-popup"),
     PopoverPortal: pass("popover-portal"),
@@ -40,23 +39,25 @@ async function renderSurface(breakpoint: "mobile" | "desktop", open = true) {
 }
 
 describe("CommunityInboxSurface", () => {
-  it("uses a scoped real nonmodal Popover surface on mobile", async () => {
+  it("uses a backdrop-free nonmodal Popover surface on mobile", async () => {
     const { renderer, anchorRef, suppressFocusReturnRef } = await renderSurface("mobile")
     expect(renderer.root.findByType("popover-root").props.modal).toBe(false)
     const trigger = renderer.root.findByType("popover-trigger").props.render
+    const triggerClasses = trigger.props.className.split(" ")
     expect(trigger.props["data-testid"]).toBe(tid.inboxTrigger)
     expect(trigger.props["aria-label"]).toBe("Close Inbox")
     expect(trigger.props["aria-pressed"]).toBe(true)
     expect(trigger.props.className).toContain("aria-expanded:text-foreground")
+    expect(triggerClasses).not.toContain("hover:bg-accent")
+    expect(triggerClasses).toContain("hover:text-foreground")
+    expect(triggerClasses).toContain("active:text-foreground")
+    expect(triggerClasses).not.toContain("border")
+    expect(triggerClasses).not.toContain("bg-accent")
+    expect(triggerClasses).not.toContain("shadow")
+    expect(triggerClasses).toContain("focus-visible:ring-2")
     expect(renderer.root.findByType("svg").props.className).not.toContain("fill-current")
     expect(renderer.root.findByType("svg").props.fill).toBe("none")
-
-    const backdrop = renderer.root.findByType("popover-backdrop")
-    expect(backdrop.props["data-testid"]).toBe(tid.inboxMobileBackdrop)
-    expect(backdrop.props.style).toEqual({
-      top: "var(--app-safe-area-top)",
-      bottom: "calc(60px + var(--app-safe-area-bottom))",
-    })
+    expect(renderer.root.findAllByType("popover-backdrop")).toHaveLength(0)
 
     const positioner = renderer.root.findByType("popover-positioner")
     expect(positioner.props).toMatchObject({
@@ -89,6 +90,7 @@ describe("CommunityInboxSurface", () => {
     expect(trigger.props["aria-label"]).toBe("Open Inbox")
     expect(trigger.props["aria-pressed"]).toBe(false)
     expect(trigger.props.className).toContain("aria-expanded:text-foreground")
+    expect(trigger.props.className.split(" ")).not.toContain("hover:bg-accent")
     expect(renderer.root.findByType("svg").props.className).not.toContain("fill-current")
     expect(renderer.root.findByType("svg").props.fill).toBe("none")
   })
@@ -104,6 +106,7 @@ describe("CommunityInboxSurface", () => {
     expect(trigger.props["aria-label"]).toBe("Inbox")
     expect(trigger.props["aria-pressed"]).toBeUndefined()
     expect(trigger.props.className).not.toContain("aria-expanded:text-foreground")
+    expect(trigger.props.className.split(" ")).toContain("hover:bg-accent")
     expect(renderer.root.findByType("svg").props.className).not.toContain("fill-current")
     expect(renderer.root.findAllByType("popover-backdrop")).toHaveLength(0)
     expect(renderer.root.findAllByType("popover-popup")).toHaveLength(0)

--- a/src/web/src/components/community/shell/community-inbox-surface.test.ts
+++ b/src/web/src/components/community/shell/community-inbox-surface.test.ts
@@ -57,6 +57,17 @@ describe("CommunityInboxSurface", () => {
     expect(triggerClasses).toContain("focus-visible:ring-2")
     expect(renderer.root.findByType("svg").props.className).not.toContain("fill-current")
     expect(renderer.root.findByType("svg").props.fill).toBe("none")
+    const unreadDot = renderer.root.find((node) => (
+      node.type === "span" && node.props.className?.includes("bg-primary")
+    ))
+    expect(unreadDot.props.className.split(" ")).toEqual(expect.arrayContaining([
+      "-right-1",
+      "-top-1",
+    ]))
+    expect(unreadDot.parent?.props.className.split(" ")).toEqual(expect.arrayContaining([
+      "relative",
+      "size-4",
+    ]))
     expect(renderer.root.findAllByType("popover-backdrop")).toHaveLength(0)
 
     const positioner = renderer.root.findByType("popover-positioner")
@@ -108,6 +119,16 @@ describe("CommunityInboxSurface", () => {
     expect(trigger.props.className).not.toContain("aria-expanded:text-foreground")
     expect(trigger.props.className.split(" ")).toContain("hover:bg-accent")
     expect(renderer.root.findByType("svg").props.className).not.toContain("fill-current")
+    const unreadDot = renderer.root.find((node) => (
+      node.type === "span" && node.props.className?.includes("bg-primary")
+    ))
+    const unreadDotClasses = unreadDot.props.className.split(" ")
+    expect(unreadDotClasses).toEqual(expect.arrayContaining([
+      "right-1",
+      "top-1",
+    ]))
+    expect(unreadDotClasses).not.toContain("-right-1")
+    expect(unreadDotClasses).not.toContain("-top-1")
     expect(renderer.root.findAllByType("popover-backdrop")).toHaveLength(0)
     expect(renderer.root.findAllByType("popover-popup")).toHaveLength(0)
   })

--- a/src/web/src/components/community/shell/community-inbox-surface.tsx
+++ b/src/web/src/components/community/shell/community-inbox-surface.tsx
@@ -71,9 +71,20 @@ export function CommunityInboxSurface({
           />
         }
       >
-        <Inbox className="size-4" />
-        {hasUnread && (
-          <span className="absolute right-1 top-1 size-2 rounded-full bg-primary" />
+        {mobile ? (
+          <span className="relative grid size-4 place-items-center">
+            <Inbox className="size-4" />
+            {hasUnread && (
+              <span className="absolute -right-1 -top-1 size-2 rounded-full bg-primary" />
+            )}
+          </span>
+        ) : (
+          <>
+            <Inbox className="size-4" />
+            {hasUnread && (
+              <span className="absolute right-1 top-1 size-2 rounded-full bg-primary" />
+            )}
+          </>
         )}
       </PopoverTrigger>
 

--- a/src/web/src/components/community/shell/community-inbox-surface.tsx
+++ b/src/web/src/components/community/shell/community-inbox-surface.tsx
@@ -4,7 +4,6 @@ import { useRef, type MutableRefObject, type ReactNode, type RefObject } from "r
 import { Inbox } from "lucide-react"
 import {
   Popover,
-  PopoverBackdrop,
   PopoverContent,
   PopoverPopup,
   PopoverPortal,
@@ -62,8 +61,10 @@ export function CommunityInboxSurface({
             ref={triggerRef}
             data-testid={tid.inboxTrigger}
             className={cn(
-              "relative grid size-11 place-items-center rounded-lg text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none sm:size-7",
-              mobile && "aria-expanded:text-foreground",
+              "relative grid size-11 place-items-center rounded-lg text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none sm:size-7",
+              mobile
+                ? "hover:text-foreground active:text-foreground aria-expanded:text-foreground"
+                : "hover:bg-accent hover:text-foreground",
             )}
             aria-label={mobile ? (open ? "Close Inbox" : "Open Inbox") : "Inbox"}
             aria-pressed={mobile ? open : undefined}
@@ -78,14 +79,6 @@ export function CommunityInboxSurface({
 
       {mobile ? (
         <PopoverPortal>
-          <PopoverBackdrop
-            data-testid={tid.inboxMobileBackdrop}
-            className="fixed inset-x-0"
-            style={{
-              top: "var(--app-safe-area-top)",
-              bottom: COMMUNITY_USER_BAR_HEIGHT_CSS,
-            }}
-          />
           <PopoverPositioner
             anchor={anchorRef}
             positionMethod="fixed"

--- a/src/web/src/components/community/shell/user-bar.test.ts
+++ b/src/web/src/components/community/shell/user-bar.test.ts
@@ -24,6 +24,26 @@ describe("UserBar", () => {
     expect(html).toContain('data-testid="community-user-bar-name"')
     expect(html).toContain('class="truncate text-sm font-medium leading-tight"')
     expect(html).toContain('class="flex shrink-0 items-center gap-1"')
+    const desktopSettingsClass = html.match(
+      /class="([^"]*)" aria-label="User settings"/,
+    )?.[1]?.split(" ")
+    expect(desktopSettingsClass).toContain("hover:bg-accent")
+  })
+
+  it("keeps the mobile Settings action as a color-only icon button", () => {
+    const html = renderToStaticMarkup(createElement(UserBar, {
+      breakpoint: "mobile",
+      user: { id: "u1", name: "User", avatar: "U" },
+    }))
+    const settingsClass = html.match(
+      /class="([^"]*)" aria-label="User settings"/,
+    )?.[1]?.split(" ")
+    expect(settingsClass).toContain("hover:text-foreground")
+    expect(settingsClass).toContain("active:text-foreground")
+    expect(settingsClass).not.toContain("hover:bg-accent")
+    expect(settingsClass).not.toContain("border")
+    expect(settingsClass).not.toContain("shadow")
+    expect(settingsClass).toContain("focus-visible:ring-2")
   })
 
   it("provides an inert account-neutral placeholder with the same outer geometry", () => {

--- a/src/web/src/components/community/shell/user-bar.tsx
+++ b/src/web/src/components/community/shell/user-bar.tsx
@@ -124,7 +124,12 @@ function Inner({ breakpoint, user, onOpenProfile, onEditProfile, inbox, hasUnrea
             closeInboxForAction()
             onEditProfile?.()
           }}
-          className="grid size-11 place-items-center rounded-lg text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none sm:size-7"
+          className={cn(
+            "grid size-11 place-items-center rounded-lg text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none sm:size-7",
+            breakpoint === "mobile"
+              ? "hover:text-foreground active:text-foreground"
+              : "hover:bg-accent hover:text-foreground",
+          )}
           aria-label="User settings"
           data-testid={tid.userSettingsOpen}
         >

--- a/src/web/src/test/e2e-ui/53-mobile-inbox-surface.spec.ts
+++ b/src/web/src/test/e2e-ui/53-mobile-inbox-surface.spec.ts
@@ -190,7 +190,46 @@ test.describe.serial("mobile Inbox interactive user-bar base", () => {
     expect(geometry.seam.userBarBottomRight).not.toBe("0px")
     expect(geometry.rootScrollTop).toBe(0)
 
-    await bob.page.mouse.click(8, 100)
+    const outsidePoint = {
+      x: Math.floor((geometry.card.left + geometry.card.right) / 2),
+      y: Math.max(1, Math.floor(geometry.card.top / 2)),
+    }
+    const outsideHit = await bob.page.evaluate(({ point, ids }) => {
+      const hit = document.elementFromPoint(point.x, point.y)
+      const interactive = hit?.closest([
+        "button",
+        "a[href]",
+        "input",
+        "select",
+        "textarea",
+        "[contenteditable='true']",
+        "[role='button']",
+        "[role='link']",
+        "[role='checkbox']",
+        "[role='radio']",
+        "[role='switch']",
+        "[role='tab']",
+        "[role='menuitem']",
+        "[role='option']",
+        "[role='combobox']",
+        "[role='listbox']",
+        "[role='slider']",
+        "[role='spinbutton']",
+        "[role='textbox']",
+        "[role='searchbox']",
+      ].join(","))
+      return {
+        exists: !!hit,
+        insideInbox: !!hit?.closest(`[data-testid='${ids.inboxMobileSurface}']`),
+        interactive: !!interactive,
+      }
+    }, { point: outsidePoint, ids: { inboxMobileSurface: tid.inboxMobileSurface } })
+    expect(outsideHit).toEqual({
+      exists: true,
+      insideInbox: false,
+      interactive: false,
+    })
+    await bob.page.mouse.click(outsidePoint.x, outsidePoint.y)
     await expect(bob.page.getByTestId(tid.inboxMobileSurface)).toHaveCount(0)
     await expect(inboxTrigger).toBeFocused()
     await expect(inboxTrigger).toHaveAttribute("aria-label", "Open Inbox")

--- a/src/web/src/test/e2e-ui/53-mobile-inbox-surface.spec.ts
+++ b/src/web/src/test/e2e-ui/53-mobile-inbox-surface.spec.ts
@@ -191,8 +191,8 @@ test.describe.serial("mobile Inbox interactive user-bar base", () => {
     expect(geometry.rootScrollTop).toBe(0)
 
     const outsidePoint = {
-      x: Math.floor((geometry.card.left + geometry.card.right) / 2),
-      y: Math.max(1, Math.floor(geometry.card.top / 2)),
+      x: Math.floor(geometry.viewport.width / 2),
+      y: 1,
     }
     const outsideHit = await bob.page.evaluate(({ point, ids }) => {
       const hit = document.elementFromPoint(point.x, point.y)

--- a/src/web/src/test/e2e-ui/53-mobile-inbox-surface.spec.ts
+++ b/src/web/src/test/e2e-ui/53-mobile-inbox-surface.spec.ts
@@ -16,7 +16,6 @@ type SurfaceGeometry = {
   viewport: { width: number; height: number }
   userBar: { top: number; bottom: number; left: number; right: number }
   card: { top: number; bottom: number; left: number; right: number; height: number }
-  backdrop: { top: number; bottom: number }
   seam: {
     cardTopLeft: string
     cardTopRight: string
@@ -50,16 +49,12 @@ async function surfaceGeometry(page: Page): Promise<SurfaceGeometry> {
     const userBar = document.querySelector<HTMLElement>(
       `[data-testid='${ids.userBar}']`,
     )
-    const backdrop = document.querySelector<HTMLElement>(
-      `[data-testid='${ids.backdrop}']`,
-    )
     const userBarSurface = userBar?.firstElementChild as HTMLElement | null
-    if (!userBar || !userBarSurface || !backdrop) {
+    if (!userBar || !userBarSurface) {
       throw new Error("missing mobile Inbox geometry")
     }
     const userRect = userBar.getBoundingClientRect()
     const cardRect = card.getBoundingClientRect()
-    const backdropRect = backdrop.getBoundingClientRect()
     const cardStyle = getComputedStyle(card)
     const userBarStyle = getComputedStyle(userBarSurface)
     const hit = document.elementFromPoint(
@@ -81,7 +76,6 @@ async function surfaceGeometry(page: Page): Promise<SurfaceGeometry> {
         right: cardRect.right,
         height: cardRect.height,
       },
-      backdrop: { top: backdropRect.top, bottom: backdropRect.bottom },
       seam: {
         cardTopLeft: cardStyle.borderTopLeftRadius,
         cardTopRight: cardStyle.borderTopRightRadius,
@@ -97,7 +91,6 @@ async function surfaceGeometry(page: Page): Promise<SurfaceGeometry> {
     }
   }, {
     userBar: tid.userBar,
-    backdrop: tid.inboxMobileBackdrop,
   })
 }
 
@@ -115,7 +108,7 @@ function observeWrites(page: Page) {
 test.describe.serial("mobile Inbox interactive user-bar base", () => {
   test.setTimeout(180_000)
 
-  test("scopes the real backdrop above the safe-area user bar and dismisses without writes", async ({ asUser }) => {
+  test("keeps the mobile shell unmasked and dismisses on outside press without writes", async ({ asUser }) => {
     const stamp = Date.now()
     const serverId = await seedServer("alice", `Inbox surface ${stamp}`)
     const channelId = await seedChannel("alice", serverId, `inbox-${stamp}`)
@@ -144,9 +137,15 @@ test.describe.serial("mobile Inbox interactive user-bar base", () => {
     await expect(inboxTrigger).toHaveAttribute("aria-pressed", "false")
     await expect(inboxIcon).toHaveAttribute("fill", "none")
     await expect(inboxIcon).not.toHaveClass(/fill-current/)
-    const closedInboxIconColor = await inboxIcon.evaluate((element) => (
-      getComputedStyle(element).color
-    ))
+    const closedTriggerStyle = await inboxTrigger.evaluate((element) => {
+      const style = getComputedStyle(element)
+      return {
+        backgroundColor: style.backgroundColor,
+        borderWidth: style.borderWidth,
+        boxShadow: style.boxShadow,
+      }
+    })
+    const closedInboxIconColor = await inboxIcon.evaluate((element) => getComputedStyle(element).color)
     await inboxTrigger.click()
     await bob.page.mouse.move(0, 0)
     const mobileSurface = bob.page.getByTestId(tid.inboxMobileSurface)
@@ -162,12 +161,21 @@ test.describe.serial("mobile Inbox interactive user-bar base", () => {
     await expect.poll(() => inboxIcon.evaluate((element) => (
       getComputedStyle(element).color
     ))).not.toBe(closedInboxIconColor)
+    await expect.poll(() => inboxTrigger.evaluate((element) => {
+      const style = getComputedStyle(element)
+      return {
+        backgroundColor: style.backgroundColor,
+        borderWidth: style.borderWidth,
+        boxShadow: style.boxShadow,
+      }
+    })).toEqual(closedTriggerStyle)
+    expect(closedTriggerStyle.borderWidth).toBe("0px")
+    expect(closedTriggerStyle.boxShadow).toBe("none")
     await expect(bob.page.getByRole("button", { name: "Close Inbox" })).toHaveCount(1)
     await expect(inboxTrigger).toBeFocused()
+    await expect(bob.page.getByTestId(tid.inboxMobileBackdrop)).toHaveCount(0)
     const geometry = await surfaceGeometry(bob.page)
     expect(Math.abs(geometry.card.bottom - geometry.userBar.top)).toBeLessThanOrEqual(1)
-    expect(Math.abs(geometry.backdrop.bottom - geometry.userBar.top)).toBeLessThanOrEqual(1)
-    expect(geometry.backdrop.top).toBe(20)
     expect(geometry.userBar.bottom).toBe(844)
     expect(geometry.userBarOwnsCenter).toBe(true)
     expect(geometry.card.height).toBeLessThanOrEqual(448)


### PR DESCRIPTION
# Why we need this PR?
> The mobile Inbox still mounted a partial visual backdrop, while touch-hover styling made the user-bar icon actions look framed instead of color-only.

## What changed
- Removed the mobile Inbox Backdrop node and left outside-click dismissal with the existing nonmodal Popover outside-press contract.
- Made mobile Inbox and Settings pure icon actions: hover, press, and open states change foreground color only; keyboard `focus-visible` remains.
- Preserved the outline Inbox glyph, ARIA toggle state, focus-return logic, seam geometry, desktop presentation, and Inbox data behavior.
- Updated component and browser regressions. Normal commit gates passed; the focused browser journey was attempted twice but stopped in shared sign-in setup before the target spec, so independent browser verification remains in the Draft QA handoff.

## Checklist
- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...
