### PR TITLE
fix(web): keep community root restore neutral

### DIFF
--- a/src/web/src/app/c/page.test.ts
+++ b/src/web/src/app/c/page.test.ts
@@ -14,6 +14,11 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/contexts/community/current-user", () => ({
   useCurrentUser: () => ({ id: mocks.userId }),
 }))
+vi.mock("@/components/community/shell/community-session-pending-frame", () => ({
+  CommunitySessionPendingFrame: (props: Record<string, unknown>) => (
+    createElement("community-session-pending-frame", props)
+  ),
+}))
 vi.mock("@/lib/community/last-community-route", () => ({
   resolveCommunityColdEntryDestination: (args: unknown) => mocks.resolve(args),
 }))
@@ -31,10 +36,16 @@ describe("CommunityIndex", () => {
     })
   })
 
-  it("resolves the exact browser location for the authenticated account", () => {
-    mocks.resolve.mockReturnValue("/c/channels/server-1/channel-1")
+  it.each([
+    "/c/channels/server-1/channel-1",
+    "/c/me/dm-1",
+    "/c/me/bots",
+    "/c/me/machines",
+  ])("replaces the root exactly once with %s", (destination) => {
+    mocks.resolve.mockReturnValue(destination)
+    let renderer!: TestRenderer.ReactTestRenderer
     act(() => {
-      TestRenderer.create(createElement(CommunityIndex))
+      renderer = TestRenderer.create(createElement(CommunityIndex))
     })
     expect(mocks.resolve).toHaveBeenCalledWith({
       accountId: "user-a",
@@ -42,7 +53,11 @@ describe("CommunityIndex", () => {
       search: "",
       hash: "",
     })
-    expect(mocks.replace).toHaveBeenCalledWith("/c/channels/server-1/channel-1")
+    expect(mocks.resolve).toHaveBeenCalledTimes(1)
+    expect(mocks.replace).toHaveBeenCalledTimes(1)
+    expect(mocks.replace).toHaveBeenCalledWith(destination)
+    expect(renderer.root.findByType("community-session-pending-frame").props.pathname)
+      .toBe("/c")
   })
 
   it("passes query and hash state to the exact-root gate", () => {

--- a/src/web/src/app/c/page.tsx
+++ b/src/web/src/app/c/page.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation"
 import { useEffect } from "react"
+import { CommunitySessionPendingFrame } from "@/components/community/shell/community-session-pending-frame"
 import { useCurrentUser } from "@/contexts/community/current-user"
 import { resolveCommunityColdEntryDestination } from "@/lib/community/last-community-route"
 
@@ -17,5 +18,5 @@ export default function CommunityIndex() {
     })
     router.replace(destination)
   }, [currentUser.id, router])
-  return null
+  return <CommunitySessionPendingFrame pathname="/c" />
 }

--- a/src/web/src/components/community/shell/community-session-pending-frame.test.ts
+++ b/src/web/src/components/community/shell/community-session-pending-frame.test.ts
@@ -84,6 +84,18 @@ describe("CommunitySessionPendingFrame", () => {
     expect(renderer.root.findByType("pending-main").props.plan.main.kind).toBe("route-resolution")
   })
 
+  it("keeps the account-scoped community root neutral while its destination resolves", () => {
+    const renderer = render("/c")
+    const frame = renderer.root.findByProps({ "aria-label": "Loading community" })
+    expect(frame.props["data-community-route-kind"]).toBe("community-root-redirect")
+    expect(renderer.root.findAllByType("rail-skeleton")).toHaveLength(0)
+    expect(renderer.root.findAllByType("me-sidebar")).toHaveLength(0)
+    expect(renderer.root.findAllByType("server-sidebar")).toHaveLength(0)
+    expect(renderer.root.findAllByType("user-bar-skeleton")).toHaveLength(0)
+    expect(renderer.root.findAllByType("pending-main")).toHaveLength(1)
+    expect(renderer.root.findByType("pending-main").props.plan.main.kind).toBe("route-resolution")
+  })
+
   it("renders no authenticated shell modules for the public invite bypass", () => {
     const renderer = render("/c/invite/token")
     expect(renderer.root.findAllByType("rail-skeleton")).toHaveLength(0)

--- a/src/web/src/lib/community/community-route.test.ts
+++ b/src/web/src/lib/community/community-route.test.ts
@@ -20,7 +20,7 @@ const removedNestedChannelPath = (...segments: string[]) => (
 
 describe("community route", () => {
   it.each([
-    ["/c", "community-root-redirect", "detail", "me", "machines"],
+    ["/c", "community-root-redirect", "neutral", "none", "route-resolution"],
     ["/c/me", "me-root", "list", "me", "me-root"],
     ["/c/me/friends", "me-friends", "detail", "me", "friends"],
     ["/c/me/machines", "me-machines", "detail", "me", "machines"],
@@ -59,13 +59,23 @@ describe("community route", () => {
     })
   })
 
+  it("keeps the account-scoped community root neutral until its destination resolves", () => {
+    expect(resolveCommunityModulePlan("/c")).toEqual({
+      route: "community-root-redirect",
+      surface: "neutral",
+      rail: "none",
+      sidebar: { kind: "none" },
+      main: { kind: "route-resolution" },
+    })
+  })
+
   it("ignores query and hash when selecting modules", () => {
     expect(resolveCommunityModulePlan("/c/channels/s1/c1?settings=1#message"))
       .toEqual(resolveCommunityModulePlan("/c/channels/s1/c1"))
   })
 
   it("publishes explicit canonical destinations only for redirect routes", () => {
-    expect(resolveCommunityModulePlan("/c").canonicalHref).toBe("/c/me/machines")
+    expect(resolveCommunityModulePlan("/c").canonicalHref).toBeUndefined()
     expect(resolveCommunityModulePlan("/c/channels/s1/settings").canonicalHref)
       .toBe("/c/channels/s1")
     expect(resolveCommunityModulePlan("/c/me/machines").canonicalHref).toBeUndefined()

--- a/src/web/src/lib/community/community-route.ts
+++ b/src/web/src/lib/community/community-route.ts
@@ -113,11 +113,10 @@ export function resolveCommunityModulePlan(href: string): CommunityModulePlan {
   if (segments.length === 1) {
     return {
       route: "community-root-redirect",
-      canonicalHref: "/c/me/machines",
-      surface: "detail",
-      rail: "community",
-      sidebar: { kind: "me" },
-      main: { kind: "machines" },
+      surface: "neutral",
+      rail: "none",
+      sidebar: { kind: "none" },
+      main: { kind: "route-resolution" },
     }
   }
 

--- a/src/web/src/test/e2e-ui/41-community-initial-load-module-skeletons.spec.ts
+++ b/src/web/src/test/e2e-ui/41-community-initial-load-module-skeletons.spec.ts
@@ -14,6 +14,52 @@ type ExpectedFrame = {
   serverId?: string
 }
 
+type ColdRootProbe = {
+  machinesSeen: boolean
+}
+
+const coldRootStorageKey = `community:lastRoute:${encodeURIComponent(userId("alice"))}`
+
+async function installColdRootProbe(page: Page, destination: string | null) {
+  await page.addInitScript(({ storageKey, storedDestination, machinesPendingTestId }) => {
+    const target = window as typeof window & { __communityColdRootProbe?: ColdRootProbe }
+    target.__communityColdRootProbe = { machinesSeen: false }
+    try {
+      if (storedDestination) localStorage.setItem(storageKey, storedDestination)
+      else localStorage.removeItem(storageKey)
+    } catch { }
+
+    const inspect = () => {
+      const machines = document.querySelector(
+        `[data-community-main-kind="machines"], [data-testid="${machinesPendingTestId}"]`,
+      )
+      if (machines) target.__communityColdRootProbe!.machinesSeen = true
+    }
+    const observe = () => {
+      if (!document.documentElement) {
+        globalThis.setTimeout(observe, 0)
+        return
+      }
+      new MutationObserver(inspect).observe(document.documentElement, {
+        childList: true,
+        subtree: true,
+      })
+      inspect()
+    }
+    observe()
+  }, {
+    storageKey: coldRootStorageKey,
+    storedDestination: destination,
+    machinesPendingTestId: tid.pendingMain("machines"),
+  })
+}
+
+async function expectNoMachinesDuringColdRootRestore(page: Page) {
+  expect(await page.evaluate(() => (
+    window as typeof window & { __communityColdRootProbe?: ColdRootProbe }
+  ).__communityColdRootProbe)).toEqual({ machinesSeen: false })
+}
+
 async function holdSession(page: Page) {
   let releaseGate!: () => void
   let disposition: "continue" | "abort" = "continue"
@@ -152,10 +198,10 @@ test.describe.serial("community initial-load module skeletons", () => {
     await seedDmMessage("alice", dmId, privateMessage)
   })
 
-  test("cold mobile paths expose only their URL-owned inert modules", async ({ asUser }) => {
+  test("cold mobile paths expose only their URL-owned inert modules", async ({ asUser }, testInfo) => {
     test.setTimeout(240_000)
     const cases: Array<[string, ExpectedFrame]> = [
-      ["/c", { route: "community-root-redirect", surface: "detail", sidebar: "me", main: "machines" }],
+      ["/c", { route: "community-root-redirect", surface: "neutral", sidebar: "none", main: "route-resolution" }],
       ["/c/me", { route: "me-root", surface: "list", sidebar: "me", main: "me-root" }],
       ["/c/me/friends", { route: "me-friends", surface: "detail", sidebar: "me", main: "friends" }],
       ["/c/me/machines", { route: "me-machines", surface: "detail", sidebar: "me", main: "machines" }],
@@ -175,6 +221,12 @@ test.describe.serial("community initial-load module skeletons", () => {
       await page.goto(pathname, { waitUntil: "commit" })
       await expect.poll(gate.hits).toBeGreaterThan(0)
       await expectOwnedFrame(page, expected, [serverName, channelName, privateMessage])
+      if (pathname === "/c") {
+        await testInfo.attach("community-root-neutral-390x844", {
+          body: await page.screenshot(),
+          contentType: "image/png",
+        })
+      }
       expect(traffic.requests).toEqual([])
       expect(traffic.sockets()).toBe(0)
       if (expected.main === "server-conversation") {
@@ -187,9 +239,10 @@ test.describe.serial("community initial-load module skeletons", () => {
     }
   })
 
-  test("desktop cold frames retain all route-owned shell columns", async ({ asUser }) => {
+  test("desktop cold frames retain all route-owned shell columns", async ({ asUser }, testInfo) => {
     test.setTimeout(120_000)
     for (const [pathname, expected] of [
+      ["/c", { route: "community-root-redirect", surface: "neutral", sidebar: "none", main: "route-resolution" }],
       [`/c/me/${dmId}`, { route: "dm-detail", surface: "detail", sidebar: "me", main: "dm" }],
       [`/c/channels/${serverId}`, { route: "server-root", surface: "list", sidebar: "server", main: "server-landing", serverId }],
       [`/c/channels/${serverId}/${channelId}`, { route: "server-detail", surface: "detail", sidebar: "server", main: "server-conversation", serverId }],
@@ -201,10 +254,94 @@ test.describe.serial("community initial-load module skeletons", () => {
       await page.goto(pathname, { waitUntil: "commit" })
       await expect.poll(gate.hits).toBeGreaterThan(0)
       await expectOwnedFrame(page, expected, [serverName, channelName, privateMessage])
+      if (pathname === "/c") {
+        await testInfo.attach("community-root-neutral-1280x900", {
+          body: await page.screenshot(),
+          contentType: "image/png",
+        })
+      }
       expect(traffic.requests).toEqual([])
       expect(traffic.sockets()).toBe(0)
       await closeHeldContext(context, gate)
     }
+  })
+
+  test("Android cold root restores channel, DM, and Bots without any Machines DOM", async ({ asUser }) => {
+    test.setTimeout(180_000)
+    const cases = [
+      {
+        destination: `/c/channels/${serverId}/${channelId}`,
+        ready: (page: Page) => page.getByText(privateMessage, { exact: true }).first(),
+      },
+      {
+        destination: `/c/me/${dmId}`,
+        ready: (page: Page) => page.getByText(privateMessage, { exact: true }).first(),
+      },
+      {
+        destination: "/c/me/bots",
+        ready: (page: Page) => page.getByRole("button", { name: /Create a bot|Connect a machine/ }),
+      },
+    ]
+
+    for (const { destination, ready } of cases) {
+      const { context, page } = await asUser("alice")
+      await page.setViewportSize({ width: 390, height: 844 })
+      await installColdRootProbe(page, destination)
+      const gate = await holdSession(page)
+      await page.goto("/c", { waitUntil: "commit" })
+      await expect.poll(gate.hits).toBeGreaterThan(0)
+      await expectOwnedFrame(page, {
+        route: "community-root-redirect",
+        surface: "neutral",
+        sidebar: "none",
+        main: "route-resolution",
+      }, [serverName, channelName, privateMessage])
+      const historyLength = await page.evaluate(() => history.length)
+
+      gate.release()
+      await expect.poll(() => new URL(page.url()).pathname).toBe(destination)
+      await expect(ready(page)).toBeVisible({ timeout: 30_000 })
+      expect(await page.evaluate(() => history.length)).toBe(historyLength)
+      await expectNoMachinesDuringColdRootRestore(page)
+      await context.close()
+    }
+  })
+
+  test("Android cold root falls back to Machines only without valid account memory", async ({ asUser }) => {
+    const { page } = await asUser("alice")
+    await page.setViewportSize({ width: 390, height: 844 })
+    await installColdRootProbe(page, null)
+    const gate = await holdSession(page)
+    await page.goto("/c", { waitUntil: "commit" })
+    await expect.poll(gate.hits).toBeGreaterThan(0)
+    await expect(page.getByTestId(tid.pendingMain("route-resolution"))).toBeVisible()
+    await expect(page.getByTestId(tid.pendingMain("machines"))).toHaveCount(0)
+    const historyLength = await page.evaluate(() => history.length)
+
+    gate.release()
+    await expect.poll(() => new URL(page.url()).pathname).toBe("/c/me/machines")
+    await expect(page.getByTestId(tid.machinePairOpen)).toBeVisible({ timeout: 30_000 })
+    expect(await page.evaluate(() => history.length)).toBe(historyLength)
+  })
+
+  test("a stale cold-root DM is replaced by the verified Machines fallback", async ({ asUser }) => {
+    const { page } = await asUser("alice")
+    const missingDm = `/c/me/dm_missing_${Date.now()}`
+    await page.setViewportSize({ width: 390, height: 844 })
+    await installColdRootProbe(page, missingDm)
+    const gate = await holdSession(page)
+    await page.goto("/c", { waitUntil: "commit" })
+    await expect.poll(gate.hits).toBeGreaterThan(0)
+    await expect(page.getByTestId(tid.pendingMain("route-resolution"))).toBeVisible()
+    const historyLength = await page.evaluate(() => history.length)
+
+    gate.release()
+    await expect.poll(() => new URL(page.url()).pathname, { timeout: 30_000 })
+      .toBe("/c/me/machines")
+    await expect(page.getByTestId(tid.machinePairOpen)).toBeVisible({ timeout: 30_000 })
+    expect(await page.evaluate(() => history.length)).toBe(historyLength)
+    expect(await page.evaluate((storageKey) => localStorage.getItem(storageKey), coldRootStorageKey))
+      .toBe("/c/me/machines")
   })
 
   test("639↔640 preserves one pending main node with zero request or socket delta", async ({ asUser }) => {

--- a/src/web/src/test/e2e-ui/46-community-loading-geometry-matrix.spec.ts
+++ b/src/web/src/test/e2e-ui/46-community-loading-geometry-matrix.spec.ts
@@ -173,7 +173,6 @@ test.describe.serial("community pending-to-loaded geometry matrix", () => {
       .getByTestId(tid.threadSplitPanel)
       .getByTestId(tid.composerInput)
     routes = [
-      { name: "root-machines", pathname: "/c", ready: (page) => page.getByTestId(tid.machinePairOpen) },
       { name: "me-list", pathname: "/c/me", mobileRail: true, ready: (page) => page.getByRole("button", { name: "Friends", exact: true }) },
       { name: "friends", pathname: "/c/me/friends", ready: (page) => page.getByPlaceholder("Search friends") },
       { name: "machines", pathname: "/c/me/machines", ready: (page) => page.getByTestId(tid.machinePairOpen) },
@@ -211,13 +210,66 @@ test.describe.serial("community pending-to-loaded geometry matrix", () => {
   })
 
   for (const theme of ["light", "dark"] as const satisfies readonly Theme[]) {
-    test(`${theme}: 20 route × viewport pending→loaded pairs keep shell CLS at zero`, async ({ asUser }, testInfo) => {
+    test(`${theme}: neutral root owns two viewport cold restores`, async ({ asUser }, testInfo) => {
+      for (const width of [390, 1280] as const) {
+        const { context, page } = await asUser("alice")
+        await page.setViewportSize({ width, height: width === 390 ? 844 : 900 })
+        await page.emulateMedia({ colorScheme: theme })
+        await page.addInitScript((storageKey) => {
+          localStorage.removeItem(storageKey)
+        }, `community:lastRoute:${encodeURIComponent(userId("alice"))}`)
+        const session = await holdSession(page)
+        await page.goto("/c", { waitUntil: "commit" })
+        await expect.poll(session.hits).toBeGreaterThan(0)
+
+        const frame = page.getByTestId(tid.initialFrame)
+        await expect(frame).toBeVisible()
+        await expect(frame).toHaveAttribute(
+          "data-community-route-kind",
+          "community-root-redirect",
+        )
+        await expect(page.getByTestId(tid.pendingMain("route-resolution"))).toBeVisible()
+        await expect(page.getByTestId(tid.pendingMain("machines"))).toHaveCount(0)
+        await expect(page.locator('[data-slot="community-shell-root"]')).toHaveCount(0)
+        await expect(page.getByTestId(tid.initialRailPending)).toHaveCount(0)
+        await expect(page.getByTestId(tid.dmSidebarPending)).toHaveCount(0)
+        await expect(page.locator(
+          `[data-testid^="${tid.channelSidebarPending("")}"]`,
+        ))
+          .toHaveCount(0)
+        await expect(page.getByTestId(tid.initialUserBarPending)).toHaveCount(0)
+        await expect(frame.getByRole("button")).toHaveCount(0)
+        await expect(frame.locator("a")).toHaveCount(0)
+        await expect(frame).not.toContainText("Machines")
+        expect(await page.evaluate(() => (
+          document.documentElement.scrollWidth <= document.documentElement.clientWidth
+        ))).toBe(true)
+
+        const pendingPath = testInfo.outputPath(`${theme}-${width}-root-neutral-pending.png`)
+        await page.screenshot({ path: pendingPath })
+        await testInfo.attach(`${theme}-${width}-root-neutral-pending`, {
+          path: pendingPath,
+          contentType: "image/png",
+        })
+
+        session.release()
+        await expect(page.getByTestId(tid.initialFrame)).toHaveCount(0, { timeout: 30_000 })
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/c/me/machines")
+        await expect(page.getByTestId(tid.machinePairOpen)).toBeVisible({ timeout: 30_000 })
+        expect(await page.evaluate(() => (
+          document.documentElement.scrollWidth <= document.documentElement.clientWidth
+        ))).toBe(true)
+        await context.close()
+      }
+    })
+
+    test(`${theme}: 18 route × viewport pending→loaded pairs keep shell CLS at zero`, async ({ asUser }, testInfo) => {
       test.setTimeout(600_000)
       const cases: MatrixCase[] = routes.flatMap((route) => ([
         { ...route, width: 390 },
         { ...route, width: 1280 },
       ]))
-      expect(cases).toHaveLength(20)
+      expect(cases).toHaveLength(18)
 
       for (const entry of cases) {
         const { context, page } = await asUser("alice")


### PR DESCRIPTION
# Why we need this PR?
The shared Web entry point for Android, desktop, and browser cold starts at `/c`. Before the account-scoped last route resolves, the static route planner currently claims the Machines module, causing a wrong-page flash when the real destination is a channel, DM, or Bots.

## What changed
- Keep the unresolved `/c` route on the existing neutral route-resolution frame with no community rail, sidebar, user bar, or Machines main.
- Preserve that neutral frame after session resolution until the account-scoped `router.replace` commits the saved leaf or the Machines fallback.
- Add unit and component coverage for the root plan and replace behavior.
- Extend the Android-sized cold-start browser matrix with document-start mutation tracking for channel, DM, and Bots restores, fallback/failure coverage, history checks, and mobile/desktop visual evidence.
- Split `/c` from the existing loading-geometry matrix so the neutral pending frame and resolved Machines geometry/CLS are both enforced without changing the other route contracts.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...
