### PR TITLE
fix(web): unify unresolved loading and metadata error states

### DIFF
--- a/src/web/src/app/c/channels/[serverId]/page.test.ts
+++ b/src/web/src/app/c/channels/[serverId]/page.test.ts
@@ -2,6 +2,7 @@ import { createElement } from "react"
 import TestRenderer, { act } from "react-test-renderer"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import ServerDefaultPage from "./page"
+import { UnresolvedMainSkeleton } from "@/components/community/shell/unresolved-main-skeleton"
 
 const mocks = vi.hoisted(() => ({
   breakpoint: { current: "mobile" as "mobile" | "desktop" | "unknown" },
@@ -33,15 +34,6 @@ vi.mock("@/lib/community/last-channel", async () => {
     getLastChannel: () => mocks.lastChannel.current,
   }
 })
-vi.mock("@/components/community/messages/message-list", () => ({
-  MessageList: (props: Record<string, unknown>) => createElement("message-list", props),
-}))
-vi.mock("@/components/community/channels/channel-header", () => ({
-  ChannelHeaderSkeleton: (props: Record<string, unknown>) => createElement("channel-header-skeleton", props),
-}))
-vi.mock("@/components/community/messages/composer", () => ({
-  ComposerSkeleton: (props: Record<string, unknown>) => createElement("composer-skeleton", props),
-}))
 
 beforeEach(() => {
   mocks.breakpoint.current = "mobile"
@@ -54,7 +46,8 @@ beforeEach(() => {
 })
 
 describe("ServerDefaultPage checkpoint route contract", () => {
-  it("keeps the mobile server root on the list route without rendering detail", async () => {
+  it.each(["mobile", "unknown"] as const)("keeps the %s server root on the list route without rendering detail", async (breakpoint) => {
+    mocks.breakpoint.current = breakpoint
     let renderer!: TestRenderer.ReactTestRenderer
     await act(async () => {
       renderer = TestRenderer.create(createElement(ServerDefaultPage))
@@ -62,6 +55,30 @@ describe("ServerDefaultPage checkpoint route contract", () => {
 
     expect(mocks.replace).not.toHaveBeenCalled()
     expect(renderer.toJSON()).toBeNull()
+  })
+
+  it("keeps metadata loading neutral, then redirects only when the target is known", async () => {
+    mocks.breakpoint.current = "desktop"
+    mocks.server.current = null
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(ServerDefaultPage))
+    })
+
+    expect(mocks.replace).not.toHaveBeenCalled()
+    expect(renderer.root.findAllByType(UnresolvedMainSkeleton)).toHaveLength(1)
+    expect(renderer.root.findByType("main").props).toMatchObject({
+      "aria-label": "Loading server",
+      "aria-busy": "true",
+      "data-community-mobile-transition": "suppress",
+    })
+    expect(renderer.root.findAll((node) => typeof node.type === "string"
+      && ["header", "button", "form", "textarea"].includes(node.type))).toHaveLength(0)
+
+    mocks.server.current = { categories: [{ channels: [{ id: "channel_ready" }] }] }
+    await act(async () => { renderer.update(createElement(ServerDefaultPage)) })
+    expect(mocks.replace).toHaveBeenCalledExactlyOnceWith("/c/channels/server_1/channel_ready")
+    expect(renderer.root.findAllByType(UnresolvedMainSkeleton)).toHaveLength(1)
   })
 
   it("replaces the desktop server root with the remembered channel and preserves search", async () => {
@@ -76,9 +93,7 @@ describe("ServerDefaultPage checkpoint route contract", () => {
     expect(mocks.replace).toHaveBeenCalledWith(
       "/c/channels/server_1/channel_2?settings=1",
     )
-    expect(renderer.root.findAllByType("message-list")).toHaveLength(1)
-    expect(renderer.root.findAllByType("channel-header-skeleton")).toHaveLength(1)
-    expect(renderer.root.findAllByType("composer-skeleton")).toHaveLength(1)
+    expect(renderer.root.findAllByType(UnresolvedMainSkeleton)).toHaveLength(1)
   })
 
   it("falls back to the first top-level channel on desktop", async () => {
@@ -102,7 +117,7 @@ describe("ServerDefaultPage checkpoint route contract", () => {
     })
 
     expect(mocks.replace).not.toHaveBeenCalled()
-    expect(renderer.root.findAllByType("message-list")).toHaveLength(0)
+    expect(renderer.root.findAllByType(UnresolvedMainSkeleton)).toHaveLength(0)
     expect(renderer.root.findAllByType("span").map((node) => node.children.join(" "))).toEqual([
       "No channels yet",
       "Create a channel from the sidebar to get started.",

--- a/src/web/src/app/c/channels/[serverId]/page.tsx
+++ b/src/web/src/app/c/channels/[serverId]/page.tsx
@@ -2,21 +2,11 @@
 
 import { useEffect } from "react"
 import { useParams, useRouter, useSearchParams } from "next/navigation"
-import { MessageList } from "@/components/community/messages/message-list"
-import { ComposerSkeleton } from "@/components/community/messages/composer"
-import { ChannelHeaderSkeleton } from "@/components/community/channels/channel-header"
+import { ServerLandingPendingFrame } from "@/components/community/shell/server-landing-pending-frame"
 import { useServer } from "@/hooks/community/use-servers"
 import { useBreakpoint } from "@/hooks/use-mobile"
 import { getLastChannel, pickServerLandingChannel } from "@/lib/community/last-channel"
 
-/**
- * /c/channels/:serverId
- *
- * Restores the last channel opened in this server (per-browser memory), falling
- * back to the first channel by position. Shows a channel-shell skeleton while
- * waiting for the server detail so the transition feels like a reveal rather
- * than a swap.
- */
 export default function ServerDefaultPage() {
   const params = useParams<{ serverId: string }>()
   const router = useRouter()
@@ -52,13 +42,5 @@ export default function ServerDefaultPage() {
     )
   }
 
-  return (
-    <>
-      <ChannelHeaderSkeleton />
-      <main className="flex min-h-0 min-w-0 flex-1 flex-col">
-        <MessageList channel="" messages={[]} loading onOpenThread={() => {}} />
-        <ComposerSkeleton />
-      </main>
-    </>
-  )
+  return <ServerLandingPendingFrame />
 }

--- a/src/web/src/components/community/channels/channel-loading-frame.test.ts
+++ b/src/web/src/components/community/channels/channel-loading-frame.test.ts
@@ -1,39 +1,19 @@
 import { createElement } from "react"
-import TestRenderer, { act } from "react-test-renderer"
-import { describe, expect, it, vi } from "vitest"
-
-vi.mock("./channel-header", () => ({
-  ChannelHeaderSkeleton: (props: Record<string, unknown>) =>
-    createElement("channel-header-skeleton", props),
-}))
-vi.mock("@/components/community/messages/message-list", () => ({
-  MessageList: (props: Record<string, unknown>) => createElement("message-list", props),
-}))
-vi.mock("@/components/community/messages/composer", () => ({
-  ComposerSkeleton: () => createElement("composer-skeleton"),
-}))
-
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import ServerLoading from "@/app/c/channels/[serverId]/loading"
 import { ChannelLoadingFrame } from "./channel-loading-frame"
 
 describe("ChannelLoadingFrame", () => {
-  it("composes canonical detail zones with mobile Back loading geometry", () => {
-    let renderer!: TestRenderer.ReactTestRenderer
-    act(() => {
-      renderer = TestRenderer.create(createElement(ChannelLoadingFrame))
-    })
+  it.each([ChannelLoadingFrame, ServerLoading])("keeps the server route fallback neutral before its leaf is known: %s", (Component) => {
+    const markup = renderToStaticMarkup(createElement(Component))
 
-    expect(renderer.root.findByType("channel-header-skeleton").props).toEqual({})
-    expect(renderer.root.findByType("message-list").props).toMatchObject({
-      channel: "",
-      messages: [],
-      loading: true,
-    })
-    expect(renderer.root.findAllByType("composer-skeleton")).toHaveLength(1)
-    const tree = renderer.toJSON() as TestRenderer.ReactTestRendererJSON
-    expect(tree.props).toMatchObject({
-      "aria-busy": "true",
-      "aria-label": "Loading conversation",
-    })
+    expect(markup.match(/data-community-unresolved-main=""/g)).toHaveLength(1)
+    expect(markup.match(/data-slot="skeleton"/g)).toHaveLength(1)
+    expect(markup).toContain('aria-busy="true"')
+    expect(markup).toContain('aria-label="Loading conversation"')
+    expect(markup).toContain('data-community-mobile-transition="suppress"')
+    expect(markup).not.toMatch(/<(?:header|button|a|form|textarea)\b/)
+    expect(markup).not.toMatch(/composer|message-list|channel-header/)
   })
-
 })

--- a/src/web/src/components/community/channels/channel-loading-frame.tsx
+++ b/src/web/src/components/community/channels/channel-loading-frame.tsx
@@ -1,21 +1,14 @@
-"use client"
-
-import { MessageList } from "@/components/community/messages/message-list"
-import { ComposerSkeleton } from "@/components/community/messages/composer"
-import { ChannelHeaderSkeleton } from "./channel-header"
+import { UnresolvedMainSkeleton } from "../shell/unresolved-main-skeleton"
 
 export function ChannelLoadingFrame() {
   return (
     <div
       aria-busy="true"
       aria-label="Loading conversation"
+      data-community-mobile-transition="suppress"
       className="flex min-h-0 min-w-0 flex-1 flex-col"
     >
-      <ChannelHeaderSkeleton />
-      <main className="flex min-h-0 min-w-0 flex-1 flex-col">
-        <MessageList channel="" messages={[]} loading onOpenThread={() => {}} />
-        <ComposerSkeleton />
-      </main>
+      <UnresolvedMainSkeleton />
       <span className="sr-only">Loading conversation</span>
     </div>
   )

--- a/src/web/src/components/community/channels/channel-route.text-scroll-target.test.ts
+++ b/src/web/src/components/community/channels/channel-route.text-scroll-target.test.ts
@@ -2,6 +2,7 @@ import React from "react"
 import TestRenderer, { act } from "react-test-renderer"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { ChannelRoute } from "./channel-route"
+import { ConversationResolutionErrorFrame } from "./conversation-resolution-error-frame"
 import { ForumChannelSurface } from "./forum-channel-surface"
 import { MessageList } from "../messages/message-list"
 import { useChannelMemberViewModel } from "../members/channel-member-view-model"
@@ -55,6 +56,9 @@ const {
     isChild: false,
     isForumPostChild: false,
     isNotifyUnit: false,
+    metadataError: false,
+    retryingMetadata: false,
+    retryMetadata: vi.fn(),
     routeHydrated: true,
     routeLifecycle: "ready" as "pending" | "ready" | "terminal-error",
   },
@@ -303,6 +307,8 @@ describe("ChannelRoute message surface ownership", () => {
       isChild: false,
       isForumPostChild: false,
       isNotifyUnit: false,
+      metadataError: false,
+      retryingMetadata: false,
       routeHydrated: true,
       routeLifecycle: "ready",
     })
@@ -354,6 +360,34 @@ describe("ChannelRoute message surface ownership", () => {
     })).toBeDefined()
     expect(mockedForumChannelSurface).not.toHaveBeenCalled()
     expect(mockedMessageList).not.toHaveBeenCalled()
+  })
+
+  it("renders the terminal metadata error without opening a feed and forwards Retry", async () => {
+    Object.assign(mockRouteModel, {
+      isChild: true, routeLifecycle: "terminal-error", routeHydrated: false,
+      metadataError: true, retryingMetadata: false,
+    })
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(React.createElement(ChannelRoute, {
+        serverParam: "server_1", channelId: "channel_1",
+      }))
+    })
+    const errorFrame = renderer.root.findByType(ConversationResolutionErrorFrame)
+    expect(errorFrame.props.retrying).toBe(false)
+    expect(renderer.root.findAllByProps({ "data-community-conversation-subtype": "unknown" })).toHaveLength(0)
+    expect(mockedUseChannelMessageFeed).not.toHaveBeenCalled()
+    expect(mockCommitLastCommunityRoute).not.toHaveBeenCalled()
+    act(() => errorFrame.props.onRetry())
+    expect(mockRouteModel.retryMetadata).toHaveBeenCalledTimes(1)
+    Object.assign(mockRouteModel, { routeLifecycle: "pending", retryingMetadata: true })
+    await act(async () => {
+      renderer.update(React.createElement(ChannelRoute, {
+        serverParam: "server_1", channelId: "channel_1",
+      }))
+    })
+    expect(renderer.root.findByType(ConversationResolutionErrorFrame).props.retrying).toBe(true)
+    await act(async () => renderer.unmount())
   })
 
   it("mounts authoritative split geometry before a thread body is active", () => {

--- a/src/web/src/components/community/channels/channel-route.tsx
+++ b/src/web/src/components/community/channels/channel-route.tsx
@@ -12,6 +12,7 @@ import { ThreadChannelSurface } from "@/components/community/channels/thread-cha
 import { ThreadSplitView } from "@/components/community/channels/thread-split-view"
 import { ThreadSplitParentSurface } from "@/components/community/channels/thread-split-parent-surface"
 import { ForumChannelSurface } from "@/components/community/channels/forum-channel-surface"
+import { ConversationResolutionErrorFrame } from "@/components/community/channels/conversation-resolution-error-frame"
 import { ConversationResolutionPendingFrame } from "@/components/community/channels/conversation-resolution-pending-frame"
 import { useChannelMemberViewModel } from "@/components/community/members/channel-member-view-model"
 import type { OpenProfile } from "@/components/community/social/profile-types"
@@ -206,7 +207,14 @@ export function ChannelRoute({ serverParam, channelId }: {
     isChild: isChildChannel,
     isForum,
   })
-  if (subtype === "unknown") return <ConversationResolutionPendingFrame />
+  if (subtype === "unknown") {
+    return routeModel.metadataError
+      ? <ConversationResolutionErrorFrame
+          retrying={routeModel.retryingMetadata}
+          onRetry={() => { void routeModel.retryMetadata() }}
+        />
+      : <ConversationResolutionPendingFrame />
+  }
   if (!channelHydrated) {
     if (subtype === "thread") {
       const split = threadSplit.mode === "split" && !!currentServer && !!parentChannelInServer

--- a/src/web/src/components/community/channels/conversation-resolution-error-frame.test.ts
+++ b/src/web/src/components/community/channels/conversation-resolution-error-frame.test.ts
@@ -1,0 +1,16 @@
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import { ConversationResolutionErrorFrame } from "./conversation-resolution-error-frame"
+
+describe("ConversationResolutionErrorFrame", () => {
+  it.each([false, true])("keeps a persistent accessible error and retry control while retrying=%s", (retrying) => {
+    const markup = renderToStaticMarkup(createElement(ConversationResolutionErrorFrame, { retrying, onRetry: () => {} }))
+    expect(markup).toContain('role="alert"')
+    expect(markup).toContain("verify this conversation")
+    expect(markup).toContain(retrying ? "Retrying…" : "Retry")
+    expect(markup.includes('disabled=""')).toBe(retrying)
+    expect(markup).toContain('type="button"')
+    expect(markup).not.toMatch(/<(?:header|form|textarea)\b|data-slot="skeleton"|\sinert(?:=|\s)|composer/)
+  })
+})

--- a/src/web/src/components/community/channels/conversation-resolution-error-frame.tsx
+++ b/src/web/src/components/community/channels/conversation-resolution-error-frame.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { AlertCircle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export function ConversationResolutionErrorFrame({
+  retrying,
+  onRetry,
+}: {
+  retrying: boolean
+  onRetry: () => void
+}) {
+  return (
+    <main className="flex min-h-0 min-w-0 flex-1 flex-col items-center justify-center gap-4 p-4 text-center">
+      <div role="alert" className="flex flex-col items-center gap-2">
+        <AlertCircle className="size-5 text-muted-foreground" aria-hidden />
+        <p className="text-sm font-medium">Couldn&apos;t verify this conversation</p>
+        <p className="text-xs text-muted-foreground">Check your connection and try again.</p>
+      </div>
+      <Button variant="outline" className="h-11 px-4 sm:h-9" onClick={onRetry} disabled={retrying}>
+        {retrying ? "Retrying…" : "Retry"}
+      </Button>
+    </main>
+  )
+}

--- a/src/web/src/components/community/channels/conversation-resolution-pending-frame.test.ts
+++ b/src/web/src/components/community/channels/conversation-resolution-pending-frame.test.ts
@@ -4,13 +4,11 @@ import { describe, expect, it } from "vitest"
 import { ConversationResolutionPendingFrame } from "./conversation-resolution-pending-frame"
 
 describe("ConversationResolutionPendingFrame", () => {
-  it("covers the unresolved main panel with one square shared Skeleton", () => {
+  it("uses the shared unresolved main visual", () => {
     const markup = renderToStaticMarkup(createElement(ConversationResolutionPendingFrame))
 
+    expect(markup.match(/data-community-unresolved-main=""/g)).toHaveLength(1)
     expect(markup.match(/data-slot="skeleton"/g)).toHaveLength(1)
-    expect(markup).toMatch(/data-slot="skeleton" class="[^"]*animate-pulse[^"]*"/)
-    expect(markup).toMatch(/data-slot="skeleton" class="[^"]*h-full[^"]*w-full[^"]*rounded-none[^"]*"/)
-    expect(markup).not.toMatch(/rounded-(?:sm|md|lg|xl|2xl|3xl|full)(?:\s|")/)
   })
 
   it("stays inert and exposes no speculative conversation content", () => {

--- a/src/web/src/components/community/channels/conversation-resolution-pending-frame.tsx
+++ b/src/web/src/components/community/channels/conversation-resolution-pending-frame.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from "@/components/ui/skeleton"
+import { UnresolvedMainSkeleton } from "../shell/unresolved-main-skeleton"
 
 /** Inert main-area placeholder used until canonical route metadata proves the subtype. */
 export function ConversationResolutionPendingFrame() {
@@ -8,9 +8,9 @@ export function ConversationResolutionPendingFrame() {
       aria-label="Resolving conversation"
       data-community-conversation-subtype="unknown"
       data-community-mobile-transition="suppress"
-      className="min-h-0 min-w-0 flex-1 bg-background"
+      className="flex min-h-0 min-w-0 flex-1 flex-col"
     >
-      <Skeleton aria-hidden className="h-full w-full rounded-none" />
+      <UnresolvedMainSkeleton />
       <span className="sr-only">Resolving conversation</span>
     </main>
   )

--- a/src/web/src/components/community/messages/message-list-facade.contract.test.ts
+++ b/src/web/src/components/community/messages/message-list-facade.contract.test.ts
@@ -78,7 +78,6 @@ describe("MessageList facade contract", () => {
 
   it("keeps all production consumers on the original path", () => {
     const importers = [
-      "src/app/c/channels/[serverId]/page.tsx",
       "src/app/c/me/[dmId]/page.tsx",
       "src/components/community/channels/thread-channel-surface.tsx",
       "src/components/community/channels/channel-route.tsx",
@@ -88,6 +87,15 @@ describe("MessageList facade contract", () => {
       const text = source(path)
       expect(text).toMatch(/messages\/message-list["']/)
       expect(text).not.toMatch(/message-list-(types|controller|view|row)/)
+    }
+  })
+
+  it("keeps unresolved server entries independent of message layout modules", () => {
+    for (const path of [
+      "src/app/c/channels/[serverId]/page.tsx",
+      "src/components/community/channels/channel-loading-frame.tsx",
+    ]) {
+      expect(source(path)).not.toMatch(/messages\/(?:message-list|composer)|[\/."]channel-header["']/)
     }
   })
 })

--- a/src/web/src/components/community/shell/community-pending-frame.test.ts
+++ b/src/web/src/components/community/shell/community-pending-frame.test.ts
@@ -11,10 +11,6 @@ vi.mock("@/components/community/bots/bot-list-view", () => ({
 vi.mock("@/components/community/social/friends-page", () => ({
   FriendsPage: (props: Record<string, unknown>) => createElement("friends-skeleton", props),
 }))
-vi.mock("@/components/community/channels/conversation-resolution-pending-frame", () => ({
-  ConversationResolutionPendingFrame: (props: Record<string, unknown>) =>
-    createElement("conversation-resolution", props),
-}))
 vi.mock("@/components/community/channels/dm-loading-frame", () => ({
   DmLoadingFrame: (props: Record<string, unknown>) => createElement("dm-skeleton", props),
 }))
@@ -23,6 +19,8 @@ vi.mock("@/components/ui/skeleton", () => ({
 }))
 
 import { CommunityPendingFrame } from "./community-pending-frame"
+import { ConversationResolutionPendingFrame } from "../channels/conversation-resolution-pending-frame"
+import { UnresolvedMainSkeleton } from "./unresolved-main-skeleton"
 
 function render(href: string, reserveBackSlot = true) {
   let renderer!: TestRenderer.ReactTestRenderer
@@ -35,11 +33,35 @@ function render(href: string, reserveBackSlot = true) {
 describe("CommunityPendingFrame", () => {
   it("suppresses the outer mobile transition for every route-pending frame", () => {
     for (const href of ["/c/me", "/c/me/dm_1", "/c/me/machines", "/c/channels/s1", "/c/channels/s1/c1"]) {
-      expect(render(href).root.findByProps({
+      expect(render(href).root.findAllByProps({
         "data-community-mobile-transition": "suppress",
-      })).toBeDefined()
+      })).not.toHaveLength(0)
     }
   })
+
+  it.each([
+    ["/c", "route-resolution", "Resolving community route"],
+    ["/c/me", "me-root", "Loading your space"],
+    ["/c/channels/s1", "server-landing", "Loading server"],
+    ["/c/channels/s1/settings", "server-landing", "Loading server"],
+    ["/c/channels/s1/c1", "server-conversation", "Resolving conversation"],
+    ["/c/me/not%5Cdm", "route-resolution", "Resolving community route"],
+  ])("shares one visual for unresolved %s and preserves its semantic owner", (href, kind, label) => {
+    const { root } = render(href)
+    expect(root.findAllByType(UnresolvedMainSkeleton)).toHaveLength(1)
+    expect(root.findAllByType("skeleton")).toHaveLength(1)
+    expect(root.findByProps({ "aria-label": label }).props["aria-busy"]).toBe("true")
+    expect(root.findByProps({ "data-community-main-kind": kind }).props)
+      .toMatchObject({ "data-community-mobile-transition": "suppress" })
+    expect(root.findAll((node) => typeof node.type === "string"
+      && ["header", "button", "a", "form", "textarea"].includes(node.type))).toHaveLength(0)
+  })
+
+  it.each(["/c/me/dm_1", "/c/me/machines", "/c/me/bots", "/c/me/friends"])(
+    "keeps the known layout for %s", (href) => {
+      expect(render(href).root.findAllByType(UnresolvedMainSkeleton)).toHaveLength(0)
+    },
+  )
 
   it("selects destination-specific @me skeletons and reserves a non-interactive Back slot", () => {
     const machines = render("/c/me/machines?from=shortcut")
@@ -71,7 +93,7 @@ describe("CommunityPendingFrame", () => {
     expect(dm.root.findByType("dm-skeleton").props.reserveBackSlot).toBe(true)
 
     const channel = render("/c/channels/s1/c1")
-    expect(channel.root.findByType("conversation-resolution").props).toEqual({})
+    expect(channel.root.findByType(ConversationResolutionPendingFrame).props).toEqual({})
 
     const serverRoot = render("/c/channels/s1")
     expect(serverRoot.root.findByProps({ "aria-label": "Loading server" }).props["aria-busy"])
@@ -82,7 +104,7 @@ describe("CommunityPendingFrame", () => {
     const renderer = render(["/c/channels/s1/c1", "extra"].join("/"))
     expect(renderer.root.findByProps({ "aria-label": "Resolving community route" }))
       .toBeDefined()
-    expect(renderer.root.findAllByType("conversation-resolution")).toHaveLength(0)
+    expect(renderer.root.findAllByType(ConversationResolutionPendingFrame)).toHaveLength(0)
     expect(renderer.root.findAllByType("dm-skeleton")).toHaveLength(0)
   })
 })

--- a/src/web/src/components/community/shell/community-pending-frame.tsx
+++ b/src/web/src/components/community/shell/community-pending-frame.tsx
@@ -6,7 +6,8 @@ import { ConversationResolutionPendingFrame } from "@/components/community/chann
 import { DmLoadingFrame } from "@/components/community/channels/dm-loading-frame"
 import { MachineListSkeleton } from "@/components/community/machines/machine-list"
 import { FriendsPage } from "@/components/community/social/friends-page"
-import { Skeleton } from "@/components/ui/skeleton"
+import { ServerLandingPendingFrame } from "./server-landing-pending-frame"
+import { UnresolvedMainSkeleton } from "./unresolved-main-skeleton"
 import {
   resolveCommunityModulePlan,
   type CommunityModulePlan,
@@ -15,26 +16,8 @@ import { tid } from "@/lib/community/testids"
 
 function MeRootPendingFrame() {
   return (
-    <main aria-busy="true" aria-label="Loading your space" className="flex min-h-0 flex-1 flex-col gap-3 p-4">
-      <Skeleton className="h-6 w-32" />
-      <Skeleton className="h-14 w-full" />
-      <Skeleton className="h-14 w-5/6" />
-    </main>
-  )
-}
-
-function ServerLandingPendingFrame() {
-  return (
-    <main aria-busy="true" aria-label="Loading server" className="flex min-h-0 flex-1 flex-col">
-      <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border/40 px-3">
-        <Skeleton className="size-6 rounded-md" />
-        <Skeleton className="h-4 w-32 rounded" />
-      </header>
-      <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 p-4">
-        <Skeleton className="size-12 rounded-xl" />
-        <Skeleton className="h-4 w-36 rounded" />
-        <Skeleton className="h-3 w-52 max-w-full rounded" />
-      </div>
+    <main aria-busy="true" aria-label="Loading your space" className="flex min-h-0 min-w-0 flex-1 flex-col">
+      <UnresolvedMainSkeleton />
     </main>
   )
 }
@@ -44,10 +27,9 @@ function RouteResolutionPendingFrame() {
     <main
       aria-busy="true"
       aria-label="Resolving community route"
-      className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 bg-background p-4"
+      className="flex min-h-0 min-w-0 flex-1 flex-col"
     >
-      <Skeleton className="size-10 rounded-xl" />
-      <Skeleton className="h-4 w-40 rounded" />
+      <UnresolvedMainSkeleton />
     </main>
   )
 }

--- a/src/web/src/components/community/shell/server-landing-pending-frame.tsx
+++ b/src/web/src/components/community/shell/server-landing-pending-frame.tsx
@@ -1,0 +1,14 @@
+import { UnresolvedMainSkeleton } from "./unresolved-main-skeleton"
+
+export function ServerLandingPendingFrame() {
+  return (
+    <main
+      aria-busy="true"
+      aria-label="Loading server"
+      data-community-mobile-transition="suppress"
+      className="flex min-h-0 min-w-0 flex-1 flex-col"
+    >
+      <UnresolvedMainSkeleton />
+    </main>
+  )
+}

--- a/src/web/src/components/community/shell/unresolved-main-skeleton.test.ts
+++ b/src/web/src/components/community/shell/unresolved-main-skeleton.test.ts
@@ -1,0 +1,19 @@
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import { UnresolvedMainSkeleton } from "./unresolved-main-skeleton"
+
+describe("UnresolvedMainSkeleton", () => {
+  it("fills the main area with one inert square Skeleton and respects reduced motion", () => {
+    const markup = renderToStaticMarkup(createElement(UnresolvedMainSkeleton))
+
+    expect(markup.match(/data-slot="skeleton"/g)).toHaveLength(1)
+    expect(markup).toContain('data-community-unresolved-main=""')
+    expect(markup).toContain('aria-hidden="true"')
+    expect(markup).toContain("h-full w-full flex-1 rounded-none")
+    expect(markup).toContain("animate-pulse")
+    expect(markup).toContain("motion-reduce:animate-none")
+    expect(markup).not.toMatch(/rounded-(?:sm|md|lg|xl|2xl|3xl|full)(?:\s|")/)
+    expect(markup).toMatch(/^<div[^>]*><\/div>$/)
+  })
+})

--- a/src/web/src/components/community/shell/unresolved-main-skeleton.tsx
+++ b/src/web/src/components/community/shell/unresolved-main-skeleton.tsx
@@ -1,0 +1,11 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export function UnresolvedMainSkeleton() {
+  return (
+    <Skeleton
+      aria-hidden
+      data-community-unresolved-main=""
+      className="min-h-0 h-full w-full flex-1 rounded-none"
+    />
+  )
+}

--- a/src/web/src/hooks/community/use-channel-route-model.retry.test.ts
+++ b/src/web/src/hooks/community/use-channel-route-model.retry.test.ts
@@ -1,0 +1,201 @@
+import { createElement, useEffect } from "react"
+import TestRenderer, { act } from "react-test-renderer"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { ApiError } from "@/lib/errors"
+import { communityKeys } from "@/lib/query-keys"
+import { useCommunityStore } from "@/stores/community"
+import { useCommunityWsStore } from "@/stores/community/ws"
+
+const mocks = vi.hoisted(() => ({ apiFetch: vi.fn(), replace: vi.fn(), toast: vi.fn() }))
+vi.mock("@/lib/api/client", () => ({ apiFetch: mocks.apiFetch, toastApiError: mocks.toast }))
+vi.mock("next/navigation", () => ({ useRouter: () => ({ replace: mocks.replace }) }))
+vi.mock("./use-servers", () => ({
+  useServer: () => ({ server: {
+    id: "server-1",
+    categories: [{ channels: [{ id: "parent-1", name: "parent", type: "text" }] }],
+  } }),
+}))
+vi.mock("./use-community-ws", () => ({ communityWsSubscribe: vi.fn(), communityWsUnsubscribe: vi.fn() }))
+vi.mock("./use-forum-sidebar-threads", () => ({
+  removeForumSidebarUnreadChild: vi.fn(), removeForumSidebarThreadExact: vi.fn(),
+}))
+vi.mock("@/lib/community/last-channel", () => ({ getLastChannel: () => null, clearLastChannel: vi.fn() }))
+vi.mock("@/lib/community/last-community-route", () => ({
+  consumeCommunityColdEntryFailure: () => false, COMMUNITY_COLD_ENTRY_FALLBACK: "/c/me/machines",
+}))
+
+import { useChannelRouteModel } from "./use-channel-route-model"
+
+let current!: ReturnType<typeof useChannelRouteModel>
+let renderer: TestRenderer.ReactTestRenderer | undefined
+let client: QueryClient
+
+function Harness({ channelId = "post-1", accountId = "viewer-1" }: { channelId?: string; accountId?: string }) {
+  const model = useChannelRouteModel("server-1", "server-1", channelId, accountId)
+  useEffect(() => { current = model }, [model])
+  return null
+}
+function tree(props: { channelId?: string; accountId?: string } = {}) {
+  return createElement(QueryClientProvider, { client }, createElement(Harness, props))
+}
+async function mount() {
+  await act(async () => { renderer = TestRenderer.create(tree()) })
+}
+async function until(predicate: () => boolean) {
+  await vi.waitFor(async () => {
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)) })
+    expect(predicate()).toBe(true)
+  }, { timeout: 2000, interval: 5 })
+}
+function deferred() {
+  let resolve!: (value: unknown) => void
+  let reject!: (error: Error) => void
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej })
+  return { promise, resolve, reject }
+}
+function payload(id = "post-1") {
+  return {
+    id, serverId: "server-1", name: "post", type: "thread", parentChannelId: "parent-1",
+    parentMessageId: "opener-1", creatorId: "viewer-1", archived: false,
+    lastMessageAt: "2026-08-09T00:00:00.000Z", createdAt: "2026-08-08T00:00:00.000Z",
+  }
+}
+
+beforeEach(() => {
+  mocks.apiFetch.mockReset()
+  mocks.replace.mockClear()
+  mocks.toast.mockClear()
+  useCommunityStore.getState().reset()
+  useCommunityWsStore.getState().reset()
+  useCommunityWsStore.getState().markAccessConnected()
+  client = new QueryClient({ defaultOptions: { queries: { retry: 1, retryDelay: 0, gcTime: Infinity } } })
+})
+afterEach(async () => {
+  await act(async () => { renderer?.unmount() })
+  renderer = undefined
+  client.clear()
+  useCommunityStore.getState().reset()
+})
+
+describe("unresolved metadata terminal error and retry", () => {
+  it("waits for the original automatic retries before showing a persistent error", async () => {
+    const first = deferred()
+    const second = deferred()
+    mocks.apiFetch.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+    await mount()
+    expect(current.routeLifecycle).toBe("pending")
+    expect(current.metadataError).toBe(false)
+    await current.retryMetadata()
+    expect(mocks.apiFetch).toHaveBeenCalledTimes(1)
+
+    await act(async () => { first.reject(new ApiError("unavailable", 500)) })
+    await until(() => mocks.apiFetch.mock.calls.length === 2)
+    expect(current.metadataError).toBe(false)
+    await act(async () => { second.reject(new ApiError("unavailable", 500)) })
+    await until(() => current.metadataError)
+    expect(current.routeLifecycle).toBe("terminal-error")
+    expect(current.retryingMetadata).toBe(false)
+    expect(mocks.replace).not.toHaveBeenCalled()
+    expect(useCommunityStore.getState().currentChannelMeta).toBeNull()
+  })
+
+  it("deduplicates manual retry, keeps its error frame in flight, and recovers through the same query", async () => {
+    mocks.apiFetch.mockRejectedValue(new ApiError("unavailable", 500))
+    await mount()
+    await until(() => current.metadataError)
+    const retry = deferred()
+    mocks.apiFetch.mockReturnValueOnce(retry.promise)
+    let request!: Promise<void>
+    await act(async () => {
+      request = current.retryMetadata()
+      void current.retryMetadata()
+    })
+    await until(() => mocks.apiFetch.mock.calls.length === 3)
+    expect(current.retryingMetadata).toBe(true)
+    expect(current.metadataError).toBe(true)
+    expect(client.getQueryState(communityKeys.channelMeta("server-1", "post-1"))?.status).toBe("pending")
+    await current.retryMetadata()
+    expect(mocks.apiFetch).toHaveBeenCalledTimes(3)
+    await act(async () => { retry.reject(new ApiError("unavailable", 500)); await request })
+    await until(() => current.metadataError && !current.retryingMetadata)
+    expect(mocks.apiFetch).toHaveBeenCalledTimes(4)
+
+    mocks.apiFetch.mockResolvedValueOnce(payload())
+    await act(async () => { await current.retryMetadata() })
+    await until(() => current.routeLifecycle === "ready")
+    expect(current.metadataError).toBe(false)
+    expect(current.currentChannelMeta?.id).toBe("post-1")
+    expect(mocks.apiFetch.mock.calls.every(([url]) => url === "/api/community/channels/post-1")).toBe(true)
+    expect(client.getQueryCache().getAll()).toHaveLength(1)
+    expect(mocks.replace).not.toHaveBeenCalled()
+  })
+
+  it.each([401, 403, 404])("preserves the existing %s exit instead of offering metadata Retry", async (status) => {
+    mocks.apiFetch.mockRejectedValue(new ApiError("denied", status))
+    await mount()
+    await until(() => current.routeLifecycle === "terminal-error")
+    expect(current.metadataError).toBe(false)
+    await current.retryMetadata()
+    expect(mocks.apiFetch).toHaveBeenCalledTimes(2)
+    if (status === 401) expect(mocks.replace).not.toHaveBeenCalled()
+    else expect(mocks.replace).toHaveBeenCalledWith("/c/channels/server-1")
+  })
+
+  it("does not replace previously verified content with the new error UI on background failure", async () => {
+    mocks.apiFetch.mockResolvedValue(payload())
+    await mount()
+    await until(() => current.routeHydrated)
+    mocks.apiFetch.mockRejectedValue(new ApiError("offline", 0))
+    await act(async () => { await client.refetchQueries({ queryKey: communityKeys.channelMeta("server-1", "post-1") }) })
+    await until(() => current.routeLifecycle === "terminal-error")
+    expect(current.currentChannelMeta?.id).toBe("post-1")
+    expect(current.metadataError).toBe(false)
+  })
+
+  it("does not let an old route retry completion clear the new route retry", async () => {
+    mocks.apiFetch.mockRejectedValue(new ApiError("offline", 0))
+    await mount()
+    await until(() => current.metadataError)
+    const oldRetry = deferred()
+    mocks.apiFetch.mockReturnValueOnce(oldRetry.promise)
+    let oldRequest!: Promise<void>
+    await act(async () => { oldRequest = current.retryMetadata() })
+    await act(async () => { renderer!.update(tree({ channelId: "post-2" })) })
+    await until(() => current.metadataError)
+    expect(current.retryingMetadata).toBe(false)
+    const newRetry = deferred()
+    mocks.apiFetch.mockReturnValueOnce(newRetry.promise)
+    let newRequest!: Promise<void>
+    await act(async () => { newRequest = current.retryMetadata() })
+    await act(async () => { oldRetry.resolve(payload()); await oldRequest })
+    expect(current.retryingMetadata).toBe(true)
+    expect(current.metadataError).toBe(true)
+    expect(useCommunityStore.getState().currentChannelMeta).toBeNull()
+    await act(async () => { newRetry.resolve(payload("post-2")); await newRequest })
+    await until(() => current.routeHydrated)
+    expect(current.currentChannelMeta?.id).toBe("post-2")
+    expect(current.retryingMetadata).toBe(false)
+  })
+
+  it.each(["account", "epoch"])("does not carry retry feedback across an %s change", async (change) => {
+    mocks.apiFetch.mockRejectedValue(new ApiError("offline", 0))
+    await mount()
+    await until(() => current.metadataError)
+    const retry = deferred()
+    mocks.apiFetch.mockReturnValueOnce(retry.promise)
+    let request!: Promise<void>
+    await act(async () => { request = current.retryMetadata() })
+    expect(current.retryingMetadata).toBe(true)
+    await act(async () => {
+      if (change === "account") renderer!.update(tree({ accountId: "viewer-2" }))
+      else {
+        useCommunityWsStore.getState().markAccessDisconnected()
+        useCommunityWsStore.getState().markAccessConnected()
+      }
+    })
+    expect(current.retryingMetadata).toBe(false)
+    await act(async () => { retry.resolve(payload()); await request })
+    expect(current.retryingMetadata).toBe(false)
+  })
+})

--- a/src/web/src/hooks/community/use-channel-route-model.ts
+++ b/src/web/src/hooks/community/use-channel-route-model.ts
@@ -1,12 +1,14 @@
 "use client"
 
-import { useEffect, useMemo } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
 import { useQueryClient } from "@tanstack/react-query"
 import { isForum as isForumType } from "@alook/shared"
 import { useServer } from "./use-servers"
 import { useCommunityStore, useCurrentChannelMeta } from "@/stores/community"
 import { toastApiError } from "@/lib/api/client"
+import { ApiError } from "@/lib/errors"
+import { useCommunityWsStore } from "@/stores/community/ws"
 import { isDefinitiveChildMetaFailure } from "@/lib/community/eject-server"
 import { clearLastChannel, getLastChannel } from "@/lib/community/last-channel"
 import {
@@ -71,6 +73,28 @@ export function useChannelRouteModel(
     .some((candidate) => candidate.id === channelId)
   const isChild = !!server?.categories && !topLevelChannel
   const metaQuery = useChildChannelMeta(serverId, channelId, isChild)
+  const accessEpoch = useCommunityWsStore((state) => state.accessEpoch)
+  const retryScope = JSON.stringify([accountId, serverId, channelId, accessEpoch])
+  const retryAttemptRef = useRef<{ scope: string } | null>(null)
+  const [retryAttempt, setRetryAttempt] = useState<{ scope: string } | null>(null)
+  const retryingMetadata = retryAttempt?.scope === retryScope
+  const metadataExit = isDefinitiveChildMetaFailure(metaQuery.error)
+    || (metaQuery.error instanceof ApiError && metaQuery.error.status === 401)
+    || !!metaQuery.data?.archived
+  const metadataError = isChild && !metaQuery.isVerified && !metadataExit
+    && (metaQuery.isError || retryingMetadata)
+  const retryMetadata = useCallback(async () => {
+    if (!metadataError || metaQuery.isFetching || retryAttemptRef.current?.scope === retryScope) return
+    const attempt = { scope: retryScope }
+    retryAttemptRef.current = attempt
+    setRetryAttempt(attempt)
+    try {
+      await metaQuery.refetch({ cancelRefetch: false })
+    } finally {
+      if (retryAttemptRef.current === attempt) retryAttemptRef.current = null
+      setRetryAttempt((current) => current === attempt ? null : current)
+    }
+  }, [metadataError, metaQuery, retryScope])
   const model = useMemo(
     () => buildChannelRouteModel(
       server,
@@ -127,5 +151,5 @@ export function useChannelRouteModel(
       toastApiError(metaQuery.error, "Failed to load thread")
     }
   }, [accountId, channelId, isChild, metaQuery.data, metaQuery.error, metaQuery.isVerified, queryClient, router, serverId, serverParam])
-  return { ...model, routeLifecycle }
+  return { ...model, routeLifecycle, metadataError, retryingMetadata, retryMetadata }
 }

--- a/src/web/src/test/e2e-ui/11-profile-ui-stability.spec.ts
+++ b/src/web/src/test/e2e-ui/11-profile-ui-stability.spec.ts
@@ -24,6 +24,7 @@ test.describe.serial("profile card stability", () => {
     await page.getByRole("button", { name: /member/i }).first().click()
     await page.getByTestId(tid.memberRow(userId("bob"))).click()
     await expect(page.getByTestId(tid.profileCard)).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByTestId(tid.profileCard).getByRole("textbox")).toBeFocused()
 
     // Close by pressing Escape; the card detaches.
     await page.keyboard.press("Escape")


### PR DESCRIPTION
# Why we need this PR?

Unresolved community routes show inconsistent placeholders, including message controls before the destination type is known. A terminal metadata failure can also leave the main area looking as if it is still loading after its error toast disappears.

## What changed

- Use one full-area, square Skeleton for unresolved root, Me, server landing/default/loading and conversation metadata states. Preserve semantic wrappers, known layouts and route selection.
- Show a persistent, accessible error with Retry when unverified conversation metadata reaches a nondefinitive terminal failure. Retry uses the existing query, shows disabled in-progress feedback and preserves definitive access exits and stale-response protection.
- Add regressions for shared ownership, initial loading, terminal failure, retry failure/success, deduplication and route/account/access-epoch changes.

Independent browser QA passed 32 cold-entry cases, known/default/empty destinations, motion checks, and four desktop/mobile error → retry failure → real HTTP 200 recovery journeys with keyboard, actual 401/403/404, route/account stale-response, WS and D1 read-state evidence. Normal pre-commit gates passed (7,034 Web tests). The existing profile-card Escape test now waits for its textbox to own focus before the original single Escape and detach assertion. The corrected original journey passed independently with zero retries; product code and timeouts are unchanged. Both normal commits passed all hooks. Final head `9bf361557` passed all applicable checks in [CI run 33995349918](https://github.com/alookai/alook/actions/runs/33995349918), including all five UI shards and both CI/UI gates. Codecov patch is 100% (target 100%, zero annotations); its report says all modified coverable lines are covered. Four unrelated jobs were skipped by the workflow scope plan.

Retained limits: physical Android was unavailable; actual Next framework loading exports were not independently forced as live owners. The legacy channel metadata archived flag still has an existing composed-hook exit gap (successful archived response remains pending); this flag differs from forum opener tags, and its absence from current production write paths does not establish absence of historical values. Initial CI tests 39/55 failures retain unknown causes despite the old-head rerun passing. No related test thresholds were relaxed. Gener approved the final visual and risk package; no deployment is included.

## Checklist

- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...
