### PR TITLE
fix(blog): add wheel scrolling to topic rail

### DIFF
--- a/src/web/blog/AGENTS.md
+++ b/src/web/blog/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/src/web/blog/CLAUDE.md
+++ b/src/web/blog/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/src/web/blog/src/app/blog/(index)/recent-posts.test.ts
+++ b/src/web/blog/src/app/blog/(index)/recent-posts.test.ts
@@ -1,8 +1,21 @@
 import { createElement, type PropsWithChildren } from "react";
 import TestRenderer, { act, type ReactTestRenderer } from "react-test-renderer";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BlogIndexPost } from "./model";
 import { RecentPosts } from "./recent-posts";
+
+const inputCapability = vi.hoisted(() => ({
+  breakpoint: "desktop" as "desktop" | "mobile" | "unknown",
+  hoverCapable: true,
+}));
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useBreakpoint: () => inputCapability.breakpoint,
+}));
+
+vi.mock("@/hooks/use-hover-capable", () => ({
+  useHoverCapable: () => inputCapability.hoverCapable,
+}));
 
 vi.mock("next/image", () => ({
   default: (props: Record<string, unknown>) => createElement("img", props),
@@ -38,6 +51,11 @@ function renderedTitles(renderer: ReactTestRenderer): string[] {
 }
 
 describe("RecentPosts", () => {
+  beforeEach(() => {
+    inputCapability.breakpoint = "desktop";
+    inputCapability.hoverCapable = true;
+  });
+
   it("filters Recent cards, renders the empty state, and returns to All", () => {
     const posts = [
       recentPost("newest", "foundations", "Foundations"),
@@ -162,5 +180,117 @@ describe("RecentPosts", () => {
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+
+  it("uses the shared rail owner for directional fades and desktop wheel ownership", () => {
+    const posts = [recentPost("newest", "foundations", "Foundations")];
+    const topics = [
+      { id: "foundations", label: "Foundations" },
+      { id: "coding", label: "Coding" },
+    ];
+    const scroller = {
+      scrollLeft: 0,
+      scrollWidth: 300,
+      clientWidth: 100,
+      getBoundingClientRect: () => ({ left: 0, right: 100 }),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    const selected = {
+      getBoundingClientRect: () => ({ left: 0, right: 44 }),
+    };
+    let renderer: ReactTestRenderer;
+
+    act(() => {
+      renderer = TestRenderer.create(
+        createElement(RecentPosts, { posts, topics }),
+        {
+          createNodeMock: (element) =>
+            element.props["data-testid"] === "blog-topic-scroller"
+              ? scroller
+              : element.type === "button" && element.props["aria-pressed"]
+                ? selected
+                : null,
+        },
+      );
+    });
+
+    expect(renderer!.root.findAllByProps({ "data-testid": "blog-topic-fade-left" }))
+      .toHaveLength(0);
+    expect(renderer!.root.findAllByProps({ "data-testid": "blog-topic-fade-right" }))
+      .toHaveLength(1);
+
+    const wheelListener = scroller.addEventListener.mock.calls
+      .find(([eventName]) => eventName === "wheel")?.[1] as ((event: WheelEvent) => void) | undefined;
+    const preventDefault = vi.fn();
+    expect(scroller.addEventListener).toHaveBeenCalledWith(
+      "wheel",
+      expect.any(Function),
+      { passive: false },
+    );
+    act(() => wheelListener?.({
+      deltaX: 0,
+      deltaY: 40,
+      ctrlKey: false,
+      shiftKey: false,
+      preventDefault,
+    } as unknown as WheelEvent));
+    expect(scroller.scrollLeft).toBe(40);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(renderer!.root.findAllByProps({ "data-testid": "blog-topic-fade-left" }))
+      .toHaveLength(1);
+
+    scroller.scrollLeft = 200;
+    act(() => wheelListener?.({
+      deltaX: 0,
+      deltaY: 40,
+      ctrlKey: false,
+      shiftKey: false,
+      preventDefault,
+    } as unknown as WheelEvent));
+    expect(scroller.scrollLeft).toBe(200);
+    expect(preventDefault).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { breakpoint: "mobile" as const, hoverCapable: true },
+    { breakpoint: "desktop" as const, hoverCapable: false },
+  ])("does not translate the Blog wheel with $breakpoint/$hoverCapable input", ({ breakpoint, hoverCapable }) => {
+    inputCapability.breakpoint = breakpoint;
+    inputCapability.hoverCapable = hoverCapable;
+    const scroller = {
+      scrollLeft: 0,
+      scrollWidth: 300,
+      clientWidth: 100,
+      getBoundingClientRect: () => ({ left: 0, right: 100 }),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    const selected = {
+      getBoundingClientRect: () => ({ left: 0, right: 44 }),
+    };
+    act(() => {
+      TestRenderer.create(
+        createElement(RecentPosts, {
+          posts: [recentPost("newest", "foundations", "Foundations")],
+          topics: [{ id: "foundations", label: "Foundations" }],
+        }),
+        {
+          createNodeMock: (element) =>
+            element.props["data-testid"] === "blog-topic-scroller"
+              ? scroller
+              : element.type === "button" && element.props["aria-pressed"]
+                ? selected
+                : null,
+        },
+      );
+    });
+
+    expect(scroller.scrollLeft).toBe(0);
+    expect(scroller.addEventListener).not.toHaveBeenCalledWith(
+      "wheel",
+      expect.any(Function),
+      { passive: false },
+    );
   });
 });

--- a/src/web/blog/src/app/blog/(index)/recent-posts.test.ts
+++ b/src/web/blog/src/app/blog/(index)/recent-posts.test.ts
@@ -182,6 +182,36 @@ describe("RecentPosts", () => {
     }
   });
 
+  it("keeps the topic rail viewport and fades inside the Blog content column", () => {
+    let renderer: ReactTestRenderer;
+
+    act(() => {
+      renderer = TestRenderer.create(
+        createElement(RecentPosts, {
+          posts: [recentPost("newest", "foundations", "Foundations")],
+          topics: [
+            { id: "foundations", label: "Foundations" },
+            { id: "coding", label: "Coding" },
+          ],
+        }),
+      );
+    });
+
+    const scroller = renderer!.root.findByProps({
+      "data-testid": "blog-topic-scroller",
+    });
+    expect(scroller.parent?.props.className).toBe("relative mt-3 sm:mt-6");
+    expect(scroller.props.className).toBe(
+      "thin-scrollbar scrollbar-none overflow-x-auto",
+    );
+
+    const topicNav = scroller.findByType("nav");
+    expect(topicNav.props.className).toContain("w-max min-w-full");
+    for (const button of topicNav.findAllByType("button")) {
+      expect(button.props.className).toContain("shrink-0");
+    }
+  });
+
   it("uses the shared rail owner for directional fades and desktop wheel ownership", () => {
     const posts = [recentPost("newest", "foundations", "Foundations")];
     const topics = [

--- a/src/web/blog/src/app/blog/(index)/recent-posts.tsx
+++ b/src/web/blog/src/app/blog/(index)/recent-posts.tsx
@@ -1,8 +1,14 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type Ref } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import {
+  HorizontalOverflowFadeOverlays,
+  useHorizontalOverflowRail,
+} from "@/components/horizontal-overflow-rail";
+import { useHoverCapable } from "@/hooks/use-hover-capable";
+import { useBreakpoint } from "@/hooks/use-mobile";
 import type { BlogIndexPost } from "./model";
 import { formatBlogPostDate } from "./model";
 
@@ -20,7 +26,24 @@ const allTopicsId = "all";
 
 export function RecentPosts({ posts, topics }: RecentPostsProps) {
   const [selectedTopicId, setSelectedTopicId] = useState(allTopicsId);
+  const breakpoint = useBreakpoint();
+  const hoverCapable = useHoverCapable();
   const topicIds = useMemo(() => new Set(topics.map((topic) => topic.id)), [topics]);
+  const topicKey = useMemo(
+    () => topics.map((topic) => `${topic.id}\0${topic.label}`).join("\0"),
+    [topics],
+  );
+  const {
+    fades,
+    onScroll,
+    scrollerRef,
+    selectedRef,
+  } = useHorizontalOverflowRail<HTMLDivElement, HTMLButtonElement>({
+    contentKey: topicKey,
+    selectedKey: selectedTopicId,
+    mapVerticalWheelToHorizontal:
+      breakpoint === "desktop" && hoverCapable,
+  });
   const visiblePosts =
     selectedTopicId === allTopicsId
       ? posts
@@ -58,27 +81,41 @@ export function RecentPosts({ posts, topics }: RecentPostsProps) {
       >
         Recent posts
       </h2>
-      <div className="thin-scrollbar scrollbar-none -mx-4 mt-3 overflow-x-auto px-4 sm:-mx-6 sm:mt-6 sm:px-6">
-        <nav
-          aria-label="Filter recent posts"
-          className="flex w-max min-w-full flex-nowrap gap-6"
+      <div className="relative -mx-4 mt-3 sm:-mx-6 sm:mt-6">
+        <div
+          ref={scrollerRef}
+          data-testid="blog-topic-scroller"
+          onScroll={onScroll}
+          className="thin-scrollbar scrollbar-none overflow-x-auto px-4 sm:px-6"
         >
-          <TopicButton
-            id={allTopicsId}
-            label="All"
-            selected={selectedTopicId === allTopicsId}
-            onSelect={selectTopic}
-          />
-          {topics.map((topic) => (
+          <nav
+            aria-label="Filter recent posts"
+            className="flex w-max min-w-full flex-nowrap gap-6"
+          >
             <TopicButton
-              key={topic.id}
-              id={topic.id}
-              label={topic.label}
-              selected={selectedTopicId === topic.id}
+              id={allTopicsId}
+              label="All"
+              selected={selectedTopicId === allTopicsId}
+              buttonRef={selectedTopicId === allTopicsId ? selectedRef : undefined}
               onSelect={selectTopic}
             />
-          ))}
-        </nav>
+            {topics.map((topic) => (
+              <TopicButton
+                key={topic.id}
+                id={topic.id}
+                label={topic.label}
+                selected={selectedTopicId === topic.id}
+                buttonRef={selectedTopicId === topic.id ? selectedRef : undefined}
+                onSelect={selectTopic}
+              />
+            ))}
+          </nav>
+        </div>
+        <HorizontalOverflowFadeOverlays
+          fades={fades}
+          leftTestId="blog-topic-fade-left"
+          rightTestId="blog-topic-fade-right"
+        />
       </div>
 
       {visiblePosts.length > 0 ? (
@@ -123,15 +160,18 @@ function TopicButton({
   id,
   label,
   selected,
+  buttonRef,
   onSelect,
 }: {
   id: string;
   label: string;
   selected: boolean;
+  buttonRef?: Ref<HTMLButtonElement>;
   onSelect: (id: string) => void;
 }) {
   return (
     <button
+      ref={buttonRef}
       id={id === allTopicsId ? undefined : id}
       type="button"
       aria-pressed={selected}

--- a/src/web/blog/src/app/blog/(index)/recent-posts.tsx
+++ b/src/web/blog/src/app/blog/(index)/recent-posts.tsx
@@ -81,12 +81,12 @@ export function RecentPosts({ posts, topics }: RecentPostsProps) {
       >
         Recent posts
       </h2>
-      <div className="relative -mx-4 mt-3 sm:-mx-6 sm:mt-6">
+      <div className="relative mt-3 sm:mt-6">
         <div
           ref={scrollerRef}
           data-testid="blog-topic-scroller"
           onScroll={onScroll}
-          className="thin-scrollbar scrollbar-none overflow-x-auto px-4 sm:px-6"
+          className="thin-scrollbar scrollbar-none overflow-x-auto"
         >
           <nav
             aria-label="Filter recent posts"

--- a/src/web/src/components/community/channels/forum-view.tsx
+++ b/src/web/src/components/community/channels/forum-view.tsx
@@ -29,7 +29,7 @@ import {
   HorizontalOverflowFadeOverlays,
   horizontalOverflowFades,
   useHorizontalOverflowRail,
-} from "../horizontal-overflow-rail"
+} from "@/components/horizontal-overflow-rail"
 
 const MAX_AVATARS = 5
 const MAX_VISIBLE_TAGS = 2

--- a/src/web/src/components/community/messages/message-reactions.tsx
+++ b/src/web/src/components/community/messages/message-reactions.tsx
@@ -23,7 +23,7 @@ import { useCommunityProfile } from "@/stores/community/ws"
 import {
   HorizontalOverflowFadeOverlays,
   useHorizontalOverflowRail,
-} from "../horizontal-overflow-rail"
+} from "@/components/horizontal-overflow-rail"
 import { MemberIdentityRow } from "../members/member-identity-row"
 
 const HOLD_MS = 450

--- a/src/web/src/components/horizontal-overflow-rail.test.ts
+++ b/src/web/src/components/horizontal-overflow-rail.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest"
 import {
   HorizontalOverflowFadeOverlays,
   horizontalOverflowFades,
+  shouldTranslateVerticalWheel,
   useHorizontalOverflowRail,
 } from "./horizontal-overflow-rail"
 
@@ -17,6 +18,35 @@ describe("horizontalOverflowFades", () => {
       .toEqual({ left: true, right: true })
     expect(horizontalOverflowFades({ scrollLeft: 140, scrollWidth: 240, clientWidth: 100 }))
       .toEqual({ left: true, right: false })
+  })
+})
+
+describe("shouldTranslateVerticalWheel", () => {
+  const overflowing = {
+    enabled: true,
+    deltaX: 0,
+    deltaY: 40,
+    ctrlKey: false,
+    shiftKey: false,
+    scrollLeft: 0,
+    scrollWidth: 240,
+    clientWidth: 100,
+  }
+
+  it("only consumes a vertical wheel when content remains in that direction", () => {
+    expect(shouldTranslateVerticalWheel(overflowing)).toBe(true)
+    expect(shouldTranslateVerticalWheel({ ...overflowing, deltaY: -40 })).toBe(false)
+    expect(shouldTranslateVerticalWheel({ ...overflowing, scrollLeft: 60, deltaY: -40 })).toBe(true)
+    expect(shouldTranslateVerticalWheel({ ...overflowing, scrollLeft: 140 })).toBe(false)
+    expect(shouldTranslateVerticalWheel({ ...overflowing, scrollWidth: 100 })).toBe(false)
+  })
+
+  it("preserves disabled, horizontal, shifted, and zoom gestures", () => {
+    expect(shouldTranslateVerticalWheel({ ...overflowing, enabled: false })).toBe(false)
+    expect(shouldTranslateVerticalWheel({ ...overflowing, deltaX: 1 })).toBe(false)
+    expect(shouldTranslateVerticalWheel({ ...overflowing, shiftKey: true })).toBe(false)
+    expect(shouldTranslateVerticalWheel({ ...overflowing, ctrlKey: true })).toBe(false)
+    expect(shouldTranslateVerticalWheel({ ...overflowing, deltaY: 0 })).toBe(false)
   })
 })
 
@@ -40,20 +70,26 @@ describe("HorizontalOverflowFadeOverlays", () => {
 })
 
 describe("useHorizontalOverflowRail", () => {
+  let wheelListener: ((event: WheelEvent) => void) | undefined
   const scroller = {
     scrollLeft: 0,
     scrollWidth: 240,
     clientWidth: 100,
     getBoundingClientRect: () => ({ left: 0, right: 100 }),
+    addEventListener: vi.fn((eventName: string, listener: EventListener) => {
+      if (eventName === "wheel") wheelListener = listener as (event: WheelEvent) => void
+    }),
+    removeEventListener: vi.fn(),
   }
   const selected = {
     getBoundingClientRect: () => ({ left: 120, right: 164 }),
   }
 
-  function Fixture() {
+  function Fixture({ mapVerticalWheelToHorizontal = false }: { mapVerticalWheelToHorizontal?: boolean }) {
     const rail = useHorizontalOverflowRail<HTMLDivElement, HTMLButtonElement>({
       contentKey: "one\0two\0three",
       selectedKey: "three",
+      mapVerticalWheelToHorizontal,
     })
     return createElement("div", {
       ref: rail.scrollerRef,
@@ -86,5 +122,58 @@ describe("useHorizontalOverflowRail", () => {
     act(() => rail.props.onKeyDown({ key: "End", currentTarget: scroller, preventDefault }))
     expect(scroller.scrollLeft).toBe(140)
     expect(preventDefault).toHaveBeenCalledTimes(3)
+  })
+
+  it("maps an enabled vertical wheel and returns it to the page at the boundary", () => {
+    scroller.scrollLeft = 0
+    wheelListener = undefined
+    scroller.addEventListener.mockClear()
+    scroller.removeEventListener.mockClear()
+    let renderer: ReactTestRenderer
+    act(() => {
+      renderer = create(createElement(Fixture, { mapVerticalWheelToHorizontal: true }), {
+        createNodeMock: (element) => element.props["data-testid"] === "rail" ? scroller : selected,
+      })
+    })
+    const preventDefault = vi.fn()
+    expect(scroller.addEventListener).toHaveBeenCalledWith(
+      "wheel",
+      expect.any(Function),
+      { passive: false },
+    )
+
+    act(() => wheelListener?.({
+      deltaX: 0,
+      deltaY: 40,
+      ctrlKey: false,
+      shiftKey: false,
+      preventDefault,
+    } as unknown as WheelEvent))
+    expect(scroller.scrollLeft).toBe(104)
+    expect(preventDefault).toHaveBeenCalledOnce()
+
+    scroller.scrollLeft = 140
+    act(() => wheelListener?.({
+      deltaX: 0,
+      deltaY: 40,
+      ctrlKey: false,
+      shiftKey: false,
+      preventDefault,
+    } as unknown as WheelEvent))
+    expect(scroller.scrollLeft).toBe(140)
+    expect(preventDefault).toHaveBeenCalledOnce()
+
+    act(() => wheelListener?.({
+      deltaX: 8,
+      deltaY: -40,
+      ctrlKey: false,
+      shiftKey: false,
+      preventDefault,
+    } as unknown as WheelEvent))
+    expect(scroller.scrollLeft).toBe(140)
+    expect(preventDefault).toHaveBeenCalledOnce()
+
+    act(() => renderer!.unmount())
+    expect(scroller.removeEventListener).toHaveBeenCalledWith("wheel", wheelListener)
   })
 })

--- a/src/web/src/components/horizontal-overflow-rail.tsx
+++ b/src/web/src/components/horizontal-overflow-rail.tsx
@@ -5,6 +5,30 @@ import type React from "react"
 
 export type HorizontalOverflowFades = { left: boolean; right: boolean }
 
+export function shouldTranslateVerticalWheel({
+  enabled,
+  deltaX,
+  deltaY,
+  ctrlKey,
+  shiftKey,
+  scrollLeft,
+  scrollWidth,
+  clientWidth,
+}: {
+  enabled: boolean
+  deltaX: number
+  deltaY: number
+  ctrlKey: boolean
+  shiftKey: boolean
+  scrollLeft: number
+  scrollWidth: number
+  clientWidth: number
+}): boolean {
+  if (!enabled || ctrlKey || shiftKey || deltaX !== 0 || deltaY === 0) return false
+  const fades = horizontalOverflowFades({ scrollLeft, scrollWidth, clientWidth })
+  return deltaY < 0 ? fades.left : fades.right
+}
+
 export function horizontalOverflowFades({
   scrollLeft,
   scrollWidth,
@@ -30,11 +54,13 @@ export function useHorizontalOverflowRail<
   selectedKey,
   scrollStep = 48,
   preserveChildKeyboard = false,
+  mapVerticalWheelToHorizontal = false,
 }: {
   contentKey: string
   selectedKey: string | null
   scrollStep?: number
   preserveChildKeyboard?: boolean
+  mapVerticalWheelToHorizontal?: boolean
 }) {
   const scrollerRef = useRef<TScroller>(null)
   const selectedRef = useRef<TSelected>(null)
@@ -85,6 +111,28 @@ export function useHorizontalOverflowRail<
       syncFades()
     }
   }, [preserveChildKeyboard, scrollStep, syncFades])
+
+  useLayoutEffect(() => {
+    const scroller = scrollerRef.current
+    if (!scroller || !mapVerticalWheelToHorizontal) return
+    const onWheel = (event: WheelEvent) => {
+      if (!shouldTranslateVerticalWheel({
+        enabled: true,
+        deltaX: event.deltaX,
+        deltaY: event.deltaY,
+        ctrlKey: event.ctrlKey,
+        shiftKey: event.shiftKey,
+        scrollLeft: scroller.scrollLeft,
+        scrollWidth: scroller.scrollWidth,
+        clientWidth: scroller.clientWidth,
+      })) return
+      event.preventDefault()
+      scroller.scrollLeft += event.deltaY
+      syncFades()
+    }
+    scroller.addEventListener("wheel", onWheel, { passive: false })
+    return () => scroller.removeEventListener("wheel", onWheel)
+  }, [mapVerticalWheelToHorizontal, syncFades])
 
   return { fades, onKeyDown, onScroll: syncFades, scrollerRef, selectedRef }
 }


### PR DESCRIPTION
## Summary

- lift the existing horizontal overflow/fade owner from Community into the neutral shared components path
- reuse that owner from Forum Tags, message reactions, and Blog Recent posts without a wrapper or copied gradient/threshold
- map vertical wheel input to horizontal movement only on desktop fine-pointer Blog rails, and return wheel ownership to the page at both boundaries
- preserve native horizontal gestures, Shift/zoom wheel, keyboard, touch/mobile, hash URLs, filtering, and category button geometry

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm typegrep:ws`
- `pnpm typegrep:agent-driver`
- `pnpm knip`
- focused Vitest: 4 files / 57 tests
- full OpenNext Cloudflare Blog build
- desktop 900×900 light/dark browser QA: start/middle/end fades, wheel capture, both boundary handoffs, native horizontal gesture, no document overflow
- mobile 390×844 browser QA: page retains vertical wheel ownership; rail offset stays unchanged

## Browser geometry

- desktop rail max: 227px
- vertical wheel: rail `0 → 120 → 227` while page remains `0`; next tick moves page `0 → 120`
- left-boundary upward wheel: page `240 → 120`, rail remains `0`
- native horizontal: rail `0 → 80`, page remains `0`
- middle state: both 14px token-backed fades; light and dark gradient origins equal the active body background
- keyboard category activation: hash `#coding-agents`, cards `23 → 7`

Draft only. Madox owns independent QA/Hosted/Codecov from this exact head; keep Draft until Gener accepts the exact head.
