### PR TITLE
fix(shared): cap reconnect unread query binds

### DIFF
--- a/src/shared/src/db/queries/community/agent-inbox.ts
+++ b/src/shared/src/db/queries/community/agent-inbox.ts
@@ -544,6 +544,10 @@ async function listAgentAllowedChannelIds(
  */
 const channelJoinBaselineGuard = sql`${communityMessage.createdAt} > COALESCE(${communityChannelMember.addedAt}, ${communityServerMember.joinedAt}, '')`;
 
+// Both agent-unread statements emit 13 fixed bindings in addition to channel
+// ids. 87 ids hit D1's 100-bind limit exactly; 88 must start a new chunk.
+const AGENT_UNREAD_CHANNEL_CHUNK_SIZE = maxInParams(13);
+
 /**
  * Cross-channel unread fill for `inboxPull`, grouped by channel/DM (not
  * global seq order — `seq` is a per-scope counter, comparing raw values
@@ -571,13 +575,6 @@ export async function listUnreadMessagesForAgent(
     opts.visibleChannelIds
   );
   if (allowedChannelIds.length === 0) return [];
-
-  // Besides the dynamic channel ids, the unread statement emits 13 fixed
-  // bindings (viewer predicates, notification-policy literals, and LIMIT).
-  // The generic 90-id cap therefore produces 103 bindings exactly when an
-  // agent reaches 90 allowed scopes. Give this query its own exact budget so
-  // every chunk stays within D1's hard 100-parameter ceiling.
-  const unreadChannelChunkSize = maxInParams(13);
 
   // D1 caps a statement at 100 bound params, and `allowedChannelIds` is
   // unbounded (a bot allowed into >100 channels). Chunk the `inArray` and merge:
@@ -638,7 +635,7 @@ export async function listUnreadMessagesForAgent(
       .limit(opts.max);
 
   const merged = (
-    await Promise.all(chunk(allowedChannelIds, unreadChannelChunkSize).map(runChunk))
+    await Promise.all(chunk(allowedChannelIds, AGENT_UNREAD_CHANNEL_CHUNK_SIZE).map(runChunk))
   ).flat();
   merged.sort((a, b) =>
     a.channelId === b.channelId
@@ -1033,7 +1030,7 @@ export async function getLatestUnreadMessageForAgent(
       .limit(1);
 
   const winners = (
-    await Promise.all(chunk(allowedChannelIds, D1_MAX_IN_PARAMS).map(runChunk))
+    await Promise.all(chunk(allowedChannelIds, AGENT_UNREAD_CHANNEL_CHUNK_SIZE).map(runChunk))
   ).flat();
   if (winners.length === 0) return null;
   let best = winners[0]!;

--- a/src/shared/test/queries/param-limit.test.ts
+++ b/src/shared/test/queries/param-limit.test.ts
@@ -239,6 +239,49 @@ describe("listUnreadMessagesForAgent bound parameters", () => {
   });
 });
 
+describe("getLatestUnreadMessageForAgent bound parameters", () => {
+  it("87 allowed channels fit exactly at the query's 13-fixed-bind budget", async () => {
+    const channelIds = Array.from({ length: 87 }, (_, index) => `channel_${index}`);
+    const typeRows = channelIds.map((id) => [id, "text"]);
+    const { db, statements } = makeD1Capture([typeRows, []]);
+
+    await expect(
+      agentInboxQueries.getLatestUnreadMessageForAgent(db as never, "user_1", {
+        accessVisibleChannelIds: channelIds,
+      }),
+    ).resolves.toBeNull();
+
+    expect(statements.map(({ params }) => params.filter(
+      (value) => typeof value === "string" && value.startsWith("channel_"),
+    ).length)).toEqual([87, 87]);
+    expect(statements.map(({ params }) => params.length)).toEqual([87, 100]);
+  });
+
+  it("88 allowed channels split into 87 + 1 instead of emitting 101 binds", async () => {
+    const channelIds = Array.from({ length: 88 }, (_, index) => `channel_${index}`);
+    const typeRows = channelIds.map((id) => [id, "text"]);
+    const { db, statements } = makeD1Capture([
+      typeRows,
+      [["message_older", "2026-09-06T01:00:00.000Z"]],
+      [["message_newer", "2026-09-06T02:00:00.000Z"]],
+    ]);
+
+    await expect(
+      agentInboxQueries.getLatestUnreadMessageForAgent(db as never, "user_1", {
+        accessVisibleChannelIds: channelIds,
+      }),
+    ).resolves.toEqual({ messageId: "message_newer" });
+
+    expect(statements.map(({ params }) => params.filter(
+      (value) => typeof value === "string" && value.startsWith("channel_"),
+    ).length)).toEqual([88, 87, 1]);
+    expect(statements.map(({ params }) => params.length)).toEqual([88, 100, 14]);
+    for (const { params } of statements) {
+      expect(params.length).toBeLessThanOrEqual(D1_MAX_BIND_PARAMS);
+    }
+  });
+});
+
 describe("mark-all-read revision guard bound parameters", () => {
   function buildGuard(targetCount: number) {
     const targets = Array.from({ length: targetCount }, (_, index) => ({


### PR DESCRIPTION
## Summary

- share the 87-channel D1 bind budget between normal inbox pulls and reconnect latest-unread lookup
- prevent `resync-wakes` from emitting 101+ bindings once a bot reaches 88 allowed scopes
- preserve global newest-message selection across query chunks

## Tests

- shared inbox/parameter tests: 78 passed
- daemon `resync-wakes`: 2 passed
- web resync route: 7 passed
- wake build/dispatch: 41 passed
- daemon reconnect socket: 1 passed
- WS delivery: 1 passed
- `pnpm typecheck`: 11/11 packages
- `pnpm test`: passed (including agent-driver 721 passed / 4 skipped and CI scripts 209 passed)

## QA boundary

The exact-head component chain passes. A live isolated 88-scope reconnect journey is not available in the current repository: local launchers and seeders bind the existing primary dev stack's ports/state, and the candidate worktree has no isolated runtime fixture. No production or healthy local state was modified for QA.
