### PR TITLE
fix(web): recover message menu touch modality

### DIFF
--- a/src/web/src/components/community/messages/message.render.test.ts
+++ b/src/web/src/components/community/messages/message.render.test.ts
@@ -877,6 +877,138 @@ describe("Message reaction picker", () => {
 })
 
 describe("Message touch action menu", () => {
+  const findMenuRow = (renderer: TestRenderer.ReactTestRenderer) => renderer.root.find(
+    (node) => typeof node.props.className === "string"
+      && node.props.className.includes("group relative -mx-2"),
+  )
+  const findControlledTouchMenu = (renderer: TestRenderer.ReactTestRenderer) => (
+    renderer.root.findAllByType("mock-dropdown-menu")
+      .find((node) => typeof node.props.open === "boolean")
+  )
+
+  it("recovers the same row from mouse input to a real touch tap and back", async () => {
+    vi.stubGlobal("window", { getSelection: () => null })
+    let renderer: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(makeTree({
+        m: baseMsg(),
+        hoverCapable: false,
+        onOpenThread: vi.fn(),
+        onCopy: vi.fn(),
+      }), { createNodeMock: () => genericMock })
+    })
+    const ownedTarget = { closest: () => null, matches: () => false }
+    const currentTarget = {
+      contains: (target: unknown) => target === ownedTarget,
+    }
+
+    let row = findMenuRow(renderer!)
+    act(() => row.props.onPointerEnter({
+      target: ownedTarget,
+      currentTarget,
+      nativeEvent: { type: "pointerenter", pointerType: "mouse" },
+    }))
+    row = findMenuRow(renderer!)
+    expect(row.props["data-slot"]).toBe("context-menu-trigger")
+    expect(row.props.onClick).toBeUndefined()
+
+    act(() => row.props.onPointerDownCapture({
+      button: 0,
+      target: ownedTarget,
+      currentTarget,
+      nativeEvent: { type: "pointerdown", pointerType: "mouse" },
+    }))
+    act(() => row.props.onClickCapture({
+      target: ownedTarget,
+      currentTarget,
+      nativeEvent: { type: "click" },
+    }))
+    expect(findControlledTouchMenu(renderer!)).toBeUndefined()
+
+    row = findMenuRow(renderer!)
+    act(() => row.props.onPointerDownCapture({
+      button: 0,
+      target: ownedTarget,
+      currentTarget,
+      nativeEvent: { type: "pointerdown", pointerType: "touch" },
+    }))
+    row = findMenuRow(renderer!)
+    expect(row.props["data-slot"]).toBeUndefined()
+    expect(row.props.onClick).toBeTypeOf("function")
+    expect(renderer!.root.findAllByProps({ "data-slot": "dropdown-menu-trigger" })
+      .filter((node) => node.props["aria-hidden"] === true)).toHaveLength(1)
+    expect(renderer!.root.findAllByProps({ "data-slot": "context-menu-trigger" }))
+      .toHaveLength(0)
+
+    act(() => row.props.onTouchStart({ target: ownedTarget, currentTarget }))
+    act(() => row.props.onTouchEnd({ target: ownedTarget, currentTarget }))
+    await act(async () => {
+      row.props.onClick({
+        clientX: 271,
+        clientY: 603,
+        target: ownedTarget,
+        currentTarget,
+        nativeEvent: { composedPath: () => [ownedTarget] },
+      })
+    })
+    expect(findControlledTouchMenu(renderer!)?.props.open).toBe(true)
+
+    act(() => findControlledTouchMenu(renderer!)?.props.onOpenChange(false))
+    row = findMenuRow(renderer!)
+    act(() => row.props.onPointerDownCapture({
+      button: 2,
+      target: ownedTarget,
+      currentTarget,
+      nativeEvent: { type: "pointerdown", pointerType: "mouse" },
+    }))
+    row = findMenuRow(renderer!)
+    expect(row.props["data-slot"]).toBe("context-menu-trigger")
+    expect(renderer!.root.findAllByProps({ "data-slot": "dropdown-menu-trigger" }))
+      .toHaveLength(1)
+  })
+
+  it("uses the touch menu for a concrete body tap on a hover-capable hybrid", async () => {
+    vi.stubGlobal("window", { getSelection: () => null })
+    let renderer: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(makeTree({
+        m: baseMsg(),
+        hoverCapable: true,
+        onOpenThread: vi.fn(),
+        onCopy: vi.fn(),
+      }), { createNodeMock: () => genericMock })
+    })
+    const ownedTarget = { closest: () => null, matches: () => false }
+    const currentTarget = {
+      contains: (target: unknown) => target === ownedTarget,
+    }
+
+    let row = findMenuRow(renderer!)
+    act(() => row.props.onPointerDownCapture({
+      button: 0,
+      target: ownedTarget,
+      currentTarget,
+      nativeEvent: { type: "pointerdown", pointerType: "touch" },
+    }))
+    row = findMenuRow(renderer!)
+    expect(row.props.onClick).toBeTypeOf("function")
+    expect(renderer!.root.findAllByProps({ "data-slot": "dropdown-menu-trigger" }))
+      .toHaveLength(1)
+
+    act(() => row.props.onTouchStart({ target: ownedTarget, currentTarget }))
+    act(() => row.props.onTouchEnd({ target: ownedTarget, currentTarget }))
+    await act(async () => {
+      row.props.onClick({
+        clientX: 44,
+        clientY: 88,
+        target: ownedTarget,
+        currentTarget,
+        nativeEvent: { composedPath: () => [ownedTarget] },
+      })
+    })
+    expect(findControlledTouchMenu(renderer!)?.props.open).toBe(true)
+  })
+
   it("swipes right past threshold into the existing reply callback exactly once", async () => {
     vi.stubGlobal("window", { getSelection: () => null })
     const vibrate = vi.fn()

--- a/src/web/src/components/community/messages/message.tsx
+++ b/src/web/src/components/community/messages/message.tsx
@@ -238,7 +238,7 @@ function MessageImpl({
   const [touchMenuOpen, setTouchMenuOpen] = useState(false)
   const [touchMenuAnchor, setTouchMenuAnchor] = useState<ReturnType<typeof createMessageMenuPointAnchor> | null>(null)
   const [linkTarget, setLinkTarget] = useState<MessageExternalLinkTarget | null>(null)
-  const [desktopMenuInputSeen, setDesktopMenuInputSeen] = useState(false)
+  const [menuInputModality, setMenuInputModality] = useState<"desktop" | "touch" | null>(null)
   const linkPointerRef = useRef<{
     href: string
     pointerType: string | null
@@ -306,7 +306,9 @@ function MessageImpl({
   const showMenu = hasMessageMenu(menuHandlers)
   const interactive = !compact && !m.failed && showMenu
   const touchInputCapable = !hoverCapable
-  const touchFallbackActive = !desktopMenuInputSeen && touchInputCapable
+  const desktopMenuInputActive = menuInputModality === "desktop"
+  const touchFallbackActive = menuInputModality === "touch"
+    || (!desktopMenuInputActive && touchInputCapable)
   // A hybrid device can alternate between mouse and touch. Switching the menu
   // shell after a mouse gesture must not remove the row's touch swipe handler.
   const swipeReplyEnabled = interactive && touchInputCapable && !selectMode && !!onReply
@@ -334,7 +336,7 @@ function MessageImpl({
           // target that was just restored into the row.
           const activeElement = typeof document === "undefined" ? null : document.activeElement
           if (shouldAdoptDesktopMenuInput(pointerType, event.currentTarget, activeElement)) {
-            setDesktopMenuInputSeen(true)
+            setMenuInputModality("desktop")
           }
           activateLinkOrOverlays?.(event)
         } else if (hoverCapable) {
@@ -357,7 +359,7 @@ function MessageImpl({
           return
         }
         keyboardLinkActivationRef.current = false
-        setDesktopMenuInputSeen(true)
+        setMenuInputModality("desktop")
         activateLinkOrOverlays?.(event)
       }
     : undefined
@@ -406,8 +408,15 @@ function MessageImpl({
             if (!messageEventBelongsToRow(event.target, event.currentTarget)) return
             keyboardLinkActivationRef.current = false
             const target = messageExternalLinkTargetFromEventTarget(event.target)
+            const pointerType = messageLinkPointerType(event.nativeEvent)
+            if (shouldActivateMessageOverlays(event.target)) {
+              if (pointerType === "mouse") setMenuInputModality("desktop")
+              else if (pointerType === "touch" || pointerType === "pen") {
+                setMenuInputModality("touch")
+              }
+            }
             linkPointerRef.current = target && event.button === 0
-              ? { href: target.href, pointerType: messageLinkPointerType(event.nativeEvent) }
+              ? { href: target.href, pointerType }
               : null
           }
         : undefined}
@@ -559,7 +568,7 @@ function MessageImpl({
               clickPointerType: messageLinkPointerType(event.nativeEvent),
               capturedPointerType: capturedPointer,
               hoverCapable,
-              desktopInputSeen: desktopMenuInputSeen || keyboardInputSeen,
+              desktopInputSeen: desktopMenuInputActive || keyboardInputSeen,
             })) return
 
             event.preventDefault()

--- a/src/web/src/test/e2e-ui/39-mobile-message-interactions.spec.ts
+++ b/src/web/src/test/e2e-ui/39-mobile-message-interactions.spec.ts
@@ -171,6 +171,31 @@ async function dispatchCancelledAvatarPress(
   await target.dispatchEvent("click", { clientX: point.x, clientY: point.y })
 }
 
+async function expectTouchActionMenu(
+  page: Page,
+  message: Locator,
+  actionName: string,
+): Promise<Locator> {
+  const action = page.getByRole("menuitem", { name: actionName })
+  await expect.poll(async () => ({
+    menuVisible: await action.isVisible(),
+    touchTriggerCount: await message.locator(
+      '[data-slot="dropdown-menu-trigger"][aria-hidden="true"]',
+    ).count(),
+    contextTriggerCount: await message.locator(
+      '[data-slot="context-menu-trigger"]',
+    ).count(),
+  }), {
+    timeout: 3_000,
+    message: "touch action menu state after same-row mouse then touch input",
+  }).toEqual({
+    menuVisible: true,
+    touchTriggerCount: 1,
+    contextTriggerCount: 0,
+  })
+  return action
+}
+
 async function latestSeq(page: Page, channelId: string): Promise<number> {
   const response = await page.request.get(`/api/community/channels/${channelId}/messages`)
   expect(response.ok()).toBe(true)
@@ -300,6 +325,39 @@ async function expectRetainedMountGets(
   expect(tracker.abortedMessageGets).toBeLessThanOrEqual(1)
   expect(tracker.failures).toEqual([])
 }
+
+test("same message row recovers its action menu from mouse to touch", async ({ asUser }) => {
+  const stamp = Date.now()
+  const serverId = await seedServer("alice", `Pointer-modality-${stamp}`)
+  const channelId = await seedChannel("alice", serverId, "pointer-modality")
+  const messageId = await seedMessage("alice", channelId, `pointer modality ${stamp}`)
+  const alice = await asUser("alice", { hasTouch: true })
+  await installInputCapability(alice.page, false)
+  await alice.page.setViewportSize({ width: 390, height: 844 })
+  const aliceProxy = await proxyCommunityWebSockets(alice.context)
+  await gotoAfterUserWsAuth(alice.page, `/c/channels/${serverId}/${channelId}`)
+  await ignoreNextDevToolsPointerCapture(alice.page)
+
+  const message = alice.page.getByTestId(tid.message(messageId))
+  const body = message.getByText(`pointer modality ${stamp}`, { exact: true })
+  await expect(body).toBeVisible()
+  const beforeSeq = await latestSeq(alice.page, channelId)
+  const messageCreatesBefore = aliceProxy.frames.filter((frame) => (
+    communityFrameEvents(frame).some((event) => event.type === "community:message.create")
+  )).length
+
+  await body.click()
+  await expect(alice.page.getByRole("menuitem")).toHaveCount(0, { timeout: 3_000 })
+  await body.tap()
+  const copyAction = await expectTouchActionMenu(alice.page, message, "Copy")
+  await alice.page.keyboard.press("Escape")
+  await expect(copyAction).toBeHidden({ timeout: 3_000 })
+
+  expect(await latestSeq(alice.page, channelId)).toBe(beforeSeq)
+  expect(aliceProxy.frames.filter((frame) => (
+    communityFrameEvents(frame).some((event) => event.type === "community:message.create")
+  ))).toHaveLength(messageCreatesBefore)
+})
 
 test("mobile reply, avatar mention, and typing rail keep exact backend and WS identity", async ({ asUser }) => {
   test.setTimeout(240_000)
@@ -610,7 +668,12 @@ test("mobile reply, avatar mention, and typing rail keep exact backend and WS id
   await expect(alice.page.getByTestId(tid.typingIndicator)).toBeVisible({ timeout: 4_000 })
   const finalChannelMessage = alice.page.getByTestId(tid.message(typingWsReadyId))
   await finalChannelMessage.getByText(`typing ws ready ${stamp}`, { exact: true }).tap()
-  await alice.page.getByRole("menuitem", { name: "Share as Image" }).click()
+  const shareAsImage = await expectTouchActionMenu(
+    alice.page,
+    finalChannelMessage,
+    "Share as Image",
+  )
+  await shareAsImage.click({ timeout: 3_000 })
   await expect(alice.page.getByTestId(tid.messageSelectionToolbar)).toBeVisible()
   await expect(alice.page.locator("[data-selection-typing-fit]"))
     .toHaveAttribute("data-selection-typing-fit", /^(visible|hidden)$/)


### PR DESCRIPTION
# Why we need this PR?

A message row permanently selected the desktop context-menu shell after seeing mouse input. On hybrid/mobile automation, a later real touch tap on the same row could no longer open the touch action menu and the downstream action click consumed the long E2E timeout.

## What changed

- Track the row's latest concrete menu-input modality so touch/pen can recover after mouse and mouse/keyboard can switch back.
- Preserve the capability-derived initial shell, swipe gating, nested-control/link behavior, and permission-filtered actions.
- Add deterministic render coverage for mouse → touch → mouse and hover-capable hybrid touch input.
- Add a real Playwright mouse-click → touch-tap regression with a three-second state-bearing menu assertion and no message-write side effect.
- Apply the same fast menu-state assertion before the existing Share as Image action.

## Verification

- Independent `/c` QA: PASS on pre-commit diff SHA-256 `126eefac7649823c3a45e65b74c0ba9e840424e2b23b4f3ed80589979c28b6ac`
- Full mobile interaction E2E: 3/3 passed
- Web tests: 774 files / 7,104 tests passed
- Root `pnpm typecheck`, `pnpm lint`, `pnpm test`, typegrep checks, knip, and `git diff --check`: passed
- Commit hooks: passed

## Checklist

- [x] Tests added/updated as needed
- [x] All local CI-equivalent checks pass
- [x] PR targets `main`

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other
