### PR TITLE
fix(desktop): use white native light backgrounds

### DIFF
--- a/scripts/ci/native-shell-theme-colors.test.ts
+++ b/scripts/ci/native-shell-theme-colors.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { describe, expect, it } from "vitest"
+
+const repositoryRoot = resolve(import.meta.dirname, "../..")
+const desktopRoot = resolve(repositoryRoot, "src/desktop/src-tauri")
+
+const macosRuntime = readFileSync(resolve(desktopRoot, "src/commands.rs"), "utf8")
+const iosRuntime = readFileSync(resolve(desktopRoot, "gen/apple/Sources/alook-desktop/main.mm"), "utf8")
+const iosSplash = JSON.parse(
+  readFileSync(
+    resolve(desktopRoot, "gen/apple/Assets.xcassets/SplashBackground.colorset/Contents.json"),
+    "utf8",
+  ),
+) as {
+  colors: Array<{
+    appearances?: Array<{ appearance: string; value: string }>
+    color: { components: Record<string, string> }
+  }>
+}
+const androidRuntime = readFileSync(
+  resolve(desktopRoot, "gen/android/app/src/main/java/ai/alook/desktop/MainActivity.kt"),
+  "utf8",
+)
+const androidLightSplash = readFileSync(
+  resolve(desktopRoot, "gen/android/app/src/main/res/values/themes.xml"),
+  "utf8",
+)
+const androidDarkSplash = readFileSync(
+  resolve(desktopRoot, "gen/android/app/src/main/res/values-night/themes.xml"),
+  "utf8",
+)
+
+describe("native shell theme color contract", () => {
+  it("uses white light chrome and preserves dark chrome on macOS", () => {
+    expect(macosRuntime).toContain("(0.063f64, 0.051f64, 0.039f64)")
+    expect(macosRuntime).toContain("(1.0f64, 1.0f64, 1.0f64)")
+    expect(macosRuntime).toContain("setBackgroundColor: color")
+  })
+
+  it("uses white light chrome and preserves dark chrome at iOS launch and runtime", () => {
+    expect(iosRuntime).toContain("colorWithRed:1.0 green:1.0 blue:1.0 alpha:1.0")
+    expect(iosRuntime).toContain("colorWithRed:0.063 green:0.051 blue:0.039 alpha:1.0")
+
+    const light = iosSplash.colors.find((entry) => !entry.appearances)
+    const dark = iosSplash.colors.find((entry) =>
+      entry.appearances?.some(({ appearance, value }) => appearance === "luminosity" && value === "dark"),
+    )
+    expect(light?.color.components).toMatchObject({ red: "1.000", green: "1.000", blue: "1.000" })
+    expect(dark?.color.components).toMatchObject({ red: "0.063", green: "0.051", blue: "0.039" })
+  })
+
+  it("uses white light chrome and preserves dark chrome at Android launch and runtime", () => {
+    expect(androidRuntime).toContain('const val COLOR_LIGHT = "#FFFFFF"')
+    expect(androidRuntime).toContain('const val COLOR_DARK = "#100D0A"')
+    expect(androidLightSplash).toContain("<item name=\"windowSplashScreenBackground\">#FFFFFF</item>")
+    expect(androidDarkSplash).toContain("<item name=\"windowSplashScreenBackground\">#100D0A</item>")
+  })
+
+  it("retains runtime theme bridges and removes the legacy light color from native owners", () => {
+    expect(iosRuntime).toContain("new MutationObserver(sync)")
+    expect(iosRuntime).toContain('addScriptMessageHandler:handler name:@"alookTheme"')
+    expect(androidRuntime).toContain("WebViewCompat.addDocumentStartJavaScript")
+    expect(androidRuntime).toContain('webView.addJavascriptInterface(ThemeBridge(this), "AlookNative")')
+
+    const nativeOwners = [macosRuntime, iosRuntime, JSON.stringify(iosSplash), androidRuntime, androidLightSplash]
+    for (const source of nativeOwners) {
+      expect(source).not.toMatch(/#ECE8DE|0\.929[^\n]+0\.910[^\n]+0\.871/)
+    }
+  })
+})

--- a/src/desktop/src-tauri/gen/android/app/src/main/java/ai/alook/desktop/MainActivity.kt
+++ b/src/desktop/src-tauri/gen/android/app/src/main/java/ai/alook/desktop/MainActivity.kt
@@ -19,7 +19,7 @@ class MainActivity : TauriActivity() {
     private var isReady = false
 
     companion object {
-        const val COLOR_LIGHT = "#ECE8DE"
+        const val COLOR_LIGHT = "#FFFFFF"
         const val COLOR_DARK = "#100D0A"
 
         const val THEME_OBSERVER_SCRIPT = """

--- a/src/desktop/src-tauri/gen/android/app/src/main/res/values/themes.xml
+++ b/src/desktop/src-tauri/gen/android/app/src/main/res/values/themes.xml
@@ -4,7 +4,7 @@
     </style>
     <!-- Splash screen theme -->
     <style name="Theme.alook_desktop.Splash" parent="Theme.SplashScreen">
-        <item name="windowSplashScreenBackground">#ECE8DE</item>
+        <item name="windowSplashScreenBackground">#FFFFFF</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/splash_icon</item>
         <item name="windowSplashScreenAnimationDuration">300</item>
         <item name="postSplashScreenTheme">@style/Theme.alook_desktop</item>

--- a/src/desktop/src-tauri/gen/apple/Assets.xcassets/SplashBackground.colorset/Contents.json
+++ b/src/desktop/src-tauri/gen/apple/Assets.xcassets/SplashBackground.colorset/Contents.json
@@ -4,9 +4,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": "0.929",
-          "green": "0.910",
-          "blue": "0.871",
+          "red": "1.000",
+          "green": "1.000",
+          "blue": "1.000",
           "alpha": "1.000"
         }
       },

--- a/src/desktop/src-tauri/gen/apple/Sources/alook-desktop/main.mm
+++ b/src/desktop/src-tauri/gen/apple/Sources/alook-desktop/main.mm
@@ -4,7 +4,7 @@
 #import <objc/runtime.h>
 
 static UIColor *alookLightColor(void) {
-    return [UIColor colorWithRed:0.929 green:0.910 blue:0.871 alpha:1.0];
+    return [UIColor colorWithRed:1.0 green:1.0 blue:1.0 alpha:1.0];
 }
 
 static UIColor *alookDarkColor(void) {

--- a/src/desktop/src-tauri/src/commands.rs
+++ b/src/desktop/src-tauri/src/commands.rs
@@ -541,7 +541,7 @@ pub fn set_window_theme(window: tauri::WebviewWindow, dark: bool) {
             let (r, g, b) = if dark {
                 (0.063f64, 0.051f64, 0.039f64)
             } else {
-                (0.929f64, 0.910f64, 0.871f64)
+                (1.0f64, 1.0f64, 1.0f64)
             };
             let color: *mut AnyObject = msg_send![
                 objc2::class!(NSColor),

--- a/src/web/src/test/e2e-ui/39-mobile-message-interactions.spec.ts
+++ b/src/web/src/test/e2e-ui/39-mobile-message-interactions.spec.ts
@@ -328,7 +328,7 @@ test("mobile reply, avatar mention, and typing rail keep exact backend and WS id
   const bobInfo = await memberInfo("alice", serverId, userId("bob"))
   const aliceInfo = await memberInfo("alice", serverId, userId("alice"))
 
-  const alice = await asUser("alice")
+  const alice = await asUser("alice", { hasTouch: true })
   const bob = await asUser("bob")
   await installInputCapability(alice.page, false)
   await alice.page.setViewportSize({ width: 390, height: 844 })
@@ -609,7 +609,7 @@ test("mobile reply, avatar mention, and typing rail keep exact backend and WS id
   await bobEditable.pressSequentially(" selection")
   await expect(alice.page.getByTestId(tid.typingIndicator)).toBeVisible({ timeout: 4_000 })
   const finalChannelMessage = alice.page.getByTestId(tid.message(typingWsReadyId))
-  await finalChannelMessage.getByText(`typing ws ready ${stamp}`, { exact: true }).click()
+  await finalChannelMessage.getByText(`typing ws ready ${stamp}`, { exact: true }).tap()
   await alice.page.getByRole("menuitem", { name: "Share as Image" }).click()
   await expect(alice.page.getByTestId(tid.messageSelectionToolbar)).toBeVisible()
   await expect(alice.page.locator("[data-selection-typing-fit]"))


### PR DESCRIPTION
# Why we need this PR?
> No linked GitHub issue.

The native shell still used the legacy cream light background around platform-owned chrome, which no longer matched the app's white light theme.

## What changed
- Set the macOS overlay titlebar frame background to white in light mode.
- Set the iOS launch background and runtime status/home safe-area background to white in light mode.
- Set the Android splash and runtime system-bar safe-area background to white in light mode.
- Preserve the existing `#100D0A` dark background and real-time theme bridges.
- Add a CI source-contract regression covering every native color owner and the theme bridges.
- Leave Web/PWA, Windows, Linux, and app content theme behavior unchanged.

Local verification: full pre-commit hook, `cargo fmt --check`, and 36 Rust unit tests all pass.

## Checklist
- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [x] Other: Native desktop/mobile shell
