### PR TITLE
fix(web): stabilize Android cold-start skeleton geometry

### DIFF
--- a/src/web/src/components/community/machines/machine-card.tsx
+++ b/src/web/src/components/community/machines/machine-card.tsx
@@ -41,18 +41,18 @@ export function MachineCard({
   return (
     <MachineCardFrame>
       <div className="flex items-start justify-between gap-3">
-        <div className="flex items-start gap-3">
-          <div className="grid size-10 place-items-center rounded-xl bg-secondary text-muted-foreground">
+        <div className="flex min-w-0 flex-1 items-start gap-3">
+          <div className="grid size-10 shrink-0 place-items-center rounded-xl bg-secondary text-muted-foreground">
             <Monitor className="size-5" />
           </div>
-          <div className="flex flex-col gap-1">
-            <div className="flex items-center gap-2">
-              <span className="text-[15px] font-medium text-foreground">
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="truncate text-[15px] font-medium text-foreground">
                 {machineName(machine)}
               </span>
               <span
                 className={[
-                  "inline-flex items-center gap-1 rounded-full px-2 py-1 text-[11px] font-medium",
+                  "inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-1 text-[11px] font-medium",
                   isOnline
                     ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
                     : "bg-muted text-muted-foreground",
@@ -67,7 +67,7 @@ export function MachineCard({
                 {isOnline ? "Online" : "Offline"}
               </span>
             </div>
-            <span className="text-xs text-muted-foreground">
+            <span className="truncate text-xs text-muted-foreground">
               {[machine.platform, machine.arch].filter(Boolean).join(" · ")}
               {machine.daemonVersion ? ` · v${machine.daemonVersion}` : ""}
             </span>

--- a/src/web/src/components/community/machines/machine-list.test.ts
+++ b/src/web/src/components/community/machines/machine-list.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   toastError: vi.fn(),
   fetchLatestDaemonVersion: vi.fn(),
   machinesLoading: { current: false },
+  machines: { current: [] as unknown[] },
   onboardingState: { current: "done" as unknown },
 }))
 
@@ -73,7 +74,7 @@ vi.mock("./machine-card", () => ({
 vi.mock("./pair-machine-sheet", () => ({ PairMachineSheet: () => null }))
 vi.mock("@/components/community/onboarding-tiles/connect-tile", () => ({ ConnectTile: () => null }))
 vi.mock("@/hooks/community/use-machines", () => ({
-  useMachines: () => ({ machines: [], isLoading: mocks.machinesLoading.current }),
+  useMachines: () => ({ machines: mocks.machines.current, isLoading: mocks.machinesLoading.current }),
 }))
 vi.mock("@/hooks/community/use-bots", () => ({ useBots: () => ({ bots: [] }) }))
 vi.mock("@/stores/community", () => ({
@@ -124,6 +125,7 @@ describe("machine daemon update UI", () => {
       package: "@alook/daemon",
     })
     mocks.machinesLoading.current = false
+    mocks.machines.current = []
     mocks.onboardingState.current = "done"
   })
 
@@ -179,15 +181,37 @@ describe("machine daemon update UI", () => {
       className: "flex flex-1 flex-col gap-6 overflow-y-auto p-6 thin-scrollbar",
     })).toHaveLength(1)
     expect(renderer.root.findAllByProps({
-      className: "flex items-center justify-between",
+      className: "flex flex-col items-stretch gap-4 sm:flex-row sm:items-center sm:justify-between",
     })).toHaveLength(1)
     expect(renderer.root.findAllByProps({
-      className: "flex min-w-0 flex-1 flex-col gap-1",
+      className: "flex min-w-0 flex-col gap-1",
+    })).toHaveLength(1)
+    expect(renderer.root.findAllByProps({
+      className: "w-full sm:w-fit sm:shrink-0",
     })).toHaveLength(1)
     expect(renderer.root.findAllByProps({ className: "flex flex-col gap-3" }))
       .toHaveLength(1)
-    expect(renderer.root.findAllByProps({ className: "h-9 w-36 rounded-md" }))
+    expect(renderer.root.findAllByProps({ className: "h-11 w-full rounded-md sm:h-9 sm:w-36" }))
       .toHaveLength(2)
+  })
+
+  it("uses the same responsive header footprint after Machines load", async () => {
+    mocks.machines.current = [machine()]
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(React.createElement(MachineList))
+    })
+
+    const heading = renderer.root.findByProps({ "data-slot": "community-machines-heading" })
+    expect(heading.props.className).toBe(
+      "flex flex-col items-stretch gap-4 sm:flex-row sm:items-center sm:justify-between",
+    )
+    expect(renderer.root.findByProps({ "data-slot": "community-machines-heading-copy" }).props.className)
+      .toBe("flex min-w-0 flex-col gap-1")
+    expect(renderer.root.findByProps({ "data-slot": "community-machines-heading-action" }).props.className)
+      .toBe("w-full sm:w-fit sm:shrink-0")
+    expect(renderer.root.findByProps({ "data-testid": tid.machinePairOpen }).props.className)
+      .toBe("min-h-11 w-full sm:min-h-9 sm:w-auto")
   })
 
   it("turns a loading Back request into an inert skeleton slot", () => {

--- a/src/web/src/components/community/machines/machine-list.tsx
+++ b/src/web/src/components/community/machines/machine-list.tsx
@@ -42,6 +42,12 @@ import {
 import { removeCommunityParam } from "@/lib/community/community-route"
 import { GuideMeAvatarMotion } from "./guide-me-avatar-motion"
 
+const MACHINE_LIST_HEADING_CLASS =
+  "flex flex-col items-stretch gap-4 sm:flex-row sm:items-center sm:justify-between"
+const MACHINE_LIST_HEADING_COPY_CLASS = "flex min-w-0 flex-col gap-1"
+const MACHINE_LIST_HEADING_ACTION_CLASS = "w-full sm:w-fit sm:shrink-0"
+const MACHINE_LIST_DESCRIPTION = "Your computers running the alook daemon."
+
 // Loading placeholder shaped like a real MachineCard (size-10 rounded-xl icon +
 // name row + meta lines + trailing kebab slot) so the list doesn't reflow when
 // data lands — replaces the old structureless muted box.
@@ -49,12 +55,12 @@ function MachineCardSkeleton() {
   return (
     <MachineCardFrame>
       <div className="flex items-start justify-between gap-3">
-        <div className="flex items-start gap-3">
+        <div className="flex min-w-0 flex-1 items-start gap-3">
           <Skeleton className="size-10 shrink-0 rounded-xl" />
-          <div className="flex flex-col gap-1">
-            <Skeleton className="h-6 w-32 rounded" />
-            <Skeleton className="h-4 w-44 rounded" />
-            <Skeleton className="h-4 w-24 rounded" />
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <Skeleton className="h-6 w-32 max-w-full rounded" />
+            <Skeleton className="h-4 w-44 max-w-full rounded" />
+            <Skeleton className="h-4 w-24 max-w-full rounded" />
           </div>
         </div>
         <Skeleton className="size-8 shrink-0 rounded-md" />
@@ -104,12 +110,17 @@ export function MachineListSkeleton({
       {machineBackBar(undefined, reserveBackSlot || Boolean(onBack))}
       <MachineListContent
         heading={(
-          <header className="flex items-center justify-between">
-            <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <header data-slot="community-machines-heading" className={MACHINE_LIST_HEADING_CLASS}>
+            <div data-slot="community-machines-heading-copy" className={MACHINE_LIST_HEADING_COPY_CLASS}>
               <Skeleton className="h-7 w-24 rounded" />
-              <Skeleton className="h-5 w-full max-w-56 rounded" />
+              <div aria-hidden className="relative w-fit max-w-full">
+                <p className="invisible text-sm">{MACHINE_LIST_DESCRIPTION}</p>
+                <Skeleton className="absolute inset-0 rounded" />
+              </div>
             </div>
-            <Skeleton className="h-9 w-36 rounded-md" />
+            <div data-slot="community-machines-heading-action" className={MACHINE_LIST_HEADING_ACTION_CLASS}>
+              <Skeleton className="h-11 w-full rounded-md sm:h-9 sm:w-36" />
+            </div>
           </header>
         )}
         cards={(
@@ -404,15 +415,23 @@ export function MachineList({ onBack }: { onBack?: () => void } = {}) {
       {backBar}
       <MachineListContent
         heading={(
-          <header className="flex items-center justify-between">
-            <div>
+          <header data-slot="community-machines-heading" className={MACHINE_LIST_HEADING_CLASS}>
+            <div data-slot="community-machines-heading-copy" className={MACHINE_LIST_HEADING_COPY_CLASS}>
               <h1 className="text-xl font-medium text-foreground">Machines</h1>
               <p className="text-sm text-muted-foreground">
-                Your computers running the alook daemon.
+                {MACHINE_LIST_DESCRIPTION}
               </p>
             </div>
-            <div data-onboarding-target="connect-machine" className="w-fit">
-              <Button data-testid={tid.machinePairOpen} onClick={openPair}>
+            <div
+              data-slot="community-machines-heading-action"
+              data-onboarding-target="connect-machine"
+              className={MACHINE_LIST_HEADING_ACTION_CLASS}
+            >
+              <Button
+                data-testid={tid.machinePairOpen}
+                className="min-h-11 w-full sm:min-h-9 sm:w-auto"
+                onClick={openPair}
+              >
                 Connect a machine
               </Button>
             </div>

--- a/src/web/src/components/community/shell/community-shell-layout.tsx
+++ b/src/web/src/components/community/shell/community-shell-layout.tsx
@@ -96,6 +96,10 @@ export function CommunityShellLayout({
   const isMobileDetail = breakpoint === "mobile" && surface === "detail"
   const isInitial = breakpoint === "unknown"
   const isInitialDetail = isInitial && surface === "detail"
+  const sidebarMobileActive = isMobileList || (isInitial && surface === "list")
+  const sidebarMobileHidden = isMobileDetail || isInitialDetail
+  const mainMobileActive = isMobileDetail || isInitialDetail
+  const mainMobileHidden = isMobileList || (isInitial && surface === "list")
   const showUserBar = isDesktop || isMobileList || isInitial || preserveHiddenMobileModules
   const transitionMode = transition?.mode
   const transitionTargetHref = transition?.targetHref
@@ -176,7 +180,10 @@ export function CommunityShellLayout({
             disabled={!isDesktop}
             className={cn(
               "min-h-0 flex-1",
-              !isDesktop && "*:data-[mobile-active=true]:flex-1!",
+              !isDesktop && [
+                "max-sm:*:data-[mobile-active=true]:flex-1!",
+                "max-sm:*:data-[mobile-hidden=true]:hidden!",
+              ],
             )}
             defaultLayout={defaultLayout}
             onLayoutChanged={onLayoutChanged}
@@ -187,12 +194,11 @@ export function CommunityShellLayout({
               minSize={160}
               maxSize={360}
               hidden={isMobileDetail}
-              data-mobile-active={isMobileList || undefined}
+              data-mobile-active={sidebarMobileActive || undefined}
+              data-mobile-hidden={sidebarMobileHidden || undefined}
               className={cn(
                 "flex flex-col bg-sidebar",
                 (isDesktop || isMobileList || isInitial) && "pb-[calc(3.75rem+var(--app-safe-area-bottom))] sm:pb-15",
-                isInitial && surface === "list" && "max-sm:flex-1!",
-                isInitialDetail && "max-sm:hidden",
               )}
             >
               <div
@@ -208,12 +214,9 @@ export function CommunityShellLayout({
               id="main"
               defaultSize="76%"
               hidden={isMobileList}
-              data-mobile-active={isMobileDetail || undefined}
-              className={cn(
-                "flex min-w-0 flex-col bg-background",
-                isInitial && surface === "list" && "max-sm:hidden",
-                isInitialDetail && "max-sm:flex-1!",
-              )}
+              data-mobile-active={mainMobileActive || undefined}
+              data-mobile-hidden={mainMobileHidden || undefined}
+              className="flex min-w-0 flex-col bg-background"
             >
               <div
                 ref={mainPanelRef}

--- a/src/web/src/components/community/shell/shell-frame-view.test.ts
+++ b/src/web/src/components/community/shell/shell-frame-view.test.ts
@@ -140,6 +140,16 @@ describe("ShellFrameView", () => {
       .toContain("max-sm:hidden")
     expect(renderer.root.findAllByType("main-content")).toHaveLength(0)
     expect(renderer.root.findAllByType("shell-overlays")).toHaveLength(0)
+    const [initialSidebar, initialMain] = renderer.root.findAllByType("panel")
+    expect(initialSidebar.props["data-mobile-hidden"]).toBe(true)
+    expect(initialMain.props["data-mobile-active"]).toBe(true)
+    const initialGroup = renderer.root.findByType("panel-group")
+    expect(initialGroup.props.className).toContain(
+      "max-sm:*:data-[mobile-active=true]:flex-1!",
+    )
+    expect(initialGroup.props.className).toContain(
+      "max-sm:*:data-[mobile-hidden=true]:hidden!",
+    )
   })
 
   it("keeps rail, sidebar, and UserBar in the unknown list shell", async () => {
@@ -160,6 +170,9 @@ describe("ShellFrameView", () => {
     expect(renderer.root.findAllByType("user-bar")).toHaveLength(1)
     expect(renderer.root.findAllByType("channel-loading-frame")).toHaveLength(1)
     expect(renderer.root.findAllByType("main-content")).toHaveLength(0)
+    const [initialSidebar, initialMain] = renderer.root.findAllByType("panel")
+    expect(initialSidebar.props["data-mobile-active"]).toBe(true)
+    expect(initialMain.props["data-mobile-hidden"]).toBe(true)
   })
 
   it("keeps the desktop panel geometry, order, and seeded overlay call", async () => {
@@ -274,9 +287,13 @@ describe("ShellFrameView", () => {
     expect(renderer.root.findAllByType("panel")[0]?.props.hidden).toBe(false)
     expect(renderer.root.findAllByType("panel")[1]?.props.hidden).toBe(true)
     expect(renderer.root.findAllByType("panel")[0]?.props["data-mobile-active"]).toBe(true)
+    expect(renderer.root.findAllByType("panel")[0]?.props["data-mobile-hidden"]).toBeUndefined()
     expect(renderer.root.findAllByType("panel")[1]?.props["data-mobile-active"]).toBeUndefined()
+    expect(renderer.root.findAllByType("panel")[1]?.props["data-mobile-hidden"]).toBe(true)
     expect(renderer.root.findByType("panel-group").props.disabled).toBe(true)
-    expect(renderer.root.findByType("panel-group").props.className).toContain("*:data-[mobile-active=true]:flex-1!")
+    expect(renderer.root.findByType("panel-group").props.className).toContain(
+      "max-sm:*:data-[mobile-active=true]:flex-1!",
+    )
     expect(renderer.root.findAllByType("shell-overlays")).toHaveLength(1)
     const listMotion = renderer.root.findByProps({ "data-community-mobile-surface": "list" })
     expect(listMotion.props.className).toContain("flex")
@@ -303,7 +320,9 @@ describe("ShellFrameView", () => {
     expect(renderer.root.findAllByType("panel")[0]?.props.hidden).toBe(true)
     expect(renderer.root.findAllByType("panel")[1]?.props.hidden).toBe(false)
     expect(renderer.root.findAllByType("panel")[0]?.props["data-mobile-active"]).toBeUndefined()
+    expect(renderer.root.findAllByType("panel")[0]?.props["data-mobile-hidden"]).toBe(true)
     expect(renderer.root.findAllByType("panel")[1]?.props["data-mobile-active"]).toBe(true)
+    expect(renderer.root.findAllByType("panel")[1]?.props["data-mobile-hidden"]).toBeUndefined()
     expect(renderer.root.findAllByType("shell-overlays")).toHaveLength(1)
     const detailMotion = renderer.root.findByProps({ "data-community-mobile-surface": "detail" })
     expect(detailMotion.props.className).toContain("flex")

--- a/src/web/src/components/ui/skeleton.test.ts
+++ b/src/web/src/components/ui/skeleton.test.ts
@@ -1,0 +1,13 @@
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import { Skeleton } from "./skeleton"
+
+describe("Skeleton", () => {
+  it("keeps pulse paint-only and disables it for reduced motion", () => {
+    const html = renderToStaticMarkup(createElement(Skeleton))
+
+    expect(html).toContain("animate-pulse")
+    expect(html).toContain("motion-reduce:animate-none")
+  })
+})

--- a/src/web/src/components/ui/skeleton.tsx
+++ b/src/web/src/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("animate-pulse rounded-md bg-muted", className)}
+      className={cn("animate-pulse rounded-md bg-muted motion-reduce:animate-none", className)}
       {...props}
     />
   )

--- a/src/web/src/test/e2e-ui/46-community-loading-geometry-matrix.spec.ts
+++ b/src/web/src/test/e2e-ui/46-community-loading-geometry-matrix.spec.ts
@@ -1,5 +1,5 @@
 import type { Locator, Page, Route } from "@playwright/test"
-import { expect, test, userId } from "./_fixtures/community-fixture"
+import { expect, sessionCookie, test, userId } from "./_fixtures/community-fixture"
 import {
   seedChannel,
   seedDm,
@@ -9,9 +9,15 @@ import {
   seedThread,
 } from "./_fixtures/seed"
 import { tid } from "./_fixtures/testids"
+import { WEB_URL } from "./_setup/paths"
 
 type Theme = "light" | "dark"
+type MobileWidth = 320 | 390 | 639
 const RAIL_OVERFLOW_SERVER_COUNT = 20
+const ANDROID_USER_AGENTS = {
+  chrome: "Mozilla/5.0 (Linux; Android 15; Pixel 9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Mobile Safari/537.36",
+  webview: "Mozilla/5.0 (Linux; Android 15; Pixel 9 Build/AP3A.240905.015; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/140.0.0.0 Mobile Safari/537.36",
+} as const
 type Geometry = Record<string, { x: number; y: number; width: number; height: number }>
 type MatrixCase = {
   name: string
@@ -48,6 +54,30 @@ async function holdRequest(page: Page, pattern: string) {
     await route.continue()
   })
   return { hits: () => hits, release }
+}
+
+async function pairMachine() {
+  const pair = await fetch(`${WEB_URL}/api/community/machines/pair`, {
+    method: "POST",
+    headers: { Cookie: sessionCookie("alice"), Origin: WEB_URL },
+  })
+  expect(pair.status).toBe(200)
+  const { tokenId } = await pair.json() as { tokenId: string }
+  const activate = await fetch(`${WEB_URL}/api/community/daemon/activate`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${tokenId}`,
+      "Content-Type": "application/json",
+      Origin: WEB_URL,
+    },
+    body: JSON.stringify({
+      hostname: `geometry-mobile-${Date.now()}`,
+      platform: "android",
+      arch: "arm64",
+      runtimeReport: [{ id: "codex", status: "healthy" }],
+    }),
+  })
+  expect(activate.status).toBe(200)
 }
 
 const shellPanel = (page: Page, id: "sidebar" | "main") => (
@@ -137,6 +167,143 @@ async function readCls(page: Page) {
   }))
 }
 
+type FirstFrameSample = {
+  overflow: number
+  geometry: Geometry
+}
+
+async function installFirstFrameProbe(page: Page, surface: "list" | "detail") {
+  await page.addInitScript((expectedSurface) => {
+    const samples: FirstFrameSample[] = []
+    Reflect.set(window, "__communityFirstFrameSamples", samples)
+
+    const rect = (selector: string) => {
+      const element = document.querySelector<HTMLElement>(selector)
+      if (!element || getComputedStyle(element).display === "none") return null
+      const box = element.getBoundingClientRect()
+      if (box.width === 0 || box.height === 0) return null
+      return { x: box.x, y: box.y, width: box.width, height: box.height }
+    }
+    const sample = () => {
+      if (document.querySelector('[data-slot="community-shell-root"]')) {
+        const activePanel = '[data-slot="resizable-panel"][data-mobile-active="true"]'
+        const hiddenPanel = '[data-slot="resizable-panel"][data-mobile-hidden="true"]'
+        const geometry = Object.fromEntries(Object.entries({
+          shell: rect('[data-slot="community-shell-root"]'),
+          surface: rect('[data-slot="community-app-surface"]'),
+          rail: rect('[data-slot="community-server-rail-viewport"]'),
+          sidebar: rect(expectedSurface === "list" ? activePanel : hiddenPanel),
+          main: rect(expectedSurface === "detail" ? activePanel : hiddenPanel),
+          userBar: rect('[data-slot="community-user-bar-overlay"]'),
+        }).filter((entry): entry is [string, NonNullable<typeof entry[1]>] => entry[1] !== null))
+        samples.push({
+          overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+          geometry,
+        })
+      }
+      if (performance.now() < 5_000) requestAnimationFrame(sample)
+    }
+    requestAnimationFrame(sample)
+  }, surface)
+}
+
+async function firstFrameSamples(page: Page): Promise<FirstFrameSample[]> {
+  return page.evaluate(() => (
+    Reflect.get(window, "__communityFirstFrameSamples") as FirstFrameSample[]
+  ))
+}
+
+function expectMobileGeometry(
+  samples: FirstFrameSample[],
+  width: MobileWidth,
+  surface: "list" | "detail",
+) {
+  expect(samples.length).toBeGreaterThan(0)
+  const first = samples[0]!
+  const geometryDrift: string[] = []
+  for (const [index, sample] of samples.entries()) {
+    expect(sample.overflow, `frame ${index} horizontal overflow`).toBe(0)
+    expect(
+      Object.keys(sample.geometry).sort(),
+      `frame ${index} visible modules: ${JSON.stringify(sample)}`,
+    ).toEqual(
+      surface === "list"
+        ? ["rail", "shell", "sidebar", "surface", "userBar"]
+        : ["main", "shell", "surface"],
+    )
+    expect(sample.geometry.shell?.width, `frame ${index} shell width`).toBeCloseTo(width, 0)
+    expect(sample.geometry.surface?.width, `frame ${index} surface width`).toBeCloseTo(
+      surface === "list" ? width - 56 : width,
+      0,
+    )
+    if (surface === "list") {
+      expect(sample.geometry.sidebar?.width, `frame ${index} sidebar width`).toBeCloseTo(width - 57, 0)
+      expect(sample.geometry.userBar?.width, `frame ${index} UserBar width`).toBeCloseTo(width, 0)
+    } else {
+      expect(sample.geometry.main?.width, `frame ${index} main width`).toBeCloseTo(width, 0)
+    }
+    for (const name of Object.keys(first.geometry)) {
+      for (const coordinate of ["x", "y", "width", "height"] as const) {
+        if (Math.abs(first.geometry[name]![coordinate] - sample.geometry[name]![coordinate]) > 1) {
+          geometryDrift.push(`frame ${index} ${name}.${coordinate}`)
+        }
+      }
+    }
+  }
+  expect(geometryDrift, "mobile landmark geometry drift").toEqual([])
+}
+
+async function expectMachinesHeadingSpacing(page: Page) {
+  const heading = page.locator('[data-slot="community-machines-heading"]')
+  await expect(heading).toBeVisible()
+  const geometry = await heading.evaluate((element) => {
+    const copy = element.querySelector<HTMLElement>('[data-slot="community-machines-heading-copy"]')!
+    const action = element.querySelector<HTMLElement>('[data-slot="community-machines-heading-action"]')!
+    const copyBox = copy.getBoundingClientRect()
+    const actionBox = action.getBoundingClientRect()
+    const headingBox = element.getBoundingClientRect()
+    return {
+      fits: element.scrollWidth <= element.clientWidth,
+      gap: actionBox.top - copyBox.bottom,
+      heading: {
+        x: headingBox.x,
+        y: headingBox.y,
+        width: headingBox.width,
+        height: headingBox.height,
+      },
+      headingWidth: headingBox.width,
+      actionWidth: actionBox.width,
+      actionHeight: actionBox.height,
+    }
+  })
+  expect(geometry.fits).toBe(true)
+  expect(geometry.gap).toBeGreaterThanOrEqual(15)
+  expect(geometry.actionWidth).toBeCloseTo(geometry.headingWidth, 0)
+  expect(geometry.actionHeight).toBeGreaterThanOrEqual(44)
+  return geometry.heading
+}
+
+async function visibleSkeletonAnimationProperties(page: Page) {
+  return page.locator('[data-slot="skeleton"]').evaluateAll((elements) => Array.from(new Set(
+    elements
+      .filter((element) => {
+        const box = element.getBoundingClientRect()
+        return getComputedStyle(element).display !== "none" && box.width > 0 && box.height > 0
+      })
+      .flatMap((element) => element.getAnimations())
+      .flatMap((animation) => animation.effect instanceof KeyframeEffect
+        ? animation.effect.getKeyframes()
+        : [])
+      .flatMap((frame) => Object.keys(frame))
+      .filter((property) => ![
+        "composite",
+        "computedOffset",
+        "easing",
+        "offset",
+      ].includes(property)),
+  )).sort())
+}
+
 test.describe.serial("community pending-to-loaded geometry matrix", () => {
   let routes!: Omit<MatrixCase, "width">[]
 
@@ -207,6 +374,68 @@ test.describe.serial("community pending-to-loaded geometry matrix", () => {
         },
       },
     ]
+  })
+
+  test("Android Chrome/WebView keep 320/390/639 cold frames mobile before breakpoint hydration", async ({ asUser }) => {
+    test.setTimeout(240_000)
+    await pairMachine()
+    for (const userAgent of Object.values(ANDROID_USER_AGENTS)) {
+      for (const width of [320, 390, 639] as const) {
+        for (const [pathname, surface] of [
+          ["/c/me", "list"],
+          ["/c/me/machines", "detail"],
+        ] as const) {
+          const { context, page } = await asUser("alice", { userAgent })
+          await page.setViewportSize({ width, height: width === 320 ? 720 : 900 })
+          await installFirstFrameProbe(page, surface)
+          const session = await holdSession(page)
+          await page.goto(pathname, { waitUntil: "commit" })
+          await expect.poll(session.hits).toBeGreaterThan(0)
+          await expect(page.getByTestId(tid.initialFrame)).toBeVisible()
+          await page.waitForTimeout(250)
+
+          expectMobileGeometry(await firstFrameSamples(page), width, surface)
+          const pendingHeading = pathname === "/c/me/machines"
+            ? await expectMachinesHeadingSpacing(page)
+            : null
+
+          session.release()
+          await expect(page.getByTestId(tid.initialFrame)).toHaveCount(0, { timeout: 30_000 })
+          await expect(
+            pathname === "/c/me"
+              ? page.getByRole("button", { name: "Friends", exact: true })
+              : page.getByTestId(tid.machinePairOpen),
+          ).toBeVisible({ timeout: 30_000 })
+          if (pendingHeading) {
+            const loadedHeading = await expectMachinesHeadingSpacing(page)
+            expectSameGeometry({ heading: pendingHeading }, { heading: loadedHeading })
+          }
+          await page.waitForTimeout(250)
+          expectMobileGeometry(await firstFrameSamples(page), width, surface)
+          await context.close()
+        }
+      }
+    }
+  })
+
+  test("community skeleton pulse changes only opacity and stops for reduced motion", async ({ asUser }) => {
+    for (const reducedMotion of ["no-preference", "reduce"] as const) {
+      const { context, page } = await asUser("alice", {
+        userAgent: ANDROID_USER_AGENTS.webview,
+      })
+      await page.setViewportSize({ width: 320, height: 720 })
+      await page.emulateMedia({ reducedMotion })
+      const session = await holdSession(page)
+      await page.goto("/c/me/machines", { waitUntil: "commit" })
+      await expect.poll(session.hits).toBeGreaterThan(0)
+      await expect(page.getByTestId(tid.initialFrame)).toBeVisible()
+
+      const animationProperties = await visibleSkeletonAnimationProperties(page)
+      expect(animationProperties).toEqual(reducedMotion === "reduce" ? [] : ["opacity"])
+
+      session.release()
+      await context.close()
+    }
   })
 
   for (const theme of ["light", "dark"] as const satisfies readonly Theme[]) {

--- a/src/web/src/test/e2e-ui/53-mobile-inbox-surface.spec.ts
+++ b/src/web/src/test/e2e-ui/53-mobile-inbox-surface.spec.ts
@@ -305,6 +305,9 @@ test.describe.serial("mobile Inbox interactive user-bar base", () => {
     })
     const inboxGets: string[] = []
     const completedInboxGets: string[] = []
+    const postAuthInboxGets = new WeakSet<Request>()
+    const completedPostAuthInboxPaths = new Set<string>()
+    let authOkReleased = false
     const eagerInboxPaths = [
       "/api/community/users/me/inbox/unreads",
       "/api/community/users/me/inbox/mentions",
@@ -313,12 +316,14 @@ test.describe.serial("mobile Inbox interactive user-bar base", () => {
       const path = new URL(request.url()).pathname
       if (request.method() === "GET" && path.includes("/users/me/inbox/")) {
         inboxGets.push(path)
+        if (authOkReleased) postAuthInboxGets.add(request)
       }
     })
     bob.page.on("requestfinished", (request) => {
       const path = new URL(request.url()).pathname
       if (request.method() === "GET" && path.includes("/users/me/inbox/")) {
         completedInboxGets.push(path)
+        if (postAuthInboxGets.has(request)) completedPostAuthInboxPaths.add(path)
       }
     })
     await bob.page.setViewportSize({ width: 639, height: 844 })
@@ -328,8 +333,9 @@ test.describe.serial("mobile Inbox interactive user-bar base", () => {
     )), { timeout: 30_000 }).toBe(true)
     await expect.poll(ws.heldConnectionCount).toBe(1)
     expect(ws.releaseHeldConnections((frame) => frame.type === "auth.ok")).toBe(1)
+    authOkReleased = true
     await expect.poll(() => eagerInboxPaths.every((path) => (
-      completedInboxGets.filter((completed) => completed === path).length >= 2
+      completedPostAuthInboxPaths.has(path)
     ))).toBe(true)
     const writes = observeWrites(bob.page)
     const wsBefore = ws.frames.length


### PR DESCRIPTION
# Why we need this PR?
Android Chrome/WebView cold loads below the `sm` breakpoint briefly rendered the desktop 24/76 resizable-panel split. At 320px the pre-fix first frame exposed both panels (`sidebar=63.1px`, `main=199.9px`) before hydration corrected the surface. The Machines loading header also reserved one subtitle line while the loaded copy wrapped to two at 320px, causing a 20px height shift.

## What changed

- Apply mobile active/hidden state to the outer `react-resizable-panels` wrappers with CSS breakpoint variants, so server/unknown frames paint the route-owned surface without changing the desktop contract.
- Give Machines loading and loaded headers one responsive footprint, including naturally matched subtitle wrapping and a 44px mobile action target.
- Align real and skeleton machine-card shrink behavior on narrow screens.
- Keep skeleton pulse paint-only and disable it for reduced motion.
- Add unit and Playwright coverage for Android Chrome/WebView at 320/390/639px across `/c/me` and `/c/me/machines`, including every sampled landmark's x/y/width/height, overflow, header parity, and animation properties.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — web 7,007; agent-driver 721 (+4 skipped); CI scripts 209
- `pnpm typegrep:ws`
- `pnpm typegrep:agent-driver`
- `pnpm knip`
- `46-community-loading-geometry-matrix.spec.ts` — 6/6 full matrix; focused Android/motion 2/2 after final assertion changes
- `41-community-initial-load-module-skeletons.spec.ts` — 7/7
- Repository-mandated independent `/c` QA — PASS, no findings
- Manual Android WebView 320px traces: `/c/me` LCP 835ms, CLS 0.00; `/c/me/machines` LCP 1306ms, CLS 0.00

## Checklist
- [x] Tests added/updated as needed
- [x] All hosted CI checks pass (validated by Madox)
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...