### PR TITLE
fix(daemon): recover self-update npm launcher

### DIFF
--- a/src/daemon/src/cli/daemonSelfUpdate.real.test.ts
+++ b/src/daemon/src/cli/daemonSelfUpdate.real.test.ts
@@ -15,6 +15,7 @@ const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "daemon-self-update-fi
 const baseDirs = new Set<string>();
 let oldTgz = "";
 let newTgz = "";
+const strippedNpmContextLauncher = path.join(fixtureRoot, "launch-without-npm-context.mjs");
 
 interface ReadyObservation {
   socket: WebSocket;
@@ -61,9 +62,13 @@ function runNpmPackage(
   tgz: string,
   args: string[],
   env: NodeJS.ProcessEnv = {},
+  withoutNpmExecPath = false,
 ): Promise<{ code: number | null; output: string }> {
   return new Promise((resolve, reject) => {
-    execFile("npm", ["exec", "--yes", `--package=${tgz}`, "--", "alook-daemon", ...args], {
+    const packageCommand = withoutNpmExecPath
+      ? [process.execPath, strippedNpmContextLauncher]
+      : ["alook-daemon"];
+    execFile("npm", ["exec", "--yes", `--package=${tgz}`, "--", ...packageCommand, ...args], {
       env: { ...process.env, ...env },
       maxBuffer: 10 * 1024 * 1024,
       shell: commandShimShell(),
@@ -174,14 +179,18 @@ async function waitFor<T>(read: () => T | undefined | false, timeoutMs = 90_000)
   throw new Error("self-update condition timed out");
 }
 
-async function startOld(baseDir: string, control: ControlServer): Promise<ReadyObservation> {
+async function startOld(
+  baseDir: string,
+  control: ControlServer,
+  withoutNpmExecPath = false,
+): Promise<ReadyObservation> {
   const result = await runNpmPackage(oldTgz, [
     "daemon", "start",
     "--machine-key", credential,
     "--server-url", control.serverUrl,
     "--ws-url", control.wsUrl,
     "--base-dir", baseDir,
-  ], { NODE_ENV: "test" });
+  ], { NODE_ENV: "test" }, withoutNpmExecPath);
   expect(result.code).toBe(0);
   expect(result.output).toContain("started in background");
   return await waitFor(() => control.ready.find((entry) => entry.frame.daemonVersion === "9.9.0"));
@@ -229,6 +238,16 @@ async function waitForUpdateSettled(baseDir: string, timeoutMs = 45_000): Promis
 }
 
 beforeAll(() => {
+  fs.writeFileSync(strippedNpmContextLauncher, [
+    'import { spawnSync } from "node:child_process";',
+    "const env = { ...process.env };",
+    "delete env.npm_execpath;",
+    'const executable = process.platform === "win32" ? "alook-daemon.cmd" : "alook-daemon";',
+    'const result = spawnSync(executable, process.argv.slice(2), { env, stdio: "inherit", shell: process.platform === "win32" });',
+    "if (result.error) throw result.error;",
+    "process.exit(result.status ?? 1);",
+    "",
+  ].join("\n"), { mode: 0o600 });
   execPackageManagerSync(["run", "build"], { cwd: packageRoot, stdio: "pipe" });
   oldTgz = packFixture("9.9.0");
   newTgz = packFixture("9.9.1");
@@ -276,6 +295,31 @@ describe("daemon self-update real package/process handoff", () => {
       });
       expect(updateEvents(baseDir)).toContain("replacement_ready");
       expect(fs.readFileSync(path.join(daemonDir(baseDir), "update.log"), "utf8")).not.toContain(credential);
+    } finally {
+      await control.close();
+    }
+  }, 120_000);
+
+  it("upgrades through PATH when the running daemon has no npm_execpath", async () => {
+    const control = await createControlServer();
+    try {
+      const baseDir = makeBaseDir(control, newTgz);
+      const firstReady = await startOld(baseDir, control, true);
+      const oldOwner = readOwner(baseDir);
+
+      firstReady.socket.send(JSON.stringify({ type: "machine:update" }));
+
+      const nextReady = await waitFor(() => control.ready.find((entry) => entry.frame.daemonVersion === "9.9.1"));
+      const newOwner = await waitFor(() => {
+        if (!fs.existsSync(pidfile(baseDir))) return false;
+        const owner = readOwner(baseDir);
+        return owner.pid !== oldOwner.pid ? owner : false;
+      });
+      expect(nextReady.frame.daemonVersion).toBe("9.9.1");
+      expect(alive(oldOwner.pid)).toBe(false);
+      expect(alive(newOwner.pid)).toBe(true);
+      expect(newOwner.machineId).toBe(oldOwner.machineId);
+      expect(updateEvents(baseDir)).toContain("replacement_ready");
     } finally {
       await control.close();
     }

--- a/src/daemon/src/cli/daemonUpdate.test.ts
+++ b/src/daemon/src/cli/daemonUpdate.test.ts
@@ -5,7 +5,12 @@ import * as path from "node:path";
 import type { ChildProcess } from "node:child_process";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readDaemonVersion } from "../version";
-import { createDaemonSelfUpdateHandler, daemonReplace } from "./daemonUpdate";
+import {
+  createDaemonSelfUpdateHandler,
+  daemonReplace,
+  resolveNpmLaunchCommand,
+  type NpmLaunchFileProbe,
+} from "./daemonUpdate";
 
 const machineId = "cm_update_unit_123456";
 
@@ -114,6 +119,96 @@ describe("daemon self-update lifecycle", () => {
     expect(spawnProcess).toHaveBeenCalledTimes(2);
   });
 
+  it("recovers a stale inherited npm path from an absolute executable on PATH", () => {
+    const owner = writePid();
+    const binDir = path.join(baseDir, "bin");
+    const fallbackNpm = path.join(binDir, "npm");
+    fs.mkdirSync(binDir);
+    fs.writeFileSync(fallbackNpm, "#!/bin/sh\n", { mode: 0o700 });
+    const spawnProcess = vi.fn(() => fakeChild());
+    const handle = createDaemonSelfUpdateHandler({
+      machineId,
+      baseDir,
+      pid: owner.pid,
+      startedAt: owner.startedAt,
+      ownerToken: owner.ownerToken,
+    }, {
+      spawnProcess: spawnProcess as typeof import("node:child_process").spawn,
+      npmExecPath: path.join(baseDir, "deleted", "npm-cli.js"),
+      npmLaunchEnv: { PATH: binDir },
+      npmLaunchPlatform: "linux",
+    });
+
+    handle();
+
+    expect(spawnProcess).toHaveBeenCalledOnce();
+    expect(spawnProcess.mock.calls[0]![0]).toBe(fallbackNpm);
+    expect(spawnProcess.mock.calls[0]![1]).toEqual([
+      "exec",
+      "--yes",
+      "--package=@alook/daemon@latest",
+      "--",
+      "alook-daemon",
+      "daemon",
+      "replace",
+      "--id",
+      machineId,
+      "--base-dir",
+      baseDir,
+      "--request-id",
+      expect.stringMatching(/^[A-Za-z0-9_-]{16,128}$/),
+    ]);
+    expect(spawnProcess.mock.calls[0]![2]).toMatchObject({ shell: false });
+  });
+
+  it("resolves missing inherited context from PATH and ignores relative or empty entries", () => {
+    const safeDir = path.join(baseDir, "safe-bin");
+    const fallbackNpm = path.join(safeDir, "npm");
+    fs.mkdirSync(safeDir);
+    fs.writeFileSync(fallbackNpm, "#!/bin/sh\n", { mode: 0o700 });
+
+    expect(resolveNpmLaunchCommand({
+      env: { PATH: ["", "relative-bin", safeDir].join(path.delimiter) },
+      platform: "linux",
+      nodePath: "/absolute/node",
+    })).toEqual({ file: fallbackNpm, prefixArgs: [] });
+  });
+
+  it("resolves a Windows npm command shim to its adjacent JavaScript CLI without a shell", () => {
+    const npmShim = "C:\\tools\\npm.cmd";
+    const npmCli = "C:\\tools\\node_modules\\npm\\bin\\npm-cli.js";
+    const files = new Set([npmShim, npmCli]);
+    const probe: NpmLaunchFileProbe = {
+      isFile: (filePath) => files.has(filePath),
+      isExecutable: () => false,
+    };
+
+    expect(resolveNpmLaunchCommand({
+      env: { Path: "relative;C:\\tools" },
+      platform: "win32",
+      nodePath: "C:\\node\\node.exe",
+      probe,
+    })).toEqual({
+      file: "C:\\node\\node.exe",
+      prefixArgs: [npmCli],
+    });
+  });
+
+  it("rejects a Windows command shim when its adjacent JavaScript CLI is absent", () => {
+    const npmShim = "C:\\tools\\npm.cmd";
+    const probe: NpmLaunchFileProbe = {
+      isFile: (filePath) => filePath === npmShim,
+      isExecutable: () => false,
+    };
+
+    expect(() => resolveNpmLaunchCommand({
+      env: { PATH: "C:\\tools" },
+      platform: "win32",
+      nodePath: "C:\\node\\node.exe",
+      probe,
+    })).toThrow("no safe npm executable was found on PATH");
+  });
+
   it("does not spawn when only the pidfile ownerToken differs from the running owner", () => {
     const diskOwner = writePid("replacement-owner");
     const spawnProcess = vi.fn(() => fakeChild());
@@ -145,6 +240,8 @@ describe("daemon self-update lifecycle", () => {
     }, {
       spawnProcess: spawnProcess as typeof import("node:child_process").spawn,
       npmExecPath: path.join(baseDir, "missing-npm-cli.js"),
+      npmLaunchEnv: { PATH: "relative-only" },
+      npmLaunchPlatform: "linux",
     });
 
     handle();
@@ -152,6 +249,8 @@ describe("daemon self-update lifecycle", () => {
     expect(spawnProcess).not.toHaveBeenCalled();
     expect(JSON.parse(fs.readFileSync(path.join(daemonDir, "daemon.pid"), "utf8"))).toEqual(owner);
     expect(fs.existsSync(path.join(daemonDir, "update-intent.json"))).toBe(false);
+    expect(fs.readFileSync(path.join(daemonDir, "update.log"), "utf8"))
+      .toContain("no safe npm executable was found on PATH");
   });
 
   it.each([

--- a/src/daemon/src/cli/daemonUpdate.test.ts
+++ b/src/daemon/src/cli/daemonUpdate.test.ts
@@ -4,6 +4,23 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { ChildProcess } from "node:child_process";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const lifecycleMocks = vi.hoisted(() => ({
+  daemonResume: vi.fn(),
+  spawn: vi.fn(),
+  stopExactDaemonPid: vi.fn(),
+}));
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...await importOriginal<typeof import("node:child_process")>(),
+  spawn: lifecycleMocks.spawn,
+}));
+vi.mock("./daemonStart", async (importOriginal) => ({
+  ...await importOriginal<typeof import("./daemonStart")>(),
+  daemonResume: lifecycleMocks.daemonResume,
+  stopExactDaemonPid: lifecycleMocks.stopExactDaemonPid,
+}));
+
 import { readDaemonVersion } from "../version";
 import {
   createDaemonSelfUpdateHandler,
@@ -30,6 +47,9 @@ describe("daemon self-update lifecycle", () => {
   let npmPath: string;
 
   beforeEach(() => {
+    lifecycleMocks.daemonResume.mockReset();
+    lifecycleMocks.spawn.mockReset();
+    lifecycleMocks.stopExactDaemonPid.mockReset();
     baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "daemon-update-unit-"));
     daemonDir = path.join(baseDir, "daemons", machineId);
     fs.mkdirSync(daemonDir, { recursive: true, mode: 0o700 });
@@ -327,5 +347,49 @@ describe("daemon self-update lifecycle", () => {
     expect(kill).not.toHaveBeenCalled();
     expect(fs.existsSync(path.join(daemonDir, "daemon.pid"))).toBe(true);
     expect(fs.existsSync(path.join(daemonDir, "update-intent.json"))).toBe(false);
+  });
+
+  it("hands rollback off through the resolved npm JavaScript launcher", async () => {
+    const owner = writePid();
+    writeLaunch("0.0.1");
+    const requestId = "request_1234567890";
+    fs.writeFileSync(path.join(daemonDir, "update-intent.json"), JSON.stringify({
+      schemaVersion: 1,
+      requestId,
+      ...owner,
+    }), { mode: 0o600 });
+    vi.stubEnv("npm_execpath", npmPath);
+    lifecycleMocks.stopExactDaemonPid.mockResolvedValue(undefined);
+    lifecycleMocks.daemonResume.mockRejectedValue(new Error("new daemon failed readiness"));
+    lifecycleMocks.spawn.mockImplementation(() => {
+      const child = fakeChild();
+      queueMicrotask(() => child.emit("exit", 0, null));
+      return child;
+    });
+
+    await daemonReplace({ id: machineId, baseDir, requestId });
+
+    expect(lifecycleMocks.stopExactDaemonPid).toHaveBeenCalledWith(owner.pid);
+    expect(lifecycleMocks.spawn).toHaveBeenCalledOnce();
+    const [command, args, options] = lifecycleMocks.spawn.mock.calls[0]!;
+    expect(command).toBe(process.execPath);
+    expect(args).toEqual([
+      npmPath,
+      "exec",
+      "--yes",
+      "--package=@alook/daemon@0.0.1",
+      "--",
+      "alook-daemon",
+      "daemon",
+      "resume",
+      "--id",
+      machineId,
+      "--base-dir",
+      baseDir,
+      "--request-id",
+      requestId,
+    ]);
+    expect(options).toMatchObject({ shell: false });
+    expect(JSON.stringify([command, args, options])).not.toContain(owner.ownerToken);
   });
 });

--- a/src/daemon/src/cli/daemonUpdate.test.ts
+++ b/src/daemon/src/cli/daemonUpdate.test.ts
@@ -121,10 +121,12 @@ describe("daemon self-update lifecycle", () => {
 
   it("recovers a stale inherited npm path from an absolute executable on PATH", () => {
     const owner = writePid();
-    const binDir = path.join(baseDir, "bin");
-    const fallbackNpm = path.join(binDir, "npm");
-    fs.mkdirSync(binDir);
-    fs.writeFileSync(fallbackNpm, "#!/bin/sh\n", { mode: 0o700 });
+    const binDir = "/safe-bin";
+    const fallbackNpm = `${binDir}/npm`;
+    const probe: NpmLaunchFileProbe = {
+      isFile: (filePath) => filePath === fallbackNpm,
+      isExecutable: (filePath) => filePath === fallbackNpm,
+    };
     const spawnProcess = vi.fn(() => fakeChild());
     const handle = createDaemonSelfUpdateHandler({
       machineId,
@@ -134,9 +136,10 @@ describe("daemon self-update lifecycle", () => {
       ownerToken: owner.ownerToken,
     }, {
       spawnProcess: spawnProcess as typeof import("node:child_process").spawn,
-      npmExecPath: path.join(baseDir, "deleted", "npm-cli.js"),
+      npmExecPath: "/deleted/npm-cli.js",
       npmLaunchEnv: { PATH: binDir },
       npmLaunchPlatform: "linux",
+      npmLaunchFileProbe: probe,
     });
 
     handle();
@@ -162,15 +165,18 @@ describe("daemon self-update lifecycle", () => {
   });
 
   it("resolves missing inherited context from PATH and ignores relative or empty entries", () => {
-    const safeDir = path.join(baseDir, "safe-bin");
-    const fallbackNpm = path.join(safeDir, "npm");
-    fs.mkdirSync(safeDir);
-    fs.writeFileSync(fallbackNpm, "#!/bin/sh\n", { mode: 0o700 });
+    const safeDir = "/safe-bin";
+    const fallbackNpm = `${safeDir}/npm`;
+    const probe: NpmLaunchFileProbe = {
+      isFile: (filePath) => filePath === fallbackNpm,
+      isExecutable: (filePath) => filePath === fallbackNpm,
+    };
 
     expect(resolveNpmLaunchCommand({
-      env: { PATH: ["", "relative-bin", safeDir].join(path.delimiter) },
+      env: { PATH: ["", "relative-bin", safeDir].join(":") },
       platform: "linux",
       nodePath: "/absolute/node",
+      probe,
     })).toEqual({ file: fallbackNpm, prefixArgs: [] });
   });
 

--- a/src/daemon/src/cli/daemonUpdate.test.ts
+++ b/src/daemon/src/cli/daemonUpdate.test.ts
@@ -180,6 +180,27 @@ describe("daemon self-update lifecycle", () => {
     })).toEqual({ file: fallbackNpm, prefixArgs: [] });
   });
 
+  it.runIf(process.platform !== "win32")(
+    "requires the executable bit through the default POSIX filesystem probe",
+    () => {
+      const binDir = path.join(baseDir, "posix-bin");
+      const fallbackNpm = path.join(binDir, "npm");
+      fs.mkdirSync(binDir);
+      fs.writeFileSync(fallbackNpm, "#!/bin/sh\n", { mode: 0o600 });
+
+      expect(() => resolveNpmLaunchCommand({
+        env: { PATH: binDir },
+        platform: "linux",
+      })).toThrow("no safe npm executable was found on PATH");
+
+      fs.chmodSync(fallbackNpm, 0o700);
+      expect(resolveNpmLaunchCommand({
+        env: { PATH: binDir },
+        platform: "linux",
+      })).toEqual({ file: fallbackNpm, prefixArgs: [] });
+    },
+  );
+
   it("resolves a Windows npm command shim to its adjacent JavaScript CLI without a shell", () => {
     const npmShim = "C:\\tools\\npm.cmd";
     const npmCli = "C:\\tools\\node_modules\\npm\\bin\\npm-cli.js";

--- a/src/daemon/src/cli/daemonUpdate.ts
+++ b/src/daemon/src/cli/daemonUpdate.ts
@@ -42,7 +42,21 @@ export interface DaemonSelfUpdateContext {
 export interface SelfUpdateDeps {
   spawnProcess?: typeof spawn;
   npmExecPath?: string;
+  npmLaunchEnv?: NodeJS.ProcessEnv;
+  npmLaunchPlatform?: NodeJS.Platform;
+  npmLaunchNodePath?: string;
+  npmLaunchFileProbe?: NpmLaunchFileProbe;
   logger?: Pick<Logger, "info" | "warn">;
+}
+
+export interface NpmLaunchCommand {
+  file: string;
+  prefixArgs: string[];
+}
+
+export interface NpmLaunchFileProbe {
+  isFile(filePath: string): boolean;
+  isExecutable(filePath: string): boolean;
 }
 
 function intentPath(baseDir: string, machineId: string): string {
@@ -156,12 +170,93 @@ function removeIntentIfMatches(baseDir: string, machineId: string, requestId: st
   } catch { /* best effort */ }
 }
 
-function npmExecPath(explicit?: string): string {
-  const value = explicit ?? process.env.npm_execpath;
-  if (!value || !path.isAbsolute(value) || !fs.existsSync(value)) {
-    throw new Error("npm launch context unavailable; daemon remains online");
+const defaultNpmLaunchFileProbe: NpmLaunchFileProbe = {
+  isFile(filePath) {
+    try {
+      return fs.statSync(filePath).isFile();
+    } catch {
+      return false;
+    }
+  },
+  isExecutable(filePath) {
+    try {
+      fs.accessSync(filePath, fs.constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+};
+
+function pathEnvironment(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): string | undefined {
+  if (platform !== "win32") return env.PATH;
+  const entry = Object.entries(env).find(([key]) => key.toLowerCase() === "path");
+  return entry?.[1];
+}
+
+function launchFromNpmPath(args: {
+  npmPath: string;
+  platform: NodeJS.Platform;
+  nodePath: string;
+  probe: NpmLaunchFileProbe;
+  requireExecutable: boolean;
+}): NpmLaunchCommand | null {
+  const pathApi = args.platform === "win32" ? path.win32 : path.posix;
+  if (!pathApi.isAbsolute(args.npmPath) || !args.probe.isFile(args.npmPath)) return null;
+  const extension = pathApi.extname(args.npmPath).toLowerCase();
+  if ([".js", ".cjs", ".mjs"].includes(extension)) {
+    return { file: args.nodePath, prefixArgs: [args.npmPath] };
   }
-  return value;
+  if (args.platform === "win32" && [".cmd", ".bat"].includes(extension)) {
+    const cliPath = pathApi.join(pathApi.dirname(args.npmPath), "node_modules", "npm", "bin", "npm-cli.js");
+    return args.probe.isFile(cliPath)
+      ? { file: args.nodePath, prefixArgs: [cliPath] }
+      : null;
+  }
+  if (args.requireExecutable && !args.probe.isExecutable(args.npmPath)) return null;
+  return { file: args.npmPath, prefixArgs: [] };
+}
+
+export function resolveNpmLaunchCommand(options: {
+  npmExecPath?: string;
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  nodePath?: string;
+  probe?: NpmLaunchFileProbe;
+} = {}): NpmLaunchCommand {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const nodePath = options.nodePath ?? process.execPath;
+  const probe = options.probe ?? defaultNpmLaunchFileProbe;
+  const inherited = options.npmExecPath ?? env.npm_execpath;
+  if (inherited) {
+    const launch = launchFromNpmPath({
+      npmPath: inherited,
+      platform,
+      nodePath,
+      probe,
+      requireExecutable: platform !== "win32",
+    });
+    if (launch) return launch;
+  }
+
+  const pathApi = platform === "win32" ? path.win32 : path.posix;
+  const names = platform === "win32" ? ["npm.exe", "npm.cmd", "npm.bat", "npm"] : ["npm"];
+  const pathValue = pathEnvironment(env, platform);
+  for (const directory of pathValue?.split(pathApi.delimiter) ?? []) {
+    if (!directory || !pathApi.isAbsolute(directory)) continue;
+    for (const name of names) {
+      const launch = launchFromNpmPath({
+        npmPath: pathApi.join(directory, name),
+        platform,
+        nodePath,
+        probe,
+        requireExecutable: platform !== "win32",
+      });
+      if (launch) return launch;
+    }
+  }
+  throw new Error("npm launch context unavailable and no safe npm executable was found on PATH; daemon remains online");
 }
 
 function readTestPackageMap(baseDir: string, machineId: string): Record<string, string> | null {
@@ -191,7 +286,6 @@ function packageSpec(baseDir: string, machineId: string, version: "latest" | str
 }
 
 function fixedNpmArgs(args: {
-  npmPath: string;
   packageSpec: string;
   command: "replace" | "resume";
   machineId: string;
@@ -199,7 +293,6 @@ function fixedNpmArgs(args: {
   requestId: string;
 }): string[] {
   return [
-    args.npmPath,
     "exec",
     "--yes",
     `--package=${args.packageSpec}`,
@@ -241,7 +334,13 @@ export function createDaemonSelfUpdateHandler(
         || current.startedAt !== context.startedAt
         || current.ownerToken !== context.ownerToken
       ) throw new Error("daemon ownership changed before update launch");
-      const npmPath = npmExecPath(deps.npmExecPath);
+      const npmLaunch = resolveNpmLaunchCommand({
+        npmExecPath: deps.npmExecPath,
+        env: deps.npmLaunchEnv,
+        platform: deps.npmLaunchPlatform,
+        nodePath: deps.npmLaunchNodePath,
+        probe: deps.npmLaunchFileProbe,
+      });
       requestId = crypto.randomUUID();
       const intent: DaemonUpdateIntent = {
         schemaVersion: UPDATE_INTENT_SCHEMA_VERSION,
@@ -251,14 +350,16 @@ export function createDaemonSelfUpdateHandler(
       writePrivateJsonAtomic(intentPath(context.baseDir, context.machineId), intent);
       const logFd = openUpdateLog(context.baseDir, context.machineId);
       try {
-        const child = (deps.spawnProcess ?? spawn)(process.execPath, fixedNpmArgs({
-          npmPath,
-          packageSpec: packageSpec(context.baseDir, context.machineId, "latest"),
-          command: "replace",
-          machineId: context.machineId,
-          baseDir: context.baseDir,
-          requestId,
-        }), {
+        const child = (deps.spawnProcess ?? spawn)(npmLaunch.file, [
+          ...npmLaunch.prefixArgs,
+          ...fixedNpmArgs({
+            packageSpec: packageSpec(context.baseDir, context.machineId, "latest"),
+            command: "replace",
+            machineId: context.machineId,
+            baseDir: context.baseDir,
+            requestId,
+          }),
+        ], {
           detached: true,
           shell: false,
           stdio: ["ignore", logFd, logFd],
@@ -295,7 +396,7 @@ function removeOldPidfileIfMatches(baseDir: string, intent: DaemonUpdateIntent):
 }
 
 async function runPinnedResume(args: {
-  npmPath: string;
+  npmLaunch: NpmLaunchCommand;
   version: string;
   machineId: string;
   baseDir: string;
@@ -303,14 +404,16 @@ async function runPinnedResume(args: {
 }): Promise<void> {
   const fd = openUpdateLog(args.baseDir, args.machineId);
   try {
-    const child = spawn(process.execPath, fixedNpmArgs({
-      npmPath: args.npmPath,
-      packageSpec: packageSpec(args.baseDir, args.machineId, args.version),
-      command: "resume",
-      machineId: args.machineId,
-      baseDir: args.baseDir,
-      requestId: args.requestId,
-    }), {
+    const child = spawn(args.npmLaunch.file, [
+      ...args.npmLaunch.prefixArgs,
+      ...fixedNpmArgs({
+        packageSpec: packageSpec(args.baseDir, args.machineId, args.version),
+        command: "resume",
+        machineId: args.machineId,
+        baseDir: args.baseDir,
+        requestId: args.requestId,
+      }),
+    ], {
       shell: false,
       stdio: ["ignore", fd, fd],
     });
@@ -356,7 +459,7 @@ export async function daemonReplace(opts: {
     throw new Error("daemon ownership changed before replacement");
   }
 
-  const npmPath = npmExecPath();
+  const npmLaunch = resolveNpmLaunchCommand();
   const acquired = acquireDaemonReplacementLock({ baseDir, machineId: opts.id, requestId: opts.requestId });
   let oldStopped = false;
   try {
@@ -376,7 +479,7 @@ export async function daemonReplace(opts: {
     } catch (error) {
       appendUpdateLog(baseDir, opts.id, "replacement_start_failed", { error });
       await runPinnedResume({
-        npmPath,
+        npmLaunch,
         version: launch.daemonVersion,
         machineId: opts.id,
         baseDir,


### PR DESCRIPTION
# Why we need this PR?

Remote daemon self-update depended on the ephemeral `npm_execpath` inherited at launch. If that path was missing or had been cleaned up, the updater could not spawn its replacement helper and left machines unable to update remotely.

## What changed

- Resolve a safe npm launch command before taking the replacement lock or stopping the old daemon.
- Prefer a valid absolute inherited `npm_execpath`, then recover from absolute `PATH` entries only.
- Require an executable npm file on POSIX; on Windows, run `npm.exe` directly or resolve `.cmd`/`.bat` shims to the adjacent `npm-cli.js` through the current Node executable.
- Preserve fixed package/arguments and `shell: false`; fail closed with the old daemon online when no safe launcher exists.
- Add focused POSIX/Windows tests, unit coverage for rollback handoff, and a real packed-process upgrade test with `npm_execpath` removed.

## Validation

- Independent exact-head QA PASS on `ef6e473743f936ac285135fa3adfd29f0ee7d6a7`
- Daemon: 1,308 tests passed
- Packed daemon: 7 tests passed
- Web: 6,496 tests passed
- Agent driver: 652 passed, 4 skipped
- CI scripts: 139 tests passed
- Typecheck, lint, knip, boundary checks, and `git diff --check` passed
- GitHub Windows, Ubuntu coverage, packed artifact, E2E, static, Codecov, and aggregate CI Gate passed
- Codecov: all modified and coverable lines are covered

## Checklist

- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [x] Other: daemon self-update
