### PR TITLE
test(web): add Replica red-team benchmark

### DIFF
--- a/src/web/scripts/replica-benchmark-report.test.ts
+++ b/src/web/scripts/replica-benchmark-report.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import {
   analyzeReplicaBenchmark,
   artifactCompatibilityFailures,
@@ -13,6 +13,16 @@ import {
   type ReplicaBenchmarkSample,
   type ReplicaScenarioContract,
 } from "../src/test/e2e-ui/perf/replica-benchmark-types"
+import {
+  emptySample,
+  isFirstPartyUrl,
+} from "../src/test/e2e-ui/perf/replica-benchmark-fixture"
+
+vi.mock("@playwright/test", () => ({
+  chromium: {},
+  expect: vi.fn(),
+  test: vi.fn(),
+}))
 
 const contract: ReplicaScenarioContract = {
   id: "j6-text-send",
@@ -76,6 +86,26 @@ describe("percentile", () => {
     expect(percentile([50, 10, 30, 20, 40], 0.5)).toBe(30)
     expect(percentile([50, 10, 30, 20, 40], 0.95)).toBe(50)
     expect(percentile([], 0.95)).toBeNull()
+  })
+})
+
+describe("benchmark coverage registration", () => {
+  it("covers the shared fixture primitives used by the Playwright runner", () => {
+    expect(isFirstPartyUrl("http://localhost:3000/api/community", "http://localhost:3000")).toBe(true)
+    expect(isFirstPartyUrl("https://example.com/api/community", "http://localhost:3000")).toBe(false)
+    expect(isFirstPartyUrl("not a URL", "http://localhost:3000")).toBe(false)
+    expect(emptySample("j5-draft", 2, 123)).toMatchObject({
+      scenario: "j5-draft",
+      iteration: 2,
+      actionAtMs: 123,
+      observationEndedAtMs: 123,
+    })
+  })
+
+  it("loads the Playwright-only spec so changed-file coverage can account for it", async () => {
+    const playwright = await import("@playwright/test")
+    await import("../src/test/e2e-ui/perf/replica.perf")
+    expect(playwright.test).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/web/scripts/replica-benchmark-report.test.ts
+++ b/src/web/scripts/replica-benchmark-report.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it } from "vitest"
+import {
+  analyzeReplicaBenchmark,
+  artifactCompatibilityFailures,
+  percentile,
+  renderReplicaBenchmarkReport,
+  sampleLatency,
+  userBlockingGets,
+} from "./replica-benchmark-report"
+import {
+  REPLICA_BENCHMARK_SCHEMA_VERSION,
+  type ReplicaBenchmarkArtifact,
+  type ReplicaBenchmarkSample,
+  type ReplicaScenarioContract,
+} from "../src/test/e2e-ui/perf/replica-benchmark-types"
+
+const contract: ReplicaScenarioContract = {
+  id: "j6-text-send",
+  label: "Text send",
+  anchor: "durable-coherent",
+  absoluteMaxMs: 50,
+  maxBaselineRatio: 0.1,
+  minSamples: 1,
+  requiredProofs: ["intent-durable", "canonical-row-matches"],
+  requireCanonicalOutcome: true,
+  requireSingleBusinessEffect: true,
+  requireZeroBlockingGets: true,
+}
+
+function sample(overrides: Partial<ReplicaBenchmarkSample> = {}): ReplicaBenchmarkSample {
+  return {
+    scenario: "j6-text-send",
+    iteration: 1,
+    actionAtMs: 1_000,
+    interactiveCoherentAtMs: 1_020,
+    localDurableAtMs: 1_018,
+    baselineObservedAtMs: null,
+    canonicalOutcomeAtMs: 2_500,
+    requests: [],
+    manualRecoveryActions: [],
+    proofs: [
+      { id: "intent-durable", passed: true, evidence: "IDB intent n1" },
+      { id: "canonical-row-matches", passed: true, evidence: "D1 row m1" },
+    ],
+    canonicalOutcomeCount: 1,
+    businessEffectCount: 1,
+    transportDeliveryCount: 2,
+    observationEndedAtMs: 2_500,
+    productFailure: null,
+    harnessError: null,
+    ...overrides,
+  }
+}
+
+function artifact(
+  mode: ReplicaBenchmarkArtifact["mode"],
+  samples: ReplicaBenchmarkSample[] = [sample()],
+  overrides: Partial<ReplicaBenchmarkArtifact> = {},
+): ReplicaBenchmarkArtifact {
+  return {
+    schemaVersion: REPLICA_BENCHMARK_SCHEMA_VERSION,
+    contractVersion: "replica-v1",
+    fixtureVersion: "stress-v1",
+    selectedScenarios: ["j6-text-send"],
+    createdAt: "2026-09-06T00:00:00.000Z",
+    gitSha: "abc123",
+    mode,
+    networkDelayMs: 1_000,
+    samples,
+    ...overrides,
+  }
+}
+
+describe("percentile", () => {
+  it("uses a deterministic nearest-rank percentile", () => {
+    expect(percentile([50, 10, 30, 20, 40], 0.5)).toBe(30)
+    expect(percentile([50, 10, 30, 20, 40], 0.95)).toBe(50)
+    expect(percentile([], 0.95)).toBeNull()
+  })
+})
+
+describe("durable-coherent timing", () => {
+  it("uses the later of durable commit and coherent paint", () => {
+    expect(sampleLatency(sample({
+      actionAtMs: 1_000,
+      localDurableAtMs: 1_030,
+      interactiveCoherentAtMs: 1_042,
+    }), "durable-coherent")).toBe(42)
+    expect(sampleLatency(sample({
+      actionAtMs: 1_000,
+      localDurableAtMs: 1_047,
+      interactiveCoherentAtMs: 1_020,
+    }), "durable-coherent")).toBe(47)
+  })
+
+  it("rejects memory-only paint when durable commit evidence is absent", () => {
+    expect(sampleLatency(sample({ localDurableAtMs: null }), "durable-coherent")).toBeNull()
+  })
+
+  it("uses explicit legacy completion only for a baseline", () => {
+    const measured = sample({
+      interactiveCoherentAtMs: 1_020,
+      localDurableAtMs: null,
+      baselineObservedAtMs: 2_100,
+    })
+    expect(sampleLatency(measured, "durable-coherent", "baseline")).toBe(1_100)
+    expect(sampleLatency(measured, "durable-coherent", "gate")).toBeNull()
+  })
+})
+
+describe("baseline and gate semantics", () => {
+  it("records an honest slow baseline without failing the harness run", () => {
+    const result = analyzeReplicaBenchmark(
+      artifact("baseline", [sample({ interactiveCoherentAtMs: 2_000, localDurableAtMs: 1_990 })]),
+      undefined,
+      [contract],
+    )
+    expect(result.qualifies).toBe(false)
+    expect(result.runPassed).toBe(true)
+    expect(result.scenarios[0]?.failures.some((failure) => failure.kind === "performance")).toBe(true)
+    expect(renderReplicaBenchmarkReport(
+      artifact("baseline", [sample({ interactiveCoherentAtMs: 2_000, localDurableAtMs: 1_990 })]),
+      undefined,
+      [contract],
+    )).toMatch(/BASELINE RECORDED/)
+  })
+
+  it("requires both the absolute target and at least a ten-times baseline gain", () => {
+    const baseline = artifact("baseline", [sample({ interactiveCoherentAtMs: 1_400, localDurableAtMs: 1_390 })])
+    const tooSlow = analyzeReplicaBenchmark(
+      artifact("gate", [sample({ interactiveCoherentAtMs: 1_045, localDurableAtMs: 1_040 })]),
+      baseline,
+      [contract],
+    )
+    expect(tooSlow.runPassed).toBe(false)
+    expect(tooSlow.scenarios[0]?.failures.map((failure) => failure.message).join(" "))
+      .toMatch(/ratio/)
+
+    const passing = analyzeReplicaBenchmark(
+      artifact("gate", [sample({ interactiveCoherentAtMs: 1_039, localDurableAtMs: 1_035 })]),
+      baseline,
+      [contract],
+    )
+    expect(passing.runPassed).toBe(true)
+  })
+
+  it("rejects a baseline with fewer complete timings than the scenario contract", () => {
+    const strictContract = { ...contract, minSamples: 2 }
+    const baseline = artifact("baseline", [
+      sample({ iteration: 1, baselineObservedAtMs: 1_500 }),
+      sample({ iteration: 2, baselineObservedAtMs: null, localDurableAtMs: null }),
+    ])
+    const result = analyzeReplicaBenchmark(
+      artifact("gate", [sample({ iteration: 1 }), sample({ iteration: 2 })]),
+      baseline,
+      [strictContract],
+    )
+    expect(result.runPassed).toBe(false)
+    expect(result.scenarios[0]?.failures.map((failure) => failure.message).join(" "))
+      .toMatch(/baseline needs 2 complete samples, got 1/)
+  })
+})
+
+describe("correctness cannot be hidden by a fast paint", () => {
+  it("fails missing durable-reopen proof", () => {
+    const result = analyzeReplicaBenchmark(
+      artifact("gate", [sample({
+        proofs: [{ id: "canonical-row-matches", passed: true, evidence: "D1 m1" }],
+      })]),
+      artifact("baseline", [sample({ interactiveCoherentAtMs: 1_500, localDurableAtMs: 1_490 })]),
+      [contract],
+    )
+    expect(result.runPassed).toBe(false)
+    expect(result.scenarios[0]?.failures.map((failure) => failure.message).join(" "))
+      .toMatch(/intent-durable/)
+  })
+
+  it("allows duplicate transport but rejects duplicate business effects", () => {
+    const baseline = artifact("baseline", [sample({ interactiveCoherentAtMs: 1_500, localDurableAtMs: 1_490 })])
+    const duplicateTransport = analyzeReplicaBenchmark(
+      artifact("gate", [sample({ interactiveCoherentAtMs: 1_040, localDurableAtMs: 1_035, transportDeliveryCount: 4 })]),
+      baseline,
+      [contract],
+    )
+    expect(duplicateTransport.runPassed).toBe(true)
+
+    const duplicateEffect = analyzeReplicaBenchmark(
+      artifact("gate", [sample({ interactiveCoherentAtMs: 1_040, localDurableAtMs: 1_035, businessEffectCount: 2 })]),
+      baseline,
+      [contract],
+    )
+    expect(duplicateEffect.runPassed).toBe(false)
+    expect(duplicateEffect.scenarios[0]?.failures.map((failure) => failure.message).join(" "))
+      .toMatch(/business effect/)
+  })
+
+  it("rejects a local intent with no unique canonical outcome", () => {
+    const result = analyzeReplicaBenchmark(
+      artifact("gate", [sample({ interactiveCoherentAtMs: 1_040, localDurableAtMs: 1_035, canonicalOutcomeCount: 0 })]),
+      artifact("baseline", [sample({ interactiveCoherentAtMs: 1_500, localDurableAtMs: 1_490 })]),
+      [contract],
+    )
+    expect(result.runPassed).toBe(false)
+    expect(result.scenarios[0]?.failures.map((failure) => failure.message).join(" "))
+      .toMatch(/canonical outcome/)
+  })
+})
+
+describe("blocking network and comparison integrity", () => {
+  it("counts only first-party GET completions before the local anchor", () => {
+    const measured = sample({
+      interactiveCoherentAtMs: 2_100,
+      localDurableAtMs: 2_090,
+      requests: [
+        {
+          requestId: "blocking",
+          method: "GET",
+          url: "http://localhost/api/community/channels/c/messages",
+          resourceType: "fetch",
+          firstParty: true,
+          networkAccess: true,
+          startedAtMs: 1_010,
+          endedAtMs: 2_010,
+          status: 200,
+        },
+        {
+          requestId: "background",
+          method: "GET",
+          url: "http://localhost/api/community/channels/c/read-state",
+          resourceType: "fetch",
+          firstParty: true,
+          networkAccess: true,
+          startedAtMs: 1_020,
+          endedAtMs: 2_500,
+          status: 200,
+        },
+        {
+          requestId: "write",
+          method: "POST",
+          url: "http://localhost/api/community/channels/c/messages",
+          resourceType: "fetch",
+          firstParty: true,
+          networkAccess: true,
+          startedAtMs: 1_030,
+          endedAtMs: 2_030,
+          status: 200,
+        },
+      ],
+    })
+    expect(userBlockingGets(measured, contract.anchor).map((request) => request.requestId))
+      .toEqual(["blocking"])
+  })
+
+  it("classifies baseline requests against legacy completion, not a missing local durable anchor", () => {
+    const measured = sample({
+      localDurableAtMs: null,
+      baselineObservedAtMs: 2_100,
+      requests: [{
+        requestId: "legacy-blocking",
+        method: "GET",
+        url: "http://localhost/api/community/channels/c/messages",
+        resourceType: "fetch",
+        firstParty: true,
+        networkAccess: true,
+        startedAtMs: 1_010,
+        endedAtMs: 2_000,
+        status: 200,
+      }],
+    })
+    expect(userBlockingGets(measured, contract.anchor, "baseline")).toHaveLength(1)
+    expect(userBlockingGets(measured, contract.anchor, "gate")).toHaveLength(0)
+  })
+
+  it("rejects comparison across a different fixture or delay", () => {
+    const candidate = artifact("gate")
+    const baseline = artifact("baseline", [sample()], {
+      fixtureVersion: "other-fixture",
+      networkDelayMs: 999,
+    })
+    expect(artifactCompatibilityFailures(candidate, baseline)).toEqual([
+      "fixtureVersion differs",
+      "networkDelayMs differs",
+    ])
+    const result = analyzeReplicaBenchmark(candidate, baseline, [contract])
+    expect(result.comparisonCompatible).toBe(false)
+    expect(result.runPassed).toBe(false)
+  })
+
+  it("rejects comparisons across different scenario selections", () => {
+    const candidate = artifact("gate")
+    const baseline = artifact("baseline", [sample()], { selectedScenarios: ["j5-draft"] })
+    expect(artifactCompatibilityFailures(candidate, baseline)).toEqual(["selectedScenarios differ"])
+  })
+})

--- a/src/web/scripts/replica-benchmark-report.test.ts
+++ b/src/web/scripts/replica-benchmark-report.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./replica-benchmark-report"
 import {
   REPLICA_BENCHMARK_SCHEMA_VERSION,
+  REPLICA_BENCHMARK_SERVER_MODE,
   type ReplicaBenchmarkArtifact,
   type ReplicaBenchmarkSample,
   type ReplicaScenarioContract,
@@ -75,6 +76,7 @@ function artifact(
     createdAt: "2026-09-06T00:00:00.000Z",
     gitSha: "abc123",
     mode,
+    serverMode: REPLICA_BENCHMARK_SERVER_MODE,
     networkDelayMs: 1_000,
     samples,
     ...overrides,
@@ -301,14 +303,16 @@ describe("blocking network and comparison integrity", () => {
     expect(userBlockingGets(measured, contract.anchor, "gate")).toHaveLength(0)
   })
 
-  it("rejects comparison across a different fixture or delay", () => {
+  it("rejects comparison across a different fixture, server mode, or delay", () => {
     const candidate = artifact("gate")
     const baseline = artifact("baseline", [sample()], {
       fixtureVersion: "other-fixture",
+      serverMode: "next-dev" as ReplicaBenchmarkArtifact["serverMode"],
       networkDelayMs: 999,
     })
     expect(artifactCompatibilityFailures(candidate, baseline)).toEqual([
       "fixtureVersion differs",
+      "serverMode differs",
       "networkDelayMs differs",
     ])
     const result = analyzeReplicaBenchmark(candidate, baseline, [contract])

--- a/src/web/scripts/replica-benchmark-report.ts
+++ b/src/web/scripts/replica-benchmark-report.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync } from "node:fs"
 import {
   REPLICA_BENCHMARK_SCHEMA_VERSION,
+  REPLICA_BENCHMARK_SERVER_MODE,
   REPLICA_SCENARIO_CONTRACTS,
   type ReplicaBenchmarkArtifact,
   type ReplicaBenchmarkSample,
@@ -108,6 +109,7 @@ export function artifactCompatibilityFailures(
   if (candidate.schemaVersion !== baseline.schemaVersion) failures.push("schemaVersion differs")
   if (candidate.contractVersion !== baseline.contractVersion) failures.push("contractVersion differs")
   if (candidate.fixtureVersion !== baseline.fixtureVersion) failures.push("fixtureVersion differs")
+  if (candidate.serverMode !== baseline.serverMode) failures.push("serverMode differs")
   if (candidate.networkDelayMs !== baseline.networkDelayMs) failures.push("networkDelayMs differs")
   if (candidate.selectedScenarios.join(",") !== baseline.selectedScenarios.join(",")) {
     failures.push("selectedScenarios differ")
@@ -132,6 +134,13 @@ function artifactShapeFailures(artifact: ReplicaBenchmarkArtifact): ReplicaBench
   }
   if (!artifact.gitSha) {
     failures.push({ kind: "harness", sampleIteration: null, message: "missing gitSha" })
+  }
+  if (artifact.serverMode !== REPLICA_BENCHMARK_SERVER_MODE) {
+    failures.push({
+      kind: "harness",
+      sampleIteration: null,
+      message: `serverMode must be ${REPLICA_BENCHMARK_SERVER_MODE}, got ${String(artifact.serverMode)}`,
+    })
   }
   if (!Array.isArray(artifact.selectedScenarios) || artifact.selectedScenarios.length === 0) {
     failures.push({ kind: "harness", sampleIteration: null, message: "no selectedScenarios" })
@@ -360,6 +369,7 @@ export function renderReplicaBenchmarkReport(
     `Verdict: **${verdict}**`,
     `Candidate: \`${artifact.gitSha}\``,
     `Mode: \`${artifact.mode}\``,
+    `Server mode: \`${artifact.serverMode}\``,
     `Network injection: \`${artifact.networkDelayMs}ms\``,
     `Contract / fixture: \`${artifact.contractVersion}\` / \`${artifact.fixtureVersion}\``,
     `Selected scenarios: \`${artifact.selectedScenarios.join(", ")}\``,

--- a/src/web/scripts/replica-benchmark-report.ts
+++ b/src/web/scripts/replica-benchmark-report.ts
@@ -1,0 +1,417 @@
+import { readFileSync, writeFileSync } from "node:fs"
+import {
+  REPLICA_BENCHMARK_SCHEMA_VERSION,
+  REPLICA_SCENARIO_CONTRACTS,
+  type ReplicaBenchmarkArtifact,
+  type ReplicaBenchmarkSample,
+  type ReplicaMeasurementAnchor,
+  type ReplicaScenarioContract,
+} from "../src/test/e2e-ui/perf/replica-benchmark-types"
+
+export type ReplicaFailureKind = "harness" | "performance" | "correctness" | "comparison"
+
+export interface ReplicaBenchmarkFailure {
+  kind: ReplicaFailureKind
+  sampleIteration: number | null
+  message: string
+}
+
+export interface ReplicaScenarioAnalysis {
+  id: string
+  label: string
+  sampleCount: number
+  completeSampleCount: number
+  p50Ms: number | null
+  p95Ms: number | null
+  baselineP95Ms: number | null
+  baselineRatio: number | null
+  blockingGetCount: number
+  manualRecoveryCount: number
+  failures: ReplicaBenchmarkFailure[]
+  qualifies: boolean
+}
+
+export interface ReplicaBenchmarkAnalysis {
+  mode: ReplicaBenchmarkArtifact["mode"]
+  artifactValid: boolean
+  comparisonCompatible: boolean
+  qualifies: boolean
+  runPassed: boolean
+  artifactFailures: ReplicaBenchmarkFailure[]
+  scenarios: ReplicaScenarioAnalysis[]
+}
+
+function finiteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value)
+}
+
+export function percentile(values: readonly number[], quantile: number): number | null {
+  if (values.length === 0) return null
+  if (!finiteNumber(quantile) || quantile < 0 || quantile > 1) {
+    throw new Error(`quantile must be between 0 and 1, got ${String(quantile)}`)
+  }
+  const sorted = [...values].sort((a, b) => a - b)
+  const rank = Math.max(1, Math.ceil(quantile * sorted.length))
+  return sorted[rank - 1] ?? null
+}
+
+function anchorAt(sample: ReplicaBenchmarkSample, anchor: ReplicaMeasurementAnchor): number | null {
+  if (anchor === "interactive-coherent") return sample.interactiveCoherentAtMs
+  if (!finiteNumber(sample.localDurableAtMs) || !finiteNumber(sample.interactiveCoherentAtMs)) {
+    return null
+  }
+  return Math.max(sample.localDurableAtMs, sample.interactiveCoherentAtMs)
+}
+
+function observedAt(
+  sample: ReplicaBenchmarkSample,
+  anchor: ReplicaMeasurementAnchor,
+  mode: ReplicaBenchmarkArtifact["mode"],
+): number | null {
+  return mode === "baseline" && finiteNumber(sample.baselineObservedAtMs)
+    ? sample.baselineObservedAtMs
+    : anchorAt(sample, anchor)
+}
+
+export function sampleLatency(
+  sample: ReplicaBenchmarkSample,
+  anchor: ReplicaMeasurementAnchor,
+  mode: ReplicaBenchmarkArtifact["mode"] = "gate",
+): number | null {
+  const end = observedAt(sample, anchor, mode)
+  if (!finiteNumber(end) || !finiteNumber(sample.actionAtMs) || end < sample.actionAtMs) return null
+  return end - sample.actionAtMs
+}
+
+export function userBlockingGets(
+  sample: ReplicaBenchmarkSample,
+  anchor: ReplicaMeasurementAnchor,
+  mode: ReplicaBenchmarkArtifact["mode"] = "gate",
+) {
+  const end = observedAt(sample, anchor, mode)
+  if (!finiteNumber(end)) return []
+  return sample.requests.filter((request) => (
+    request.firstParty
+    && request.networkAccess !== false
+    && request.method.toUpperCase() === "GET"
+    && finiteNumber(request.endedAtMs)
+    && request.startedAtMs >= sample.actionAtMs
+    && request.endedAtMs <= end
+  ))
+}
+
+export function artifactCompatibilityFailures(
+  candidate: ReplicaBenchmarkArtifact,
+  baseline: ReplicaBenchmarkArtifact,
+): string[] {
+  const failures: string[] = []
+  if (candidate.schemaVersion !== baseline.schemaVersion) failures.push("schemaVersion differs")
+  if (candidate.contractVersion !== baseline.contractVersion) failures.push("contractVersion differs")
+  if (candidate.fixtureVersion !== baseline.fixtureVersion) failures.push("fixtureVersion differs")
+  if (candidate.networkDelayMs !== baseline.networkDelayMs) failures.push("networkDelayMs differs")
+  if (candidate.selectedScenarios.join(",") !== baseline.selectedScenarios.join(",")) {
+    failures.push("selectedScenarios differ")
+  }
+  return failures
+}
+
+function artifactShapeFailures(artifact: ReplicaBenchmarkArtifact): ReplicaBenchmarkFailure[] {
+  const failures: ReplicaBenchmarkFailure[] = []
+  if (artifact.schemaVersion !== REPLICA_BENCHMARK_SCHEMA_VERSION) {
+    failures.push({
+      kind: "harness",
+      sampleIteration: null,
+      message: `unsupported schemaVersion ${String(artifact.schemaVersion)}`,
+    })
+  }
+  if (!artifact.contractVersion) {
+    failures.push({ kind: "harness", sampleIteration: null, message: "missing contractVersion" })
+  }
+  if (!artifact.fixtureVersion) {
+    failures.push({ kind: "harness", sampleIteration: null, message: "missing fixtureVersion" })
+  }
+  if (!artifact.gitSha) {
+    failures.push({ kind: "harness", sampleIteration: null, message: "missing gitSha" })
+  }
+  if (!Array.isArray(artifact.selectedScenarios) || artifact.selectedScenarios.length === 0) {
+    failures.push({ kind: "harness", sampleIteration: null, message: "no selectedScenarios" })
+  }
+  const knownScenarioIds = new Set(REPLICA_SCENARIO_CONTRACTS.map((contract) => contract.id))
+  const unknownScenarioIds = artifact.selectedScenarios.filter((id) => !knownScenarioIds.has(id))
+  if (unknownScenarioIds.length > 0) {
+    failures.push({
+      kind: "harness",
+      sampleIteration: null,
+      message: `unknown selectedScenarios: ${unknownScenarioIds.join(", ")}`,
+    })
+  }
+  if (artifact.networkDelayMs !== 1_000) {
+    failures.push({
+      kind: "harness",
+      sampleIteration: null,
+      message: `networkDelayMs must be 1000, got ${String(artifact.networkDelayMs)}`,
+    })
+  }
+  return failures
+}
+
+function correctnessFailures(
+  sample: ReplicaBenchmarkSample,
+  contract: ReplicaScenarioContract,
+): ReplicaBenchmarkFailure[] {
+  const failures: ReplicaBenchmarkFailure[] = []
+  if (sample.harnessError) {
+    failures.push({ kind: "harness", sampleIteration: sample.iteration, message: sample.harnessError })
+  }
+  if (sample.productFailure) {
+    failures.push({ kind: "correctness", sampleIteration: sample.iteration, message: sample.productFailure })
+  }
+  const proofById = new Map(sample.proofs.map((proof) => [proof.id, proof]))
+  for (const proofId of contract.requiredProofs) {
+    const proof = proofById.get(proofId)
+    if (!proof?.passed) {
+      failures.push({
+        kind: "correctness",
+        sampleIteration: sample.iteration,
+        message: `required proof failed or missing: ${proofId}`,
+      })
+    }
+  }
+  if (sample.manualRecoveryActions.length > 0) {
+    failures.push({
+      kind: "correctness",
+      sampleIteration: sample.iteration,
+      message: `manual recovery required: ${sample.manualRecoveryActions.join(", ")}`,
+    })
+  }
+  if (contract.requireCanonicalOutcome && sample.canonicalOutcomeCount !== 1) {
+    failures.push({
+      kind: "correctness",
+      sampleIteration: sample.iteration,
+      message: `expected exactly one canonical outcome, got ${String(sample.canonicalOutcomeCount)}`,
+    })
+  }
+  if (contract.requireSingleBusinessEffect && sample.businessEffectCount !== 1) {
+    failures.push({
+      kind: "correctness",
+      sampleIteration: sample.iteration,
+      message: `expected exactly one business effect, got ${String(sample.businessEffectCount)}`,
+    })
+  }
+  return failures
+}
+
+export function analyzeScenario(
+  artifact: ReplicaBenchmarkArtifact,
+  contract: ReplicaScenarioContract,
+  baseline?: ReplicaBenchmarkArtifact,
+): ReplicaScenarioAnalysis {
+  const samples = artifact.samples.filter((sample) => sample.scenario === contract.id)
+  const failures: ReplicaBenchmarkFailure[] = []
+  const latencies: number[] = []
+  let blockingGetCount = 0
+  let manualRecoveryCount = 0
+
+  if (samples.length < contract.minSamples) {
+    failures.push({
+      kind: "harness",
+      sampleIteration: null,
+      message: `need ${contract.minSamples} samples, got ${samples.length}`,
+    })
+  }
+
+  for (const sample of samples) {
+    if (contract.anchor !== null) {
+      const latency = sampleLatency(sample, contract.anchor, artifact.mode)
+      if (latency === null) {
+        failures.push({
+          kind: sample.productFailure ? "performance" : "harness",
+          sampleIteration: sample.iteration,
+          message: `missing or invalid ${contract.anchor} latency`,
+        })
+      } else {
+        latencies.push(latency)
+      }
+      const blocking = userBlockingGets(sample, contract.anchor, artifact.mode)
+      blockingGetCount += blocking.length
+      if (contract.requireZeroBlockingGets && blocking.length > 0) {
+        failures.push({
+          kind: "performance",
+          sampleIteration: sample.iteration,
+          message: `${blocking.length} first-party GET(s) completed before local readiness`,
+        })
+      }
+    }
+    manualRecoveryCount += sample.manualRecoveryActions.length
+    failures.push(...correctnessFailures(sample, contract))
+  }
+
+  const p50Ms = percentile(latencies, 0.5)
+  const p95Ms = percentile(latencies, 0.95)
+  if (contract.absoluteMaxMs !== null && (p95Ms === null || p95Ms >= contract.absoluteMaxMs)) {
+    failures.push({
+      kind: "performance",
+      sampleIteration: null,
+      message: `p95 must be <${contract.absoluteMaxMs}ms, got ${String(p95Ms)}`,
+    })
+  }
+
+  let baselineP95Ms: number | null = null
+  let baselineRatio: number | null = null
+  if (artifact.mode === "gate" && contract.maxBaselineRatio !== null) {
+    if (!baseline) {
+      failures.push({ kind: "comparison", sampleIteration: null, message: "missing baseline artifact" })
+    } else {
+      const baselineLatencies = baseline.samples
+        .filter((sample) => sample.scenario === contract.id)
+        .map((sample) => contract.anchor === null ? null : sampleLatency(sample, contract.anchor, "baseline"))
+        .filter((latency): latency is number => latency !== null)
+      baselineP95Ms = percentile(baselineLatencies, 0.95)
+      if (baselineLatencies.length < contract.minSamples) {
+        failures.push({
+          kind: "comparison",
+          sampleIteration: null,
+          message: `baseline needs ${contract.minSamples} complete samples, got ${baselineLatencies.length}`,
+        })
+      } else if (baselineP95Ms === null || baselineP95Ms <= 0 || p95Ms === null) {
+        failures.push({
+          kind: "comparison",
+          sampleIteration: null,
+          message: "baseline has no valid positive p95",
+        })
+      } else {
+        baselineRatio = p95Ms / baselineP95Ms
+        if (baselineRatio > contract.maxBaselineRatio) {
+          failures.push({
+            kind: "performance",
+            sampleIteration: null,
+            message: `p95 ratio must be <=${contract.maxBaselineRatio}, got ${baselineRatio.toFixed(3)}`,
+          })
+        }
+      }
+    }
+  }
+
+  return {
+    id: contract.id,
+    label: contract.label,
+    sampleCount: samples.length,
+    completeSampleCount: latencies.length,
+    p50Ms,
+    p95Ms,
+    baselineP95Ms,
+    baselineRatio,
+    blockingGetCount,
+    manualRecoveryCount,
+    failures,
+    qualifies: failures.length === 0,
+  }
+}
+
+export function analyzeReplicaBenchmark(
+  artifact: ReplicaBenchmarkArtifact,
+  baseline?: ReplicaBenchmarkArtifact,
+  contracts: readonly ReplicaScenarioContract[] = REPLICA_SCENARIO_CONTRACTS,
+): ReplicaBenchmarkAnalysis {
+  const artifactFailures = artifactShapeFailures(artifact)
+  const selected = new Set(artifact.selectedScenarios)
+  const selectedContracts = contracts.filter((contract) => selected.has(contract.id))
+  let comparisonCompatible = true
+  if (artifact.mode === "gate" && baseline) {
+    const compatibility = artifactCompatibilityFailures(artifact, baseline)
+    comparisonCompatible = compatibility.length === 0
+    artifactFailures.push(...compatibility.map((message) => ({
+      kind: "comparison" as const,
+      sampleIteration: null,
+      message,
+    })))
+  }
+  const scenarios = selectedContracts.map((contract) => analyzeScenario(artifact, contract, baseline))
+  const qualifies = artifactFailures.length === 0 && scenarios.every((scenario) => scenario.qualifies)
+  const artifactValid = artifactFailures.every((failure) => failure.kind !== "harness")
+    && scenarios.every((scenario) => scenario.failures.every((failure) => failure.kind !== "harness"))
+  return {
+    mode: artifact.mode,
+    artifactValid,
+    comparisonCompatible,
+    qualifies,
+    runPassed: artifact.mode === "baseline" ? artifactValid : qualifies,
+    artifactFailures,
+    scenarios,
+  }
+}
+
+function metric(value: number | null, suffix = "ms") {
+  return value === null ? "—" : `${value.toFixed(1)}${suffix}`
+}
+
+export function renderReplicaBenchmarkReport(
+  artifact: ReplicaBenchmarkArtifact,
+  baseline?: ReplicaBenchmarkArtifact,
+  contracts: readonly ReplicaScenarioContract[] = REPLICA_SCENARIO_CONTRACTS,
+): string {
+  const analysis = analyzeReplicaBenchmark(artifact, baseline, contracts)
+  const verdict = artifact.mode === "baseline"
+    ? analysis.runPassed ? "BASELINE RECORDED" : "INVALID BASELINE"
+    : analysis.runPassed ? "PASS" : "FAIL"
+  const lines = [
+    "# Alook Replica Benchmark",
+    "",
+    `Verdict: **${verdict}**`,
+    `Candidate: \`${artifact.gitSha}\``,
+    `Mode: \`${artifact.mode}\``,
+    `Network injection: \`${artifact.networkDelayMs}ms\``,
+    `Contract / fixture: \`${artifact.contractVersion}\` / \`${artifact.fixtureVersion}\``,
+    `Selected scenarios: \`${artifact.selectedScenarios.join(", ")}\``,
+    "",
+    "| Scenario | n | p50 | p95 | baseline p95 | ratio | blocking GET | manual recovery | qualifies |",
+    "|---|---:|---:|---:|---:|---:|---:|---:|:---:|",
+  ]
+  for (const scenario of analysis.scenarios) {
+    lines.push(
+      `| ${scenario.label} | ${scenario.completeSampleCount}/${scenario.sampleCount} | `
+      + `${metric(scenario.p50Ms)} | ${metric(scenario.p95Ms)} | ${metric(scenario.baselineP95Ms)} | `
+      + `${scenario.baselineRatio === null ? "—" : scenario.baselineRatio.toFixed(3)} | `
+      + `${scenario.blockingGetCount} | ${scenario.manualRecoveryCount} | ${scenario.qualifies ? "yes" : "no"} |`,
+    )
+  }
+  const failures = [
+    ...analysis.artifactFailures,
+    ...analysis.scenarios.flatMap((scenario) => scenario.failures.map((failure) => ({
+      ...failure,
+      message: `${scenario.id}: ${failure.message}`,
+    }))),
+  ]
+  if (failures.length > 0) {
+    lines.push("", "## Failures", "")
+    for (const failure of failures) {
+      const iteration = failure.sampleIteration === null ? "" : ` sample ${failure.sampleIteration}`
+      lines.push(`- [${failure.kind}]${iteration}: ${failure.message}`)
+    }
+  }
+  return lines.join("\n")
+}
+
+function argValue(name: string) {
+  const index = process.argv.indexOf(name)
+  return index === -1 ? undefined : process.argv[index + 1]
+}
+
+function main() {
+  const candidatePath = argValue("--candidate")
+  const outputPath = argValue("--out")
+  const baselinePath = argValue("--baseline")
+  if (!candidatePath || !outputPath) {
+    throw new Error("usage: tsx replica-benchmark-report.ts --candidate <json> [--baseline <json>] --out <md>")
+  }
+  const artifact = JSON.parse(readFileSync(candidatePath, "utf8")) as ReplicaBenchmarkArtifact
+  const baseline = baselinePath
+    ? JSON.parse(readFileSync(baselinePath, "utf8")) as ReplicaBenchmarkArtifact
+    : undefined
+  const report = renderReplicaBenchmarkReport(artifact, baseline)
+  writeFileSync(outputPath, report)
+  const analysis = analyzeReplicaBenchmark(artifact, baseline)
+  if (!analysis.runPassed) process.exitCode = 1
+}
+
+if (process.argv[1]?.endsWith("replica-benchmark-report.ts")) main()

--- a/src/web/src/test/e2e-ui/perf/replica-benchmark-fixture.ts
+++ b/src/web/src/test/e2e-ui/perf/replica-benchmark-fixture.ts
@@ -1,0 +1,163 @@
+import type { BrowserContext, CDPSession, Page, Request, Response } from "@playwright/test"
+import { mkdirSync, writeFileSync } from "node:fs"
+import { dirname } from "node:path"
+import type {
+  ReplicaBenchmarkArtifact,
+  ReplicaBenchmarkSample,
+  ReplicaNetworkEvent,
+} from "./replica-benchmark-types"
+
+type MutableNetworkEvent = ReplicaNetworkEvent & {
+  responseFromServiceWorker: boolean
+}
+
+export function isFirstPartyUrl(rawUrl: string, baseUrl: string): boolean {
+  try {
+    return new URL(rawUrl).origin === new URL(baseUrl).origin
+  } catch {
+    return false
+  }
+}
+
+export class ReplicaNetworkProbe {
+  private readonly events: MutableNetworkEvent[] = []
+  private readonly byRequest = new Map<Request, MutableNetworkEvent>()
+  private readonly responseByRequest = new Map<Request, Response>()
+  private session: CDPSession | null = null
+  private nextId = 1
+
+  private readonly onRequest = (request: Request) => {
+    const event: MutableNetworkEvent = {
+      requestId: `request-${this.nextId++}`,
+      method: request.method(),
+      url: request.url(),
+      resourceType: request.resourceType(),
+      firstParty: isFirstPartyUrl(request.url(), this.baseUrl),
+      networkAccess: null,
+      startedAtMs: Date.now(),
+      endedAtMs: null,
+      status: null,
+      responseFromServiceWorker: false,
+    }
+    this.byRequest.set(request, event)
+    this.events.push(event)
+  }
+
+  private readonly onResponse = (response: Response) => {
+    const request = response.request()
+    const event = this.byRequest.get(request)
+    if (!event) return
+    event.status = response.status()
+    event.responseFromServiceWorker = response.fromServiceWorker()
+    this.responseByRequest.set(request, response)
+  }
+
+  private readonly onRequestDone = (request: Request) => {
+    const event = this.byRequest.get(request)
+    if (!event) return
+    event.endedAtMs = Date.now()
+    const response = this.responseByRequest.get(request)
+    if (response) event.responseFromServiceWorker = response.fromServiceWorker()
+  }
+
+  constructor(
+    private readonly page: Page,
+    private readonly context: BrowserContext,
+    private readonly baseUrl: string,
+    private readonly latencyMs = 1_000,
+  ) {}
+
+  async start(offline = false) {
+    this.page.on("request", this.onRequest)
+    this.page.on("response", this.onResponse)
+    this.page.on("requestfinished", this.onRequestDone)
+    this.page.on("requestfailed", this.onRequestDone)
+    this.session = await this.context.newCDPSession(this.page)
+    await this.session.send("Network.enable")
+    await this.setOffline(offline)
+  }
+
+  async setOffline(offline: boolean) {
+    if (!this.session) throw new Error("network probe has not started")
+    await this.session.send("Network.emulateNetworkConditions", {
+      offline,
+      latency: offline ? 0 : this.latencyMs,
+      downloadThroughput: offline ? 0 : -1,
+      uploadThroughput: offline ? 0 : -1,
+      connectionType: offline ? "none" : "other",
+    })
+  }
+
+  requestsSince(actionAtMs: number): ReplicaNetworkEvent[] {
+    return this.events
+      .filter((event) => event.startedAtMs >= actionAtMs)
+      .map(({ responseFromServiceWorker, ...event }) => ({
+        ...event,
+        networkAccess: responseFromServiceWorker ? false : event.endedAtMs === null ? null : true,
+      }))
+  }
+
+  async stop() {
+    this.page.off("request", this.onRequest)
+    this.page.off("response", this.onResponse)
+    this.page.off("requestfinished", this.onRequestDone)
+    this.page.off("requestfailed", this.onRequestDone)
+    if (this.session) {
+      await this.session.send("Network.emulateNetworkConditions", {
+        offline: false,
+        latency: 0,
+        downloadThroughput: -1,
+        uploadThroughput: -1,
+        connectionType: "none",
+      }).catch(() => {})
+      await this.session.detach().catch(() => {})
+      this.session = null
+    }
+  }
+}
+
+export class ReplicaArtifactWriter {
+  readonly artifact: ReplicaBenchmarkArtifact
+
+  constructor(
+    artifact: Omit<ReplicaBenchmarkArtifact, "samples">,
+    private readonly outputPath: string,
+  ) {
+    this.artifact = { ...artifact, samples: [] }
+  }
+
+  append(sample: ReplicaBenchmarkSample) {
+    this.artifact.samples.push(sample)
+    this.flush()
+  }
+
+  flush() {
+    mkdirSync(dirname(this.outputPath), { recursive: true })
+    writeFileSync(this.outputPath, JSON.stringify(this.artifact, null, 2))
+  }
+}
+
+export function emptySample(
+  scenario: ReplicaBenchmarkSample["scenario"],
+  iteration: number,
+  actionAtMs = Date.now(),
+): ReplicaBenchmarkSample {
+  return {
+    scenario,
+    iteration,
+    actionAtMs,
+    interactiveCoherentAtMs: null,
+    localDurableAtMs: null,
+    baselineObservedAtMs: null,
+    canonicalOutcomeAtMs: null,
+    requests: [],
+    manualRecoveryActions: [],
+    proofs: [],
+    canonicalOutcomeCount: null,
+    businessEffectCount: null,
+    transportDeliveryCount: null,
+    observationEndedAtMs: actionAtMs,
+    productFailure: null,
+    harnessError: null,
+  }
+}

--- a/src/web/src/test/e2e-ui/perf/replica-benchmark-types.ts
+++ b/src/web/src/test/e2e-ui/perf/replica-benchmark-types.ts
@@ -1,6 +1,8 @@
-export const REPLICA_BENCHMARK_SCHEMA_VERSION = 1
+export const REPLICA_BENCHMARK_SCHEMA_VERSION = 2
+export const REPLICA_BENCHMARK_SERVER_MODE = "opennext-preview:production-build:wrangler-local:auth-dev"
 
 export type ReplicaBenchmarkMode = "baseline" | "gate"
+export type ReplicaBenchmarkServerMode = typeof REPLICA_BENCHMARK_SERVER_MODE
 
 export type ReplicaScenarioId =
   | "j0-first-bootstrap"
@@ -62,6 +64,7 @@ export interface ReplicaBenchmarkArtifact {
   createdAt: string
   gitSha: string
   mode: ReplicaBenchmarkMode
+  serverMode: ReplicaBenchmarkServerMode
   networkDelayMs: number
   samples: ReplicaBenchmarkSample[]
 }

--- a/src/web/src/test/e2e-ui/perf/replica-benchmark-types.ts
+++ b/src/web/src/test/e2e-ui/perf/replica-benchmark-types.ts
@@ -1,5 +1,5 @@
 export const REPLICA_BENCHMARK_SCHEMA_VERSION = 2
-export const REPLICA_BENCHMARK_SERVER_MODE = "opennext-preview:production-build:wrangler-local:auth-dev"
+export const REPLICA_BENCHMARK_SERVER_MODE = "opennext-production-build:ws-port-3010:wrangler-multiconfig-local:auth-dev"
 
 export type ReplicaBenchmarkMode = "baseline" | "gate"
 export type ReplicaBenchmarkServerMode = typeof REPLICA_BENCHMARK_SERVER_MODE

--- a/src/web/src/test/e2e-ui/perf/replica-benchmark-types.ts
+++ b/src/web/src/test/e2e-ui/perf/replica-benchmark-types.ts
@@ -1,0 +1,248 @@
+export const REPLICA_BENCHMARK_SCHEMA_VERSION = 1
+
+export type ReplicaBenchmarkMode = "baseline" | "gate"
+
+export type ReplicaScenarioId =
+  | "j0-first-bootstrap"
+  | "j1-covered-reopen"
+  | "j2-covered-navigation"
+  | "j3-history-search"
+  | "j4-read-state"
+  | "j5-draft"
+  | "j6-text-send"
+  | "j7-domain-rejection"
+  | "j8-gap-reconnect"
+  | "j9-multi-client"
+  | "j10-revocation"
+
+export type ReplicaMeasurementAnchor = "interactive-coherent" | "durable-coherent"
+
+export interface ReplicaNetworkEvent {
+  requestId: string
+  method: string
+  url: string
+  resourceType: string
+  firstParty: boolean
+  networkAccess: boolean | null
+  startedAtMs: number
+  endedAtMs: number | null
+  status: number | null
+}
+
+export interface ReplicaProof {
+  id: string
+  passed: boolean
+  evidence: string
+}
+
+export interface ReplicaBenchmarkSample {
+  scenario: ReplicaScenarioId
+  iteration: number
+  actionAtMs: number
+  interactiveCoherentAtMs: number | null
+  localDurableAtMs: number | null
+  baselineObservedAtMs: number | null
+  canonicalOutcomeAtMs: number | null
+  requests: ReplicaNetworkEvent[]
+  manualRecoveryActions: string[]
+  proofs: ReplicaProof[]
+  canonicalOutcomeCount: number | null
+  businessEffectCount: number | null
+  transportDeliveryCount: number | null
+  observationEndedAtMs: number
+  productFailure: string | null
+  harnessError: string | null
+}
+
+export interface ReplicaBenchmarkArtifact {
+  schemaVersion: typeof REPLICA_BENCHMARK_SCHEMA_VERSION
+  contractVersion: string
+  fixtureVersion: string
+  selectedScenarios: ReplicaScenarioId[]
+  createdAt: string
+  gitSha: string
+  mode: ReplicaBenchmarkMode
+  networkDelayMs: number
+  samples: ReplicaBenchmarkSample[]
+}
+
+export interface ReplicaScenarioContract {
+  id: ReplicaScenarioId
+  label: string
+  anchor: ReplicaMeasurementAnchor | null
+  absoluteMaxMs: number | null
+  maxBaselineRatio: number | null
+  minSamples: number
+  requiredProofs: string[]
+  requireCanonicalOutcome: boolean
+  requireSingleBusinessEffect: boolean
+  requireZeroBlockingGets: boolean
+}
+
+export const REPLICA_SCENARIO_CONTRACTS: readonly ReplicaScenarioContract[] = [
+  {
+    id: "j0-first-bootstrap",
+    label: "J0 First bootstrap",
+    anchor: null,
+    absoluteMaxMs: null,
+    maxBaselineRatio: null,
+    minSamples: 1,
+    requiredProofs: ["bootstrap-honest", "versions-compatible", "no-half-world"],
+    requireCanonicalOutcome: false,
+    requireSingleBusinessEffect: false,
+    requireZeroBlockingGets: false,
+  },
+  {
+    id: "j1-covered-reopen",
+    label: "J1 Covered app reopen",
+    anchor: "interactive-coherent",
+    absoluteMaxMs: 100,
+    maxBaselineRatio: 0.1,
+    minSamples: 5,
+    requiredProofs: ["covered-world-visible", "transaction-consistent"],
+    requireCanonicalOutcome: false,
+    requireSingleBusinessEffect: false,
+    requireZeroBlockingGets: true,
+  },
+  {
+    id: "j2-covered-navigation",
+    label: "J2 Covered channel/thread navigation",
+    anchor: "interactive-coherent",
+    absoluteMaxMs: 50,
+    maxBaselineRatio: 0.1,
+    minSamples: 5,
+    requiredProofs: [
+      "target-tail-visible",
+      "latest-navigation-wins",
+      "ordering-correct",
+      "read-state-correct",
+      "route-correct",
+      "surface-kind-correct",
+    ],
+    requireCanonicalOutcome: false,
+    requireSingleBusinessEffect: false,
+    requireZeroBlockingGets: true,
+  },
+  {
+    id: "j3-history-search",
+    label: "J3 Covered history, back, and search",
+    anchor: "interactive-coherent",
+    absoluteMaxMs: 50,
+    maxBaselineRatio: 0.1,
+    minSamples: 5,
+    requiredProofs: [
+      "covered-result-complete",
+      "coverage-miss-not-empty",
+      "pagination-correct",
+      "visual-anchor-stable",
+    ],
+    requireCanonicalOutcome: false,
+    requireSingleBusinessEffect: false,
+    requireZeroBlockingGets: true,
+  },
+  {
+    id: "j4-read-state",
+    label: "J4 Read state",
+    anchor: "durable-coherent",
+    absoluteMaxMs: 50,
+    maxBaselineRatio: 0.1,
+    minSamples: 3,
+    requiredProofs: [
+      "read-durable",
+      "watermark-monotonic",
+      "mark-all-boundary-correct",
+      "attention-domains-preserved",
+    ],
+    requireCanonicalOutcome: false,
+    requireSingleBusinessEffect: false,
+    requireZeroBlockingGets: true,
+  },
+  {
+    id: "j5-draft",
+    label: "J5 Draft survives offline reopen",
+    anchor: "interactive-coherent",
+    absoluteMaxMs: 100,
+    maxBaselineRatio: 0.1,
+    minSamples: 3,
+    requiredProofs: ["draft-durable", "draft-scope-isolated", "no-server-message-before-send"],
+    requireCanonicalOutcome: false,
+    requireSingleBusinessEffect: false,
+    requireZeroBlockingGets: true,
+  },
+  {
+    id: "j6-text-send",
+    label: "J6 Text send survives offline reopen",
+    anchor: "durable-coherent",
+    absoluteMaxMs: 50,
+    maxBaselineRatio: 0.1,
+    minSamples: 3,
+    requiredProofs: ["intent-durable", "canonical-row-matches", "read-state-correct"],
+    requireCanonicalOutcome: true,
+    requireSingleBusinessEffect: true,
+    requireZeroBlockingGets: true,
+  },
+  {
+    id: "j7-domain-rejection",
+    label: "J7 Domain rejection",
+    anchor: "durable-coherent",
+    absoluteMaxMs: 50,
+    maxBaselineRatio: 0.1,
+    minSamples: 3,
+    requiredProofs: ["intent-durable", "rejection-explicit", "input-recoverable"],
+    requireCanonicalOutcome: true,
+    requireSingleBusinessEffect: false,
+    requireZeroBlockingGets: true,
+  },
+  {
+    id: "j8-gap-reconnect",
+    label: "J8 Gap and reconnect continuity",
+    anchor: null,
+    absoluteMaxMs: null,
+    maxBaselineRatio: null,
+    minSamples: 3,
+    requiredProofs: [
+      "gap-repaired",
+      "duplicate-delivery-idempotent",
+      "compatible-frontier",
+      "realtime-correct",
+      "delta-cost-proportional",
+    ],
+    requireCanonicalOutcome: false,
+    requireSingleBusinessEffect: true,
+    requireZeroBlockingGets: false,
+  },
+  {
+    id: "j9-multi-client",
+    label: "J9 Multi-client convergence",
+    anchor: null,
+    absoluteMaxMs: null,
+    maxBaselineRatio: null,
+    minSamples: 3,
+    requiredProofs: [
+      "canonical-order-unique",
+      "single-intent-outcome",
+      "read-watermark-monotonic",
+      "compatible-frontier",
+    ],
+    requireCanonicalOutcome: true,
+    requireSingleBusinessEffect: true,
+    requireZeroBlockingGets: false,
+  },
+  {
+    id: "j10-revocation",
+    label: "J10 Permission revocation",
+    anchor: null,
+    absoluteMaxMs: null,
+    maxBaselineRatio: null,
+    minSamples: 3,
+    requiredProofs: [
+      "revoked-projection-removed",
+      "fallback-accessible",
+      "audience-semantics-preserved",
+      "existence-masked",
+    ],
+    requireCanonicalOutcome: false,
+    requireSingleBusinessEffect: false,
+    requireZeroBlockingGets: false,
+  },
+] as const

--- a/src/web/src/test/e2e-ui/perf/replica.perf.ts
+++ b/src/web/src/test/e2e-ui/perf/replica.perf.ts
@@ -31,9 +31,11 @@ import {
 } from "./replica-benchmark-fixture"
 import {
   REPLICA_BENCHMARK_SCHEMA_VERSION,
+  REPLICA_BENCHMARK_SERVER_MODE,
   type ReplicaBenchmarkArtifact,
   type ReplicaBenchmarkMode,
   type ReplicaBenchmarkSample,
+  type ReplicaBenchmarkServerMode,
   type ReplicaProof,
   type ReplicaScenarioId,
 } from "./replica-benchmark-types"
@@ -52,7 +54,7 @@ const CONTRACT_VERSION = [
   "oracle:4d1533d443adbeb583f29bd6c5bd997079b81a08277b687165b0b61f54ee7b6b",
   "wire:ea168934b360d45159446cefd13e09c0bd4d1d6dce6d3a567012b8c6ca43e29e",
   "server-contract:d8659d58465bf57a0f5d7cb9d0819092c3ac0cce",
-  "harness-protocol:v2",
+  "harness-protocol:v3",
 ].join("+")
 
 interface SeedManifest {
@@ -377,6 +379,11 @@ test("Alook Replica vertical benchmark", async ({ browser }) => {
     }, null, 2))
     return
   }
+  const serverMode = process.env.REPLICA_BENCH_SERVER_MODE
+  expect(
+    serverMode,
+    "REPLICA_BENCH_SERVER_MODE must pin the production-like OpenNext runtime",
+  ).toBe(REPLICA_BENCHMARK_SERVER_MODE)
   const gitSha = process.env.REPLICA_BENCH_GIT_SHA ?? "working-tree"
   const outputPath = process.env.REPLICA_BENCH_OUTPUT
     ?? resolve(ARTIFACTS_DIR, `replica-${MODE}.json`)
@@ -389,6 +396,7 @@ test("Alook Replica vertical benchmark", async ({ browser }) => {
     createdAt: new Date().toISOString(),
     gitSha,
     mode: MODE,
+    serverMode: serverMode as ReplicaBenchmarkServerMode,
     networkDelayMs: 1_000,
   }, outputPath)
 

--- a/src/web/src/test/e2e-ui/perf/replica.perf.ts
+++ b/src/web/src/test/e2e-ui/perf/replica.perf.ts
@@ -1,0 +1,658 @@
+/**
+ * Black-box Alook Replica benchmark. This deliberately imports no Replica
+ * runtime code: browser-visible state, generic durable browser storage, HTTP
+ * authority, and the request trace are the only evidence sources.
+ */
+import {
+  test,
+  expect,
+  chromium,
+  type APIRequestContext,
+  type BrowserContext,
+  type Browser,
+  type Locator,
+  type Page,
+} from "@playwright/test"
+import { createHash } from "node:crypto"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { resolve } from "node:path"
+import { DEV_PASSWORD } from "@alook/shared"
+import { composerEditable } from "../_fixtures/actions"
+import { tid } from "../_fixtures/testids"
+import {
+  analyzeReplicaBenchmark,
+  renderReplicaBenchmarkReport,
+} from "../../../../scripts/replica-benchmark-report"
+import {
+  emptySample,
+  ReplicaArtifactWriter,
+  ReplicaNetworkProbe,
+} from "./replica-benchmark-fixture"
+import {
+  REPLICA_BENCHMARK_SCHEMA_VERSION,
+  type ReplicaBenchmarkArtifact,
+  type ReplicaBenchmarkMode,
+  type ReplicaBenchmarkSample,
+  type ReplicaProof,
+  type ReplicaScenarioId,
+} from "./replica-benchmark-types"
+
+const BASE_URL = process.env.ALOOK_SERVER_URL || "http://localhost:3000"
+const ARTIFACTS_DIR = resolve(__dirname, "..", "..", "..", "..", "perf-artifacts")
+const MANIFEST_PATH = resolve(ARTIFACTS_DIR, "seed-manifest.json")
+const MODE = (process.env.REPLICA_BENCH_MODE ?? "baseline") as ReplicaBenchmarkMode
+const SELECTED_SCENARIOS: ReplicaScenarioId[] = [
+  "j1-covered-reopen",
+  "j2-covered-navigation",
+  "j5-draft",
+  "j6-text-send",
+]
+const CONTRACT_VERSION = [
+  "oracle:4d1533d443adbeb583f29bd6c5bd997079b81a08277b687165b0b61f54ee7b6b",
+  "wire:ea168934b360d45159446cefd13e09c0bd4d1d6dce6d3a567012b8c6ca43e29e",
+  "server-contract:d8659d58465bf57a0f5d7cb9d0819092c3ac0cce",
+  "harness-protocol:v2",
+].join("+")
+
+interface SeedManifest {
+  owner: { email: string; userId: string }
+  servers: Array<{
+    id: string
+    name: string
+    channels: Array<{ id: string; name: string; messageCount: number }>
+  }>
+}
+
+interface ApiMessage {
+  id: string
+  seq: number
+  content: string | null
+  clientNonce?: string | null
+}
+
+class ProductFailure extends Error {}
+
+function proof(id: string, passed: boolean, evidence: string): ReplicaProof {
+  return { id, passed, evidence }
+}
+
+function loadManifest(): { manifest: SeedManifest; fixtureVersion: string } {
+  let raw: Buffer
+  try {
+    raw = readFileSync(MANIFEST_PATH)
+  } catch {
+    throw new Error(`Missing ${MANIFEST_PATH}. Run seed:stress before this benchmark.`)
+  }
+  return {
+    manifest: JSON.parse(raw.toString("utf8")) as SeedManifest,
+    fixtureVersion: `origin-reset-v1+seed-sha256:${createHash("sha256").update(raw).digest("hex")}`,
+  }
+}
+
+/**
+ * Mandatory anti-contamination preflight. It runs against an about:blank page,
+ * before auth or the first product navigation can install a worker. Chromium's
+ * `all` origin-storage wipe includes service workers, Cache Storage, and IDB.
+ */
+async function resetOriginBeforeBootstrap(context: BrowserContext): Promise<void> {
+  const page = context.pages()[0] ?? await context.newPage()
+  const session = await context.newCDPSession(page)
+  try {
+    await session.send("Storage.clearDataForOrigin", {
+      origin: new URL(BASE_URL).origin,
+      storageTypes: "all",
+    })
+    await session.send("Network.enable")
+    await session.send("Network.clearBrowserCache")
+  } finally {
+    await session.detach()
+  }
+}
+
+async function authenticateAs(context: BrowserContext, email: string): Promise<void> {
+  let response = await context.request.post(`${BASE_URL}/api/auth/sign-in/email`, {
+    data: { email, password: DEV_PASSWORD },
+  })
+  if (!response.ok()) {
+    response = await context.request.post(`${BASE_URL}/api/auth/sign-up/email`, {
+      data: { name: email.split("@")[0], email, password: DEV_PASSWORD },
+    })
+  }
+  if (!response.ok()) throw new Error(`Could not authenticate ${email} (${response.status()})`)
+}
+
+async function apiMessages(api: APIRequestContext, channelId: string): Promise<ApiMessage[]> {
+  const response = await api.get(`${BASE_URL}/api/community/channels/${channelId}/messages?limit=100`)
+  if (!response.ok()) throw new Error(`messages authority returned ${response.status()}`)
+  return ((await response.json()) as { messages: ApiMessage[] }).messages
+}
+
+async function apiReadState(api: APIRequestContext, channelId: string) {
+  const response = await api.get(`${BASE_URL}/api/community/channels/${channelId}/read-state`)
+  if (!response.ok()) throw new Error(`read-state authority returned ${response.status()}`)
+  return await response.json() as { lastReadMessageId: string | null; lastReadSeq: number }
+}
+
+async function waitForReadThrough(
+  api: APIRequestContext,
+  channelId: string,
+  targetSeq: number,
+  timeoutMs = 15_000,
+) {
+  const deadline = Date.now() + timeoutMs
+  let state = await apiReadState(api, channelId)
+  while (state.lastReadSeq < targetSeq && Date.now() < deadline) {
+    await new Promise((resolveWait) => setTimeout(resolveWait, 100))
+    state = await apiReadState(api, channelId)
+  }
+  return state
+}
+
+async function waitForCanonicalCount(
+  api: APIRequestContext,
+  channelId: string,
+  marker: string,
+  timeoutMs = 20_000,
+): Promise<{ count: number; messages: ApiMessage[]; observedAtMs: number }> {
+  const deadline = Date.now() + timeoutMs
+  let messages: ApiMessage[] = []
+  while (Date.now() < deadline) {
+    messages = await apiMessages(api, channelId)
+    const count = messages.filter((message) => message.content === marker).length
+    if (count > 0) return { count, messages, observedAtMs: Date.now() }
+    await new Promise((resolveWait) => setTimeout(resolveWait, 100))
+  }
+  return { count: 0, messages, observedAtMs: Date.now() }
+}
+
+async function durableStorageContains(page: Page, marker: string): Promise<boolean> {
+  return page.evaluate(async (needle) => {
+    for (let index = 0; index < localStorage.length; index += 1) {
+      const key = localStorage.key(index)
+      if (key && `${key}:${localStorage.getItem(key) ?? ""}`.includes(needle)) return true
+    }
+    const databases = typeof indexedDB.databases === "function" ? await indexedDB.databases() : []
+    for (const database of databases) {
+      if (!database.name) continue
+      const found = await new Promise<boolean>((resolveFound) => {
+        const open = indexedDB.open(database.name!)
+        open.onerror = () => resolveFound(false)
+        open.onsuccess = () => {
+          const db = open.result
+          const stores = Array.from(db.objectStoreNames)
+          if (stores.length === 0) {
+            db.close()
+            resolveFound(false)
+            return
+          }
+          const tx = db.transaction(stores, "readonly")
+          let matched = false
+          for (const storeName of stores) {
+            const request = tx.objectStore(storeName).getAll()
+            request.onsuccess = () => {
+              try {
+                if (JSON.stringify(request.result).includes(needle)) matched = true
+              } catch {}
+            }
+          }
+          tx.oncomplete = () => {
+            db.close()
+            resolveFound(matched)
+          }
+          tx.onerror = () => {
+            db.close()
+            resolveFound(false)
+          }
+        }
+      })
+      if (found) return true
+    }
+    return false
+  }, marker)
+}
+
+async function waitForDurableMarker(page: Page, marker: string, timeoutMs = 2_000): Promise<number | null> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await durableStorageContains(page, marker)) return Date.now()
+    await page.waitForTimeout(10)
+  }
+  return null
+}
+
+async function waitForSurface(
+  page: Page,
+  expectedMessageId?: string,
+  timeoutMs = 20_000,
+  root: Page | Locator = page,
+) {
+  await root.getByTestId(tid.messageScroller).last().waitFor({ state: "visible", timeout: timeoutMs })
+  if (expectedMessageId) {
+    await root.locator(`[data-msg-id="${expectedMessageId}"]`).waitFor({ state: "attached", timeout: timeoutMs })
+  }
+  await composerEditable(page, root).last().waitFor({ state: "visible", timeout: timeoutMs })
+}
+
+async function ensureThreadFixture(
+  browser: Browser,
+  email: string,
+  parentChannelId: string,
+): Promise<{ threadId: string; parentMessageId: string }> {
+  const context = await browser.newContext()
+  try {
+    await resetOriginBeforeBootstrap(context)
+    await authenticateAs(context, email)
+    const parentMessages = await apiMessages(context.request, parentChannelId)
+    const parent = parentMessages[0]
+    if (!parent) throw new Error(`Cannot create thread fixture: ${parentChannelId} is empty`)
+    const created = await context.request.post(`${BASE_URL}/api/community/channels`, {
+      data: { type: "thread", messageId: parent.id, name: "replica-benchmark-thread" },
+    })
+    if (!created.ok()) throw new Error(`thread fixture returned ${created.status()}`)
+    const { id: threadId } = await created.json() as { id: string }
+    const content = "replica benchmark canonical thread tail"
+    const posted = await context.request.post(`${BASE_URL}/api/community/channels/${threadId}/messages`, {
+      data: { content, nonce: "replica_benchmark_thread_fixture_v1" },
+    })
+    if (!posted.ok()) throw new Error(`thread tail fixture returned ${posted.status()}`)
+    return { threadId, parentMessageId: parent.id }
+  } finally {
+    await context.close()
+  }
+}
+
+async function canonicalFixtureFingerprint(
+  browser: Browser,
+  email: string,
+  channelIds: string[],
+): Promise<string> {
+  const context = await browser.newContext()
+  try {
+    await resetOriginBeforeBootstrap(context)
+    await authenticateAs(context, email)
+    const projections = await Promise.all(channelIds.map(async (channelId) => ({
+      channelId,
+      messages: (await apiMessages(context.request, channelId)).map((message) => ({
+        id: message.id,
+        seq: message.seq,
+        content: message.content,
+        clientNonce: message.clientNonce ?? null,
+      })),
+    })))
+    return createHash("sha256").update(JSON.stringify(projections)).digest("hex")
+  } finally {
+    await context.close()
+  }
+}
+
+async function launchProfile(profileDir: string) {
+  return chromium.launchPersistentContext(profileDir, {
+    baseURL: BASE_URL,
+    headless: true,
+    serviceWorkers: "allow",
+  })
+}
+
+async function primeCoveredProfile(
+  profileDir: string,
+  email: string,
+  routes: string[],
+): Promise<Map<string, string>> {
+  const context = await launchProfile(profileDir)
+  const tails = new Map<string, string>()
+  try {
+    await resetOriginBeforeBootstrap(context)
+    await authenticateAs(context, email)
+    const page = context.pages()[0] ?? await context.newPage()
+    for (const route of routes) {
+      await page.goto(route, { waitUntil: "commit" })
+      await waitForSurface(page)
+      const tailId = await page.locator("[data-msg-id]").last().getAttribute("data-msg-id")
+      if (!tailId) throw new Error(`No message tail while priming ${route}`)
+      tails.set(route, tailId)
+    }
+    if (MODE === "gate") {
+      await page.evaluate(async () => {
+        if (!("serviceWorker" in navigator)) throw new Error("service workers unavailable")
+        await Promise.race([
+          navigator.serviceWorker.ready,
+          new Promise((_, reject) => setTimeout(() => reject(new Error("service worker not ready")), 10_000)),
+        ])
+      })
+    }
+  } finally {
+    await context.close()
+  }
+  return tails
+}
+
+async function recordSample(
+  writer: ReplicaArtifactWriter,
+  scenario: ReplicaScenarioId,
+  iteration: number,
+  journey: (sample: ReplicaBenchmarkSample) => Promise<void>,
+) {
+  const sample = emptySample(scenario, iteration)
+  try {
+    await journey(sample)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (error instanceof ProductFailure) sample.productFailure = message
+    else sample.harnessError = message
+  } finally {
+    sample.observationEndedAtMs = Date.now()
+    writer.append(sample)
+  }
+}
+
+test("Alook Replica vertical benchmark", async ({ browser }) => {
+  test.setTimeout(600_000)
+  expect(["baseline", "gate"]).toContain(MODE)
+  expect(process.env.NEXT_PUBLIC_MOCK_NETWORK, "mock network must be off").not.toBe("true")
+  const { manifest, fixtureVersion: manifestFixtureVersion } = loadManifest()
+  const server = manifest.servers.find((candidate) => candidate.channels.length >= 2)
+  expect(server, "stress fixture needs a server with two channels").toBeTruthy()
+  const [channelA, channelB] = server!.channels
+  const routeA = `${BASE_URL}/c/channels/${server!.id}/${channelA.id}`
+  const routeB = `${BASE_URL}/c/channels/${server!.id}/${channelB.id}`
+  const threadFixture = await ensureThreadFixture(browser, manifest.owner.email, channelA.id)
+  const threadRoute = `${BASE_URL}/c/channels/${server!.id}/${threadFixture.threadId}`
+  const canonicalFingerprint = await canonicalFixtureFingerprint(
+    browser,
+    manifest.owner.email,
+    [channelA.id, channelB.id, threadFixture.threadId],
+  )
+  const fixtureVersion = [
+    manifestFixtureVersion,
+    `thread:${threadFixture.threadId}`,
+    `parent:${threadFixture.parentMessageId}`,
+    `canonical-sha256:${canonicalFingerprint}`,
+  ].join("+")
+  if (process.env.REPLICA_BENCH_PREPARE_ONLY === "1") {
+    writeFileSync(resolve(ARTIFACTS_DIR, "replica-fixture.json"), JSON.stringify({
+      fixtureVersion,
+      manifestPath: MANIFEST_PATH,
+      threadFixture,
+    }, null, 2))
+    return
+  }
+  const gitSha = process.env.REPLICA_BENCH_GIT_SHA ?? "working-tree"
+  const outputPath = process.env.REPLICA_BENCH_OUTPUT
+    ?? resolve(ARTIFACTS_DIR, `replica-${MODE}.json`)
+  const reportPath = outputPath.replace(/\.json$/, ".md")
+  const writer = new ReplicaArtifactWriter({
+    schemaVersion: REPLICA_BENCHMARK_SCHEMA_VERSION,
+    contractVersion: CONTRACT_VERSION,
+    fixtureVersion,
+    selectedScenarios: SELECTED_SCENARIOS,
+    createdAt: new Date().toISOString(),
+    gitSha,
+    mode: MODE,
+    networkDelayMs: 1_000,
+  }, outputPath)
+
+  for (let iteration = 1; iteration <= 5; iteration += 1) {
+    await recordSample(writer, "j1-covered-reopen", iteration, async (sample) => {
+      const profileDir = mkdtempSync(resolve(tmpdir(), "alook-replica-j1-"))
+      let context: BrowserContext | null = null
+      let probe: ReplicaNetworkProbe | null = null
+      try {
+        const tails = await primeCoveredProfile(profileDir, manifest.owner.email, [routeA])
+        const tailId = tails.get(routeA)
+        if (!tailId) throw new Error("primed route has no tail identity")
+        context = await launchProfile(profileDir)
+        const page = context.pages()[0] ?? await context.newPage()
+        probe = new ReplicaNetworkProbe(page, context, BASE_URL)
+        await probe.start(MODE === "gate")
+        sample.actionAtMs = Date.now()
+        try {
+          const legacyTimeout = MODE === "baseline" ? 40_000 : 20_000
+          await page.goto(routeA, { waitUntil: "commit", timeout: legacyTimeout })
+          await waitForSurface(page, tailId, legacyTimeout)
+        } catch (error) {
+          throw new ProductFailure(`covered reopen did not restore locally: ${String(error)}`)
+        }
+        sample.interactiveCoherentAtMs = Date.now()
+        if (MODE === "baseline") sample.baselineObservedAtMs = sample.interactiveCoherentAtMs
+        const routeCorrect = new URL(page.url()).pathname === new URL(routeA).pathname
+        const tailVisible = await page.locator(`[data-msg-id="${tailId}"]`).isVisible()
+        sample.proofs.push(
+          proof("covered-world-visible", routeCorrect && tailVisible, `route=${page.url()} tail=${tailId}`),
+          proof("transaction-consistent", routeCorrect && tailVisible, "route, message tail, and composer share one frame"),
+        )
+        if (!routeCorrect || !tailVisible) throw new ProductFailure("covered reopen exposed an incoherent world")
+      } finally {
+        if (probe) {
+          sample.requests = probe.requestsSince(sample.actionAtMs)
+          await probe.stop()
+        }
+        await context?.close().catch(() => {})
+        rmSync(profileDir, { recursive: true, force: true })
+      }
+    })
+  }
+
+  {
+    const context = await browser.newContext()
+    await resetOriginBeforeBootstrap(context)
+    await authenticateAs(context, manifest.owner.email)
+    const page = await context.newPage()
+    const apiProjection = new Map<string, ApiMessage[]>()
+    for (const [route, channel] of [
+      [routeA, channelA],
+      [routeB, channelB],
+      [threadRoute, { id: threadFixture.threadId }],
+    ] as const) {
+      await page.goto(route, { waitUntil: "commit" })
+      await waitForSurface(page)
+      apiProjection.set(channel.id, await apiMessages(context.request, channel.id))
+    }
+    await page.goto(routeA, { waitUntil: "commit" })
+    await waitForSurface(page)
+    const probe = new ReplicaNetworkProbe(page, context, BASE_URL)
+    await probe.start(false)
+    try {
+      for (let iteration = 1; iteration <= 5; iteration += 1) {
+        const target = iteration === 1
+          ? { id: channelB.id, route: routeB, surface: "channel" as const }
+          : iteration === 2 || iteration === 4
+            ? { id: channelA.id, route: routeA, surface: "channel" as const }
+            : { id: threadFixture.threadId, route: threadRoute, surface: "thread" as const }
+        const expected = apiProjection.get(target.id) ?? []
+        const tail = expected.at(-1)
+        await recordSample(writer, "j2-covered-navigation", iteration, async (sample) => {
+          if (!tail) throw new Error(`fixture channel ${target.id} has no tail`)
+          sample.actionAtMs = Date.now()
+          if (target.surface === "thread") {
+            await page.getByTestId(tid.threadIndicator(threadFixture.parentMessageId)).click({ noWaitAfter: true })
+          } else {
+            await page.getByTestId(tid.channelRow(target.id)).click({ noWaitAfter: true })
+          }
+          try {
+            await page.waitForURL(new RegExp(`/${target.id}$`), { waitUntil: "commit", timeout: 20_000 })
+            const targetRoot = target.surface === "thread" ? page.getByTestId(tid.threadSplitPanel) : page
+            await waitForSurface(page, tail.id, 20_000, targetRoot)
+          } catch (error) {
+            throw new ProductFailure(`covered navigation did not resolve coherently: ${String(error)}`)
+          }
+          sample.interactiveCoherentAtMs = Date.now()
+          if (MODE === "baseline") sample.baselineObservedAtMs = sample.interactiveCoherentAtMs
+          sample.requests = probe.requestsSince(sample.actionAtMs)
+          const targetRoot = target.surface === "thread" ? page.getByTestId(tid.threadSplitPanel) : page
+          const domIds = await targetRoot.locator("[data-msg-id]").evaluateAll((rows) => (
+            rows.map((row) => row.getAttribute("data-msg-id")).filter(Boolean)
+          ))
+          const expectedIds = expected.map((message) => message.id)
+          const visibleExpectedIds = expectedIds.filter((id) => domIds.includes(id))
+          const read = await waitForReadThrough(context.request, target.id, tail.seq)
+          const routeCorrect = new URL(page.url()).pathname === new URL(target.route).pathname
+          const orderingCorrect = visibleExpectedIds.join(",") === domIds.join(",")
+          const readCorrect = read.lastReadSeq === tail.seq
+          const surfaceCorrect = target.surface === "thread"
+            ? await page.getByTestId(tid.threadSplitPanel).isVisible()
+            : await page.getByTestId(tid.threadSplitPanel).count() === 0
+          sample.proofs.push(
+            proof("target-tail-visible", domIds.includes(tail.id), `tail=${tail.id}`),
+            proof("latest-navigation-wins", routeCorrect, `latest target=${target.id}`),
+            proof("ordering-correct", orderingCorrect, `dom=${domIds.join(",")} authority=${visibleExpectedIds.join(",")}`),
+            proof("read-state-correct", readCorrect, `read=${read.lastReadSeq} latest=${tail.seq}`),
+            proof("route-correct", routeCorrect, page.url()),
+            proof("surface-kind-correct", surfaceCorrect, `expected=${target.surface}`),
+          )
+          if (!routeCorrect || !orderingCorrect || !readCorrect || !surfaceCorrect) {
+            throw new ProductFailure("navigation route, surface, ordering, or read projection diverged")
+          }
+        })
+      }
+    } finally {
+      await probe.stop()
+      await context.close()
+    }
+  }
+
+  for (let iteration = 1; iteration <= 3; iteration += 1) {
+    await recordSample(writer, "j5-draft", iteration, async (sample) => {
+      const profileDir = mkdtempSync(resolve(tmpdir(), "alook-replica-j5-"))
+      const marker = `replica-draft-${Date.now()}-${iteration}`
+      let context: BrowserContext | null = null
+      let probe: ReplicaNetworkProbe | null = null
+      try {
+        await primeCoveredProfile(profileDir, manifest.owner.email, [routeB, routeA])
+        context = await launchProfile(profileDir)
+        let page = context.pages()[0] ?? await context.newPage()
+        await page.goto(routeA, { waitUntil: "commit" })
+        await waitForSurface(page)
+        await composerEditable(page).fill(marker)
+        const storedBeforeClose = await waitForDurableMarker(page, marker)
+        await context.close()
+        context = await launchProfile(profileDir)
+        page = context.pages()[0] ?? await context.newPage()
+        probe = new ReplicaNetworkProbe(page, context, BASE_URL)
+        await probe.start(MODE === "gate")
+        sample.actionAtMs = Date.now()
+        try {
+          await page.goto(routeA, { waitUntil: "commit", timeout: 20_000 })
+          await composerEditable(page).waitFor({ state: "visible", timeout: 20_000 })
+          await expect(composerEditable(page)).toContainText(marker, { timeout: 20_000 })
+        } catch (error) {
+          throw new ProductFailure(`draft did not survive covered reopen: ${String(error)}`)
+        }
+        sample.interactiveCoherentAtMs = Date.now()
+        if (MODE === "baseline") sample.baselineObservedAtMs = sample.interactiveCoherentAtMs
+        const serverCount = (await apiMessages(context.request, channelA.id))
+          .filter((message) => message.content === marker).length
+        await page.goto(routeB, { waitUntil: "commit", timeout: 20_000 })
+        await composerEditable(page).waitFor({ state: "visible", timeout: 20_000 })
+        const leaked = (await composerEditable(page).textContent())?.includes(marker) ?? false
+        sample.proofs.push(
+          proof("draft-durable", storedBeforeClose !== null, `durable evidence at ${String(storedBeforeClose)}`),
+          proof("draft-scope-isolated", !leaked, `channel ${channelB.id} contains marker=${leaked}`),
+          proof("no-server-message-before-send", serverCount === 0, `authority rows=${serverCount}`),
+        )
+        if (storedBeforeClose === null || leaked || serverCount !== 0) {
+          throw new ProductFailure("draft durability, isolation, or no-send invariant failed")
+        }
+      } finally {
+        if (probe) {
+          sample.requests = probe.requestsSince(sample.actionAtMs)
+          await probe.stop()
+        }
+        await context?.close().catch(() => {})
+        rmSync(profileDir, { recursive: true, force: true })
+      }
+    })
+  }
+
+  for (let iteration = 1; iteration <= 3; iteration += 1) {
+    await recordSample(writer, "j6-text-send", iteration, async (sample) => {
+      const profileDir = mkdtempSync(resolve(tmpdir(), "alook-replica-j6-"))
+      const marker = `replica-send-${Date.now()}-${iteration}`
+      let context: BrowserContext | null = null
+      let probe: ReplicaNetworkProbe | null = null
+      let initialRequests = sample.requests
+      try {
+        await primeCoveredProfile(profileDir, manifest.owner.email, [routeA])
+        context = await launchProfile(profileDir)
+        let page = context.pages()[0] ?? await context.newPage()
+        await page.goto(routeA, { waitUntil: "commit" })
+        await waitForSurface(page)
+        await composerEditable(page).fill(marker)
+        probe = new ReplicaNetworkProbe(page, context, BASE_URL)
+        await probe.start(MODE === "gate")
+        sample.actionAtMs = Date.now()
+        await composerEditable(page).press("Enter")
+        const row = page.locator("[data-msg-id]").filter({ hasText: marker }).last()
+        try {
+          await row.waitFor({ state: "attached", timeout: 20_000 })
+        } catch (error) {
+          throw new ProductFailure(`local text intent did not paint: ${String(error)}`)
+        }
+        sample.interactiveCoherentAtMs = Date.now()
+        const localRowId = await row.getAttribute("data-msg-id")
+        const durableAt = await waitForDurableMarker(page, marker)
+        sample.localDurableAtMs = durableAt
+        initialRequests = probe.requestsSince(sample.actionAtMs)
+        await probe.stop()
+        probe = null
+        await context.close()
+
+        context = await launchProfile(profileDir)
+        page = context.pages()[0] ?? await context.newPage()
+        probe = new ReplicaNetworkProbe(page, context, BASE_URL)
+        await probe.start(MODE === "gate")
+        let survivedReopen = false
+        try {
+          await page.goto(routeA, { waitUntil: "commit", timeout: 20_000 })
+          const reopenedRow = page.locator("[data-msg-id]").filter({ hasText: marker }).last()
+          await reopenedRow.waitFor({ state: "attached", timeout: 20_000 })
+          survivedReopen = true
+        } catch {}
+        if (MODE === "gate") await probe.setOffline(false)
+        const canonical = await waitForCanonicalCount(context.request, channelA.id, marker)
+        sample.canonicalOutcomeAtMs = canonical.observedAtMs
+        sample.canonicalOutcomeCount = canonical.count
+        sample.businessEffectCount = canonical.count
+        sample.transportDeliveryCount = [...initialRequests, ...probe.requestsSince(sample.actionAtMs)]
+          .filter((request) => request.method === "POST" && request.url.includes(`/${channelA.id}/messages`))
+          .length
+        if (MODE === "baseline") sample.baselineObservedAtMs = canonical.observedAtMs
+        const canonicalRow = canonical.messages.find((message) => message.content === marker)
+        const read = await apiReadState(context.request, channelA.id)
+        const intentDurable = durableAt !== null && survivedReopen
+        const canonicalMatches = canonical.count === 1 && Boolean(canonicalRow)
+        const readCorrect = canonicalRow ? read.lastReadSeq <= canonicalRow.seq && read.lastReadSeq >= 0 : false
+        sample.proofs.push(
+          proof("intent-durable", intentDurable, `stored=${String(durableAt)} reopened=${survivedReopen}`),
+          proof("canonical-row-matches", canonicalMatches, `local=${String(localRowId)} canonical=${canonicalRow?.id ?? "none"}`),
+          proof("read-state-correct", readCorrect, `read=${read.lastReadSeq} canonical=${canonicalRow?.seq ?? "none"}`),
+        )
+        if (MODE === "gate" && (!intentDurable || !canonicalMatches || !readCorrect)) {
+          throw new ProductFailure("text intent durability or canonical exactly-once invariant failed")
+        }
+      } finally {
+        if (probe) {
+          sample.requests = [...initialRequests, ...probe.requestsSince(sample.actionAtMs)]
+          await probe.stop()
+        } else {
+          sample.requests = initialRequests
+        }
+        await context?.close().catch(() => {})
+        rmSync(profileDir, { recursive: true, force: true })
+      }
+    })
+  }
+
+  const baselinePath = process.env.REPLICA_BENCH_BASELINE
+  const baseline = baselinePath
+    ? JSON.parse(readFileSync(baselinePath, "utf8")) as ReplicaBenchmarkArtifact
+    : undefined
+  writer.flush()
+  writeFileSync(reportPath, renderReplicaBenchmarkReport(writer.artifact, baseline))
+  const analysis = analyzeReplicaBenchmark(writer.artifact, baseline)
+  expect(analysis.artifactValid, `invalid benchmark artifact; see ${reportPath}`).toBe(true)
+  if (MODE === "gate") {
+    expect(baseline, "REPLICA_BENCH_BASELINE is required in gate mode").toBeTruthy()
+    expect(analysis.runPassed, `Replica gate failed; see ${reportPath}`).toBe(true)
+  }
+})


### PR DESCRIPTION
## Scope

Independent Replica benchmark/red-team harness for J1 shell bootstrap, J2 channel/thread switching, J5 durable draft recovery, and J6 durable/idempotent text send.

- Applies 1 s latency to every real first-party network access.
- Separates baseline canonical completion from candidate local durable/coherent completion.
- Requires compatible frozen fixture, contract hashes, sample counts, and scenario selection.
- Generates a machine-readable JSON artifact and a Markdown gate report.
- Keeps package/runtime code unchanged.

## Verification

Pre-commit repository checks passed: typecheck, lint, tests, coverage validation, typegrep boundaries, and Knip. The Playwright baseline completed 16/16 samples with zero harness errors.

This PR is intentionally Draft. Do not merge until the Replica candidate is measured against the frozen baseline and the red-team gate passes.
