### PR TITLE
ci(e2e): reuse builds and stabilize ui shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -655,9 +655,68 @@ jobs:
       - working-directory: src/web
         run: npx @lhci/cli autorun --config=lighthouserc.json && node scripts/print-lighthouse-scores.mjs
 
+  ui-e2e-build:
+    name: UI Playwright E2E build
+    needs: scope
+    outputs:
+      artifact_name: ${{ steps.artifact_identity.outputs.artifact_name }}
+      artifact_attempt: ${{ steps.artifact_identity.outputs.artifact_attempt }}
+    if: needs.scope.outputs.run_ui_e2e == 'true' && github.event_name != 'push'
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ fromJSON(needs.scope.outputs.e2e_matrix).include[0].image }}
+      options: --init --ipc=host --user 1001
+    defaults:
+      run:
+        shell: bash
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Validate execution plan
+        env:
+          CI_EXECUTION_PLAN: ${{ needs.scope.outputs.execution_plan }}
+          CI_PLAN_HASH: ${{ needs.scope.outputs.plan_hash }}
+          CI_PROJECTION_NAME: e2e_matrix
+          CI_PROJECTION_VALUE: ${{ needs.scope.outputs.e2e_matrix }}
+        run: node scripts/ci/validate-execution-plan.mjs
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Record build artifact identity
+        id: artifact_identity
+        run: |
+          printf 'artifact_name=ui-e2e-build-%s-%s\n' "${{ github.run_id }}" "${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
+          printf 'artifact_attempt=%s\n' "${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
+      - run: printf 'BETTER_AUTH_SECRET=ci-e2e-ui-secret\nBETTER_AUTH_URL=http://localhost:3000\nDEVICE_CLIENT_IDS=e2e-test-client\nENCRYPTION_KEY=ci-e2e-encryption-key-32chars!!\nDEV_WS_DO_URL=http://localhost:3000\nNODE_ENV=development\n' > src/web/.dev.vars
+      - name: Build Web and Blog OpenNext workers
+        env:
+          NEXT_PUBLIC_WS_DO_PORT: "3000"
+        run: |
+          pnpm --filter @alook/web exec opennextjs-cloudflare build
+          pnpm --filter @alook/web build:blog
+      - name: Create exact-head build artifact
+        run: |
+          node scripts/ci/e2e-build-artifact.mjs create \
+            --directory .ci/ui-e2e-build \
+            --run-id "${{ github.run_id }}" \
+            --attempt "${{ steps.artifact_identity.outputs.artifact_attempt }}" \
+            --head-sha "${{ github.sha }}"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ steps.artifact_identity.outputs.artifact_name }}
+          path: |
+            .ci/ui-e2e-build/ui-e2e-build.tgz
+            .ci/ui-e2e-build/ui-e2e-build-manifest.json
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 7
+
   e2e-ui:
     name: UI Playwright E2E (${{ matrix.shard }}/${{ matrix.total }})
-    needs: scope
+    needs: [scope, ui-e2e-build]
     if: needs.scope.outputs.run_ui_e2e == 'true' && github.event_name != 'push'
     runs-on: ubuntu-latest
     container:
@@ -699,7 +758,19 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: printf 'BETTER_AUTH_SECRET=ci-e2e-ui-secret\nBETTER_AUTH_URL=http://localhost:3000\nDEVICE_CLIENT_IDS=e2e-test-client\nENCRYPTION_KEY=ci-e2e-encryption-key-32chars!!\nDEV_WS_DO_URL=http://localhost:3000\nNODE_ENV=development\n' > src/web/.dev.vars
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ needs.ui-e2e-build.outputs.artifact_name }}
+          path: .ci/ui-e2e-build
+      - name: Verify exact-head build artifact
+        run: |
+          node scripts/ci/e2e-build-artifact.mjs verify \
+            --directory .ci/ui-e2e-build \
+            --run-id "${{ github.run_id }}" \
+            --attempt "${{ needs.ui-e2e-build.outputs.artifact_attempt }}" \
+            --head-sha "${{ github.sha }}"
       - env:
+          ALOOK_E2E_PREBUILT: "1"
           E2E_SPECS: ${{ toJSON(matrix.specs) }}
         run: |
           mapfile -t specs < <(node -e 'for (const spec of JSON.parse(process.env.E2E_SPECS)) console.log(spec)')
@@ -819,13 +890,14 @@ jobs:
   ui-e2e-gate:
     name: UI E2E Gate
     if: always()
-    needs: [scope, e2e-ui, merge-reports]
+    needs: [scope, ui-e2e-build, e2e-ui, merge-reports]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
       CI_GATE_RESULTS: >-
         [
           {"name":"scope","expected":true,"result":"${{ needs.scope.result }}"},
+          {"name":"ui-e2e-build","expected":${{ needs.scope.outputs.run_ui_e2e == 'true' && github.event_name != 'push' }},"result":"${{ needs.ui-e2e-build.result }}"},
           {"name":"e2e-ui","expected":${{ needs.scope.outputs.run_ui_e2e == 'true' && github.event_name != 'push' }},"result":"${{ needs.e2e-ui.result }}"},
           {"name":"merge-reports","expected":${{ needs.scope.outputs.run_ui_e2e == 'true' && github.event_name != 'push' }},"result":"${{ needs.merge-reports.result }}"}
         ]

--- a/scripts/ci/e2e-build-artifact.mjs
+++ b/scripts/ci/e2e-build-artifact.mjs
@@ -1,13 +1,17 @@
 import { createHash } from "node:crypto"
 import {
+  closeSync,
   existsSync,
   mkdirSync,
+  mkdtempSync,
+  openSync,
   readFileSync,
   rmSync,
   statSync,
   writeFileSync,
 } from "node:fs"
-import { resolve, sep } from "node:path"
+import { tmpdir } from "node:os"
+import { join, resolve, sep } from "node:path"
 import { spawnSync } from "node:child_process"
 import { fileURLToPath } from "node:url"
 
@@ -60,12 +64,37 @@ export function assertBuildOutputs(root) {
 }
 
 function runTar(args) {
-  const result = spawnSync("tar", args, { encoding: "utf8" })
-  if (result.status !== 0) {
-    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.status}`
-    throw new Error(`tar failed: ${detail}`)
+  const scratch = mkdtempSync(join(tmpdir(), "alook-ui-e2e-tar-"))
+  const stdoutPath = join(scratch, "stdout")
+  const stderrPath = join(scratch, "stderr")
+  let stdoutFd
+  let stderrFd
+  try {
+    stdoutFd = openSync(stdoutPath, "w")
+    stderrFd = openSync(stderrPath, "w")
+    const result = spawnSync("tar", args, {
+      stdio: ["ignore", stdoutFd, stderrFd],
+    })
+    closeSync(stdoutFd)
+    stdoutFd = undefined
+    closeSync(stderrFd)
+    stderrFd = undefined
+
+    if (result.error) throw new Error(`tar failed to start: ${result.error.message}`)
+    const detail = readFileSync(stderrPath, "utf8").trim().slice(0, 4_096)
+    if (result.signal) {
+      throw new Error(`tar terminated by signal ${result.signal}${detail ? `: ${detail}` : ""}`)
+    }
+    if (result.status === null) throw new Error("tar failed without an exit status")
+    if (result.status !== 0) {
+      throw new Error(`tar failed with exit ${String(result.status)}${detail ? `: ${detail}` : ""}`)
+    }
+    return readFileSync(stdoutPath, "utf8")
+  } finally {
+    if (stdoutFd !== undefined) closeSync(stdoutFd)
+    if (stderrFd !== undefined) closeSync(stderrFd)
+    rmSync(scratch, { recursive: true, force: true })
   }
-  return result.stdout
 }
 
 function normalizedArchiveMember(value) {

--- a/scripts/ci/e2e-build-artifact.mjs
+++ b/scripts/ci/e2e-build-artifact.mjs
@@ -1,0 +1,244 @@
+import { createHash } from "node:crypto"
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs"
+import { resolve, sep } from "node:path"
+import { spawnSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+
+export const BUILD_ARTIFACT_VERSION = 1
+export const BUILD_ARCHIVE_NAME = "ui-e2e-build.tgz"
+export const BUILD_MANIFEST_NAME = "ui-e2e-build-manifest.json"
+export const BUILD_OUTPUT_ROOTS = [
+  "src/web/.open-next",
+  "src/web/blog/.open-next",
+]
+export const BUILD_ENTRYPOINTS = BUILD_OUTPUT_ROOTS.map((root) => `${root}/worker.js`)
+
+function requiredString(value, label) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label} is required`)
+  }
+  return value
+}
+
+function positiveInteger(value, label) {
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${label} must be a positive integer`)
+  }
+  return parsed
+}
+
+function exactHeadSha(value) {
+  const sha = requiredString(value, "head SHA")
+  if (!/^[0-9a-f]{40}$/.test(sha)) {
+    throw new Error("head SHA must be an exact lowercase 40-character commit SHA")
+  }
+  return sha
+}
+
+export function sha256File(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex")
+}
+
+function assertRegularFile(path, label) {
+  if (!existsSync(path) || !statSync(path).isFile()) {
+    throw new Error(`${label} is missing: ${path}`)
+  }
+}
+
+export function assertBuildOutputs(root) {
+  for (const entrypoint of BUILD_ENTRYPOINTS) {
+    assertRegularFile(resolve(root, entrypoint), "OpenNext worker entrypoint")
+  }
+}
+
+function runTar(args) {
+  const result = spawnSync("tar", args, { encoding: "utf8" })
+  if (result.status !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.status}`
+    throw new Error(`tar failed: ${detail}`)
+  }
+  return result.stdout
+}
+
+function normalizedArchiveMember(value) {
+  return value.endsWith("/") ? value.slice(0, -1) : value
+}
+
+export function verifyArchiveMembers(archive) {
+  const members = runTar(["-tzf", archive])
+    .split("\n")
+    .filter(Boolean)
+    .map(normalizedArchiveMember)
+  if (members.length === 0) throw new Error("build archive is empty")
+  for (const member of members) {
+    const segments = member.split("/")
+    const allowed = BUILD_OUTPUT_ROOTS.some(
+      (root) => member === root || member.startsWith(`${root}/`),
+    )
+    if (
+      member.startsWith("/")
+      || member.includes("\\")
+      || segments.includes("..")
+      || !allowed
+    ) {
+      throw new Error(`build archive contains an unexpected member: ${member}`)
+    }
+  }
+  for (const entrypoint of BUILD_ENTRYPOINTS) {
+    if (!members.includes(entrypoint)) {
+      throw new Error(`build archive is missing OpenNext worker entrypoint: ${entrypoint}`)
+    }
+  }
+  return members
+}
+
+function exactManifestKeys(manifest) {
+  const expected = [
+    "archiveSha256",
+    "attempt",
+    "headSha",
+    "lockfileSha256",
+    "roots",
+    "runId",
+    "version",
+  ]
+  const actual = Object.keys(manifest).sort()
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    throw new Error("build manifest fields do not match the exact contract")
+  }
+}
+
+function artifactPaths(root, directory) {
+  const repositoryRoot = resolve(root)
+  const artifactDirectory = resolve(repositoryRoot, directory)
+  if (!artifactDirectory.startsWith(`${repositoryRoot}${sep}`)) {
+    throw new Error("artifact directory must be inside the repository root")
+  }
+  return {
+    artifactDirectory,
+    archive: resolve(artifactDirectory, BUILD_ARCHIVE_NAME),
+    manifest: resolve(artifactDirectory, BUILD_MANIFEST_NAME),
+  }
+}
+
+export function createBuildArtifact({ root, directory, runId, attempt, headSha }) {
+  const repositoryRoot = resolve(root)
+  const identity = {
+    runId: requiredString(String(runId ?? ""), "run ID"),
+    attempt: positiveInteger(attempt, "attempt"),
+    headSha: exactHeadSha(headSha),
+  }
+  const lockfile = resolve(repositoryRoot, "pnpm-lock.yaml")
+  assertRegularFile(lockfile, "pnpm lockfile")
+  assertBuildOutputs(repositoryRoot)
+
+  const paths = artifactPaths(repositoryRoot, directory)
+  mkdirSync(paths.artifactDirectory, { recursive: true })
+  rmSync(paths.archive, { force: true })
+  rmSync(paths.manifest, { force: true })
+  runTar(["-czf", paths.archive, "-C", repositoryRoot, ...BUILD_OUTPUT_ROOTS])
+  verifyArchiveMembers(paths.archive)
+
+  const manifest = {
+    version: BUILD_ARTIFACT_VERSION,
+    ...identity,
+    lockfileSha256: sha256File(lockfile),
+    archiveSha256: sha256File(paths.archive),
+    roots: BUILD_OUTPUT_ROOTS,
+  }
+  writeFileSync(paths.manifest, `${JSON.stringify(manifest, null, 2)}\n`)
+  return { ...paths, manifestData: manifest }
+}
+
+function assertManifestDigest(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/.test(value)) {
+    throw new Error(`${label} must be a lowercase SHA-256 digest`)
+  }
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual !== expected) {
+    throw new Error(`${label} mismatch: expected ${expected}, received ${actual}`)
+  }
+}
+
+export function verifyBuildArtifact({ root, directory, runId, attempt, headSha }) {
+  const repositoryRoot = resolve(root)
+  const paths = artifactPaths(repositoryRoot, directory)
+  assertRegularFile(paths.archive, "build archive")
+  assertRegularFile(paths.manifest, "build manifest")
+
+  let manifest
+  try {
+    manifest = JSON.parse(readFileSync(paths.manifest, "utf8"))
+  } catch (error) {
+    throw new Error(`build manifest is invalid JSON: ${String(error)}`)
+  }
+  if (typeof manifest !== "object" || manifest === null || Array.isArray(manifest)) {
+    throw new Error("build manifest must be an object")
+  }
+  exactManifestKeys(manifest)
+  assertEqual(manifest.version, BUILD_ARTIFACT_VERSION, "build manifest version")
+  assertEqual(manifest.runId, requiredString(String(runId ?? ""), "run ID"), "build run ID")
+  assertEqual(manifest.attempt, positiveInteger(attempt, "attempt"), "build attempt")
+  assertEqual(manifest.headSha, exactHeadSha(headSha), "build head SHA")
+  if (
+    !Array.isArray(manifest.roots)
+    || manifest.roots.length !== BUILD_OUTPUT_ROOTS.length
+    || manifest.roots.some((value, index) => value !== BUILD_OUTPUT_ROOTS[index])
+  ) {
+    throw new Error("build output roots mismatch")
+  }
+  assertManifestDigest(manifest.lockfileSha256, "lockfile digest")
+  assertManifestDigest(manifest.archiveSha256, "archive digest")
+
+  const lockfile = resolve(repositoryRoot, "pnpm-lock.yaml")
+  assertRegularFile(lockfile, "pnpm lockfile")
+  assertEqual(sha256File(lockfile), manifest.lockfileSha256, "build lockfile SHA-256")
+  assertEqual(sha256File(paths.archive), manifest.archiveSha256, "build archive SHA-256")
+  verifyArchiveMembers(paths.archive)
+
+  for (const outputRoot of BUILD_OUTPUT_ROOTS) {
+    rmSync(resolve(repositoryRoot, outputRoot), { recursive: true, force: true })
+  }
+  runTar(["-xzf", paths.archive, "-C", repositoryRoot])
+  assertBuildOutputs(repositoryRoot)
+  return manifest
+}
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv
+  const args = { command }
+  for (let index = 0; index < rest.length; index += 2) {
+    const key = rest[index]?.replace(/^--/, "").replace(/-([a-z])/g, (_, letter) => letter.toUpperCase())
+    if (!key || rest[index + 1] === undefined) throw new Error(`invalid argument: ${rest[index] ?? ""}`)
+    args[key] = rest[index + 1]
+  }
+  return args
+}
+
+export function runCli(argv) {
+  const args = parseArgs(argv)
+  const options = {
+    root: args.root ?? process.cwd(),
+    directory: args.directory ?? ".ci/ui-e2e-build",
+    runId: args.runId,
+    attempt: args.attempt,
+    headSha: args.headSha,
+  }
+  if (args.command === "create") return createBuildArtifact(options)
+  if (args.command === "verify") return verifyBuildArtifact(options)
+  throw new Error("expected create or verify command")
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  runCli(process.argv.slice(2))
+}

--- a/scripts/ci/e2e-build-artifact.test.ts
+++ b/scripts/ci/e2e-build-artifact.test.ts
@@ -16,6 +16,7 @@ import {
   BUILD_OUTPUT_ROOTS,
   createBuildArtifact,
   runCli,
+  verifyArchiveMembers,
   verifyBuildArtifact,
 } from "./e2e-build-artifact.mjs"
 
@@ -77,6 +78,45 @@ describe("UI E2E build artifact", () => {
     }
   })
 
+  it("verifies a real archive listing larger than spawnSync's default buffer", () => {
+    const artifact = fixture()
+    const listingRoot = join(
+      artifact.root,
+      BUILD_OUTPUT_ROOTS[0],
+      "assets",
+      "large-listing",
+    )
+    mkdirSync(listingRoot, { recursive: true })
+    for (let index = 0; index < 5_200; index += 1) {
+      writeFileSync(
+        join(listingRoot, `${String(index).padStart(5, "0")}-${"x".repeat(180)}.txt`),
+        "",
+      )
+    }
+    const large = createBuildArtifact({
+      root: artifact.root,
+      directory: ".ci/large-build",
+      runId: "123",
+      attempt: 2,
+      headSha: HEAD_SHA,
+    })
+    const listing = spawnSync("tar", ["-tzf", large.archive], {
+      encoding: "utf8",
+      maxBuffer: 4 * 1024 * 1024,
+    })
+    expect(listing.status).toBe(0)
+    expect(Buffer.byteLength(listing.stdout)).toBeGreaterThan(1024 * 1024)
+
+    removeBuildOutputs(artifact.root)
+    expect(() => verifyBuildArtifact({
+      root: artifact.root,
+      directory: ".ci/large-build",
+      runId: "123",
+      attempt: 2,
+      headSha: HEAD_SHA,
+    })).not.toThrow()
+  })
+
   it.each([
     ["run ID", { runId: "124", attempt: 2, headSha: HEAD_SHA }],
     ["attempt", { runId: "123", attempt: 3, headSha: HEAD_SHA }],
@@ -115,6 +155,22 @@ describe("UI E2E build artifact", () => {
       attempt: 2,
       headSha: HEAD_SHA,
     })).toThrow("archive SHA-256 mismatch")
+  })
+
+  it("reports tar child launch and exit failures explicitly", () => {
+    const artifact = fixture()
+    const corruptArchive = join(artifact.root, "corrupt.tgz")
+    writeFileSync(corruptArchive, "not a tar archive")
+    expect(() => verifyArchiveMembers(corruptArchive)).toThrow(/tar failed with exit [1-9]\d*/)
+
+    const originalPath = process.env.PATH
+    process.env.PATH = join(artifact.root, "missing-bin")
+    try {
+      expect(() => verifyArchiveMembers(artifact.archive)).toThrow("tar failed to start:")
+    } finally {
+      if (originalPath === undefined) delete process.env.PATH
+      else process.env.PATH = originalPath
+    }
   })
 
   it("fails closed when either artifact file is missing", () => {

--- a/scripts/ci/e2e-build-artifact.test.ts
+++ b/scripts/ci/e2e-build-artifact.test.ts
@@ -9,7 +9,8 @@ import {
 } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { afterEach, describe, expect, it } from "vitest"
+import { fileURLToPath } from "node:url"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import {
   BUILD_ARCHIVE_NAME,
   BUILD_MANIFEST_NAME,
@@ -51,6 +52,23 @@ function removeBuildOutputs(root: string) {
 }
 
 describe("UI E2E build artifact", () => {
+  it("rejects incomplete create identities before reading the filesystem", () => {
+    const options = {
+      root: ".",
+      directory: ".ci/ui-e2e-build",
+      runId: "123",
+      attempt: 2,
+      headSha: HEAD_SHA,
+    }
+
+    expect(() => createBuildArtifact({ ...options, runId: "" }))
+      .toThrow("run ID is required")
+    expect(() => createBuildArtifact({ ...options, attempt: 0 }))
+      .toThrow("attempt must be a positive integer")
+    expect(() => createBuildArtifact({ ...options, headSha: "A".repeat(40) }))
+      .toThrow("head SHA must be an exact lowercase 40-character commit SHA")
+  })
+
   it("round-trips both hidden OpenNext trees with exact run identity and digests", () => {
     const artifact = fixture()
     removeBuildOutputs(artifact.root)
@@ -115,7 +133,7 @@ describe("UI E2E build artifact", () => {
       attempt: 2,
       headSha: HEAD_SHA,
     })).not.toThrow()
-  })
+  }, 15_000)
 
   it.each([
     ["run ID", { runId: "124", attempt: 2, headSha: HEAD_SHA }],
@@ -157,13 +175,25 @@ describe("UI E2E build artifact", () => {
     })).toThrow("archive SHA-256 mismatch")
   })
 
-  it("reports tar child launch and exit failures explicitly", () => {
+  it("reports tar child launch, signal, and exit failures explicitly", () => {
     const artifact = fixture()
     const corruptArchive = join(artifact.root, "corrupt.tgz")
     writeFileSync(corruptArchive, "not a tar archive")
     expect(() => verifyArchiveMembers(corruptArchive)).toThrow(/tar failed with exit [1-9]\d*/)
 
     const originalPath = process.env.PATH
+    const signalBin = join(artifact.root, "signal-bin")
+    mkdirSync(signalBin)
+    writeFileSync(join(signalBin, "tar"), "#!/bin/sh\nkill -TERM $$\n", { mode: 0o755 })
+    process.env.PATH = signalBin
+    try {
+      expect(() => verifyArchiveMembers(artifact.archive))
+        .toThrow("tar terminated by signal SIGTERM")
+    } finally {
+      if (originalPath === undefined) delete process.env.PATH
+      else process.env.PATH = originalPath
+    }
+
     process.env.PATH = join(artifact.root, "missing-bin")
     try {
       expect(() => verifyArchiveMembers(artifact.archive)).toThrow("tar failed to start:")
@@ -308,6 +338,24 @@ describe("UI E2E build artifact", () => {
     expect(() => runCli(["unknown"])).toThrow("expected create or verify")
     expect(artifact.archive).toBe(join(artifact.artifactDirectory, BUILD_ARCHIVE_NAME))
     expect(artifact.manifest).toBe(join(artifact.artifactDirectory, BUILD_MANIFEST_NAME))
+  })
+
+  it("executes the direct CLI entrypoint", async () => {
+    const cliPath = fileURLToPath(new URL("./e2e-build-artifact.mjs", import.meta.url))
+    const result = spawnSync(process.execPath, [cliPath, "unknown"], { encoding: "utf8" })
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain("expected create or verify command")
+
+    const originalArgv = [...process.argv]
+    process.argv.splice(0, process.argv.length, process.execPath, cliPath, "unknown")
+    vi.resetModules()
+    try {
+      await expect(import("./e2e-build-artifact.mjs"))
+        .rejects.toThrow("expected create or verify command")
+    } finally {
+      process.argv.splice(0, process.argv.length, ...originalArgv)
+    }
   })
 
   it("refuses artifact directories outside the repository", () => {

--- a/scripts/ci/e2e-build-artifact.test.ts
+++ b/scripts/ci/e2e-build-artifact.test.ts
@@ -1,0 +1,267 @@
+import { createHash } from "node:crypto"
+import { spawnSync } from "node:child_process"
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import {
+  BUILD_ARCHIVE_NAME,
+  BUILD_MANIFEST_NAME,
+  BUILD_OUTPUT_ROOTS,
+  createBuildArtifact,
+  runCli,
+  verifyBuildArtifact,
+} from "./e2e-build-artifact.mjs"
+
+const HEAD_SHA = "a".repeat(40)
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "alook-ui-e2e-build-"))
+  roots.push(root)
+  writeFileSync(join(root, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n")
+  for (const output of BUILD_OUTPUT_ROOTS) {
+    mkdirSync(join(root, output, "assets"), { recursive: true })
+    writeFileSync(join(root, output, "worker.js"), `export default ${JSON.stringify(output)}\n`)
+    writeFileSync(join(root, output, "assets", "asset.txt"), output)
+  }
+  const result = createBuildArtifact({
+    root,
+    directory: ".ci/ui-e2e-build",
+    runId: "123",
+    attempt: 2,
+    headSha: HEAD_SHA,
+  })
+  return { root, ...result }
+}
+
+function removeBuildOutputs(root: string) {
+  for (const output of BUILD_OUTPUT_ROOTS) rmSync(join(root, output), { recursive: true })
+}
+
+describe("UI E2E build artifact", () => {
+  it("round-trips both hidden OpenNext trees with exact run identity and digests", () => {
+    const artifact = fixture()
+    removeBuildOutputs(artifact.root)
+
+    const manifest = verifyBuildArtifact({
+      root: artifact.root,
+      directory: ".ci/ui-e2e-build",
+      runId: "123",
+      attempt: 2,
+      headSha: HEAD_SHA,
+    })
+
+    expect(manifest).toMatchObject({
+      version: 1,
+      runId: "123",
+      attempt: 2,
+      headSha: HEAD_SHA,
+      roots: BUILD_OUTPUT_ROOTS,
+    })
+    expect(manifest.lockfileSha256).toMatch(/^[0-9a-f]{64}$/)
+    expect(manifest.archiveSha256).toMatch(/^[0-9a-f]{64}$/)
+    for (const output of BUILD_OUTPUT_ROOTS) {
+      expect(readFileSync(join(artifact.root, output, "assets", "asset.txt"), "utf8"))
+        .toBe(output)
+    }
+  })
+
+  it.each([
+    ["run ID", { runId: "124", attempt: 2, headSha: HEAD_SHA }],
+    ["attempt", { runId: "123", attempt: 3, headSha: HEAD_SHA }],
+    ["head SHA", { runId: "123", attempt: 2, headSha: "b".repeat(40) }],
+  ])("rejects the wrong %s before extraction", (_, identity) => {
+    const artifact = fixture()
+    removeBuildOutputs(artifact.root)
+
+    expect(() => verifyBuildArtifact({
+      root: artifact.root,
+      directory: ".ci/ui-e2e-build",
+      ...identity,
+    })).toThrow("mismatch")
+    for (const output of BUILD_OUTPUT_ROOTS) {
+      expect(() => readFileSync(join(artifact.root, output, "worker.js"), "utf8")).toThrow()
+    }
+  })
+
+  it("rejects lockfile and archive corruption", () => {
+    const lockfileArtifact = fixture()
+    writeFileSync(join(lockfileArtifact.root, "pnpm-lock.yaml"), "changed\n")
+    expect(() => verifyBuildArtifact({
+      root: lockfileArtifact.root,
+      directory: ".ci/ui-e2e-build",
+      runId: "123",
+      attempt: 2,
+      headSha: HEAD_SHA,
+    })).toThrow("lockfile SHA-256 mismatch")
+
+    const archiveArtifact = fixture()
+    writeFileSync(archiveArtifact.archive, "corrupt")
+    expect(() => verifyBuildArtifact({
+      root: archiveArtifact.root,
+      directory: ".ci/ui-e2e-build",
+      runId: "123",
+      attempt: 2,
+      headSha: HEAD_SHA,
+    })).toThrow("archive SHA-256 mismatch")
+  })
+
+  it("fails closed when either artifact file is missing", () => {
+    const missingArchive = fixture()
+    rmSync(missingArchive.archive)
+    expect(() => verifyBuildArtifact({
+      root: missingArchive.root,
+      directory: ".ci/ui-e2e-build",
+      runId: "123",
+      attempt: 2,
+      headSha: HEAD_SHA,
+    })).toThrow("build archive is missing")
+
+    const missingManifest = fixture()
+    rmSync(missingManifest.manifest)
+    expect(() => verifyBuildArtifact({
+      root: missingManifest.root,
+      directory: ".ci/ui-e2e-build",
+      runId: "123",
+      attempt: 2,
+      headSha: HEAD_SHA,
+    })).toThrow("build manifest is missing")
+  })
+
+  it.each([
+    ["extra fields", (manifest: Record<string, unknown>) => { manifest.extra = true }, "exact contract"],
+    ["version", (manifest: Record<string, unknown>) => { manifest.version = 2 }, "version mismatch"],
+    ["roots", (manifest: Record<string, unknown>) => { manifest.roots = [BUILD_OUTPUT_ROOTS[0]] }, "roots mismatch"],
+    ["lockfile digest", (manifest: Record<string, unknown>) => { manifest.lockfileSha256 = "invalid" }, "lockfile digest"],
+    ["archive digest", (manifest: Record<string, unknown>) => { manifest.archiveSha256 = "invalid" }, "archive digest"],
+  ])("rejects invalid manifest %s", (_name, mutate, error) => {
+    const artifact = fixture()
+    const manifest = JSON.parse(readFileSync(artifact.manifest, "utf8")) as Record<string, unknown>
+    mutate(manifest)
+    writeFileSync(artifact.manifest, `${JSON.stringify(manifest, null, 2)}\n`)
+
+    expect(() => verifyBuildArtifact({
+      root: artifact.root,
+      directory: ".ci/ui-e2e-build",
+      runId: "123",
+      attempt: 2,
+      headSha: HEAD_SHA,
+    })).toThrow(error)
+  })
+
+  it.each([
+    ["invalid JSON", "{", "invalid JSON"],
+    ["a non-object", "[]", "must be an object"],
+  ])("rejects a manifest containing %s", (_name, contents, error) => {
+    const artifact = fixture()
+    writeFileSync(artifact.manifest, contents)
+
+    expect(() => verifyBuildArtifact({
+      root: artifact.root,
+      directory: ".ci/ui-e2e-build",
+      runId: "123",
+      attempt: 2,
+      headSha: HEAD_SHA,
+    })).toThrow(error)
+  })
+
+  it("rejects unexpected archive members even when the manifest digest matches", () => {
+    const artifact = fixture()
+    writeFileSync(join(artifact.root, "unexpected.txt"), "unexpected")
+    const tar = spawnSync("tar", [
+      "-czf",
+      artifact.archive,
+      "-C",
+      artifact.root,
+      ...BUILD_OUTPUT_ROOTS,
+      "unexpected.txt",
+    ])
+    expect(tar.status).toBe(0)
+    const manifest = JSON.parse(readFileSync(artifact.manifest, "utf8"))
+    manifest.archiveSha256 = createHash("sha256")
+      .update(readFileSync(artifact.archive))
+      .digest("hex")
+    writeFileSync(artifact.manifest, `${JSON.stringify(manifest, null, 2)}\n`)
+
+    expect(() => verifyBuildArtifact({
+      root: artifact.root,
+      directory: ".ci/ui-e2e-build",
+      runId: "123",
+      attempt: 2,
+      headSha: HEAD_SHA,
+    })).toThrow("unexpected member: unexpected.txt")
+  })
+
+  it("rejects an archive missing either worker even when the manifest digest matches", () => {
+    const artifact = fixture()
+    rmSync(join(artifact.root, BUILD_OUTPUT_ROOTS[1], "worker.js"))
+    const tar = spawnSync("tar", [
+      "-czf",
+      artifact.archive,
+      "-C",
+      artifact.root,
+      ...BUILD_OUTPUT_ROOTS,
+    ])
+    expect(tar.status).toBe(0)
+    const manifest = JSON.parse(readFileSync(artifact.manifest, "utf8"))
+    manifest.archiveSha256 = createHash("sha256")
+      .update(readFileSync(artifact.archive))
+      .digest("hex")
+    writeFileSync(artifact.manifest, `${JSON.stringify(manifest, null, 2)}\n`)
+
+    expect(() => verifyBuildArtifact({
+      root: artifact.root,
+      directory: ".ci/ui-e2e-build",
+      runId: "123",
+      attempt: 2,
+      headSha: HEAD_SHA,
+    })).toThrow(`missing OpenNext worker entrypoint: ${BUILD_OUTPUT_ROOTS[1]}/worker.js`)
+  })
+
+  it("requires both worker entrypoints and exposes strict create/verify CLI commands", () => {
+    const artifact = fixture()
+    rmSync(join(artifact.root, BUILD_OUTPUT_ROOTS[1], "worker.js"))
+    expect(() => createBuildArtifact({
+      root: artifact.root,
+      directory: ".ci/second",
+      runId: "123",
+      attempt: 2,
+      headSha: HEAD_SHA,
+    })).toThrow("OpenNext worker entrypoint is missing")
+
+    removeBuildOutputs(artifact.root)
+    expect(() => runCli([
+      "verify",
+      "--root", artifact.root,
+      "--directory", ".ci/ui-e2e-build",
+      "--run-id", "123",
+      "--attempt", "2",
+      "--head-sha", HEAD_SHA,
+    ])).not.toThrow()
+    expect(() => runCli(["unknown"])).toThrow("expected create or verify")
+    expect(artifact.archive).toBe(join(artifact.artifactDirectory, BUILD_ARCHIVE_NAME))
+    expect(artifact.manifest).toBe(join(artifact.artifactDirectory, BUILD_MANIFEST_NAME))
+  })
+
+  it("refuses artifact directories outside the repository", () => {
+    const artifact = fixture()
+    expect(() => createBuildArtifact({
+      root: artifact.root,
+      directory: "../outside",
+      runId: "123",
+      attempt: 2,
+      headSha: HEAD_SHA,
+    })).toThrow("inside the repository root")
+  })
+})

--- a/scripts/ci/e2e-shards.mjs
+++ b/scripts/ci/e2e-shards.mjs
@@ -4,71 +4,80 @@ import { fileURLToPath } from "node:url"
 
 export const E2E_SPEC_ROOT = "src/web/src/test/e2e-ui"
 export const E2E_SHARD_BUDGET_SECONDS = 240
-export const DEFAULT_SPEC_SECONDS = E2E_SHARD_BUDGET_SECONDS
+export const E2E_FIXED_SETUP_SECONDS = 60
+export const E2E_SAFETY_MARGIN_SECONDS = 15
+export const E2E_SPEC_BUDGET_SECONDS = E2E_SHARD_BUDGET_SECONDS
+  - E2E_FIXED_SETUP_SECONDS
+  - E2E_SAFETY_MARGIN_SECONDS
+export const DEFAULT_SPEC_SECONDS = E2E_SPEC_BUDGET_SECONDS
 export const PLAYWRIGHT_IMAGE_REPOSITORY = "mcr.microsoft.com/playwright"
 
 export const SPEC_SECONDS = {
-  "01-auth.spec.ts": 5,
-  "02-server-channel-message.spec.ts": 75,
-  "03-realtime-multiuser.spec.ts": 63,
-  "04-dm.spec.ts": 42,
-  "05-mention-bot.spec.ts": 15,
-  "06-channel-member-admin.spec.ts": 17,
-  "07-invite.spec.ts": 10,
-  "08-mobile.spec.ts": 7,
-  "09-forum-thread.spec.ts": 35,
-  "10-eject-nav-auth.spec.ts": 30,
-  "11-profile-ui-stability.spec.ts": 9,
-  "12-friends.spec.ts": 6,
-  "13-mentions.spec.ts": 50,
-  "14-forum-post-tags-presence.spec.ts": 59,
-  "15-mention-scope.spec.ts": 74,
-  "16-jump-to-present.spec.ts": 30,
-  "17-forum-sidebar-stage-b.spec.ts": 35,
-  "18-new-divider-scroll.spec.ts": 46,
-  "19-marketing-seo.spec.ts": 5,
-  "20-community-attachment-thumbnails.spec.ts": 60,
-  "21-mobile-message-layout.spec.ts": 20,
-  "22-committed-message-delivery.spec.ts": 85,
-  "23-message-selection-context-menu.spec.ts": 10,
-  "24-composer-overflow.spec.ts": 35,
-  "25-community-ws-reconnect-overlay.spec.ts": 60,
-  "25-composer-accessory-rail-occupancy.spec.ts": 95,
-  "26-mobile-forum-post-actions.spec.ts": 45,
-  "27-canonical-forum-post-delete.spec.ts": 30,
-  "28-community-delete-media-cleanup.spec.ts": 45,
-  "29-community-bot-avatar-cleanup.spec.ts": 15,
-  "29-multi-device-read-state.spec.ts": 45,
-  "30-bot-profile-audit-preview.spec.ts": 35,
-  "31-mention-candidate-pagination.spec.ts": 10,
-  "31-machine-guide-motion.spec.ts": 10,
-  "32-mobile-ws-foreground-validation.spec.ts": 80,
-  "33-picker-async-layout.spec.ts": 57,
-  "34-inbox-read-race.spec.ts": 42,
-  "35-channel-ref-directory-states.spec.ts": 60,
-  "35-bot-token-usage-quota.spec.ts": 45,
-  "36-server-switch-pending-checkpoint.spec.ts": 60,
-  "37-server-rail-pdd.spec.ts": 120,
-  "38-community-navigation-checkpoint-matrix.spec.ts": 60,
-  "39-mobile-message-interactions.spec.ts": 20,
-  "39-mobile-composer-send.spec.ts": 45,
-  "40-mobile-server-header-hierarchy.spec.ts": 28,
-  "40-server-rail-unread.spec.ts": 60,
-  "41-account-unread-projection.spec.ts": 55,
-  "41-community-initial-load-module-skeletons.spec.ts": 30,
-  "42-versioned-avatar-identity.spec.ts": 50,
-  "44-mobile-reaction-details.spec.ts": 70,
-  "45-desktop-thread-split-view.spec.ts": 60,
-  "46-community-loading-geometry-matrix.spec.ts": 150,
-  "50-daemon-update-notice.spec.ts": 35,
-  "51-mobile-forum-tag-editor.spec.ts": 60,
-  "51-share-image-assets.spec.ts": 20,
-  "52-chat-composer-ordered-list.spec.ts": 90,
-  "53-mobile-inbox-surface.spec.ts": 45,
-  "54-authenticated-context-menu-policy.spec.ts": 55,
-  "54-blog-multizone.spec.ts": 60,
-  "55-message-scroll-characterization.spec.ts": 180,
-  "56-remote-image-state-contract.spec.ts": 15,
+  "01-auth.spec.ts": 3.997,
+  "02-server-channel-message.spec.ts": 9.687,
+  "03-realtime-multiuser.spec.ts": 13.037,
+  "04-dm.spec.ts": 15.545,
+  "05-mention-bot.spec.ts": 4.117,
+  "06-channel-member-admin.spec.ts": 3.819,
+  "07-invite.spec.ts": 9.843,
+  "08-mobile.spec.ts": 37.929,
+  "09-forum-thread.spec.ts": 4.538,
+  "10-eject-nav-auth.spec.ts": 6.193,
+  "11-profile-ui-stability.spec.ts": 2.554,
+  "12-friends.spec.ts": 3.905,
+  "13-mentions.spec.ts": 9.591,
+  "14-forum-post-tags-presence.spec.ts": 16.213,
+  "15-mention-scope.spec.ts": 10.94,
+  "16-jump-to-present.spec.ts": 5.997,
+  "17-forum-sidebar-stage-b.spec.ts": 43.842,
+  "18-new-divider-scroll.spec.ts": 10.956,
+  "19-marketing-seo.spec.ts": 1.713,
+  "20-community-attachment-thumbnails.spec.ts": 11.117,
+  "21-mobile-message-layout.spec.ts": 5.12,
+  "22-committed-message-delivery.spec.ts": 40.086,
+  "23-message-selection-context-menu.spec.ts": 3.392,
+  "24-composer-overflow.spec.ts": 12.763,
+  "25-community-ws-reconnect-overlay.spec.ts": 36.437,
+  "25-composer-accessory-rail-occupancy.spec.ts": 40.804,
+  "26-mobile-forum-post-actions.spec.ts": 21.297,
+  "27-canonical-forum-post-delete.spec.ts": 11.097,
+  "28-community-delete-media-cleanup.spec.ts": 11.925,
+  "28-thread-realtime-audiences.spec.ts": 26.477,
+  "29-community-bot-avatar-cleanup.spec.ts": 8.216,
+  "29-multi-device-read-state.spec.ts": 72.169,
+  "30-bot-profile-audit-preview.spec.ts": 29.213,
+  "31-machine-guide-motion.spec.ts": 4.201,
+  "31-mention-candidate-pagination.spec.ts": 3.836,
+  "32-mobile-ws-foreground-validation.spec.ts": 95.792,
+  "33-picker-async-layout.spec.ts": 18.776,
+  "34-inbox-read-race.spec.ts": 26.519,
+  "35-bot-token-usage-quota.spec.ts": 10.867,
+  "35-channel-ref-directory-states.spec.ts": 12.626,
+  "36-server-switch-pending-checkpoint.spec.ts": 5.732,
+  "37-server-rail-pdd.spec.ts": 21.594,
+  "38-community-navigation-checkpoint-matrix.spec.ts": 4.646,
+  "39-mobile-composer-send.spec.ts": 16.534,
+  "39-mobile-message-interactions.spec.ts": 58.479,
+  "40-mobile-server-header-hierarchy.spec.ts": 14.449,
+  "40-server-rail-unread.spec.ts": 11.954,
+  "41-account-unread-projection.spec.ts": 28.753,
+  "41-community-initial-load-module-skeletons.spec.ts": 29.632,
+  "42-versioned-avatar-identity.spec.ts": 13.96,
+  "43-composer-attachment-drafts.spec.ts": 12.139,
+  "44-mobile-reaction-details.spec.ts": 32.952,
+  "45-desktop-thread-split-view.spec.ts": 11.647,
+  "46-community-loading-geometry-android.spec.ts": 49.779,
+  "46-community-loading-geometry-dark.spec.ts": 63.284,
+  "46-community-loading-geometry-light.spec.ts": 63.095,
+  "50-daemon-update-notice.spec.ts": 7.656,
+  "51-mobile-forum-tag-editor.spec.ts": 26.043,
+  "51-share-image-assets.spec.ts": 46.186,
+  "52-chat-composer-ordered-list.spec.ts": 16.531,
+  "53-mobile-inbox-surface.spec.ts": 8.362,
+  "54-authenticated-context-menu-policy.spec.ts": 13.721,
+  "54-blog-multizone.spec.ts": 5.485,
+  "55-message-scroll-characterization.spec.ts": 45.089,
+  "56-remote-image-state-contract.spec.ts": 3.122,
 }
 
 function walk(directory) {
@@ -146,19 +155,29 @@ function weightedSpecs(specs, weights, defaultSeconds, budgetSeconds) {
     .sort((left, right) => right.seconds - left.seconds || left.path.localeCompare(right.path))
 }
 
-function packE2eShards(weighted, shardCount) {
+function roundedSeconds(value) {
+  return Math.round(value * 1_000) / 1_000
+}
+
+function packE2eShards(weighted, shardCount, fixedSetupSeconds, safetyMarginSeconds) {
   const shards = Array.from({ length: shardCount }, (_, index) => ({
     shard: index + 1,
-    predicted_seconds: 0,
+    spec_seconds: 0,
+    fixed_setup_seconds: fixedSetupSeconds,
+    safety_margin_seconds: safetyMarginSeconds,
+    predicted_seconds: roundedSeconds(fixedSetupSeconds + safetyMarginSeconds),
     files: [],
   }))
 
   for (const spec of weighted) {
     const target = [...shards].sort(
-      (left, right) => left.predicted_seconds - right.predicted_seconds || left.shard - right.shard,
+      (left, right) => left.spec_seconds - right.spec_seconds || left.shard - right.shard,
     )[0]
     target.files.push(spec.path)
-    target.predicted_seconds += spec.seconds
+    target.spec_seconds = roundedSeconds(target.spec_seconds + spec.seconds)
+    target.predicted_seconds = roundedSeconds(
+      target.spec_seconds + fixedSetupSeconds + safetyMarginSeconds,
+    )
   }
 
   return shards.map((shard) => ({
@@ -172,15 +191,27 @@ export function planE2eShards(specs, options = {}) {
     weights = SPEC_SECONDS,
     defaultSeconds = DEFAULT_SPEC_SECONDS,
     budgetSeconds = E2E_SHARD_BUDGET_SECONDS,
+    fixedSetupSeconds = E2E_FIXED_SETUP_SECONDS,
+    safetyMarginSeconds = E2E_SAFETY_MARGIN_SECONDS,
   } = options
-  const weighted = weightedSpecs(specs, weights, defaultSeconds, budgetSeconds)
+  if (!Number.isFinite(fixedSetupSeconds) || fixedSetupSeconds < 0) {
+    throw new Error("fixedSetupSeconds must be a non-negative finite number")
+  }
+  if (!Number.isFinite(safetyMarginSeconds) || safetyMarginSeconds < 0) {
+    throw new Error("safetyMarginSeconds must be a non-negative finite number")
+  }
+  const specBudgetSeconds = budgetSeconds - fixedSetupSeconds - safetyMarginSeconds
+  if (!Number.isFinite(specBudgetSeconds) || specBudgetSeconds <= 0) {
+    throw new Error("fixed setup and safety margin must leave a positive spec budget")
+  }
+  const weighted = weightedSpecs(specs, weights, defaultSeconds, specBudgetSeconds)
   const totalSeconds = weighted.reduce((total, spec) => total + spec.seconds, 0)
-  let shardCount = Math.ceil(totalSeconds / budgetSeconds)
-  let shards = packE2eShards(weighted, shardCount)
+  let shardCount = Math.ceil(totalSeconds / specBudgetSeconds)
+  let shards = packE2eShards(weighted, shardCount, fixedSetupSeconds, safetyMarginSeconds)
 
-  while (shards.some((shard) => shard.predicted_seconds > budgetSeconds)) {
+  while (shards.some((shard) => shard.spec_seconds > specBudgetSeconds)) {
     shardCount += 1
-    shards = packE2eShards(weighted, shardCount)
+    shards = packE2eShards(weighted, shardCount, fixedSetupSeconds, safetyMarginSeconds)
   }
   return shards
 }
@@ -201,6 +232,9 @@ export function createE2eMatrix(specs = discoverE2eSpecs(), image = resolvePlayw
       shard: shard.shard,
       total: shards.length,
       image,
+      spec_seconds: shard.spec_seconds,
+      fixed_setup_seconds: shard.fixed_setup_seconds,
+      safety_margin_seconds: shard.safety_margin_seconds,
       predicted_seconds: shard.predicted_seconds,
       specs: shard.files.map((path) => `src/test/e2e-ui/${path}`),
     })),
@@ -218,11 +252,11 @@ function parseArgs(argv) {
 
 function writeSummary(path, matrix) {
   const rows = matrix.include
-    .map((shard) => `| ${shard.shard}/${shard.total} | ${shard.predicted_seconds}s | \`${shard.specs.join(" ")}\` |`)
+    .map((shard) => `| ${shard.shard}/${shard.total} | ${shard.spec_seconds}s | ${shard.fixed_setup_seconds}s | ${shard.safety_margin_seconds}s | ${shard.predicted_seconds}s | \`${shard.specs.join(" ")}\` |`)
     .join("\n")
   appendFileSync(
     path,
-    `## UI E2E shards\n\nPredicted Playwright execution only; ${E2E_SHARD_BUDGET_SECONDS}s budget per shard. Runner setup and dependency installation are not included.\n\n| Shard | Predicted Playwright | Specs |\n| --- | ---: | --- |\n${rows}\n`,
+    `## UI E2E shards\n\nPredicted Playwright command step; ${E2E_SHARD_BUDGET_SECONDS}s budget per shard. Each total includes measured spec time, fixed service setup, and an explicit safety margin.\n\n| Shard | Specs | Fixed setup | Margin | Predicted total | Files |\n| --- | ---: | ---: | ---: | ---: | --- |\n${rows}\n`,
   )
 }
 

--- a/scripts/ci/e2e-shards.mjs
+++ b/scripts/ci/e2e-shards.mjs
@@ -3,8 +3,8 @@ import { relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 export const E2E_SPEC_ROOT = "src/web/src/test/e2e-ui"
-export const E2E_SHARD_COUNT = 5
-export const DEFAULT_SPEC_SECONDS = 60
+export const E2E_SHARD_BUDGET_SECONDS = 240
+export const DEFAULT_SPEC_SECONDS = E2E_SHARD_BUDGET_SECONDS
 export const PLAYWRIGHT_IMAGE_REPOSITORY = "mcr.microsoft.com/playwright"
 
 export const SPEC_SECONDS = {
@@ -109,16 +109,7 @@ export function resolvePlaywrightImage(lockfile) {
   return `${PLAYWRIGHT_IMAGE_REPOSITORY}:v${resolvePlaywrightVersion(lockfile)}-noble`
 }
 
-export function planE2eShards(
-  specs,
-  shardCount = E2E_SHARD_COUNT,
-  weights = SPEC_SECONDS,
-  defaultSeconds = DEFAULT_SPEC_SECONDS,
-) {
-  if (!Number.isInteger(shardCount) || shardCount < 1) {
-    throw new Error("shardCount must be a positive integer")
-  }
-
+function weightedSpecs(specs, weights, defaultSeconds, budgetSeconds) {
   const uniqueSpecs = [...new Set(specs)]
   if (uniqueSpecs.length !== specs.length) {
     throw new Error("spec paths must be unique")
@@ -126,17 +117,41 @@ export function planE2eShards(
   if (uniqueSpecs.length === 0) {
     throw new Error("at least one spec is required")
   }
+  if (uniqueSpecs.some((path) => typeof path !== "string" || path.length === 0)) {
+    throw new Error("spec paths must be non-empty strings")
+  }
+  if (!Number.isInteger(budgetSeconds) || budgetSeconds < 1) {
+    throw new Error("budgetSeconds must be a positive integer")
+  }
+  if (!Number.isFinite(defaultSeconds) || defaultSeconds <= 0) {
+    throw new Error("defaultSeconds must be a positive finite number")
+  }
 
-  const effectiveShardCount = Math.min(shardCount, uniqueSpecs.length)
-  const shards = Array.from({ length: effectiveShardCount }, (_, index) => ({
+  return uniqueSpecs
+    .map((path) => ({
+      path,
+      seconds: Object.hasOwn(weights, path) ? weights[path] : defaultSeconds,
+    }))
+    .map((spec) => {
+      if (!Number.isFinite(spec.seconds) || spec.seconds <= 0) {
+        throw new Error(`spec estimate must be a positive finite number: ${spec.path}`)
+      }
+      if (spec.seconds > budgetSeconds) {
+        throw new Error(
+          `spec estimate exceeds the ${budgetSeconds}s Playwright budget: ${spec.path} (${spec.seconds}s); split the spec or add a stable case manifest`,
+        )
+      }
+      return spec
+    })
+    .sort((left, right) => right.seconds - left.seconds || left.path.localeCompare(right.path))
+}
+
+function packE2eShards(weighted, shardCount) {
+  const shards = Array.from({ length: shardCount }, (_, index) => ({
     shard: index + 1,
     predicted_seconds: 0,
     files: [],
   }))
-
-  const weighted = uniqueSpecs
-    .map((path) => ({ path, seconds: weights[path] ?? defaultSeconds }))
-    .sort((left, right) => right.seconds - left.seconds || left.path.localeCompare(right.path))
 
   for (const spec of weighted) {
     const target = [...shards].sort(
@@ -150,6 +165,24 @@ export function planE2eShards(
     ...shard,
     files: shard.files.sort(),
   }))
+}
+
+export function planE2eShards(specs, options = {}) {
+  const {
+    weights = SPEC_SECONDS,
+    defaultSeconds = DEFAULT_SPEC_SECONDS,
+    budgetSeconds = E2E_SHARD_BUDGET_SECONDS,
+  } = options
+  const weighted = weightedSpecs(specs, weights, defaultSeconds, budgetSeconds)
+  const totalSeconds = weighted.reduce((total, spec) => total + spec.seconds, 0)
+  let shardCount = Math.ceil(totalSeconds / budgetSeconds)
+  let shards = packE2eShards(weighted, shardCount)
+
+  while (shards.some((shard) => shard.predicted_seconds > budgetSeconds)) {
+    shardCount += 1
+    shards = packE2eShards(weighted, shardCount)
+  }
+  return shards
 }
 
 export function createE2eMatrix(specs = discoverE2eSpecs(), image = resolvePlaywrightImage()) {
@@ -189,7 +222,7 @@ function writeSummary(path, matrix) {
     .join("\n")
   appendFileSync(
     path,
-    `## UI E2E shards\n\n| Shard | Predicted | Specs |\n| --- | ---: | --- |\n${rows}\n`,
+    `## UI E2E shards\n\nPredicted Playwright execution only; ${E2E_SHARD_BUDGET_SECONDS}s budget per shard. Runner setup and dependency installation are not included.\n\n| Shard | Predicted Playwright | Specs |\n| --- | ---: | --- |\n${rows}\n`,
   )
 }
 

--- a/scripts/ci/e2e-shards.mjs
+++ b/scripts/ci/e2e-shards.mjs
@@ -76,7 +76,7 @@ export const SPEC_SECONDS = {
   "53-mobile-inbox-surface.spec.ts": 8.362,
   "54-authenticated-context-menu-policy.spec.ts": 13.721,
   "54-blog-multizone.spec.ts": 5.485,
-  "55-message-scroll-characterization.spec.ts": 45.089,
+  "55-message-scroll-characterization.spec.ts": 109.548,
   "56-remote-image-state-contract.spec.ts": 3.122,
 }
 

--- a/scripts/ci/e2e-shards.test.ts
+++ b/scripts/ci/e2e-shards.test.ts
@@ -142,6 +142,11 @@ describe("planE2eShards", () => {
     expect(() => planE2eShards([""])).toThrow("non-empty strings")
     expect(() => planE2eShards(["a.spec.ts"], { budgetSeconds: 0 }))
       .toThrow("positive spec budget")
+    expect(() => planE2eShards(["a.spec.ts"], {
+      budgetSeconds: 1.5,
+      fixedSetupSeconds: 0,
+      safetyMarginSeconds: 0,
+    })).toThrow("budgetSeconds must be a positive integer")
     expect(() => planE2eShards(["a.spec.ts"], { defaultSeconds: Number.NaN }))
       .toThrow("positive finite")
     expect(() => planE2eShards(["a.spec.ts"], { weights: { "a.spec.ts": 0 } }))

--- a/scripts/ci/e2e-shards.test.ts
+++ b/scripts/ci/e2e-shards.test.ts
@@ -78,11 +78,12 @@ describe("planE2eShards", () => {
     expect(first).toHaveLength(9)
     expect([...assigned].sort()).toEqual(specs)
     expect(new Set(assigned).size).toBe(specs.length)
+    expect(SPEC_SECONDS["55-message-scroll-characterization.spec.ts"]).toBe(109.548)
     expect(specSeconds).toEqual([
-      147.775, 147.715, 147.351, 148.789, 146.004, 147.401, 148.302, 147.005, 147.628,
+      156.526, 155.455, 155.858, 156.114, 153.041, 153.044, 154.015, 153.713, 154.663,
     ])
     expect(predictedSeconds).toEqual([
-      222.775, 222.715, 222.351, 223.789, 221.004, 222.401, 223.302, 222.005, 222.628,
+      231.526, 230.455, 230.858, 231.114, 228.041, 228.044, 229.015, 228.713, 229.663,
     ])
     expect(first.every((shard) => (
       shard.fixed_setup_seconds === E2E_FIXED_SETUP_SECONDS

--- a/scripts/ci/e2e-shards.test.ts
+++ b/scripts/ci/e2e-shards.test.ts
@@ -4,8 +4,9 @@ import { join } from "node:path"
 import { describe, expect, it, vi } from "vitest"
 import {
   createE2eMatrix,
+  DEFAULT_SPEC_SECONDS,
   discoverE2eSpecs,
-  E2E_SHARD_COUNT,
+  E2E_SHARD_BUDGET_SECONDS,
   planE2eShards,
   resolvePlaywrightImage,
   resolvePlaywrightVersion,
@@ -68,29 +69,64 @@ describe("planE2eShards", () => {
     const totals = first.map((shard) => shard.predicted_seconds)
 
     expect(first).toEqual(second)
-    expect(first).toHaveLength(E2E_SHARD_COUNT)
+    expect(first).toHaveLength(15)
     expect([...assigned].sort()).toEqual(specs)
     expect(new Set(assigned).size).toBe(specs.length)
-    expect(totals.sort((left, right) => left - right)).toEqual([597, 597, 597, 597, 597])
-    expect(Math.max(...totals) / Math.min(...totals)).toBeLessThanOrEqual(1.15)
+    expect(totals).toEqual([
+      240, 240, 220, 221, 220, 219, 218, 222, 220, 220, 224, 220, 221, 220, 220,
+    ])
+    expect(Math.max(...totals)).toBeLessThanOrEqual(E2E_SHARD_BUDGET_SECONDS)
+    expect(first).toHaveLength(
+      Math.ceil(totals.reduce((total, seconds) => total + seconds, 0)
+        / E2E_SHARD_BUDGET_SECONDS) + 1,
+    )
   })
 
   it("includes an unknown spec with a conservative default weight", () => {
-    const shards = planE2eShards(["known.spec.ts", "new.spec.ts"], 2, {
-      "known.spec.ts": 5,
-    }, 60)
+    const shards = planE2eShards(["known.spec.ts", "new.spec.ts"], {
+      weights: { "known.spec.ts": 5 },
+    })
 
     expect(shards.flatMap((shard) => shard.files).sort()).toEqual([
       "known.spec.ts",
       "new.spec.ts",
     ])
-    expect(shards.map((shard) => shard.predicted_seconds).sort((a, b) => a - b)).toEqual([5, 60])
+    expect(DEFAULT_SPEC_SECONDS).toBe(E2E_SHARD_BUDGET_SECONDS)
+    expect(shards.map((shard) => shard.predicted_seconds).sort((a, b) => a - b))
+      .toEqual([5, E2E_SHARD_BUDGET_SECONDS])
   })
 
-  it("rejects duplicate paths and invalid shard counts", () => {
+  it("increments the total-time lower bound when LPT does not fit", () => {
+    const weights = {
+      "a.spec.ts": 3,
+      "b.spec.ts": 3,
+      "c.spec.ts": 2,
+      "d.spec.ts": 2,
+      "e.spec.ts": 2,
+    }
+    const shards = planE2eShards(Object.keys(weights), { weights, budgetSeconds: 6 })
+
+    expect(Math.ceil(12 / 6)).toBe(2)
+    expect(shards).toHaveLength(3)
+    expect(shards.every((shard) => shard.predicted_seconds <= 6)).toBe(true)
+  })
+
+  it("rejects duplicate or empty paths and invalid planning values", () => {
     expect(() => planE2eShards(["a.spec.ts", "a.spec.ts"])).toThrow("unique")
     expect(() => planE2eShards([])).toThrow("at least one")
-    expect(() => planE2eShards(["a.spec.ts"], 0)).toThrow("positive integer")
+    expect(() => planE2eShards([""])).toThrow("non-empty strings")
+    expect(() => planE2eShards(["a.spec.ts"], { budgetSeconds: 0 }))
+      .toThrow("positive integer")
+    expect(() => planE2eShards(["a.spec.ts"], { defaultSeconds: Number.NaN }))
+      .toThrow("positive finite")
+    expect(() => planE2eShards(["a.spec.ts"], { weights: { "a.spec.ts": 0 } }))
+      .toThrow("positive finite")
+  })
+
+  it("requires an oversized spec to be split or given a stable case manifest", () => {
+    expect(() => planE2eShards(["slow.spec.ts"], {
+      weights: { "slow.spec.ts": E2E_SHARD_BUDGET_SECONDS + 1 },
+    })).toThrow("split the spec or add a stable case manifest")
   })
 })
 
@@ -112,7 +148,8 @@ describe("createE2eMatrix", () => {
       "src/test/e2e-ui/04-dm.spec.ts",
       "src/test/e2e-ui/05-mention-bot.spec.ts",
     ])
-    expect(matrix.include.every((entry) => entry.total === E2E_SHARD_COUNT)).toBe(true)
+    expect(matrix.include).toHaveLength(1)
+    expect(matrix.include.every((entry) => entry.total === 1)).toBe(true)
     expect(matrix.include.every(
       (entry) => entry.image === "mcr.microsoft.com/playwright:v1.62.1-noble",
     )).toBe(true)
@@ -161,6 +198,9 @@ describe("E2E shard CLI", () => {
         "src/test/e2e-ui/54-blog-multizone.spec.ts",
       )
       expect(readFileSync(summary, "utf8")).toContain("| 1/1 | 60s |")
+      expect(readFileSync(summary, "utf8")).toContain(
+        "Predicted Playwright execution only; 240s budget per shard",
+      )
     } finally {
       rmSync(directory, { recursive: true, force: true })
     }

--- a/scripts/ci/e2e-shards.test.ts
+++ b/scripts/ci/e2e-shards.test.ts
@@ -6,11 +6,15 @@ import {
   createE2eMatrix,
   DEFAULT_SPEC_SECONDS,
   discoverE2eSpecs,
+  E2E_FIXED_SETUP_SECONDS,
+  E2E_SAFETY_MARGIN_SECONDS,
   E2E_SHARD_BUDGET_SECONDS,
+  E2E_SPEC_BUDGET_SECONDS,
   planE2eShards,
   resolvePlaywrightImage,
   resolvePlaywrightVersion,
   runCli,
+  SPEC_SECONDS,
 } from "./e2e-shards.mjs"
 
 describe("resolvePlaywrightVersion", () => {
@@ -66,19 +70,30 @@ describe("planE2eShards", () => {
     const first = planE2eShards(specs)
     const second = planE2eShards([...specs].reverse())
     const assigned = first.flatMap((shard) => shard.files)
-    const totals = first.map((shard) => shard.predicted_seconds)
+    const specSeconds = first.map((shard) => shard.spec_seconds)
+    const predictedSeconds = first.map((shard) => shard.predicted_seconds)
 
     expect(first).toEqual(second)
-    expect(first).toHaveLength(15)
+    expect(Object.keys(SPEC_SECONDS).sort()).toEqual(specs)
+    expect(first).toHaveLength(9)
     expect([...assigned].sort()).toEqual(specs)
     expect(new Set(assigned).size).toBe(specs.length)
-    expect(totals).toEqual([
-      240, 240, 220, 221, 220, 219, 218, 222, 220, 220, 224, 220, 221, 220, 220,
+    expect(specSeconds).toEqual([
+      147.775, 147.715, 147.351, 148.789, 146.004, 147.401, 148.302, 147.005, 147.628,
     ])
-    expect(Math.max(...totals)).toBeLessThanOrEqual(E2E_SHARD_BUDGET_SECONDS)
+    expect(predictedSeconds).toEqual([
+      222.775, 222.715, 222.351, 223.789, 221.004, 222.401, 223.302, 222.005, 222.628,
+    ])
+    expect(first.every((shard) => (
+      shard.fixed_setup_seconds === E2E_FIXED_SETUP_SECONDS
+      && shard.safety_margin_seconds === E2E_SAFETY_MARGIN_SECONDS
+      && shard.predicted_seconds
+        === shard.spec_seconds + E2E_FIXED_SETUP_SECONDS + E2E_SAFETY_MARGIN_SECONDS
+    ))).toBe(true)
+    expect(Math.max(...predictedSeconds)).toBeLessThanOrEqual(E2E_SHARD_BUDGET_SECONDS)
     expect(first).toHaveLength(
-      Math.ceil(totals.reduce((total, seconds) => total + seconds, 0)
-        / E2E_SHARD_BUDGET_SECONDS) + 1,
+      Math.ceil(specSeconds.reduce((total, seconds) => total + seconds, 0)
+        / E2E_SPEC_BUDGET_SECONDS),
     )
   })
 
@@ -91,9 +106,13 @@ describe("planE2eShards", () => {
       "known.spec.ts",
       "new.spec.ts",
     ])
-    expect(DEFAULT_SPEC_SECONDS).toBe(E2E_SHARD_BUDGET_SECONDS)
+    expect(DEFAULT_SPEC_SECONDS).toBe(E2E_SPEC_BUDGET_SECONDS)
+    expect(shards.find((shard) => shard.files.includes("new.spec.ts"))?.files)
+      .toEqual(["new.spec.ts"])
+    expect(shards.map((shard) => shard.spec_seconds).sort((a, b) => a - b))
+      .toEqual([5, E2E_SPEC_BUDGET_SECONDS])
     expect(shards.map((shard) => shard.predicted_seconds).sort((a, b) => a - b))
-      .toEqual([5, E2E_SHARD_BUDGET_SECONDS])
+      .toEqual([80, E2E_SHARD_BUDGET_SECONDS])
   })
 
   it("increments the total-time lower bound when LPT does not fit", () => {
@@ -104,11 +123,16 @@ describe("planE2eShards", () => {
       "d.spec.ts": 2,
       "e.spec.ts": 2,
     }
-    const shards = planE2eShards(Object.keys(weights), { weights, budgetSeconds: 6 })
+    const shards = planE2eShards(Object.keys(weights), {
+      weights,
+      budgetSeconds: 6,
+      fixedSetupSeconds: 0,
+      safetyMarginSeconds: 0,
+    })
 
     expect(Math.ceil(12 / 6)).toBe(2)
     expect(shards).toHaveLength(3)
-    expect(shards.every((shard) => shard.predicted_seconds <= 6)).toBe(true)
+    expect(shards.every((shard) => shard.spec_seconds <= 6)).toBe(true)
   })
 
   it("rejects duplicate or empty paths and invalid planning values", () => {
@@ -116,16 +140,20 @@ describe("planE2eShards", () => {
     expect(() => planE2eShards([])).toThrow("at least one")
     expect(() => planE2eShards([""])).toThrow("non-empty strings")
     expect(() => planE2eShards(["a.spec.ts"], { budgetSeconds: 0 }))
-      .toThrow("positive integer")
+      .toThrow("positive spec budget")
     expect(() => planE2eShards(["a.spec.ts"], { defaultSeconds: Number.NaN }))
       .toThrow("positive finite")
     expect(() => planE2eShards(["a.spec.ts"], { weights: { "a.spec.ts": 0 } }))
       .toThrow("positive finite")
+    expect(() => planE2eShards(["a.spec.ts"], { fixedSetupSeconds: Number.NaN }))
+      .toThrow("non-negative finite")
+    expect(() => planE2eShards(["a.spec.ts"], { safetyMarginSeconds: -1 }))
+      .toThrow("non-negative finite")
   })
 
   it("requires an oversized spec to be split or given a stable case manifest", () => {
     expect(() => planE2eShards(["slow.spec.ts"], {
-      weights: { "slow.spec.ts": E2E_SHARD_BUDGET_SECONDS + 1 },
+      weights: { "slow.spec.ts": E2E_SPEC_BUDGET_SECONDS + 0.001 },
     })).toThrow("split the spec or add a stable case manifest")
   })
 })
@@ -150,6 +178,12 @@ describe("createE2eMatrix", () => {
     ])
     expect(matrix.include).toHaveLength(1)
     expect(matrix.include.every((entry) => entry.total === 1)).toBe(true)
+    expect(matrix.include[0]).toMatchObject({
+      spec_seconds: 46.383,
+      fixed_setup_seconds: 60,
+      safety_margin_seconds: 15,
+      predicted_seconds: 121.383,
+    })
     expect(matrix.include.every(
       (entry) => entry.image === "mcr.microsoft.com/playwright:v1.62.1-noble",
     )).toBe(true)
@@ -162,7 +196,10 @@ describe("createE2eMatrix", () => {
     expect(matrix.include[0]).toMatchObject({
       shard: 1,
       total: 1,
-      predicted_seconds: 60,
+      spec_seconds: 5.485,
+      fixed_setup_seconds: 60,
+      safety_margin_seconds: 15,
+      predicted_seconds: 80.485,
       specs: ["src/test/e2e-ui/54-blog-multizone.spec.ts"],
     })
     expect(() => createE2eMatrix(["future.spec.ts"])).toThrow("inventory")
@@ -197,9 +234,11 @@ describe("E2E shard CLI", () => {
       expect(readFileSync(output, "utf8")).toContain(
         "src/test/e2e-ui/54-blog-multizone.spec.ts",
       )
-      expect(readFileSync(summary, "utf8")).toContain("| 1/1 | 60s |")
       expect(readFileSync(summary, "utf8")).toContain(
-        "Predicted Playwright execution only; 240s budget per shard",
+        "| 1/1 | 5.485s | 60s | 15s | 80.485s |",
+      )
+      expect(readFileSync(summary, "utf8")).toContain(
+        "Predicted Playwright command step; 240s budget per shard",
       )
     } finally {
       rmSync(directory, { recursive: true, force: true })

--- a/scripts/ci/workflow-contract.test.ts
+++ b/scripts/ci/workflow-contract.test.ts
@@ -229,6 +229,14 @@ describe("E2E UI workflow", () => {
     expect(ciJob("e2e-ui")).toContain("needs.scope.outputs.e2e_matrix")
   })
 
+  it("keeps UI E2E on read-only PR and merge-queue runs without main history access", () => {
+    expect(ciJob("e2e-ui")).toContain("github.event_name != 'push'")
+    expect(ciJob("merge-reports")).toContain("github.event_name != 'push'")
+    expect(workflow).toContain("actions: read")
+    expect(workflow).not.toMatch(/^  pull_request_target:/m)
+    expect(workflow).not.toContain("e2e-timing-history")
+  })
+
   it("keeps failure diagnostics best-effort and merge inputs strict", () => {
     expect(workflow).toContain("src/web/e2e-service-logs/")
     expect(workflow).toContain("continue-on-error: true")

--- a/scripts/ci/workflow-contract.test.ts
+++ b/scripts/ci/workflow-contract.test.ts
@@ -278,6 +278,54 @@ describe("E2E UI workflow", () => {
     expect(ciJob("e2e-ui")).not.toContain("playwright install-deps")
     expect(ciJob("e2e-ui")).not.toContain("playwright install chromium")
   })
+
+  it("builds one exact-head OpenNext artifact and makes every shard verify it without fallback", () => {
+    const producer = ciJob("ui-e2e-build")
+    const shard = ciJob("e2e-ui")
+    const gate = ciJob("ui-e2e-gate")
+    const devVars = "printf 'BETTER_AUTH_SECRET=ci-e2e-ui-secret\\nBETTER_AUTH_URL=http://localhost:3000\\nDEVICE_CLIENT_IDS=e2e-test-client\\nENCRYPTION_KEY=ci-e2e-encryption-key-32chars!!\\nDEV_WS_DO_URL=http://localhost:3000\\nNODE_ENV=development\\n' > src/web/.dev.vars"
+
+    expect(producer).toContain("image: ${{ fromJSON(needs.scope.outputs.e2e_matrix).include[0].image }}")
+    expect(producer).toContain("options: --init --ipc=host --user 1001")
+    expect(producer).toContain("NEXT_PUBLIC_WS_DO_PORT: \"3000\"")
+    expect(producer).toContain(devVars)
+    expect(shard).toContain(devVars)
+    expect(producer.match(/opennextjs-cloudflare build/g)).toHaveLength(1)
+    expect(producer.match(/pnpm --filter @alook\/web build:blog/g)).toHaveLength(1)
+    expect(producer).toContain("e2e-build-artifact.mjs create")
+    expect(producer).toContain("name: ${{ steps.artifact_identity.outputs.artifact_name }}")
+    expect(producer).toContain("ui-e2e-build-manifest.json")
+    expect(producer).toContain("ui-e2e-build.tgz")
+    expect(producer).toContain("include-hidden-files: true")
+    expect(producer).toContain("--directory .ci/ui-e2e-build")
+
+    expect(shard).toContain("needs: [scope, ui-e2e-build]")
+    expect(shard).toContain("actions/download-artifact")
+    expect(shard).toContain("e2e-build-artifact.mjs verify")
+    expect(shard).toContain('ALOOK_E2E_PREBUILT: "1"')
+    expect(shard).not.toContain("opennextjs-cloudflare build")
+    expect(shard).not.toContain("pnpm --filter @alook/web build:blog")
+    expect(shard.indexOf("e2e-build-artifact.mjs verify"))
+      .toBeLessThan(shard.indexOf("playwright test"))
+
+    expect(gate).toContain("needs: [scope, ui-e2e-build, e2e-ui, merge-reports]")
+    expect(gate).toContain('{"name":"ui-e2e-build"')
+  })
+
+  it("pins partial reruns to the successful producer's artifact identity", () => {
+    const producer = ciJob("ui-e2e-build")
+    const shard = ciJob("e2e-ui")
+
+    expect(producer).toContain("artifact_name: ${{ steps.artifact_identity.outputs.artifact_name }}")
+    expect(producer).toContain("artifact_attempt: ${{ steps.artifact_identity.outputs.artifact_attempt }}")
+    expect(producer).toContain('artifact_name=ui-e2e-build-%s-%s\\n')
+    expect(producer).toContain('--attempt "${{ steps.artifact_identity.outputs.artifact_attempt }}"')
+    expect(producer).toContain("name: ${{ steps.artifact_identity.outputs.artifact_name }}")
+
+    expect(shard).toContain("name: ${{ needs.ui-e2e-build.outputs.artifact_name }}")
+    expect(shard).toContain('--attempt "${{ needs.ui-e2e-build.outputs.artifact_attempt }}"')
+    expect(shard).not.toContain("name: ui-e2e-build-${{ github.run_id }}-${{ github.run_attempt }}")
+  })
 })
 
 describe("Bun workflow setup", () => {
@@ -357,7 +405,8 @@ describe("CI workflow graph", () => {
     expect(scope).toContain("name: execution-plan-${{ github.run_id }}-${{ github.run_attempt }}")
     for (const job of [
       "auth-build", "blog-build", "static-checks", "test-linux", "test-windows", "app-packed-artifact",
-      "e2e", "desktop-rust", "lighthouse", "e2e-ui", "merge-reports", "ci-gate", "ui-e2e-gate",
+      "e2e", "desktop-rust", "lighthouse", "ui-e2e-build", "e2e-ui", "merge-reports",
+      "ci-gate", "ui-e2e-gate",
     ]) {
       const definition = ciJob(job)
       expect(definition, job).toContain("CI_EXECUTION_PLAN: ${{ needs.scope.outputs.execution_plan }}")

--- a/src/web/src/app/c/me/[dmId]/page.tsx
+++ b/src/web/src/app/c/me/[dmId]/page.tsx
@@ -41,7 +41,7 @@ import {
   communityWsSubscribe,
   communityWsUnsubscribe,
   communityWsSendTyping,
-  communityWsResetTypingThrottle,
+  communityWsEndTyping,
 } from "@/hooks/community/use-community-ws"
 import {
   advanceCommunityOnboarding,
@@ -426,7 +426,7 @@ function DmView() {
     void receipt.committed.then((result) => {
       if (result.ok) advanceOnboardingAfterSend()
     })
-    communityWsResetTypingThrottle({ channelId: dmId })
+    communityWsEndTyping({ channelId: dmId })
     setReplyTo(null)
     return true
   }

--- a/src/web/src/components/community/channels/channel-route.text-scroll-target.test.ts
+++ b/src/web/src/components/community/channels/channel-route.text-scroll-target.test.ts
@@ -223,7 +223,7 @@ vi.mock("@/hooks/community/mutations", () => ({
 }))
 vi.mock("@/hooks/community/use-community-ws", () => ({
   communityWsSendTyping: vi.fn(),
-  communityWsResetTypingThrottle: vi.fn(),
+  communityWsEndTyping: vi.fn(),
   communityWsClaimSecondaryChannel: vi.fn(),
   communityWsReleaseSecondaryChannel: vi.fn(),
 }))

--- a/src/web/src/components/community/channels/text-channel-surface.test.ts
+++ b/src/web/src/components/community/channels/text-channel-surface.test.ts
@@ -85,7 +85,7 @@ vi.mock("@/hooks/community/mutations", () => ({
 }))
 vi.mock("@/hooks/community/use-community-ws", () => ({
   communityWsSendTyping: vi.fn(),
-  communityWsResetTypingThrottle: vi.fn(),
+  communityWsEndTyping: vi.fn(),
 }))
 
 function feed(overrides: Record<string, unknown> = {}) {

--- a/src/web/src/components/community/messages/message-channel-controller-send.test.ts
+++ b/src/web/src/components/community/messages/message-channel-controller-send.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
   getRetryPayload: vi.fn(),
   dispatch: vi.fn(),
   toastApiError: vi.fn(),
-  resetTyping: vi.fn(),
+  endTyping: vi.fn(),
   zip: vi.fn(),
   toVm: vi.fn((channelId: string, attachment: { id: string }) => ({
     kind: "file", url: `/api/${channelId}/${attachment.id}`, name: attachment.id, size: 1,
@@ -27,7 +27,7 @@ vi.mock("@/hooks/community/mutations", () => ({
   zipUploadResultsWithDimensions: mocks.zip,
 }))
 vi.mock("@/hooks/community/use-community-ws", () => ({
-  communityWsResetTypingThrottle: mocks.resetTyping,
+  communityWsEndTyping: mocks.endTyping,
 }))
 vi.mock("@/lib/api/client", () => ({ toastApiError: mocks.toastApiError }))
 
@@ -78,7 +78,7 @@ describe("message channel send helpers", () => {
     expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:new")
     expect(URL.revokeObjectURL).not.toHaveBeenCalledWith("blob:supplied")
     expect(runner).not.toHaveBeenCalled()
-    expect(mocks.resetTyping).not.toHaveBeenCalled()
+    expect(mocks.endTyping).not.toHaveBeenCalled()
     expect(clearReply).not.toHaveBeenCalled()
   })
 
@@ -113,7 +113,7 @@ describe("message channel send helpers", () => {
       return true
     })
     const runner = vi.fn(async () => { order.push("run") })
-    mocks.resetTyping.mockImplementation(() => order.push("typing"))
+    mocks.endTyping.mockImplementation(() => order.push("typing"))
     const clearReply = vi.fn(() => order.push("clear"))
     expect(acceptChannelMessage({
       markdown: "hello",
@@ -127,7 +127,7 @@ describe("message channel send helpers", () => {
       clearReply,
     })).toBe(true)
     expect(runner).toHaveBeenCalledWith("nonce_1")
-    expect(mocks.resetTyping).toHaveBeenCalledWith({ channelId: "channel_1" })
+    expect(mocks.endTyping).toHaveBeenCalledWith({ channelId: "channel_1" })
     expect(order).toEqual(["accept", "run", "typing", "clear"])
     expect(URL.revokeObjectURL).not.toHaveBeenCalled()
   })
@@ -169,7 +169,7 @@ describe("message channel send helpers", () => {
       mentionType: undefined,
     })
     expect(runner).toHaveBeenCalledWith("nonce_1")
-    expect(mocks.resetTyping).toHaveBeenCalledWith({ channelId: "channel_1" })
+    expect(mocks.endTyping).toHaveBeenCalledWith({ channelId: "channel_1" })
     expect(clearReply).toHaveBeenCalledOnce()
   })
 

--- a/src/web/src/components/community/messages/message-channel-controller-send.ts
+++ b/src/web/src/components/community/messages/message-channel-controller-send.ts
@@ -11,7 +11,7 @@ import {
 } from "@/hooks/community/mutations"
 import { toastApiError } from "@/lib/api/client"
 import { useMessageStreamStore } from "@/stores/community/message-stream"
-import { communityWsResetTypingThrottle } from "@/hooks/community/use-community-ws"
+import { communityWsEndTyping } from "@/hooks/community/use-community-ws"
 import { canonicalizeReplyContent } from "@/lib/community/reply-content"
 
 type ChannelMessageScope = {
@@ -183,7 +183,7 @@ export function acceptChannelMessage({
     return false
   }
   void runAcceptedIntent(nonce)
-  communityWsResetTypingThrottle({ channelId })
+  communityWsEndTyping({ channelId })
   clearReply()
   return true
 }

--- a/src/web/src/components/community/messages/use-composer-controller.test.ts
+++ b/src/web/src/components/community/messages/use-composer-controller.test.ts
@@ -935,6 +935,51 @@ describe("useComposerController", () => {
     expect(vi.getTimerCount()).toBe(1)
   })
 
+  it("resets the leading-edge typing timer only after an accepted send", async () => {
+    vi.useFakeTimers()
+    const onTyping = vi.fn()
+    const reject = vi.fn(() => false)
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(Harness, {
+        ...acceptedProps(reject),
+        onTyping,
+      }))
+    })
+
+    await act(async () => {
+      editorOptions.onUpdate({ editor })
+    })
+    expect(onTyping).toHaveBeenCalledOnce()
+
+    await enter()
+    await act(async () => {
+      editorOptions.onUpdate({ editor })
+    })
+    expect(onTyping).toHaveBeenCalledOnce()
+    await act(async () => {
+      vi.advanceTimersByTime(3_000)
+    })
+
+    const accept = vi.fn(() => true)
+    clearContent.mockImplementationOnce(() => {
+      editorOptions.onUpdate({ editor })
+    })
+    await act(async () => {
+      renderer.update(createElement(Harness, {
+        ...acceptedProps(accept),
+        onTyping,
+      }))
+    })
+    await enter()
+    expect(onTyping).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      editorOptions.onUpdate({ editor })
+    })
+    expect(onTyping).toHaveBeenCalledTimes(2)
+  })
+
   it("skips all draft restore and chat focus effects in forum mode", async () => {
     const props: ComposerProps = {
       channel: "forum",
@@ -1259,8 +1304,10 @@ describe("useComposerController", () => {
     expect(source).toContain("useLayoutEffect(")
     expect(source).toContain("emitUpdate: false")
     expect(source).toContain("errorOnInvalidContent: true")
-    expect(source).toContain("restoringDraftRef.current = false")
+    expect(source).toContain("suppressUpdateEffectsRef.current = false")
     expect(source).toContain("3_000")
-    expect(source).not.toContain("clearTimeout(")
+    expect(source.indexOf("clearTimeout(typingTimer.current)"))
+      .toBeLessThan(source.indexOf("editor.commands.clearContent()"))
+    expect(source).toContain("typingTimer.current = null")
   })
 })

--- a/src/web/src/components/community/messages/use-composer-controller.ts
+++ b/src/web/src/components/community/messages/use-composer-controller.ts
@@ -112,10 +112,8 @@ export function useComposerController(
     },
     [],
   )
-  const restoringDraftRef = useRef(false)
-  const resolvedPlaceholder =
-    placeholder ??
-    (context === "channel" ? `Message /${channel}` : `Message ${channel}`)
+  const suppressUpdateEffectsRef = useRef(false)
+  const resolvedPlaceholder = placeholder ?? (context === "channel" ? `Message /${channel}` : `Message ${channel}`)
   const placeholderRef = useRef(resolvedPlaceholder)
   const resolvePlaceholder = useCallback(() => placeholderRef.current, [])
   const suggestions = useComposerSuggestions({
@@ -203,7 +201,7 @@ export function useComposerController(
     },
     onUpdate: ({ editor: updatedEditor }) => {
       setEditorHasContent(!updatedEditor.isEmpty)
-      if (restoringDraftRef.current) return
+      if (suppressUpdateEffectsRef.current) return
       fireTyping()
       emitDirtyTransition()
       const key = draftKeyRef.current
@@ -233,7 +231,7 @@ export function useComposerController(
     if (!editor || isForumThreadBody || !draftKey) return
     const doc = readComposerDraft(draftKey)
     if (!doc) return
-    restoringDraftRef.current = true
+    suppressUpdateEffectsRef.current = true
     try {
       editor.commands.setContent(doc as JSONContent, {
         emitUpdate: false,
@@ -242,9 +240,7 @@ export function useComposerController(
       setEditorHasContent(!editor.isEmpty)
     } catch {
       clearComposerDraft(draftKey)
-    } finally {
-      restoringDraftRef.current = false
-    }
+    } finally { suppressUpdateEffectsRef.current = false }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor, draftKey])
   const previousHasContentRef = useRef(false)
@@ -288,7 +284,11 @@ export function useComposerController(
         await onDeferredSubmit?.(markdown, payload, mentionType)
       }
       if (isForumThreadBody) return
-      editor.commands.clearContent()
+      const accepted = sendContract === "accepted"
+      if (accepted && typingTimer.current) clearTimeout(typingTimer.current)
+      if (accepted) typingTimer.current = null
+      suppressUpdateEffectsRef.current = accepted
+      try { editor.commands.clearContent() } finally { suppressUpdateEffectsRef.current = false }
       setEditorHasContent(false)
       if (draftKeyRef.current) clearComposerDraft(draftKeyRef.current)
       transferPendingFiles()

--- a/src/web/src/hooks/community/use-community-ws.test.ts
+++ b/src/web/src/hooks/community/use-community-ws.test.ts
@@ -72,8 +72,8 @@ describe("useCommunityWs — public helper contracts", () => {
     expect(useCommunityStore.getState().subscription.dmConversationId).toBeUndefined()
   })
 
-  it("free typing helpers no-op before mount, throttle, and send again after reset", async () => {
-    const { communityWsResetTypingThrottle, communityWsSendTyping } = await import("./use-community-ws")
+  it("ends a typing burst, resets the throttle, and permits an immediate fresh start", async () => {
+    const { communityWsEndTyping, communityWsSendTyping } = await import("./use-community-ws")
     const target = { channelId: "ch_typing_contract" }
 
     communityWsSendTyping(target)
@@ -82,6 +82,8 @@ describe("useCommunityWs — public helper contracts", () => {
     await mountHook()
     flushEffects()
     const send = getStableSend()
+    communityWsEndTyping(target)
+    expect(send).not.toHaveBeenCalled()
     communityWsSendTyping(target)
     communityWsSendTyping(target)
     expect(send).toHaveBeenCalledOnce()
@@ -90,10 +92,14 @@ describe("useCommunityWs — public helper contracts", () => {
       channelId: "ch_typing_contract",
     })
 
-    communityWsResetTypingThrottle(target)
+    communityWsEndTyping(target)
     communityWsSendTyping(target)
-    expect(send).toHaveBeenCalledTimes(2)
+    expect(send).toHaveBeenCalledTimes(3)
     expect(send).toHaveBeenNthCalledWith(2, {
+      type: "community:typing.stop",
+      channelId: "ch_typing_contract",
+    })
+    expect(send).toHaveBeenNthCalledWith(3, {
       type: "community:typing.start",
       channelId: "ch_typing_contract",
     })

--- a/src/web/src/hooks/community/use-community-ws.ts
+++ b/src/web/src/hooks/community/use-community-ws.ts
@@ -208,15 +208,11 @@ export function communityWsSendTyping(target: { channelId: string }) {
   send({ type: "community:typing.start", channelId: key })
 }
 
-/**
- * Reset the outbound typing.start throttle for a channel. Sending a message
- * ends the current typing burst; the very next keystroke should re-emit
- * typing.start immediately, not wait out the 8s dedup window.
- */
-export function communityWsResetTypingThrottle(target: { channelId: string }) {
+export function communityWsEndTyping(target: { channelId: string }) {
   const key = target.channelId
   if (!key) return
-  useCommunityStore.getState().lastTypingSent.delete(key)
+  const hadActiveBurst = useCommunityStore.getState().lastTypingSent.delete(key)
+  if (hadActiveBurst) activeSend?.({ type: "community:typing.stop", channelId: key })
 }
 
 export function useCommunityWs(options?: UseCommunityWsOptions): void {

--- a/src/web/src/test/e2e-service-definitions.test.ts
+++ b/src/web/src/test/e2e-service-definitions.test.ts
@@ -1,18 +1,29 @@
 import { EventEmitter } from "node:events"
 import type { ChildProcess } from "node:child_process"
 import { createRequire } from "node:module"
-import { describe, expect, it } from "vitest"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, resolve } from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
 import {
+  E2E_PREBUILT_ENTRYPOINTS,
   E2E_WRANGLER_VERSION,
   hasExactHealth,
   readinessExitMessage,
   resolveE2EWranglerRuntime,
+  serviceBuildCommands,
   serviceDefinitions,
   waitForHealth,
   waitForServicesReady,
   wranglerLogEnvironment,
 } from "./e2e-ui/_setup/services"
 import { resolveMachineWsUrl, resolveWsUrl } from "./e2e-ui/_setup/paths"
+
+const temporaryRoots: string[] = []
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
 
 describe("UI E2E service definitions", () => {
   it("isolates the exact E2E Wrangler from the normal project CLI", () => {
@@ -52,6 +63,22 @@ describe("UI E2E service definitions", () => {
       { name: "web", command: "pnpm" },
       { name: "ws-do", command: "pnpm" },
     ])
+  })
+
+  it("skips both builds only when both prebuilt worker entrypoints exist", () => {
+    const root = mkdtempSync(resolve(tmpdir(), "alook-prebuilt-services-"))
+    temporaryRoots.push(root)
+    for (const entrypoint of E2E_PREBUILT_ENTRYPOINTS) {
+      mkdirSync(dirname(resolve(root, entrypoint)), { recursive: true })
+      writeFileSync(resolve(root, entrypoint), "export default {}\n")
+    }
+
+    expect(serviceBuildCommands(true, true, root)).toEqual([])
+    rmSync(resolve(root, E2E_PREBUILT_ENTRYPOINTS[1]))
+    expect(() => serviceBuildCommands(true, true, root))
+      .toThrow("prebuilt OpenNext worker entrypoint is missing")
+    expect(serviceBuildCommands(true, false, root)).toHaveLength(2)
+    expect(serviceBuildCommands(false, true, root)).toEqual([])
   })
 
   it("uses the web URL for ws-do in the CI single-runtime topology", () => {

--- a/src/web/src/test/e2e-ui/24-composer-overflow.spec.ts
+++ b/src/web/src/test/e2e-ui/24-composer-overflow.spec.ts
@@ -1,5 +1,5 @@
 import { type Locator, type Page } from "@playwright/test"
-import { test, expect, userId } from "./_fixtures/community-fixture"
+import { test, expect, userId, userName } from "./_fixtures/community-fixture"
 import { composerEditable, ignoreNextDevToolsPointerCapture } from "./_fixtures/actions"
 import { tid } from "./_fixtures/testids"
 import {
@@ -228,6 +228,10 @@ test.describe.serial("community composer text containment", () => {
       secondaryChannelName,
     )
     dmId = await seedDm("alice", userId("carol"))
+  })
+
+  test.afterAll(async () => {
+    await renameUser("bob", userName("bob"))
   })
 
   test("default channel placeholder stays in the editable width and leaves controls clickable", async ({ asUser }) => {

--- a/src/web/src/test/e2e-ui/25-composer-accessory-rail-occupancy.spec.ts
+++ b/src/web/src/test/e2e-ui/25-composer-accessory-rail-occupancy.spec.ts
@@ -1,11 +1,28 @@
 import type { Page, TestInfo } from "@playwright/test"
-import { test, expect } from "./_fixtures/community-fixture"
+import { test, expect, userName } from "./_fixtures/community-fixture"
 import { composerEditable, gotoAfterUserWsAuth, sendMessage } from "./_fixtures/actions"
 import { renameUser, seedChannel, seedJoinServer, seedMessage, seedServer } from "./_fixtures/seed"
 import { tid } from "./_fixtures/testids"
 
 const VIEWPORT_WIDTHS = [320, 390, 639, 640, 1280] as const
 const LONG_TYPING_NAME = `Typing ${"occupancy ".repeat(8)}edge`
+
+test.afterAll(async () => {
+  const restorations = await Promise.allSettled([
+    renameUser("bob", userName("bob")),
+    renameUser("carol", userName("carol")),
+  ])
+  expect(restorations.map((result) => result.status)).toEqual(["fulfilled", "fulfilled"])
+})
+
+async function sendExactMessageAndObserve(sender: Page, observer: Page, text: string) {
+  const editable = composerEditable(sender)
+  await editable.click()
+  await sender.keyboard.press("ControlOrMeta+A")
+  await sender.keyboard.press("Backspace")
+  await sendMessage(sender, text)
+  await expect(observer.getByText(text, { exact: true }).first()).toBeVisible()
+}
 
 type Rect = {
   left: number
@@ -430,13 +447,12 @@ test("composer accessory rail reallocates every occupied slot without overflow",
   })
 
   const bobEditor = composerEditable(bob.page)
-  await expect(async () => {
-    await bobEditor.click()
-    await bob.page.keyboard.press("ControlOrMeta+A")
-    await bob.page.keyboard.press("Backspace")
-    await bob.page.keyboard.type("typing occupancy")
-    await expect(alice.page.getByTestId(tid.typingIndicator)).toBeVisible({ timeout: 4_000 })
-  }).toPass({ timeout: 20_000 })
+  await bobEditor.click()
+  await bob.page.keyboard.press("ControlOrMeta+A")
+  await bob.page.keyboard.press("Backspace")
+  await bob.page.keyboard.type("typing occupancy")
+  await expect(alice.page.getByTestId(tid.typingIndicator))
+    .toContainText(LONG_TYPING_NAME, { timeout: 20_000 })
 
   const typingAndCenter = await captureState({
     page: alice.page,
@@ -474,16 +490,19 @@ test("composer accessory rail reallocates every occupied slot without overflow",
   expect(leftOnly[320].typingText?.whiteSpace).toBe("nowrap")
   expect(leftOnly[320].typingText!.scrollWidth).toBeGreaterThan(leftOnly[320].typingText!.clientWidth)
 
-  await sendMessage(bob.page, `long typing clear ${Date.now()}`)
+  await sendExactMessageAndObserve(
+    bob.page,
+    alice.page,
+    `long typing clear ${Date.now()}`,
+  )
   await expect(alice.page.getByTestId(tid.typingIndicator)).toHaveCount(0)
   const carolEditor = composerEditable(carol.page)
-  await expect(async () => {
-    await carolEditor.click()
-    await carol.page.keyboard.press("ControlOrMeta+A")
-    await carol.page.keyboard.press("Backspace")
-    await carol.page.keyboard.type("short selection typing")
-    await expect(alice.page.getByTestId(tid.typingIndicator)).toBeVisible({ timeout: 4_000 })
-  }).toPass({ timeout: 20_000 })
+  await carolEditor.click()
+  await carol.page.keyboard.press("ControlOrMeta+A")
+  await carol.page.keyboard.press("Backspace")
+  await carol.page.keyboard.type("short selection typing")
+  await expect(alice.page.getByTestId(tid.typingIndicator))
+    .toContainText("Cy", { timeout: 20_000 })
 
   row = alice.page.getByTestId(tid.message(selectableMessageId))
   await row.hover()
@@ -508,15 +527,14 @@ test("composer accessory rail reallocates every occupied slot without overflow",
     expect(selectionShort[width].center!.center).toBe(selectionNone[width].center!.center)
   }
 
-  await expect(async () => {
-    await bobEditor.click()
-    await bob.page.keyboard.press("ControlOrMeta+A")
-    await bob.page.keyboard.press("Backspace")
-    await bob.page.keyboard.type("multiple selection typing")
-    await expect(alice.page.getByTestId(tid.typingIndicator)).toContainText(" and ", {
-      timeout: 4_000,
-    })
-  }).toPass({ timeout: 20_000 })
+  await bobEditor.click()
+  await bob.page.keyboard.press("ControlOrMeta+A")
+  await bob.page.keyboard.press("Backspace")
+  await bob.page.keyboard.type("multiple selection typing")
+  await expect(alice.page.getByTestId(tid.typingIndicator))
+    .toContainText(LONG_TYPING_NAME, { timeout: 20_000 })
+  await expect(alice.page.getByTestId(tid.typingIndicator)).toContainText("Cy")
+  await expect(alice.page.getByTestId(tid.typingIndicator)).toContainText(" and ")
   const selectionMultiple = await captureState({
     page: alice.page,
     testInfo,
@@ -532,16 +550,24 @@ test("composer accessory rail reallocates every occupied slot without overflow",
     expect(selectionMultiple[width].center!.center).toBe(selectionNone[width].center!.center)
   }
 
-  await sendMessage(bob.page, `multiple typing clear ${Date.now()}`)
-  await sendMessage(carol.page, `short typing clear ${Date.now()}`)
+  await sendExactMessageAndObserve(
+    bob.page,
+    alice.page,
+    `multiple typing clear ${Date.now()}`,
+  )
+  await sendExactMessageAndObserve(
+    carol.page,
+    alice.page,
+    `short typing clear ${Date.now()}`,
+  )
   await expect(alice.page.getByTestId(tid.typingIndicator)).toHaveCount(0)
-  await expect(async () => {
-    await bobEditor.click()
-    await bob.page.keyboard.press("ControlOrMeta+A")
-    await bob.page.keyboard.press("Backspace")
-    await bob.page.keyboard.type("long selection typing")
-    await expect(alice.page.getByTestId(tid.typingIndicator)).toHaveCount(1, { timeout: 4_000 })
-  }).toPass({ timeout: 20_000 })
+  await bobEditor.click()
+  await bob.page.keyboard.press("ControlOrMeta+A")
+  await bob.page.keyboard.press("Backspace")
+  await bob.page.keyboard.type("long selection typing")
+  await expect(alice.page.getByTestId(tid.typingIndicator))
+    .toContainText(LONG_TYPING_NAME, { timeout: 20_000 })
+  await expect(alice.page.getByTestId(tid.typingIndicator)).not.toContainText("Cy")
   const selectionLong = await captureState({
     page: alice.page,
     testInfo,
@@ -558,7 +584,11 @@ test("composer accessory rail reallocates every occupied slot without overflow",
     expect(selectionLong[width].typing).toBeNull()
   }
 
-  await sendMessage(bob.page, `theme typing clear ${Date.now()}`)
+  await sendExactMessageAndObserve(
+    bob.page,
+    alice.page,
+    `theme typing clear ${Date.now()}`,
+  )
   await expect(alice.page.getByTestId(tid.typingIndicator)).toHaveCount(0)
   await captureState({
     page: alice.page,

--- a/src/web/src/test/e2e-ui/30-bot-profile-audit-preview.spec.ts
+++ b/src/web/src/test/e2e-ui/30-bot-profile-audit-preview.spec.ts
@@ -487,6 +487,7 @@ test("owner-only bot mark sticker, Stop lifecycle, owner swap, and URL-owned aud
     for (let index = 0; index < 11; index += 1) {
       machine.socket.send(JSON.stringify({
         type: "bot_audit_event",
+        eventId: `bae_${suffix}_${String(index).padStart(2, "0")}`,
         agentId: botId,
         sessionId: `session-${suffix}`,
         launchId: `launch-${suffix}`,
@@ -552,6 +553,7 @@ test("owner-only bot mark sticker, Stop lifecycle, owner swap, and URL-owned aud
       /open activity log 0$/i.test(text))).toBe(false)
     machine.socket.send(JSON.stringify({
       type: "bot_audit_event",
+      eventId: `bae_${suffix}_11`,
       agentId: botId,
       sessionId: `session-${suffix}`,
       launchId: `launch-${suffix}`,

--- a/src/web/src/test/e2e-ui/33-picker-async-layout.spec.ts
+++ b/src/web/src/test/e2e-ui/33-picker-async-layout.spec.ts
@@ -1,5 +1,5 @@
 import type { Locator, Page } from "@playwright/test"
-import { expect, test, userId } from "./_fixtures/community-fixture"
+import { expect, test, userId, userName } from "./_fixtures/community-fixture"
 import { tid } from "./_fixtures/testids"
 import {
   memberInfo,
@@ -95,6 +95,14 @@ test.describe.serial("invite and participant picker async states", () => {
     await seedMessage("carol", emptyThreadId, "existing participant carol")
     bobName = (await memberInfo("alice", participantServerId, userId("bob"))).name
     carolName = (await memberInfo("alice", participantServerId, userId("carol"))).name
+  })
+
+  test.afterAll(async () => {
+    const restorations = await Promise.allSettled([
+      renameUser("bob", userName("bob")),
+      renameUser("carol", userName("carol")),
+    ])
+    expect(restorations.map((result) => result.status)).toEqual(["fulfilled", "fulfilled"])
   })
 
   test("Invite friends keeps cold data provisional, search local, row pending, and title clear", async ({ asUser }) => {

--- a/src/web/src/test/e2e-ui/39-mobile-composer-send.spec.ts
+++ b/src/web/src/test/e2e-ui/39-mobile-composer-send.spec.ts
@@ -2,6 +2,7 @@ import type { Page, TestInfo } from "@playwright/test"
 import { test, expect, userId } from "./_fixtures/community-fixture"
 import {
   composerEditable,
+  gotoAfterUserWsAuth,
   ignoreNextDevToolsPointerCapture,
   installInputCapability,
 } from "./_fixtures/actions"
@@ -51,7 +52,7 @@ async function expectHoverKeyboardSend({
       && new URL(request.url()).pathname === `/api/community/channels/${channelId}/messages`
     ) messagePosts += 1
   })
-  await page.goto(route, { waitUntil: "commit" })
+  await gotoAfterUserWsAuth(page, route)
   await ignoreNextDevToolsPointerCapture(page)
 
   const editable = composerEditable(page)
@@ -128,7 +129,7 @@ async function expectExplicitTouchSend({
       && new URL(request.url()).pathname === `/api/community/channels/${channelId}/messages`
     ) messagePosts += 1
   })
-  await page.goto(route, { waitUntil: "commit" })
+  await gotoAfterUserWsAuth(page, route)
   await ignoreNextDevToolsPointerCapture(page)
 
   const editable = composerEditable(page)

--- a/src/web/src/test/e2e-ui/46-community-loading-geometry-android.spec.ts
+++ b/src/web/src/test/e2e-ui/46-community-loading-geometry-android.spec.ts
@@ -1,0 +1,16 @@
+import { test } from "./_fixtures/community-fixture"
+import {
+  runAndroidLoadingGeometry,
+  runSkeletonLoadingMotion,
+} from "./_fixtures/community-loading-geometry"
+
+test.describe.serial("community Android loading geometry", () => {
+  test("Android Chrome/WebView keep 320/390/639 cold frames mobile before breakpoint hydration", async ({ asUser }) => {
+    test.setTimeout(240_000)
+    await runAndroidLoadingGeometry(asUser)
+  })
+
+  test("community skeleton pulse changes only opacity and stops for reduced motion", async ({ asUser }) => {
+    await runSkeletonLoadingMotion(asUser)
+  })
+})

--- a/src/web/src/test/e2e-ui/46-community-loading-geometry-dark.spec.ts
+++ b/src/web/src/test/e2e-ui/46-community-loading-geometry-dark.spec.ts
@@ -1,0 +1,24 @@
+import { test } from "./_fixtures/community-fixture"
+import {
+  runNeutralRootGeometry,
+  runRouteLoadingGeometry,
+  seedGeometryRoutes,
+} from "./_fixtures/community-loading-geometry"
+
+test.describe.serial("community dark loading geometry", () => {
+  let routes!: Awaited<ReturnType<typeof seedGeometryRoutes>>
+
+  test.beforeAll(async () => {
+    test.setTimeout(120_000)
+    routes = await seedGeometryRoutes()
+  })
+
+  test("dark: neutral root owns two viewport cold restores", async ({ asUser }, testInfo) => {
+    await runNeutralRootGeometry("dark", asUser, testInfo)
+  })
+
+  test("dark: 18 route × viewport pending→loaded pairs keep shell CLS at zero", async ({ asUser }, testInfo) => {
+    test.setTimeout(600_000)
+    await runRouteLoadingGeometry("dark", routes, asUser, testInfo)
+  })
+})

--- a/src/web/src/test/e2e-ui/46-community-loading-geometry-light.spec.ts
+++ b/src/web/src/test/e2e-ui/46-community-loading-geometry-light.spec.ts
@@ -1,0 +1,24 @@
+import { test } from "./_fixtures/community-fixture"
+import {
+  runNeutralRootGeometry,
+  runRouteLoadingGeometry,
+  seedGeometryRoutes,
+} from "./_fixtures/community-loading-geometry"
+
+test.describe.serial("community light loading geometry", () => {
+  let routes!: Awaited<ReturnType<typeof seedGeometryRoutes>>
+
+  test.beforeAll(async () => {
+    test.setTimeout(120_000)
+    routes = await seedGeometryRoutes()
+  })
+
+  test("light: neutral root owns two viewport cold restores", async ({ asUser }, testInfo) => {
+    await runNeutralRootGeometry("light", asUser, testInfo)
+  })
+
+  test("light: 18 route × viewport pending→loaded pairs keep shell CLS at zero", async ({ asUser }, testInfo) => {
+    test.setTimeout(600_000)
+    await runRouteLoadingGeometry("light", routes, asUser, testInfo)
+  })
+})

--- a/src/web/src/test/e2e-ui/_fixtures/community-loading-geometry.ts
+++ b/src/web/src/test/e2e-ui/_fixtures/community-loading-geometry.ts
@@ -26,6 +26,7 @@ type CommunityAsUser = (
 ) => Promise<{ context: BrowserContext; page: Page }>
 type MobileWidth = 320 | 390 | 639
 const RAIL_OVERFLOW_SERVER_COUNT = 20
+const ISOLATED_GEOMETRY_USER: UserKey = "dave"
 const ANDROID_USER_AGENTS = {
   chrome: "Mozilla/5.0 (Linux; Android 15; Pixel 9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Mobile Safari/537.36",
   webview: "Mozilla/5.0 (Linux; Android 15; Pixel 9 Build/AP3A.240905.015; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/140.0.0.0 Mobile Safari/537.36",
@@ -318,28 +319,37 @@ async function visibleSkeletonAnimationProperties(page: Page) {
 
 export async function seedGeometryRoutes(): Promise<Omit<MatrixCase, "width">[]> {
   const stamp = Date.now()
-    const serverId = await seedServer("alice", `Geometry ${stamp}`)
+    const serverId = await seedServer(ISOLATED_GEOMETRY_USER, `Geometry ${stamp}`)
     for (let index = 1; index < RAIL_OVERFLOW_SERVER_COUNT; index += 1) {
-      await seedServer("alice", `Geometry rail ${stamp}-${index}`)
+      await seedServer(ISOLATED_GEOMETRY_USER, `Geometry rail ${stamp}-${index}`)
     }
-    const textId = await seedChannel("alice", serverId, `geometry-text-${stamp}`)
-    const forumId = await seedChannel("alice", serverId, `geometry-forum-${stamp}`, "forum")
+    const textId = await seedChannel(ISOLATED_GEOMETRY_USER, serverId, `geometry-text-${stamp}`)
+    const forumId = await seedChannel(
+      ISOLATED_GEOMETRY_USER,
+      serverId,
+      `geometry-forum-${stamp}`,
+      "forum",
+    )
     const textMessage = `geometry opener ${stamp}`
     const threadMessage = `geometry reply ${stamp}`
     const forumTitle = `Geometry forum post ${stamp}`
     const forumMessage = `geometry forum reply ${stamp}`
     const dmMessage = `geometry dm ${stamp}`
-    const openerId = await seedMessage("alice", textId, textMessage)
-    const threadId = await seedThread("alice", openerId, `geometry-thread-${stamp}`)
-    await seedMessage("alice", threadId, threadMessage)
+    const openerId = await seedMessage(ISOLATED_GEOMETRY_USER, textId, textMessage)
+    const threadId = await seedThread(
+      ISOLATED_GEOMETRY_USER,
+      openerId,
+      `geometry-thread-${stamp}`,
+    )
+    await seedMessage(ISOLATED_GEOMETRY_USER, threadId, threadMessage)
     const forumPostId = await seedForumThread(
-      "alice",
+      ISOLATED_GEOMETRY_USER,
       forumId,
       forumTitle,
       forumMessage,
     )
-    const dmId = await seedDm("alice", userId("bob"))
-    await seedMessage("alice", dmId, dmMessage)
+    const dmId = await seedDm(ISOLATED_GEOMETRY_USER, userId("bob"))
+    await seedMessage(ISOLATED_GEOMETRY_USER, dmId, dmMessage)
 
     const main = (page: Page) => shellPanel(page, "main")
     const messageReady = (content: string) => (page: Page) =>
@@ -451,12 +461,12 @@ export async function runNeutralRootGeometry(
   testInfo: TestInfo,
 ) {
       for (const width of [390, 1280] as const) {
-        const { context, page } = await asUser("alice")
+        const { context, page } = await asUser(ISOLATED_GEOMETRY_USER)
         await page.setViewportSize({ width, height: width === 390 ? 844 : 900 })
         await page.emulateMedia({ colorScheme: theme })
         await page.addInitScript((storageKey) => {
           localStorage.removeItem(storageKey)
-        }, `community:lastRoute:${encodeURIComponent(userId("alice"))}`)
+        }, `community:lastRoute:${encodeURIComponent(userId(ISOLATED_GEOMETRY_USER))}`)
         const session = await holdSession(page)
         await page.goto("/c", { waitUntil: "commit" })
         await expect.poll(session.hits).toBeGreaterThan(0)
@@ -515,7 +525,7 @@ export async function runRouteLoadingGeometry(
       expect(cases).toHaveLength(18)
 
       for (const entry of cases) {
-        const { context, page } = await asUser("alice")
+        const { context, page } = await asUser(ISOLATED_GEOMETRY_USER)
         await page.setViewportSize({ width: entry.width, height: entry.width === 390 ? 844 : 900 })
         await page.emulateMedia({ colorScheme: theme })
         await startClsObserver(page)

--- a/src/web/src/test/e2e-ui/_fixtures/community-loading-geometry.ts
+++ b/src/web/src/test/e2e-ui/_fixtures/community-loading-geometry.ts
@@ -1,5 +1,12 @@
-import type { Locator, Page, Route } from "@playwright/test"
-import { expect, sessionCookie, test, userId } from "./_fixtures/community-fixture"
+import type {
+  BrowserContext,
+  BrowserContextOptions,
+  Locator,
+  Page,
+  Route,
+  TestInfo,
+} from "@playwright/test"
+import { expect, sessionCookie, userId } from "./community-fixture"
 import {
   seedChannel,
   seedDm,
@@ -7,11 +14,16 @@ import {
   seedMessage,
   seedServer,
   seedThread,
-} from "./_fixtures/seed"
-import { tid } from "./_fixtures/testids"
-import { WEB_URL } from "./_setup/paths"
+} from "./seed"
+import { tid } from "./testids"
+import { WEB_URL } from "../_setup/paths"
+import type { UserKey } from "../_setup/users"
 
 type Theme = "light" | "dark"
+type CommunityAsUser = (
+  key: UserKey,
+  options?: Omit<BrowserContextOptions, "storageState">,
+) => Promise<{ context: BrowserContext; page: Page }>
 type MobileWidth = 320 | 390 | 639
 const RAIL_OVERFLOW_SERVER_COUNT = 20
 const ANDROID_USER_AGENTS = {
@@ -304,12 +316,8 @@ async function visibleSkeletonAnimationProperties(page: Page) {
   )).sort())
 }
 
-test.describe.serial("community pending-to-loaded geometry matrix", () => {
-  let routes!: Omit<MatrixCase, "width">[]
-
-  test.beforeAll(async () => {
-    test.setTimeout(120_000)
-    const stamp = Date.now()
+export async function seedGeometryRoutes(): Promise<Omit<MatrixCase, "width">[]> {
+  const stamp = Date.now()
     const serverId = await seedServer("alice", `Geometry ${stamp}`)
     for (let index = 1; index < RAIL_OVERFLOW_SERVER_COUNT; index += 1) {
       await seedServer("alice", `Geometry rail ${stamp}-${index}`)
@@ -339,7 +347,7 @@ test.describe.serial("community pending-to-loaded geometry matrix", () => {
     const threadComposerReady = (page: Page) => page
       .getByTestId(tid.threadSplitPanel)
       .getByTestId(tid.composerInput)
-    routes = [
+  return [
       { name: "me-list", pathname: "/c/me", mobileRail: true, ready: (page) => page.getByRole("button", { name: "Friends", exact: true }) },
       { name: "friends", pathname: "/c/me/friends", ready: (page) => page.getByPlaceholder("Search friends") },
       { name: "machines", pathname: "/c/me/machines", ready: (page) => page.getByTestId(tid.machinePairOpen) },
@@ -373,11 +381,10 @@ test.describe.serial("community pending-to-loaded geometry matrix", () => {
           ready: threadComposerReady,
         },
       },
-    ]
-  })
+  ]
+}
 
-  test("Android Chrome/WebView keep 320/390/639 cold frames mobile before breakpoint hydration", async ({ asUser }) => {
-    test.setTimeout(240_000)
+export async function runAndroidLoadingGeometry(asUser: CommunityAsUser) {
     await pairMachine()
     for (const userAgent of Object.values(ANDROID_USER_AGENTS)) {
       for (const width of [320, 390, 639] as const) {
@@ -416,9 +423,9 @@ test.describe.serial("community pending-to-loaded geometry matrix", () => {
         }
       }
     }
-  })
+}
 
-  test("community skeleton pulse changes only opacity and stops for reduced motion", async ({ asUser }) => {
+export async function runSkeletonLoadingMotion(asUser: CommunityAsUser) {
     for (const reducedMotion of ["no-preference", "reduce"] as const) {
       const { context, page } = await asUser("alice", {
         userAgent: ANDROID_USER_AGENTS.webview,
@@ -436,10 +443,13 @@ test.describe.serial("community pending-to-loaded geometry matrix", () => {
       session.release()
       await context.close()
     }
-  })
+}
 
-  for (const theme of ["light", "dark"] as const satisfies readonly Theme[]) {
-    test(`${theme}: neutral root owns two viewport cold restores`, async ({ asUser }, testInfo) => {
+export async function runNeutralRootGeometry(
+  theme: Theme,
+  asUser: CommunityAsUser,
+  testInfo: TestInfo,
+) {
       for (const width of [390, 1280] as const) {
         const { context, page } = await asUser("alice")
         await page.setViewportSize({ width, height: width === 390 ? 844 : 900 })
@@ -490,10 +500,14 @@ test.describe.serial("community pending-to-loaded geometry matrix", () => {
         ))).toBe(true)
         await context.close()
       }
-    })
+}
 
-    test(`${theme}: 18 route × viewport pending→loaded pairs keep shell CLS at zero`, async ({ asUser }, testInfo) => {
-      test.setTimeout(600_000)
+export async function runRouteLoadingGeometry(
+  theme: Theme,
+  routes: Omit<MatrixCase, "width">[],
+  asUser: CommunityAsUser,
+  testInfo: TestInfo,
+) {
       const cases: MatrixCase[] = routes.flatMap((route) => ([
         { ...route, width: 390 },
         { ...route, width: 1280 },
@@ -569,6 +583,4 @@ test.describe.serial("community pending-to-loaded geometry matrix", () => {
         })
         await context.close()
       }
-    })
-  }
-})
+}

--- a/src/web/src/test/e2e-ui/_setup/services.ts
+++ b/src/web/src/test/e2e-ui/_setup/services.ts
@@ -1,6 +1,6 @@
 import { spawn, spawnSync, type ChildProcess } from "child_process"
 import { createRequire } from "module"
-import { closeSync, cpSync, existsSync, mkdirSync, openSync, rmSync } from "fs"
+import { closeSync, cpSync, existsSync, mkdirSync, openSync, rmSync, statSync } from "fs"
 import { dirname, resolve } from "path"
 import { REPO_ROOT, SERVICE_LOG_DIR, SERVICE_STATE_PATH, WEB_URL, WS_URL } from "./paths"
 import {
@@ -29,6 +29,10 @@ export interface ServiceDefinition {
 }
 
 export const E2E_WRANGLER_VERSION = "4.113.0"
+export const E2E_PREBUILT_ENTRYPOINTS = [
+  "src/web/.open-next/worker.js",
+  "src/web/blog/.open-next/worker.js",
+] as const
 
 export function resolveE2EWranglerRuntime(): {
   command: string
@@ -226,9 +230,22 @@ export async function waitForServicesReady(
   await Promise.all(services.map((service) => wait(service)))
 }
 
-export function prepareServices(): void {
-  if (!SINGLE_RUNTIME) return
-  const builds = [
+export function serviceBuildCommands(
+  singleRuntime = SINGLE_RUNTIME,
+  prebuilt = process.env.ALOOK_E2E_PREBUILT === "1",
+  root = REPO_ROOT,
+): Array<{ name: string; args: string[] }> {
+  if (!singleRuntime) return []
+  if (prebuilt) {
+    for (const entrypoint of E2E_PREBUILT_ENTRYPOINTS) {
+      const path = resolve(root, entrypoint)
+      if (!existsSync(path) || !statSync(path).isFile()) {
+        throw new Error(`prebuilt OpenNext worker entrypoint is missing: ${path}`)
+      }
+    }
+    return []
+  }
+  return [
     {
       name: "web worker",
       args: ["--filter", "@alook/web", "exec", "opennextjs-cloudflare", "build"],
@@ -238,7 +255,10 @@ export function prepareServices(): void {
       args: ["--filter", "@alook/web", "build:blog"],
     },
   ]
-  for (const build of builds) {
+}
+
+export function prepareServices(): void {
+  for (const build of serviceBuildCommands()) {
     const res = spawnSync("pnpm", build.args, {
       cwd: REPO_ROOT,
       stdio: "inherit",

--- a/src/ws-do/src/ws-durable.ts
+++ b/src/ws-do/src/ws-durable.ts
@@ -41,6 +41,9 @@ export class WebSocketDurableObject extends DurableObject<Env> {
    */
   private typingDedup = new Map<string, Map<string, number>>()
 
+  /** Preserve start/stop delivery order independently for each user and scope. */
+  private typingFanoutChains = new Map<string, Promise<void>>()
+
   /** Typing dedup window: 8 seconds */
   private static readonly TYPING_DEDUP_MS = 8_000
 
@@ -52,6 +55,7 @@ export class WebSocketDurableObject extends DurableObject<Env> {
       env: this.env,
       log,
       typingDedup: this.typingDedup,
+      typingFanoutChains: this.typingFanoutChains,
       typingDedupMs: WebSocketDurableObject.TYPING_DEDUP_MS,
       subrequestBatchSize: WebSocketDurableObject.SUBREQUEST_BATCH_SIZE,
     }

--- a/src/ws-do/src/ws-durable/internal.ts
+++ b/src/ws-do/src/ws-durable/internal.ts
@@ -69,6 +69,7 @@ export interface WsDurableContext {
   readonly env: Env
   readonly log: Logger
   readonly typingDedup: Map<string, Map<string, number>>
+  readonly typingFanoutChains: Map<string, Promise<void>>
   readonly typingDedupMs: number
   readonly subrequestBatchSize: number
 }

--- a/src/ws-do/src/ws-durable/presence-typing.test.ts
+++ b/src/ws-do/src/ws-durable/presence-typing.test.ts
@@ -619,12 +619,7 @@ describe("WebSocketDurableObject", () => {
   })
 
 
-  describe("webSocketMessage — community:typing.start authz (fanOutTyping)", () => {
-    // fanOutTyping runs fire-and-forget (`.catch()`, not awaited) inside
-    // webSocketMessage, so `await durable.webSocketMessage(...)` alone
-    // doesn't guarantee its internal DB-then-broadcast chain has settled.
-    // Flush a macrotask so all pending microtasks (getDM/getChannelForMember
-    // → listMembers → Promise.all(fetch)) drain before asserting.
+  describe("webSocketMessage — community typing authz and dedup", () => {
     const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
 
     it("does nothing when a typing frame has no channelId", async () => {
@@ -904,6 +899,136 @@ describe("WebSocketDurableObject", () => {
 
       expect(fetch).toHaveBeenCalledTimes(81)
       expect(maximum).toBe(40)
+    })
+
+    it("rejects typing.stop before authentication", async () => {
+      const { durable } = createDO()
+      const ws = createMockWebSocket()
+      ws.serializeAttachment({ type: "user", userId: "sender-1", authenticated: false })
+
+      await durable.webSocketMessage(
+        ws as any,
+        JSON.stringify({ type: "community:typing.stop", channelId: "chan-1" }),
+      )
+      await flushAsyncWork()
+
+      expect(ws.close).toHaveBeenCalledWith(1008, "Not authenticated")
+      expect(mockGetChannelForMember).not.toHaveBeenCalled()
+      expect(mockStubFetch).not.toHaveBeenCalled()
+    })
+
+    it("consumes a typing.stop without a channel and does not fan out", async () => {
+      const { durable } = createDO()
+      const ws = createMockWebSocket()
+      ws.serializeAttachment({ type: "user", userId: "sender-1", authenticated: true })
+
+      await durable.webSocketMessage(
+        ws as any,
+        JSON.stringify({ type: "community:typing.stop" }),
+      )
+      await flushAsyncWork()
+
+      expect(mockGetChannelForMember).not.toHaveBeenCalled()
+      expect(mockStubFetch).not.toHaveBeenCalled()
+    })
+
+    it("clears only the sender and scope while keeping stop fan-out membership-authorized", async () => {
+      const { durable, env } = createDO()
+      const typingDedup = (durable as unknown as {
+        typingDedup: Map<string, Map<string, number>>
+      }).typingDedup
+      typingDedup.set("chan-1", new Map([
+        ["sender-1", 10_000],
+        ["other-1", 11_000],
+      ]))
+      typingDedup.set("chan-2", new Map([["sender-1", 12_000]]))
+      mockGetChannelForMember.mockResolvedValue({ id: "chan-1", serverId: "server-1" })
+      mockResolveScopeMemberUserIds.mockResolvedValue(["sender-1", "recipient-1"])
+      const ws = createMockWebSocket()
+      ws.serializeAttachment({ type: "user", userId: "sender-1", authenticated: true })
+
+      await durable.webSocketMessage(
+        ws as any,
+        JSON.stringify({
+          type: "community:typing.stop",
+          channelId: "chan-1",
+          userId: "spoofed-user",
+        }),
+      )
+      await flushAsyncWork()
+
+      expect(typingDedup.get("chan-1")).toEqual(new Map([["other-1", 11_000]]))
+      expect(typingDedup.get("chan-2")).toEqual(new Map([["sender-1", 12_000]]))
+      expect(mockGetChannelForMember).toHaveBeenCalledWith(expect.anything(), "chan-1", "sender-1")
+      expect((env.WS_DO as any).idFromName).toHaveBeenCalledWith("user:recipient-1")
+      expect((env.WS_DO as any).idFromName).not.toHaveBeenCalledWith("user:sender-1")
+      const request = mockStubFetch.mock.calls[0]![0] as Request
+      expect(JSON.parse(await request.text())).toEqual({
+        type: "community:typing.stop",
+        channelId: "chan-1",
+        userId: "sender-1",
+      })
+    })
+
+    it("does not fan out a typing.stop from a non-member", async () => {
+      const { durable } = createDO()
+      mockGetChannelForMember.mockResolvedValue(null)
+      const ws = createMockWebSocket()
+      ws.serializeAttachment({ type: "user", userId: "attacker", authenticated: true })
+
+      await durable.webSocketMessage(
+        ws as any,
+        JSON.stringify({ type: "community:typing.stop", channelId: "chan-private" }),
+      )
+      await flushAsyncWork()
+
+      expect(mockGetChannelForMember).toHaveBeenCalledWith(
+        expect.anything(),
+        "chan-private",
+        "attacker",
+      )
+      expect(mockResolveChannelRecipientUserIds).not.toHaveBeenCalled()
+      expect(mockStubFetch).not.toHaveBeenCalled()
+    })
+
+    it("serializes a delayed start-stop-immediate-start sequence without time advancement", async () => {
+      const { durable } = createDO()
+      mockGetChannelForMember.mockResolvedValue({ id: "chan-1", serverId: "server-1" })
+      mockResolveScopeMemberUserIds.mockResolvedValue(["sender-1", "recipient-1"])
+      const ws = createMockWebSocket()
+      ws.serializeAttachment({ type: "user", userId: "sender-1", authenticated: true })
+      let releaseFirstFetch!: () => void
+      mockStubFetch.mockImplementationOnce(() => new Promise<Response>((resolve) => {
+        releaseFirstFetch = () => resolve(new Response(null, { status: 200 }))
+      }))
+      const now = vi.spyOn(Date, "now").mockReturnValue(10_000)
+      try {
+        const deliveries = [
+          "community:typing.start",
+          "community:typing.stop",
+          "community:typing.start",
+        ].map((type) => (
+          durable.webSocketMessage(
+            ws as any,
+            JSON.stringify({ type, channelId: "chan-1" }),
+          )
+        ))
+        await flushAsyncWork()
+        expect(mockStubFetch).toHaveBeenCalledTimes(1)
+        releaseFirstFetch()
+        await Promise.all(deliveries)
+
+        const frames = await Promise.all(mockStubFetch.mock.calls.map(async ([request]) => (
+          JSON.parse(await (request as Request).text()) as { type: string }
+        )))
+        expect(frames.map((frame) => frame.type)).toEqual([
+          "community:typing.start",
+          "community:typing.stop",
+          "community:typing.start",
+        ])
+      } finally {
+        now.mockRestore()
+      }
     })
 
     it("contains no local reach classifier after delegating to shared", () => {

--- a/src/ws-do/src/ws-durable/presence-typing.test.ts
+++ b/src/ws-do/src/ws-durable/presence-typing.test.ts
@@ -901,6 +901,36 @@ describe("WebSocketDurableObject", () => {
       expect(maximum).toBe(40)
     })
 
+    it("logs a serialized fan-out failure and accepts the next operation", async () => {
+      const { durable } = createDO()
+      mockGetChannelForMember
+        .mockRejectedValueOnce(new Error("D1 unavailable"))
+        .mockResolvedValueOnce({ id: "chan-1", serverId: "server-1" })
+      mockResolveScopeMemberUserIds.mockResolvedValue(["sender-1", "recipient-1"])
+      const ws = createMockWebSocket()
+      ws.serializeAttachment({ type: "user", userId: "sender-1", authenticated: true })
+
+      await durable.webSocketMessage(
+        ws as any,
+        JSON.stringify({ type: "community:typing.start", channelId: "chan-1" }),
+      )
+      await durable.webSocketMessage(
+        ws as any,
+        JSON.stringify({ type: "community:typing.stop", channelId: "chan-1" }),
+      )
+
+      expect(mockLogWarn).toHaveBeenCalledWith("community:typing.start fan-out failed", {
+        err: "Error: D1 unavailable",
+      })
+      expect(mockStubFetch).toHaveBeenCalledTimes(1)
+      const request = mockStubFetch.mock.calls[0]![0] as Request
+      expect(JSON.parse(await request.text())).toEqual({
+        type: "community:typing.stop",
+        channelId: "chan-1",
+        userId: "sender-1",
+      })
+    })
+
     it("rejects typing.stop before authentication", async () => {
       const { durable } = createDO()
       const ws = createMockWebSocket()

--- a/src/ws-do/src/ws-durable/presence-typing.ts
+++ b/src/ws-do/src/ws-durable/presence-typing.ts
@@ -26,11 +26,31 @@ function normalizeBrowserPayload(
   return { ok: true, payload: normalized.event }
 }
 
+async function serializeTypingFanOut(
+  context: WsDurableContext,
+  userId: string,
+  channelId: string,
+  type: "start" | "stop",
+  operation: () => Promise<void>,
+): Promise<void> {
+  const key = `${channelId}\u0000${userId}`
+  const previous = context.typingFanoutChains.get(key) ?? Promise.resolve()
+  const delivery = previous.then(operation).catch((err) => {
+    context.log.warn(`community:typing.${type} fan-out failed`, { err: String(err) })
+  })
+  context.typingFanoutChains.set(key, delivery)
+  try {
+    await delivery
+  } finally {
+    if (context.typingFanoutChains.get(key) === delivery) context.typingFanoutChains.delete(key)
+  }
+}
+
 export function handleClientTypingStart(
   context: WsDurableContext,
   state: UserConnectionState,
   parsed: unknown,
-): boolean {
+): false | Promise<void> {
   const msg = parsed as { type: string }
   if (msg.type !== WS_EVENTS.TYPING_START) return false
   const typingMsg = parsed as {
@@ -38,7 +58,7 @@ export function handleClientTypingStart(
     channelId?: string
   }
   const scopeKey = typingMsg.channelId
-  if (!scopeKey) return true
+  if (!scopeKey) return Promise.resolve()
 
   const now = Date.now()
   let scopeMap = context.typingDedup.get(scopeKey)
@@ -47,7 +67,7 @@ export function handleClientTypingStart(
     context.typingDedup.set(scopeKey, scopeMap)
   }
   const lastTs = scopeMap.get(state.userId) || 0
-  if (now - lastTs < context.typingDedupMs) return true
+  if (now - lastTs < context.typingDedupMs) return Promise.resolve()
   scopeMap.set(state.userId, now)
 
   if (context.typingDedup.size > 200) {
@@ -71,10 +91,28 @@ export function handleClientTypingStart(
     discriminator: state.discriminator,
   }
 
-  fanOutTyping(context, state.userId, typingMsg.channelId, event).catch((err) => {
-    context.log.warn("community:typing.start fan-out failed", { err: String(err) })
-  })
-  return true
+  return serializeTypingFanOut(context, state.userId, scopeKey, "start", () => (
+    fanOutTyping(context, state.userId, scopeKey, event)
+  ))
+}
+
+export function handleClientTypingStop(
+  context: WsDurableContext,
+  state: UserConnectionState,
+  parsed: unknown,
+): false | Promise<void> {
+  const msg = parsed as { type: string; channelId?: string }
+  if (msg.type !== WS_EVENTS.TYPING_STOP) return false
+  const scopeKey = msg.channelId
+  if (!scopeKey) return Promise.resolve()
+
+  const scopeMap = context.typingDedup.get(scopeKey)
+  scopeMap?.delete(state.userId)
+  if (scopeMap?.size === 0) context.typingDedup.delete(scopeKey)
+
+  return serializeTypingFanOut(context, state.userId, scopeKey, "stop", () => (
+    fanOutTypingStop(context, state.userId, scopeKey)
+  ))
 }
 
 export async function notifyUserDO(

--- a/src/ws-do/src/ws-durable/user-auth.ts
+++ b/src/ws-do/src/ws-durable/user-auth.ts
@@ -20,6 +20,7 @@ import type {
 import {
   broadcastPresence,
   handleClientTypingStart,
+  handleClientTypingStop,
   notifyUserDO,
   sendPresenceSnapshot,
 } from "./presence-typing"
@@ -335,7 +336,18 @@ export async function handleWebSocketMessage(
   }
 
   if (state.type === "user" && await handleUserAgentInterrupt(context, state, parsed)) return
-  if (state.type === "user" && handleClientTypingStart(context, state, parsed)) return
+  if (state.type === "user") {
+    const typingStart = handleClientTypingStart(context, state, parsed)
+    if (typingStart) {
+      await typingStart
+      return
+    }
+    const typingStop = handleClientTypingStop(context, state, parsed)
+    if (typingStop) {
+      await typingStop
+      return
+    }
+  }
 }
 
 export async function handleWebSocketClose(


### PR DESCRIPTION
# Why we need this PR?
> No linked GitHub issue. Keep UI Playwright shards within a 240-second predicted command budget while removing repeated Web/Blog builds and the realtime/fixture races exposed by the new shard boundaries.

## What changed
- Build Web and Blog once in a dedicated pinned-image job, publish an exact-head artifact with run, producer-attempt, lockfile, archive, path, and worker-entrypoint verification, and reuse it fail-closed in every shard, including partial reruns.
- Calibrate the current UI E2E inventory and deterministically pack every spec with 60 seconds of fixed setup plus a 15-second safety margin; unknown or indivisibly oversized specs fail conservatively.
- Split the loading-geometry matrix into independently shardable Android, dark, and light specs without reducing route, viewport, theme, or motion coverage.
- Make accepted sends emit an authenticated, membership-scoped typing stop and serialize `start -> stop -> immediate start` fan-out per user/channel while preserving rejected-send behavior.
- Wait for authenticated user WebSocket readiness in the mobile send journey and restore mutated Bob/Carol seed names after the affected suites.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [x] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [ ] Other: ...
