### PR TITLE
fix(web): fill unresolved conversation panel

### DIFF
--- a/src/web/src/components/community/channels/conversation-resolution-pending-frame.test.ts
+++ b/src/web/src/components/community/channels/conversation-resolution-pending-frame.test.ts
@@ -1,0 +1,26 @@
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import { ConversationResolutionPendingFrame } from "./conversation-resolution-pending-frame"
+
+describe("ConversationResolutionPendingFrame", () => {
+  it("covers the unresolved main panel with one square shared Skeleton", () => {
+    const markup = renderToStaticMarkup(createElement(ConversationResolutionPendingFrame))
+
+    expect(markup.match(/data-slot="skeleton"/g)).toHaveLength(1)
+    expect(markup).toMatch(/data-slot="skeleton" class="[^"]*animate-pulse[^"]*"/)
+    expect(markup).toMatch(/data-slot="skeleton" class="[^"]*h-full[^"]*w-full[^"]*rounded-none[^"]*"/)
+    expect(markup).not.toMatch(/rounded-(?:sm|md|lg|xl|2xl|3xl|full)(?:\s|")/)
+  })
+
+  it("stays inert and exposes no speculative conversation content", () => {
+    const markup = renderToStaticMarkup(createElement(ConversationResolutionPendingFrame))
+
+    expect(markup).toContain('aria-busy="true"')
+    expect(markup).toContain('aria-label="Resolving conversation"')
+    expect(markup).toContain('data-community-conversation-subtype="unknown"')
+    expect(markup).toContain('<span class="sr-only">Resolving conversation</span>')
+    expect(markup).not.toMatch(/<(?:header|button|a|form|textarea)\b/)
+    expect(markup).not.toMatch(/Message|Forum|Thread|composer|previous channel/i)
+  })
+})

--- a/src/web/src/components/community/channels/conversation-resolution-pending-frame.test.ts
+++ b/src/web/src/components/community/channels/conversation-resolution-pending-frame.test.ts
@@ -19,6 +19,7 @@ describe("ConversationResolutionPendingFrame", () => {
     expect(markup).toContain('aria-busy="true"')
     expect(markup).toContain('aria-label="Resolving conversation"')
     expect(markup).toContain('data-community-conversation-subtype="unknown"')
+    expect(markup).toContain('data-community-mobile-transition="suppress"')
     expect(markup).toContain('<span class="sr-only">Resolving conversation</span>')
     expect(markup).not.toMatch(/<(?:header|button|a|form|textarea)\b/)
     expect(markup).not.toMatch(/Message|Forum|Thread|composer|previous channel/i)

--- a/src/web/src/components/community/channels/conversation-resolution-pending-frame.tsx
+++ b/src/web/src/components/community/channels/conversation-resolution-pending-frame.tsx
@@ -7,6 +7,7 @@ export function ConversationResolutionPendingFrame() {
       aria-busy="true"
       aria-label="Resolving conversation"
       data-community-conversation-subtype="unknown"
+      data-community-mobile-transition="suppress"
       className="min-h-0 min-w-0 flex-1 bg-background"
     >
       <Skeleton aria-hidden className="h-full w-full rounded-none" />

--- a/src/web/src/components/community/channels/conversation-resolution-pending-frame.tsx
+++ b/src/web/src/components/community/channels/conversation-resolution-pending-frame.tsx
@@ -7,13 +7,9 @@ export function ConversationResolutionPendingFrame() {
       aria-busy="true"
       aria-label="Resolving conversation"
       data-community-conversation-subtype="unknown"
-      className="flex min-h-0 min-w-0 flex-1 items-center justify-center bg-background p-4"
+      className="min-h-0 min-w-0 flex-1 bg-background"
     >
-      <div aria-hidden className="flex w-full max-w-56 flex-col items-center gap-3">
-        <Skeleton className="size-10 rounded-xl" />
-        <Skeleton className="h-4 w-40 rounded" />
-        <Skeleton className="h-3 w-28 rounded" />
-      </div>
+      <Skeleton aria-hidden className="h-full w-full rounded-none" />
       <span className="sr-only">Resolving conversation</span>
     </main>
   )

--- a/src/web/src/components/community/shell/community-pending-frame.test.ts
+++ b/src/web/src/components/community/shell/community-pending-frame.test.ts
@@ -33,6 +33,14 @@ function render(href: string, reserveBackSlot = true) {
 }
 
 describe("CommunityPendingFrame", () => {
+  it("suppresses the outer mobile transition for every route-pending frame", () => {
+    for (const href of ["/c/me", "/c/me/dm_1", "/c/me/machines", "/c/channels/s1", "/c/channels/s1/c1"]) {
+      expect(render(href).root.findByProps({
+        "data-community-mobile-transition": "suppress",
+      })).toBeDefined()
+    }
+  })
+
   it("selects destination-specific @me skeletons and reserves a non-interactive Back slot", () => {
     const machines = render("/c/me/machines?from=shortcut")
     expect(machines.root.findByType("machine-skeleton").props).toMatchObject({

--- a/src/web/src/components/community/shell/community-pending-frame.tsx
+++ b/src/web/src/components/community/shell/community-pending-frame.tsx
@@ -106,6 +106,7 @@ export function CommunityPendingFrame({
     <div
       data-testid={tid.pendingMain(plan.main.kind)}
       data-community-main-kind={plan.main.kind}
+      data-community-mobile-transition="suppress"
       className="flex min-h-0 min-w-0 flex-1 flex-col"
     >
       {content}

--- a/src/web/src/components/community/shell/community-shell-layout.tsx
+++ b/src/web/src/components/community/shell/community-shell-layout.tsx
@@ -25,6 +25,7 @@ import { Shell } from "./shell"
 
 const SHELL_SURFACE_CLASS = "rounded-tl-xl rounded-tr-none rounded-br-none rounded-bl-none ring-0 border-l border-t border-border/40 shadow-none"
 const MOBILE_SURFACE_TRANSITION_MS = 180
+const MOBILE_TRANSITION_SUPPRESSION_SELECTOR = '[data-community-mobile-transition="suppress"]'
 const communityLayoutStorage: Pick<Storage, "getItem" | "setItem"> = {
   getItem: (key) => typeof localStorage === "undefined" ? null : localStorage.getItem(key),
   setItem: (key, value) => {
@@ -112,6 +113,11 @@ export function CommunityShellLayout({
 
     const element = surface === "list" ? sidebarPanelRef.current : mainPanelRef.current
     if (!element?.animate) return
+    if (element.querySelector?.(MOBILE_TRANSITION_SUPPRESSION_SELECTOR)) {
+      mobileSurfaceAnimationRef.current?.cancel()
+      mobileSurfaceAnimationRef.current = null
+      return
+    }
     mobileSurfaceAnimationRef.current?.cancel()
     mobileSurfaceAnimationRef.current = element.animate([
       {

--- a/src/web/src/components/community/shell/shell-frame-view.test.ts
+++ b/src/web/src/components/community/shell/shell-frame-view.test.ts
@@ -358,6 +358,76 @@ describe("ShellFrameView", () => {
     expect(animate).toHaveBeenCalledOnce()
   })
 
+  it("keeps pending mobile surfaces still and does not replay their expired transition", async () => {
+    const cancel = vi.fn()
+    const animate = vi.fn(() => ({ cancel }))
+    let pending = false
+    const nodeMock = {
+      offsetWidth: 240,
+      animate,
+      querySelector: vi.fn(() => pending ? {} : null),
+    }
+    const common = {
+      breakpoint: "mobile" as const,
+      sidebar: () => createElement("sidebar-content"),
+      cancelPendingNavigation: vi.fn(),
+      rail,
+      profile,
+      inbox,
+    }
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(
+        ShellFrameView,
+        { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c1", "detail") },
+        createElement("main-content"),
+      ), { createNodeMock: () => nodeMock })
+    })
+
+    pending = true
+    await act(async () => {
+      renderer.update(createElement(
+        ShellFrameView,
+        { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c2", "detail") },
+        createElement("main-content", { "data-community-mobile-transition": "suppress" }),
+      ))
+    })
+    expect(animate).not.toHaveBeenCalled()
+    expect(nodeMock.querySelector).toHaveBeenLastCalledWith(
+      '[data-community-mobile-transition="suppress"]',
+    )
+
+    pending = false
+    await act(async () => {
+      renderer.update(createElement(
+        ShellFrameView,
+        { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c2", "detail") },
+        createElement("main-content"),
+      ))
+    })
+    expect(animate).not.toHaveBeenCalled()
+
+    await act(async () => {
+      renderer.update(createElement(
+        ShellFrameView,
+        { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c3", "detail") },
+        createElement("main-content"),
+      ))
+    })
+    expect(animate).toHaveBeenCalledOnce()
+
+    pending = true
+    await act(async () => {
+      renderer.update(createElement(
+        ShellFrameView,
+        { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c4", "detail") },
+        createElement("main-content", { "data-community-mobile-transition": "suppress" }),
+      ))
+    })
+    expect(animate).toHaveBeenCalledOnce()
+    expect(cancel).toHaveBeenCalledOnce()
+  })
+
   it("preserves child component identity across the 639 to 640 breakpoint", async () => {
     let mounts = 0
     function StatefulMain() {


### PR DESCRIPTION
# Why we need this PR?
> The unresolved conversation route currently renders a small centered placeholder instead of covering the main panel while its canonical subtype is being resolved. On mobile, stretching that placeholder exposed the outer 180ms surface transition as a full-panel flash.

## What changed
- Replace the three-piece centered placeholder with one edge-to-edge shared Skeleton.
- Keep the existing shimmer, remove corner radius, and preserve the inert route-owned accessibility contract.
- Suppress the outer mobile surface transition while any route or conversation subtype is pending, without replaying it after metadata resolves.
- Preserve normal transitions for already-resolved list/detail navigation and reduced-motion behavior.
- Add regression coverage for full-area geometry, speculative-content absence, pending suppression, resolved handoff, and the next resolved transition.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: N/A
