### PR TITLE
fix(web): reveal truncated bot audit logs

### DIFF
--- a/src/web/src/components/community/bots/bot-activity-row.tsx
+++ b/src/web/src/components/community/bots/bot-activity-row.tsx
@@ -1,6 +1,11 @@
 "use client"
 
-import { useState } from "react"
+import { useId, useLayoutEffect, useRef, useState, type ReactNode } from "react"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import type { AuditEvent, AuditKind } from "@/hooks/community/use-bot-audit-log"
 import {
   formatAlookAuditCommand,
@@ -17,17 +22,15 @@ import {
  * make each row feel like a card. A tag is quieter and reads like a log
  * severity column.
  *
- * Height is stable per row (thinking rows collapse to 8 lines by default;
- * expanding grows in-place) so live appends don't shift already-visible
- * rows.
+ * Every body stays on one line so live appends never shift already-visible
+ * rows. Truncated bodies reveal the complete retained log in a tooltip:
+ * hover/focus on desktop, tap on mobile.
  */
 export function BotActivityRow({ event }: { event: AuditEvent }) {
-  const [expanded, setExpanded] = useState(false)
-
   return (
     <div
       data-testid="bot-activity-row"
-      className="group grid grid-cols-[64px_56px_1fr] items-baseline gap-x-3 px-4 py-1.5 hover:bg-accent/30"
+      className="group grid min-h-11 grid-cols-[64px_56px_minmax(0,1fr)] items-center gap-x-3 px-4 hover:bg-accent/30 sm:min-h-0 sm:items-baseline sm:py-1.5"
     >
       <time
         dateTime={event.createdAt}
@@ -38,7 +41,7 @@ export function BotActivityRow({ event }: { event: AuditEvent }) {
       </time>
       <KindTag kind={event.kind} />
       <div className="min-w-0 text-left">
-        <RowBody event={event} expanded={expanded} onToggle={() => setExpanded((v) => !v)} />
+        <RowBody event={event} />
       </div>
     </div>
   )
@@ -69,25 +72,14 @@ function kindMeta(kind: AuditKind): { label: string; tone: string } {
   return { label: "think", tone: "text-muted-foreground/70" }
 }
 
-/** Thinking rows show up to this many lines before offering "Show more". */
-const THINKING_COLLAPSED_LINES = 8
-
-function RowBody({
-  event,
-  expanded,
-  onToggle,
-}: {
-  event: AuditEvent
-  expanded: boolean
-  onToggle: () => void
-}) {
+function RowBody({ event }: { event: AuditEvent }) {
   if (event.kind === "cli_invocation") {
     const command = formatAlookAuditCommand(event.payload)
     const subcommand = command.replace(/^alook\s+/, "")
     return (
-      <span className="font-mono text-[13px] text-foreground">
+      <TruncatedAuditLog fullText={command}>
         alook <span className="text-muted-foreground">{subcommand}</span>
-      </span>
+      </TruncatedAuditLog>
     )
   }
   if (event.kind === "tool_call") {
@@ -95,54 +87,54 @@ function RowBody({
     const name = formatAuditToolName(event.payload)
     if (p?.target) {
       return (
-        <div
-          title={p.target}
-          className="truncate font-mono text-[13px] text-foreground"
-        >
+        <TruncatedAuditLog fullText={`${name} · ${p.target}`}>
           {name} <span className="text-muted-foreground/60">·</span>{" "}
           <span className="text-muted-foreground">{p.target}</span>
-        </div>
+        </TruncatedAuditLog>
       )
     }
-    return <span className="font-mono text-[13px] text-foreground">{name}</span>
+    return <TruncatedAuditLog fullText={name}>{name}</TruncatedAuditLog>
   }
   if (event.kind === "turn_interrupt") {
+    const detail = "Stop accepted by daemon — waiting for the active turn to become idle."
     return (
-      <div
+      <TruncatedAuditLog
+        fullText={detail}
         data-testid="bot-activity-event-turn_interrupt"
-        className="truncate font-mono text-[13px] text-foreground"
       >
         <span>Stop accepted by daemon</span>{" "}
         <span className="text-muted-foreground">
           — waiting for the active turn to become idle.
         </span>
-      </div>
+      </TruncatedAuditLog>
     )
   }
   if (event.kind === "session_reset") {
+    const detail = "Session reset requested — the bot will start a fresh session on its next message."
     return (
-      <div
+      <TruncatedAuditLog
+        fullText={detail}
         data-testid="bot-activity-event-session_reset"
-        className="truncate font-mono text-[13px] text-foreground"
       >
         <span>Session reset requested</span>{" "}
         <span className="text-muted-foreground">
           — the bot will start a fresh session on its next message.
         </span>
-      </div>
+      </TruncatedAuditLog>
     )
   }
   if (event.kind === "nap") {
+    const detail = "Reset its own session — the bot napped and will start fresh on its next message."
     return (
-      <div
+      <TruncatedAuditLog
+        fullText={detail}
         data-testid="bot-activity-event-nap"
-        className="truncate font-mono text-[13px] text-foreground"
       >
         <span>Reset its own session</span>{" "}
         <span className="text-muted-foreground">
           — the bot napped and will start fresh on its next message.
         </span>
-      </div>
+      </TruncatedAuditLog>
     )
   }
   if (event.kind === "model_changed") {
@@ -152,23 +144,25 @@ function RowBody({
     const from = p?.from ?? "default"
     const to = p?.to ?? "default"
     return (
-      <div
+      <TruncatedAuditLog
+        fullText={`${from} → ${to}`}
         data-testid="bot-activity-event-model_changed"
-        className="truncate font-mono text-[13px] text-foreground"
       >
         {from} <span className="text-muted-foreground/60">→</span> {to}
-      </div>
+      </TruncatedAuditLog>
     )
   }
   if (event.kind === "provider_changed") {
     const p = event.payload as { from?: string; to?: string } | null
+    const from = p?.from ?? "?"
+    const to = p?.to ?? "?"
     return (
-      <div
+      <TruncatedAuditLog
+        fullText={`${from} → ${to}`}
         data-testid="bot-activity-event-provider_changed"
-        className="truncate font-mono text-[13px] text-foreground"
       >
-        {p?.from ?? "?"} <span className="text-muted-foreground/60">→</span> {p?.to ?? "?"}
-      </div>
+        {from} <span className="text-muted-foreground/60">→</span> {to}
+      </TruncatedAuditLog>
     )
   }
   if (event.kind === "error") {
@@ -183,13 +177,14 @@ function RowBody({
     // bad-model culprit inline. Both muted so the message reads first.
     const detail = p?.model ? `${p?.code ?? "error"} · ${p.model}` : p?.code ?? p?.scope ?? "error"
     return (
-      <div
+      <TruncatedAuditLog
+        fullText={`${message} · ${detail}`}
         data-testid="bot-activity-event-error"
-        className="flex min-w-0 flex-col gap-0.5"
       >
-        <span className="wrap-break-word font-mono text-[13px] text-destructive">{message}</span>
-        <span className="truncate font-mono text-[11px] text-muted-foreground/70">{detail}</span>
-      </div>
+        <span className="text-destructive">{message}</span>{" "}
+        <span className="text-muted-foreground/60">·</span>{" "}
+        <span className="text-[11px] text-muted-foreground/70">{detail}</span>
+      </TruncatedAuditLog>
     )
   }
   if (event.kind === "wake_trigger") {
@@ -203,57 +198,117 @@ function RowBody({
     const channel = p?.channel ?? "/unknown"
     const seqLabel = p?.seq != null ? `#${p.seq}` : ""
     const verb = p?.reason === "mention" ? "Mentioned by" : "Woken by"
+    const detail = `${verb} ${sender} in ${channel}${seqLabel ? ` ${seqLabel}` : ""}`
     return (
-      <div className="truncate font-mono text-[13px] text-foreground">
+      <TruncatedAuditLog fullText={detail}>
         <span className="text-muted-foreground">{verb}</span> {sender}{" "}
         <span className="text-muted-foreground">in</span> {channel}
         {seqLabel ? <span className="text-muted-foreground/70"> {seqLabel}</span> : null}
-      </div>
+      </TruncatedAuditLog>
     )
   }
   const p = event.payload as { text?: string; truncated?: boolean; chars?: number } | null
   const text = p?.text ?? ""
   const truncated = p?.truncated ?? false
-  // `chars` from the daemon is the codepoint count of the pre-truncation
-  // string; compare against the codepoint count of the shown slice so an
-  // emoji-heavy body doesn't over-report the hidden remainder.
   const chars = p?.chars ?? countCodepoints(text)
-  const lines = text.split("\n")
-  const overflowsLineLimit = lines.length > THINKING_COLLAPSED_LINES
-  const shownText = expanded
-    ? text
-    : overflowsLineLimit
-      ? lines.slice(0, THINKING_COLLAPSED_LINES).join("\n")
-      : text
-  const canExpand = overflowsLineLimit || truncated
-  const hiddenLines = overflowsLineLimit ? lines.length - THINKING_COLLAPSED_LINES : 0
-  const hiddenChars = truncated ? Math.max(0, chars - countCodepoints(shownText)) : 0
+  // The daemon can cap stored thinking text. The tooltip reveals every
+  // retained character and states the unavailable remainder honestly.
+  const omittedChars = truncated ? Math.max(0, chars - countCodepoints(text)) : 0
+  const fullText = omittedChars > 0
+    ? `${text}\n… ${omittedChars} character${omittedChars === 1 ? "" : "s"} not retained in the audit log`
+    : text
   return (
-    <div className="flex min-w-0 flex-col gap-1">
-      <div className="whitespace-pre-wrap wrap-break-word font-mono text-[12.5px] leading-relaxed text-muted-foreground">
-        {shownText}
-      </div>
-      {canExpand && !expanded ? (
-        <button
-          type="button"
-          onClick={onToggle}
-          className="self-start text-[11px] text-muted-foreground/70 underline-offset-2 hover:text-foreground hover:underline"
-        >
-          {overflowsLineLimit
-            ? `Show ${hiddenLines} more line${hiddenLines === 1 ? "" : "s"}`
-            : `Show ${hiddenChars} more character${hiddenChars === 1 ? "" : "s"}`}
-        </button>
-      ) : null}
-      {expanded && canExpand ? (
-        <button
-          type="button"
-          onClick={onToggle}
-          className="self-start text-[11px] text-muted-foreground/70 underline-offset-2 hover:text-foreground hover:underline"
-        >
-          Collapse
-        </button>
-      ) : null}
-    </div>
+    <TruncatedAuditLog
+      fullText={fullText}
+      className="text-[12.5px] text-muted-foreground"
+    >
+      {text}
+    </TruncatedAuditLog>
+  )
+}
+
+function TruncatedAuditLog({
+  children,
+  fullText,
+  className = "",
+  ...props
+}: {
+  children: ReactNode
+  fullText: string
+  className?: string
+  "data-testid"?: string
+}) {
+  const triggerId = useId()
+  const textRef = useRef<HTMLSpanElement | null>(null)
+  const pointerTypeRef = useRef<string | null>(null)
+  const [isTruncated, setIsTruncated] = useState(false)
+  const [open, setOpen] = useState(false)
+
+  useLayoutEffect(() => {
+    const element = textRef.current
+    if (!element) return
+    const measure = () => {
+      const nextIsTruncated = element.scrollWidth > element.clientWidth + 1
+      setIsTruncated(nextIsTruncated)
+      if (!nextIsTruncated) setOpen(false)
+    }
+    measure()
+    if (typeof ResizeObserver === "undefined") return
+    const observer = new ResizeObserver(measure)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [fullText])
+
+  const trigger = (
+    <button
+      type="button"
+      disabled={!isTruncated}
+      data-activity-tooltip-trigger={isTruncated || undefined}
+      onPointerDown={(event) => {
+        pointerTypeRef.current = event.pointerType
+      }}
+      onClick={() => {
+        if (
+          isTruncated
+          && (pointerTypeRef.current === "touch" || pointerTypeRef.current === "pen")
+        ) {
+          setOpen(true)
+        }
+      }}
+      className="block min-h-11 w-full min-w-0 cursor-default rounded-sm text-left outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 sm:min-h-0"
+    >
+      <span
+        ref={textRef}
+        className={`block truncate font-mono text-[13px] text-foreground ${className}`}
+        {...props}
+      >
+        {children}
+      </span>
+    </button>
+  )
+
+  return (
+    <Tooltip
+      disabled={!isTruncated}
+      open={open && isTruncated}
+      triggerId={triggerId}
+      onOpenChange={setOpen}
+    >
+      <TooltipTrigger
+        id={triggerId}
+        disabled={!isTruncated}
+        closeOnClick={false}
+        render={trigger}
+      />
+      <TooltipContent
+        role="tooltip"
+        side="bottom"
+        align="start"
+        className="thin-scrollbar max-h-[min(24rem,calc(100dvh-2rem))] max-w-[min(32rem,calc(100vw-2rem))] overflow-y-auto whitespace-pre-wrap wrap-break-word font-mono text-[12px] leading-relaxed"
+      >
+        {fullText}
+      </TooltipContent>
+    </Tooltip>
   )
 }
 

--- a/src/web/src/test/e2e-ui/30-bot-profile-audit-preview.spec.ts
+++ b/src/web/src/test/e2e-ui/30-bot-profile-audit-preview.spec.ts
@@ -25,7 +25,19 @@ async function settleSheet(sheet: Locator): Promise<void> {
     const sample = () => {
       const bounds = element.getBoundingClientRect()
       const style = getComputedStyle(element)
-      const current = [bounds.x, bounds.y, bounds.width, bounds.height, style.opacity, style.transform].join(":")
+      const current = [
+        bounds.x,
+        bounds.y,
+        bounds.width,
+        bounds.height,
+        style.opacity,
+        style.transform,
+        style.backgroundColor,
+        style.borderTopColor,
+        style.borderRightColor,
+        style.borderBottomColor,
+        style.borderLeftColor,
+      ].join(":")
       stableFrames = current === previous ? stableFrames + 1 : 0
       previous = current
       if (stableFrames >= 3 || performance.now() >= deadline) resolveStable()
@@ -33,6 +45,44 @@ async function settleSheet(sheet: Locator): Promise<void> {
     }
     requestAnimationFrame(sample)
   }))
+}
+
+async function expectSheetThemeTokens(sheet: Locator): Promise<void> {
+  const colors = await sheet.evaluate((element) => {
+    const probe = document.createElement("div")
+    probe.style.cssText = [
+      "position:fixed",
+      "visibility:hidden",
+      "background-color:var(--background)",
+      "border:1px solid var(--border)",
+    ].join(";")
+    document.body.appendChild(probe)
+
+    const sheetStyle = getComputedStyle(element)
+    const probeStyle = getComputedStyle(probe)
+    const header = element.querySelector<HTMLElement>("[data-slot='sheet-header']")
+    const body = element.querySelector<HTMLElement>("[data-slot='sheet-body']")
+    if (!header || !body) throw new Error("missing sheet surface")
+    const result = {
+      expectedBackground: probeStyle.backgroundColor,
+      expectedBorder: probeStyle.borderLeftColor,
+      sheetBackground: sheetStyle.backgroundColor,
+      sheetBorder: sheetStyle.borderLeftColor,
+      headerBackground: getComputedStyle(header).backgroundColor,
+      headerBorder: getComputedStyle(header).borderBottomColor,
+      bodyBackground: getComputedStyle(body).backgroundColor,
+    }
+    probe.remove()
+    return result
+  })
+
+  expect(colors).toMatchObject({
+    sheetBackground: colors.expectedBackground,
+    sheetBorder: colors.expectedBorder,
+    headerBackground: "rgba(0, 0, 0, 0)",
+    headerBorder: colors.expectedBorder,
+    bodyBackground: colors.expectedBackground,
+  })
 }
 
 async function attachPageScreenshot(testInfo: TestInfo, name: string, page: Page): Promise<void> {
@@ -277,6 +327,84 @@ async function openBotProfile(page: Page, botName: string): Promise<void> {
   await page.getByRole("button", { name: botName, exact: true }).click()
   await expect(page.getByTestId(tid.profileCard)).toBeVisible()
 }
+
+test("full audit log reveals a truncated row by hover and touch", async ({ asUser }, testInfo) => {
+  test.setTimeout(120_000)
+  const suffix = Date.now().toString(36)
+  const longAuditTarget = `/Users/alice/workspace/${"deeply-nested-audit-target/".repeat(5)}result-${suffix}.md`
+  const fullAuditText = `read · ${longAuditTarget}`
+  const { credential, machineId } = await pairMachine()
+  const botId = await createBot(machineId, `Tooltip bot ${suffix}`)
+  const machine = connectMachine(credential)
+  await machine.opened
+
+  try {
+    machine.socket.send(JSON.stringify({
+      type: "bot_audit_event",
+      agentId: botId,
+      sessionId: `session-${suffix}`,
+      launchId: `launch-${suffix}`,
+      event: { kind: "tool_call", payload: { name: "Read", target: longAuditTarget } },
+    }))
+
+    await expect.poll(async () => {
+      const response = await fetch(
+        `${WEB_URL}/api/community/bots/${botId}/audit-log?limit=10`,
+        { headers: headersFor("alice") },
+      )
+      if (!response.ok) return false
+      const { events } = (await response.json()) as {
+        events: Array<{ payload?: { target?: string } | null }>
+      }
+      return events.some((event) => event.payload?.target === longAuditTarget)
+    }).toBe(true)
+
+    const { page } = await asUser("alice")
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await gotoAfterUserWsAuth(page, `/c/me/bots?audit=${botId}`)
+    const sheet = page.getByTestId(tid.botActivityModal)
+    await settleSheet(sheet)
+    const trigger = sheet.locator("[data-activity-tooltip-trigger]").filter({ hasText: "read" })
+    await expect(trigger).toHaveCount(1)
+    await expect.poll(() => trigger.locator("span").first().evaluate((element) => (
+      element.scrollWidth > element.clientWidth
+    ))).toBe(true)
+
+    await trigger.hover()
+    const tooltip = page.getByRole("tooltip")
+    await expect(tooltip).toHaveText(fullAuditText)
+    await expect(tooltip).toHaveCSS("opacity", "1")
+    await attachPageScreenshot(testInfo, "bot-activity-log-tooltip-desktop", page)
+    await page.emulateMedia({ colorScheme: "dark" })
+    await expect(page.locator("html")).toHaveClass(/dark/)
+    await settleSheet(sheet)
+    await expectSheetThemeTokens(sheet)
+    await expect(tooltip).toHaveCSS("opacity", "1")
+    await attachPageScreenshot(testInfo, "bot-activity-log-tooltip-desktop-dark", page)
+    await page.mouse.move(0, 0)
+    await expect(tooltip).toBeHidden()
+
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.emulateMedia({ colorScheme: "light" })
+    await expect(page.locator("html")).not.toHaveClass(/dark/)
+    await settleSheet(sheet)
+    await trigger.dispatchEvent("pointerdown", { pointerType: "touch" })
+    await trigger.dispatchEvent("click")
+    await expect(tooltip).toHaveText(fullAuditText)
+    await expect(tooltip).toHaveCSS("opacity", "1")
+    await attachPageScreenshot(testInfo, "bot-activity-log-tooltip-mobile", page)
+    await page.emulateMedia({ colorScheme: "dark" })
+    await expect(page.locator("html")).toHaveClass(/dark/)
+    await settleSheet(sheet)
+    await expectSheetThemeTokens(sheet)
+    await expect(tooltip).toHaveCSS("opacity", "1")
+    await attachPageScreenshot(testInfo, "bot-activity-log-tooltip-mobile-dark", page)
+    await page.mouse.click(4, 4)
+    await expect(tooltip).toBeHidden()
+  } finally {
+    machine.socket.close()
+  }
+})
 
 test("owner-only bot mark sticker, Stop lifecycle, owner swap, and URL-owned audit modal", async ({ asUser }, testInfo) => {
   test.setTimeout(180_000)


### PR DESCRIPTION
## Summary

- keep every bot audit-log body on one stable truncated line
- reveal the full retained content on desktop hover/focus and mobile tap
- add real D1/WebSocket coverage for overflow detection, desktop/mobile interaction, theme variants, and settled screenshot evidence

## Testing

- pre-commit repository typecheck, lint, and test hooks
- `pnpm --filter @alook/web exec vitest run --config vitest.workspace.config.ts src/components/community/bots/bot-activity-row.test.ts src/components/community/bots/bot-activity-modal.test.ts` (12/12)
- `pnpm --filter @alook/web typecheck`
- `pnpm --filter @alook/web exec playwright test src/test/e2e-ui/30-bot-profile-audit-preview.spec.ts --grep "full audit log reveals a truncated row by hover and touch"` (1/1)

## QA

- PC and mobile, light and dark
- dark screenshots wait for the existing Sheet theme transition to settle; no shared Sheet behavior changed
