### PR TITLE
fix(daemon): disable audit for self-update npm exec

### DIFF
--- a/src/daemon/src/cli/daemonSelfUpdate.real.test.ts
+++ b/src/daemon/src/cli/daemonSelfUpdate.real.test.ts
@@ -68,7 +68,7 @@ function runNpmPackage(
     const packageCommand = withoutNpmExecPath
       ? [process.execPath, strippedNpmContextLauncher]
       : ["alook-daemon"];
-    execFile("npm", ["exec", "--yes", `--package=${tgz}`, "--", ...packageCommand, ...args], {
+    execFile("npm", ["exec", "--yes", "--no-audit", `--package=${tgz}`, "--", ...packageCommand, ...args], {
       env: { ...process.env, ...env },
       maxBuffer: 10 * 1024 * 1024,
       shell: commandShimShell(),

--- a/src/daemon/src/cli/daemonUpdate.test.ts
+++ b/src/daemon/src/cli/daemonUpdate.test.ts
@@ -111,6 +111,7 @@ describe("daemon self-update lifecycle", () => {
       npmPath,
       "exec",
       "--yes",
+      "--no-audit",
       "--package=@alook/daemon@latest",
       "--",
       "alook-daemon",
@@ -169,6 +170,7 @@ describe("daemon self-update lifecycle", () => {
     expect(spawnProcess.mock.calls[0]![1]).toEqual([
       "exec",
       "--yes",
+      "--no-audit",
       "--package=@alook/daemon@latest",
       "--",
       "alook-daemon",
@@ -377,6 +379,7 @@ describe("daemon self-update lifecycle", () => {
       npmPath,
       "exec",
       "--yes",
+      "--no-audit",
       "--package=@alook/daemon@0.0.1",
       "--",
       "alook-daemon",

--- a/src/daemon/src/cli/daemonUpdate.ts
+++ b/src/daemon/src/cli/daemonUpdate.ts
@@ -295,6 +295,7 @@ function fixedNpmArgs(args: {
   return [
     "exec",
     "--yes",
+    "--no-audit",
     `--package=${args.packageSpec}`,
     "--",
     "alook-daemon",


### PR DESCRIPTION
# Why we need this PR?
> Closes N/A — fixes an internal daemon self-update blocker.

`npm exec --package=...` performs a transient install before launching the daemon. Its default audit request can stall on registry or proxy networking before daemon startup, blocking bootstrap, replacement, and rollback resume.

## What changed
- Pass `--no-audit` in the production fixed npm arguments used by replacement and rollback resume.
- Pass the same flag in the real self-update bootstrap so the test reaches the daemon lifecycle deterministically.
- Lock the fixed argument order for latest replacement, PATH fallback, and rollback resume.

## Checklist
- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [x] Other: Daemon (`@alook/daemon`)
