### PR TITLE
fix(web): gate message pin actions by role

### DIFF
--- a/src/web/src/components/community/channels/channel-route.text-scroll-target.dom.test.ts
+++ b/src/web/src/components/community/channels/channel-route.text-scroll-target.dom.test.ts
@@ -22,6 +22,7 @@ const {
   mockCommitLastCommunityRoute,
   mockNavigationGate,
   mockCurrentChannelId,
+  mockCanManageServer,
 } = vi.hoisted(() => ({
   mockRouter: { push: vi.fn(), replace: vi.fn(), back: vi.fn() },
   mockUiHandlers: { replacePath: vi.fn(), goBackMobile: vi.fn() },
@@ -35,6 +36,7 @@ const {
   mockCommitLastCommunityRoute: vi.fn(),
   mockNavigationGate: { allowed: true },
   mockCurrentChannelId: { value: "channel_1" as string | null },
+  mockCanManageServer: vi.fn((role?: string | null) => role === "owner" || role === "admin"),
   mockRouteModel: {
     server: {
       id: "server_1",
@@ -125,7 +127,7 @@ vi.mock("@/components/community/messages/message-context-sheet", () => ({ Messag
 vi.mock("@/components/community/messages/thread-opener", () => ({ ThreadOpener: () => null }))
 vi.mock("@/components/community/members/add-members-dialog", () => ({ AddMembersDialog: () => null }))
 vi.mock("@alook/shared", () => ({
-  canManageServer: () => false,
+  canManageServer: mockCanManageServer,
   devWsDoPort: () => 8789,
   isForum: () => false,
   deriveThreadName: () => "thread",
@@ -322,6 +324,7 @@ describe("ChannelRoute message surface ownership", () => {
     mockCommitLastCommunityRoute.mockClear()
     mockNavigationGate.allowed = true
     mockCurrentChannelId.value = "channel_1"
+    mockMemberViewModel.myRole = "member"
     Object.assign(mockRouteModel, {
       server: {
         id: "server_1",
@@ -455,6 +458,27 @@ describe("ChannelRoute message surface ownership", () => {
       "viewer_1",
       "/c/channels/server_1/channel_1",
     )
+  })
+
+  it.each([
+    ["owner", true],
+    ["admin", true],
+    ["member", false],
+  ] as const)("maps the %s role to the live text-channel Pin capability", (role, allowed) => {
+    mockMemberViewModel.myRole = role
+    mockedUseChannelMessageFeed.mockReturnValue(feed())
+
+    act(() => {
+      render(React.createElement(ChannelRoute, {
+        serverParam: "server_1",
+        channelId: "channel_1",
+      }))
+    })
+
+    expect(mockCanManageServer).toHaveBeenCalledWith(role)
+    const onPin = mockedMessageList.mock.calls.at(-1)?.[0].onPin
+    if (allowed) expect(onPin).toEqual(expect.any(Function))
+    else expect(onPin).toBeUndefined()
   })
 
   it("defers child msg cleanup until the handoff nonce has its own cleanup", () => {

--- a/src/web/src/components/community/channels/channel-route.tsx
+++ b/src/web/src/components/community/channels/channel-route.tsx
@@ -305,6 +305,7 @@ export function ChannelRoute({ serverParam, channelId }: {
             serverParam={serverParam}
             channelName={channelName}
             viewer={currentUser}
+            canManagePins={canManageServer(myRole)}
             anchorMessageId={jumpTargetId}
             parentChannelId={currentChannelMeta?.parentChannelId ?? null}
             parentMessageId={currentChannelMeta?.parentMessageId ?? null}
@@ -365,6 +366,7 @@ export function ChannelRoute({ serverParam, channelId }: {
       serverParam={serverParam}
       channelName={channelName}
       viewer={currentUser}
+      canManagePins={canManageServer(myRole)}
       anchorMessageId={jumpTargetId}
       onNavigateParent={navigateServerRoot}
       notificationLevel={(channelNotif[channelId] as ChannelNotifLevel) ?? USE_SERVER_DEFAULT}

--- a/src/web/src/components/community/channels/text-channel-surface.dom.test.ts
+++ b/src/web/src/components/community/channels/text-channel-surface.dom.test.ts
@@ -5,6 +5,8 @@ import { MessageChannelController } from "../messages/message-channel-controller
 import type { MessageChannelControllerValue } from "../messages/message-channel-controller"
 import { ChannelHeader } from "./channel-header"
 import { TextChannelSurface } from "./text-channel-surface"
+import { MessageContextSheet } from "../messages/message-context-sheet"
+import { MessageList } from "../messages/message-list"
 import { useChannelMessageFeed } from "@/hooks/community/use-channel-message-feed"
 import { buildAttachmentUploadFormData } from "@/hooks/community/mutations/uploads"
 import { useMessageStreamStore } from "@/stores/community/message-stream"
@@ -35,8 +37,12 @@ vi.mock("@/components/community/channels/channel-header", () => ({
   ChannelHeader: vi.fn(() => null),
 }))
 vi.mock("@/components/community/channels/channel-shell", () => ({
-  ChannelShell: ({ header, body }: { header: React.ReactNode; body: React.ReactNode }) =>
-    React.createElement(React.Fragment, null, header, body),
+  ChannelShell: ({ header, body, panels, dialogs }: {
+    header: React.ReactNode
+    body: React.ReactNode
+    panels?: React.ReactNode
+    dialogs?: React.ReactNode
+  }) => React.createElement(React.Fragment, null, header, body, panels, dialogs),
 }))
 vi.mock("@/components/community/messages/composer", () => ({
   Composer: vi.fn(() => null),
@@ -101,6 +107,8 @@ function feed(overrides: Record<string, unknown> = {}) {
 }
 
 const mockedChannelHeader = vi.mocked(ChannelHeader)
+const mockedMessageContextSheet = vi.mocked(MessageContextSheet)
+const mockedMessageList = vi.mocked(MessageList)
 const mockedUseChannelMessageFeed = vi.mocked(useChannelMessageFeed)
 
 function renderController(
@@ -242,8 +250,10 @@ describe("MessageChannelController scroll target ownership", () => {
 
     expect(latestActions).toBe(firstActions)
     act(() => latestActions.onPin("m_target"))
-    expect(latestOpenPinned).toHaveBeenCalledTimes(1)
+    expect(latestOpenPinned).not.toHaveBeenCalled()
     expect(firstOpenPinned).not.toHaveBeenCalled()
+    act(() => mutationMocks.pinMessage.mock.calls.at(-1)?.[1]?.onSuccess?.())
+    expect(latestOpenPinned).toHaveBeenCalledTimes(1)
     await act(async () => {
       await latestActions.onCreateThread("m_target")
     })
@@ -271,6 +281,8 @@ describe("MessageChannelController scroll target ownership", () => {
       ))
     })
 
+    expect(latestOpenPinned).not.toHaveBeenCalled()
+    act(() => mutationMocks.pinMessage.mock.calls.at(-1)?.[1]?.onSuccess?.())
     expect(latestOpenPinned).toHaveBeenCalledTimes(1)
     expect(firstOpenPinned).not.toHaveBeenCalled()
   })
@@ -342,6 +354,7 @@ describe("TextChannelSurface header hierarchy", () => {
         serverParam: "server_1",
         channelName: "general",
         viewer: { id: "viewer_1", name: "Viewer", avatar: "V" },
+        canManagePins: false,
         anchorMessageId: null,
         onNavigateParent,
         notificationLevel: "default",
@@ -362,5 +375,55 @@ describe("TextChannelSurface header hierarchy", () => {
     expect(headerProps.mobileBack).toBe(onNavigateParent)
     expect(headerProps.kind).toBe("text")
     expect(headerProps).not.toHaveProperty("onBack")
+  })
+
+  it("keeps pinned reads available while gating live and preview Pin actions", () => {
+    mockedUseChannelMessageFeed.mockReturnValue(feed())
+    const baseProps = {
+      channelId: "channel_1",
+      serverId: "server_1",
+      serverParam: "server_1",
+      channelName: "general",
+      viewer: { id: "viewer_1", name: "Viewer", avatar: "V" },
+      anchorMessageId: null,
+      notificationLevel: "default" as const,
+      onSetNotificationLevel: vi.fn(),
+      composerMembers: [],
+      composerMentionCandidates: undefined,
+      channelRefCandidates: [],
+      memberPanelProps: { members: [] },
+      manageMembersDialog: null,
+      uiHandlers: {},
+      onOpenThread: vi.fn(),
+      onOpenProfile: vi.fn(),
+      resolveUserName: (userId: string) => userId,
+    }
+    let renderer: ReturnType<typeof render>
+
+    act(() => {
+      renderer = render(React.createElement(TextChannelSurface, {
+        ...baseProps,
+        canManagePins: true,
+      }))
+    })
+    expect(mockedMessageList.mock.calls.at(-1)?.[0].onPin).toEqual(expect.any(Function))
+    expect(mockedMessageContextSheet.mock.calls.at(-1)?.[0]).toEqual(expect.objectContaining({
+      canManagePins: true,
+      onOpenPinned: expect.any(Function),
+    }))
+    expect(mockedChannelHeader.mock.calls.at(-1)?.[0].onToggle).toEqual(expect.any(Function))
+
+    act(() => {
+      renderer!.rerender(React.createElement(TextChannelSurface, {
+        ...baseProps,
+        canManagePins: false,
+      }))
+    })
+    expect(mockedMessageList.mock.calls.at(-1)?.[0].onPin).toBeUndefined()
+    expect(mockedMessageContextSheet.mock.calls.at(-1)?.[0]).toEqual(expect.objectContaining({
+      canManagePins: false,
+      onOpenPinned: expect.any(Function),
+    }))
+    expect(mockedChannelHeader.mock.calls.at(-1)?.[0].onToggle).toEqual(expect.any(Function))
   })
 })

--- a/src/web/src/components/community/channels/text-channel-surface.tsx
+++ b/src/web/src/components/community/channels/text-channel-surface.tsx
@@ -26,6 +26,7 @@ export function TextChannelSurface({
   serverParam,
   channelName,
   viewer,
+  canManagePins,
   anchorMessageId,
   onNavigateParent,
   notificationLevel,
@@ -46,6 +47,7 @@ export function TextChannelSurface({
   serverParam: string
   channelName: string
   viewer: { id: string; name: string; discriminator?: string; avatar: string }
+  canManagePins: boolean
   anchorMessageId: string | null
   onNavigateParent?: () => void
   notificationLevel: ChannelNotifLevel
@@ -133,6 +135,7 @@ export function TextChannelSurface({
                 typingUsers={controller.typingUsers}
                 onOpenThread={onOpenThread}
                 {...controller.messageActions}
+                onPin={canManagePins ? controller.messageActions.onPin : undefined}
                 onOpenProfile={onOpenProfile}
                 resolveUserName={resolveUserName}
                 resolveAuthorMentionText={mentionInsertion.resolveAuthorMentionText}
@@ -207,6 +210,8 @@ export function TextChannelSurface({
                 onOpenProfile={onOpenProfile}
                 resolveUserName={resolveUserName}
                 onReply={controller.onSheetReply}
+                canManagePins={canManagePins}
+                onOpenPinned={() => setRightPanel("pinned")}
               />
             </>
           )}

--- a/src/web/src/components/community/channels/text-channel-surface.wiring.dom.test.ts
+++ b/src/web/src/components/community/channels/text-channel-surface.wiring.dom.test.ts
@@ -94,6 +94,7 @@ describe("TextChannelSurface reply target wiring", () => {
       serverParam: "server_1",
       channelName: "general",
       viewer: { id: "viewer_1", name: "Viewer", avatar: "V" },
+      canManagePins: false,
       anchorMessageId: null,
       notificationLevel: "default",
       onSetNotificationLevel: vi.fn(),

--- a/src/web/src/components/community/channels/thread-channel-surface.dom.test.ts
+++ b/src/web/src/components/community/channels/thread-channel-surface.dom.test.ts
@@ -169,6 +169,7 @@ function surfaceProps(overrides: Record<string, unknown> = {}) {
     serverParam: "server_1",
     channelName: "Thread name",
     viewer: { id: "viewer_1", name: "Viewer", discriminator: "1111", avatar: "V" },
+    canManagePins: true,
     anchorMessageId: "m_target",
     parentChannelId: "parent_1",
     parentMessageId: "opener_1",
@@ -305,6 +306,27 @@ describe("ThreadChannelSurface ownership", () => {
     }))
     act(() => composerProps.onCancelReply?.())
     expect(mocks.setReplyTo).toHaveBeenCalledWith(null)
+  })
+
+  it("gates live and preview Pin actions without removing the pinned panel control", () => {
+    let renderer: ReturnType<typeof render>
+    act(() => {
+      renderer = render(renderSurface({ canManagePins: true }))
+    })
+    expect(mockedMessageList.mock.calls.at(-1)?.[0].onPin).toEqual(expect.any(Function))
+    expect(mockedMessageContextSheet.mock.calls.at(-1)?.[0]).toEqual(expect.objectContaining({
+      canManagePins: true,
+      onOpenPinned: expect.any(Function),
+    }))
+    expect(mockedChannelHeader.mock.calls.at(-1)?.[0].onToggle).toEqual(expect.any(Function))
+
+    act(() => renderer!.rerender(renderSurface({ canManagePins: false })))
+    expect(mockedMessageList.mock.calls.at(-1)?.[0].onPin).toBeUndefined()
+    expect(mockedMessageContextSheet.mock.calls.at(-1)?.[0]).toEqual(expect.objectContaining({
+      canManagePins: false,
+      onOpenPinned: expect.any(Function),
+    }))
+    expect(mockedChannelHeader.mock.calls.at(-1)?.[0].onToggle).toEqual(expect.any(Function))
   })
 
   it("keeps authoritative thread chrome mounted across body loading and error", () => {

--- a/src/web/src/components/community/channels/thread-channel-surface.tsx
+++ b/src/web/src/components/community/channels/thread-channel-surface.tsx
@@ -35,6 +35,7 @@ export function ThreadChannelSurface({
   serverParam,
   channelName,
   viewer,
+  canManagePins,
   anchorMessageId,
   parentChannelId,
   parentMessageId,
@@ -62,6 +63,7 @@ export function ThreadChannelSurface({
   serverParam: string
   channelName: string
   viewer: { id: string; name: string; discriminator?: string; avatar: string }
+  canManagePins: boolean
   anchorMessageId: string | null
   parentChannelId: string | null
   parentMessageId: string | null
@@ -233,6 +235,7 @@ export function ThreadChannelSurface({
                 typingUsers={controller.typingUsers}
                 onOpenThread={ignoreNestedThread}
                 {...controller.threadActions}
+                onPin={canManagePins ? controller.threadActions.onPin : undefined}
                 onOpenProfile={onOpenProfile}
                 resolveUserName={resolveUserName}
                 resolveAuthorMentionText={mentionInsertion.resolveAuthorMentionText}
@@ -308,6 +311,8 @@ export function ThreadChannelSurface({
                 onOpenProfile={onOpenProfile}
                 resolveUserName={resolveUserName}
                 onReply={controller.onSheetReply}
+                canManagePins={canManagePins}
+                onOpenPinned={openPinned}
               />
             </>
           )}

--- a/src/web/src/components/community/channels/thread-split-parent-surface.tsx
+++ b/src/web/src/components/community/channels/thread-split-parent-surface.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type { ComponentProps } from "react"
-import { isForum, USE_SERVER_DEFAULT } from "@alook/shared"
+import { canManageServer, isForum, USE_SERVER_DEFAULT } from "@alook/shared"
 import { toastApiError } from "@/lib/api/client"
 import type { Channel } from "@/lib/community/models/navigation"
 import type { ServerDetail } from "@/hooks/community/use-servers"
@@ -86,6 +86,7 @@ export function ThreadSplitParentSurface({
       serverParam={serverParam}
       channelName={channel.name}
       viewer={viewer}
+      canManagePins={canManageServer(members.myRole)}
       anchorMessageId={null}
       onNavigateParent={onNavigateParent}
       notificationLevel={notificationLevel}

--- a/src/web/src/components/community/messages/message-channel-controller-actions.test.ts
+++ b/src/web/src/components/community/messages/message-channel-controller-actions.test.ts
@@ -131,13 +131,15 @@ describe("createMessageActions", () => {
     const harness = setup()
     harness.actions.onPin("m1")
     expect(harness.pinMessageMutate).toHaveBeenCalled()
-    expect(harness.onOpenPinned).toHaveBeenCalledOnce()
+    expect(harness.onOpenPinned).not.toHaveBeenCalled()
     const pinOptions = harness.pinMessageMutate.mock.calls[0][1]
     pinOptions.onSuccess()
     expect(mocks.toast).toHaveBeenCalledWith("Message pinned")
+    expect(harness.onOpenPinned).toHaveBeenCalledOnce()
     const pinFailure = new Error("pin failed")
     pinOptions.onError(pinFailure)
     expect(mocks.toastApiError).toHaveBeenCalledWith(pinFailure, "Failed to pin message")
+    expect(harness.onOpenPinned).toHaveBeenCalledOnce()
 
     harness.actionContext.current.pinnedIds = new Set(["m1"])
     harness.actions.onPin("m1")
@@ -146,9 +148,11 @@ describe("createMessageActions", () => {
     const unpinOptions = harness.unpinMessageMutate.mock.calls[0][1]
     unpinOptions.onSuccess()
     expect(mocks.toast).toHaveBeenCalledWith("Message unpinned")
+    expect(harness.onOpenPinned).toHaveBeenCalledOnce()
     const unpinFailure = new Error("unpin failed")
     unpinOptions.onError(unpinFailure)
     expect(mocks.toastApiError).toHaveBeenCalledWith(unpinFailure, "Failed to unpin message")
+    expect(harness.onOpenPinned).toHaveBeenCalledOnce()
 
     let resolveThread: (value: { id: string }) => void = () => {}
     harness.createThreadAsync.mockImplementationOnce(() => new Promise((resolve) => {

--- a/src/web/src/components/community/messages/message-channel-controller-actions.ts
+++ b/src/web/src/components/community/messages/message-channel-controller-actions.ts
@@ -104,10 +104,12 @@ export function createMessageActions({
         return
       }
       pinMessageMutate({ channelId, messageId: id }, {
-        onSuccess: () => toast("Message pinned"),
+        onSuccess: () => {
+          toast("Message pinned")
+          actionContext.current.onOpenPinned()
+        },
         onError: (error) => toastApiError(error, "Failed to pin message"),
       })
-      actionContext.current.onOpenPinned()
     },
     onMark: (id) => toggleMark(channelId, id),
     onCreateThread: async (id) => {

--- a/src/web/src/components/community/messages/message-context-sheet.navigation.dom.test.ts
+++ b/src/web/src/components/community/messages/message-context-sheet.navigation.dom.test.ts
@@ -6,6 +6,10 @@ const mocks = vi.hoisted(() => ({
   push: vi.fn(),
   close: vi.fn(),
   openThread: undefined as undefined | ((threadId: string) => void),
+  pin: undefined as undefined | ((messageId: string) => void),
+  pinMutate: vi.fn(),
+  unpinMutate: vi.fn(),
+  toastApiError: vi.fn(),
 }))
 
 vi.mock("next/navigation", () => ({
@@ -46,8 +50,15 @@ vi.mock("@/components/ui/sheet-resize-handle", () => ({
   SheetResizeHandle: () => null,
 }))
 vi.mock("./message-row", () => ({
-  MessageRow: ({ onOpenThread }: { onOpenThread: (threadId: string) => void }) => {
+  MessageRow: ({
+    onOpenThread,
+    onPinId,
+  }: {
+    onOpenThread: (threadId: string) => void
+    onPinId?: (messageId: string) => void
+  }) => {
     mocks.openThread = onOpenThread
+    mocks.pin = onPinId
     return null
   },
 }))
@@ -61,13 +72,13 @@ vi.mock("@/contexts/community/current-user", () => ({
 vi.mock("@/stores/community", () => ({ useUiHandlers: () => ({}) }))
 vi.mock("@/hooks/use-hover-capable", () => ({ useHoverCapable: () => true }))
 vi.mock("@/hooks/community/mutations", () => ({
-  usePinMessage: () => ({ mutate: vi.fn() }),
-  useUnpinMessage: () => ({ mutate: vi.fn() }),
+  usePinMessage: () => ({ mutate: mocks.pinMutate }),
+  useUnpinMessage: () => ({ mutate: mocks.unpinMutate }),
   useCreateThread: () => ({ mutateAsync: vi.fn() }),
   useToggleMark: () => vi.fn(),
 }))
 vi.mock("sonner", () => ({ toast: vi.fn() }))
-vi.mock("@/lib/api/client", () => ({ apiFetch: vi.fn(), toastApiError: vi.fn() }))
+vi.mock("@/lib/api/client", () => ({ apiFetch: vi.fn(), toastApiError: mocks.toastApiError }))
 
 import {
   MessageContextSheet,
@@ -78,6 +89,7 @@ describe("MessageContextSheet thread navigation", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.openThread = undefined
+    mocks.pin = undefined
   })
 
   it("opens a rendered channel thread by its flat child id and closes the sheet", () => {
@@ -112,5 +124,66 @@ describe("MessageContextSheet thread navigation", () => {
     })).toBe(false)
     expect(push).not.toHaveBeenCalled()
     expect(close).not.toHaveBeenCalled()
+  })
+
+  it("exposes preview Pin only to managers and opens pinned only after success", () => {
+    const onOpenPinned = vi.fn()
+    const member = render(React.createElement(MessageContextSheet, {
+      open: true,
+      onOpenChange: mocks.close,
+      channelId: "parent_1",
+      targetSeq: 1,
+      canManagePins: false,
+      onOpenPinned,
+    }))
+    expect(mocks.pin).toBeUndefined()
+
+    member.rerender(React.createElement(MessageContextSheet, {
+      open: true,
+      onOpenChange: mocks.close,
+      channelId: "parent_1",
+      targetSeq: 1,
+      canManagePins: true,
+      onOpenPinned,
+    }))
+    expect(mocks.pin).toEqual(expect.any(Function))
+
+    act(() => mocks.pin?.("message_1"))
+    expect(mocks.pinMutate).toHaveBeenCalledWith(
+      { channelId: "parent_1", messageId: "message_1" },
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    )
+    expect(mocks.close).not.toHaveBeenCalled()
+    expect(onOpenPinned).not.toHaveBeenCalled()
+
+    const options = mocks.pinMutate.mock.calls.at(-1)?.[1]
+    const error = new Error("role changed")
+    act(() => options.onError(error))
+    expect(mocks.toastApiError).toHaveBeenCalledWith(error, "Failed to pin message")
+    expect(mocks.close).not.toHaveBeenCalled()
+    expect(onOpenPinned).not.toHaveBeenCalled()
+
+    act(() => options.onSuccess())
+    expect(mocks.close).toHaveBeenCalledWith(false)
+    expect(onOpenPinned).toHaveBeenCalledOnce()
+  })
+
+  it("never opens pinned automatically after preview Unpin", () => {
+    const onOpenPinned = vi.fn()
+    render(React.createElement(MessageContextSheet, {
+      open: true,
+      onOpenChange: mocks.close,
+      channelId: "parent_1",
+      targetSeq: 1,
+      pinnedIds: new Set(["message_1"]),
+      canManagePins: true,
+      onOpenPinned,
+    }))
+
+    act(() => mocks.pin?.("message_1"))
+    const options = mocks.unpinMutate.mock.calls.at(-1)?.[1]
+    act(() => options.onSuccess())
+    expect(mocks.close).not.toHaveBeenCalled()
+    expect(onOpenPinned).not.toHaveBeenCalled()
   })
 })

--- a/src/web/src/components/community/messages/message-context-sheet.tsx
+++ b/src/web/src/components/community/messages/message-context-sheet.tsx
@@ -145,6 +145,8 @@ export function MessageContextSheet({
   onOpenProfile,
   resolveUserName,
   onReply,
+  canManagePins = false,
+  onOpenPinned,
   type = "channel",
 }: {
   open: boolean
@@ -162,6 +164,8 @@ export function MessageContextSheet({
   // composer's replyTo state AND close the sheet — the sheet is a
   // read-only preview, replying belongs on the main surface.
   onReply?: (target: ReplyTarget) => void
+  canManagePins?: boolean
+  onOpenPinned?: () => void
   type?: ScopeType
 }) {
   const currentUser = useCurrentUser()
@@ -290,11 +294,17 @@ export function MessageContextSheet({
       })
     } else {
       pinMessageMut.mutate({ channelId, messageId: id }, {
-        onSuccess: () => toast("Message pinned"),
+        onSuccess: () => {
+          toast("Message pinned")
+          if (onOpenPinned) {
+            onOpenChange(false)
+            onOpenPinned()
+          }
+        },
         onError: (e) => toastApiError(e, "Failed to pin message"),
       })
     }
-  }, [type, channelId, pinnedIds, pinMessageMut, unpinMessageMut])
+  }, [type, channelId, pinnedIds, pinMessageMut, unpinMessageMut, onOpenChange, onOpenPinned])
 
   const onCreateThreadId = useCallback(async (id: string) => {
     if (type === "dm") return
@@ -435,7 +445,7 @@ export function MessageContextSheet({
           onReact={toggleReaction}
           onReply={onReply ? onReplyId : undefined}
           onCopy={onCopyId}
-          onPin={type === "channel" ? onPinId : undefined}
+          onPin={type === "channel" && canManagePins ? onPinId : undefined}
           onMark={onMarkId}
           onCreateThread={type === "channel" ? onCreateThreadId : undefined}
           onPreviewImage={onPreviewImage}

--- a/src/web/src/components/community/messages/message.render.dom.test.ts
+++ b/src/web/src/components/community/messages/message.render.dom.test.ts
@@ -743,6 +743,58 @@ describe("Message ordinary-link gesture ownership", () => {
   })
 })
 
+describe("Message Pin menu capability", () => {
+  it.each([
+    ["desktop right-click", true, "context-menu-item"],
+    ["mobile touch", false, "dropdown-menu-item"],
+  ] as const)("gates Pin and Unpin in the %s menu", async (_label, hoverCapable, slot) => {
+    const onPin = vi.fn()
+    let renderer: DomRenderer
+    await act(async () => {
+      renderer = render(makeTree({
+        m: baseMsg(),
+        hoverCapable,
+        onOpenThread: vi.fn(),
+        onCopy: vi.fn(),
+      }), { createNodeMock: () => genericMock })
+    })
+    if (hoverCapable) {
+      const row = renderer!.root.find(
+        (node) => typeof node.props.className === "string"
+          && node.props.className.includes("group relative -mx-2"),
+      )
+      act(() => row.props.onPointerEnter({ target: { closest: () => null } }))
+    }
+    const labels = () => renderer!.root
+      .findAllByProps({ "data-slot": slot })
+      .map((item) => textContent(item).trim())
+    expect(labels()).not.toContain("Pin Message")
+    expect(labels()).not.toContain("Unpin Message")
+
+    act(() => renderer!.rerender(makeTree({
+      m: baseMsg(),
+      hoverCapable,
+      onOpenThread: vi.fn(),
+      onCopy: vi.fn(),
+      onPin,
+      pinned: false,
+    })))
+    expect(labels()).toContain("Pin Message")
+    expect(labels()).not.toContain("Unpin Message")
+
+    act(() => renderer!.rerender(makeTree({
+      m: baseMsg(),
+      hoverCapable,
+      onOpenThread: vi.fn(),
+      onCopy: vi.fn(),
+      onPin,
+      pinned: true,
+    })))
+    expect(labels()).not.toContain("Pin Message")
+    expect(labels()).toContain("Unpin Message")
+  })
+})
+
 describe("Message portal event ownership", () => {
   it("keeps a reaction dialog mounted and ignores its pointer, click, and swipe events", async () => {
     vi.useFakeTimers()


### PR DESCRIPTION
## Why we need this PR?

Ordinary server members currently receive Pin and Unpin handlers in message menus even though the backend rejects those mutations. The Pin flow can also open Pinned Messages before the mutation succeeds, including on a 403 or role race.

> No linked issue.

## What changed

- Derive one owner/admin pin-management capability from the existing server role.
- Omit Pin and Unpin from member menus across text channels, threads, split parents, and message-context previews on desktop and mobile.
- Keep Pinned Messages readable for all channel members.
- Open Pinned Messages only after a successful Pin mutation; failures report the error and leave the panel closed.
- Add regression coverage for role wiring, menu parity, preview behavior, and Pin/Unpin success and failure ordering.

## Checklist

- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other
