### PR TITLE
fix(web): start mobile surface transitions before paint

### DIFF
--- a/src/web/src/components/community/shell/community-shell-layout.tsx
+++ b/src/web/src/components/community/shell/community-shell-layout.tsx
@@ -81,7 +81,11 @@ export function CommunityShellLayout({
   const sidebarPanelRef = useRef<HTMLDivElement>(null)
   const mainPanelRef = useRef<HTMLDivElement>(null)
   const previousCommittedHrefRef = useRef<string | null>(null)
-  const mobileNavigationPendingRef = useRef(false)
+  const pendingTransitionRef = useRef<{
+    sourceHref: string | null
+    targetHref: string
+  } | null>(null)
+  const canceledTransitionTargetsRef = useRef(new Set<string>())
   const mobileSurfaceAnimationRef = useRef<Animation | null>(null)
   const [sidebarWidth, setSidebarWidth] = useState(240)
 
@@ -111,15 +115,27 @@ export function CommunityShellLayout({
   useLayoutEffect(() => {
     if (!transitionTargetHref) return
     if (transitionMode !== "committed") {
-      mobileNavigationPendingRef.current = true
       mobileSurfaceAnimationRef.current?.cancel()
       mobileSurfaceAnimationRef.current = null
+      const pendingTransition = pendingTransitionRef.current
+      if (pendingTransition && pendingTransition.targetHref !== transitionTargetHref) {
+        canceledTransitionTargetsRef.current.add(pendingTransition.targetHref)
+      }
+      canceledTransitionTargetsRef.current.delete(transitionTargetHref)
+      pendingTransitionRef.current = {
+        sourceHref: previousCommittedHrefRef.current,
+        targetHref: transitionTargetHref,
+      }
       return
     }
     const previousHref = previousCommittedHrefRef.current
+    const pendingTransition = pendingTransitionRef.current
+    pendingTransitionRef.current = null
+    if (pendingTransition && pendingTransition.targetHref !== transitionTargetHref) {
+      canceledTransitionTargetsRef.current.add(pendingTransition.targetHref)
+    }
     previousCommittedHrefRef.current = transitionTargetHref
-    if (mobileNavigationPendingRef.current) {
-      mobileNavigationPendingRef.current = false
+    if (canceledTransitionTargetsRef.current.delete(transitionTargetHref)) {
       mobileSurfaceAnimationRef.current?.cancel()
       mobileSurfaceAnimationRef.current = null
       return

--- a/src/web/src/components/community/shell/community-shell-layout.tsx
+++ b/src/web/src/components/community/shell/community-shell-layout.tsx
@@ -81,6 +81,7 @@ export function CommunityShellLayout({
   const sidebarPanelRef = useRef<HTMLDivElement>(null)
   const mainPanelRef = useRef<HTMLDivElement>(null)
   const previousCommittedHrefRef = useRef<string | null>(null)
+  const mobileNavigationPendingRef = useRef(false)
   const mobileSurfaceAnimationRef = useRef<Animation | null>(null)
   const [sidebarWidth, setSidebarWidth] = useState(240)
 
@@ -108,9 +109,21 @@ export function CommunityShellLayout({
   const transitionTargetHref = transition?.targetHref
 
   useLayoutEffect(() => {
-    if (transitionMode !== "committed" || !transitionTargetHref) return
+    if (!transitionTargetHref) return
+    if (transitionMode !== "committed") {
+      mobileNavigationPendingRef.current = true
+      mobileSurfaceAnimationRef.current?.cancel()
+      mobileSurfaceAnimationRef.current = null
+      return
+    }
     const previousHref = previousCommittedHrefRef.current
     previousCommittedHrefRef.current = transitionTargetHref
+    if (mobileNavigationPendingRef.current) {
+      mobileNavigationPendingRef.current = false
+      mobileSurfaceAnimationRef.current?.cancel()
+      mobileSurfaceAnimationRef.current = null
+      return
+    }
     if (
       breakpoint !== "mobile"
       || !previousHref

--- a/src/web/src/components/community/shell/community-shell-layout.tsx
+++ b/src/web/src/components/community/shell/community-shell-layout.tsx
@@ -2,6 +2,7 @@
 
 import {
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   type CSSProperties,
@@ -106,7 +107,7 @@ export function CommunityShellLayout({
   const transitionMode = transition?.mode
   const transitionTargetHref = transition?.targetHref
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (transitionMode !== "committed" || !transitionTargetHref) return
     const previousHref = previousCommittedHrefRef.current
     previousCommittedHrefRef.current = transitionTargetHref

--- a/src/web/src/components/community/shell/shell-frame-view.dom.test.ts
+++ b/src/web/src/components/community/shell/shell-frame-view.dom.test.ts
@@ -1,4 +1,4 @@
-import { createElement, useState, type ReactNode } from "react"
+import { createElement, useEffect, useState, type ReactNode } from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { act, render } from "@/test/react-dom-harness"
 import { ShellFrameView } from "./shell-frame-view"
@@ -368,13 +368,21 @@ describe("ShellFrameView", () => {
     expect(detailMotion.className).toContain("flex")
   })
 
-  it("animates committed mobile switches without remounting and skips reduced motion", async () => {
+  it("starts both committed mobile switch directions before passive effects and skips reduced motion", async () => {
     const cancel = vi.fn()
-    const animate = vi.fn(() => ({ cancel }))
+    const effectOrder: string[] = []
+    const animate = vi.fn(() => {
+      effectOrder.push("animate")
+      return { cancel }
+    })
     Object.defineProperty(HTMLElement.prototype, "animate", {
       configurable: true,
       value: animate,
     })
+    function PassiveFrameProbe({ href }: { href: string }) {
+      useEffect(() => { effectOrder.push(`passive:${href}`) }, [href])
+      return createElement("main-content")
+    }
     const sidebar = () => createElement("sidebar-content")
     const common = {
       breakpoint: "mobile" as const,
@@ -387,16 +395,41 @@ describe("ShellFrameView", () => {
     const renderer = render(createElement(
       ShellFrameView,
       { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c1", "detail") },
-      createElement("main-content"),
+      createElement(PassiveFrameProbe, { href: "/c/channels/s1/c1" }),
     ))
     expect(animate).not.toHaveBeenCalled()
+    const sidebarPanel = renderer.container.querySelector<HTMLElement>('[data-testid="sidebar"]')!
+    const mainPanel = renderer.container.querySelector<HTMLElement>('[data-testid="main"]')!
+    sidebarPanel.scrollTop = 37
+    mainPanel.dataset.dndOwner = "stable"
+    effectOrder.length = 0
 
     renderer.rerender(createElement(
       ShellFrameView,
-      { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c2", "detail") },
-      createElement("main-content"),
+      { ...common, checkpoint: committedCheckpoint("/c/channels/s1", "list") },
+      createElement(PassiveFrameProbe, { href: "/c/channels/s1" }),
     ))
     expect(animate).toHaveBeenCalledOnce()
+    expect(animate).toHaveBeenLastCalledWith([
+      { opacity: 0.92, transform: "translate3d(-8px, 0, 0)" },
+      { opacity: 1, transform: "translate3d(0, 0, 0)" },
+    ], {
+      duration: 180,
+      easing: "cubic-bezier(0.22, 1, 0.36, 1)",
+    })
+    expect(effectOrder).toEqual(["animate", "passive:/c/channels/s1"])
+    expect(renderer.container.querySelector('[data-testid="sidebar"]')).toBe(sidebarPanel)
+    expect(renderer.container.querySelector('[data-testid="main"]')).toBe(mainPanel)
+    expect(sidebarPanel.scrollTop).toBe(37)
+    expect(mainPanel.dataset.dndOwner).toBe("stable")
+
+    effectOrder.length = 0
+    renderer.rerender(createElement(
+      ShellFrameView,
+      { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c2", "detail") },
+      createElement(PassiveFrameProbe, { href: "/c/channels/s1/c2" }),
+    ))
+    expect(animate).toHaveBeenCalledTimes(2)
     expect(animate).toHaveBeenLastCalledWith([
       { opacity: 0.92, transform: "translate3d(8px, 0, 0)" },
       { opacity: 1, transform: "translate3d(0, 0, 0)" },
@@ -404,14 +437,35 @@ describe("ShellFrameView", () => {
       duration: 180,
       easing: "cubic-bezier(0.22, 1, 0.36, 1)",
     })
+    expect(effectOrder).toEqual(["animate", "passive:/c/channels/s1/c2"])
+    expect(renderer.container.querySelector('[data-testid="sidebar"]')).toBe(sidebarPanel)
+    expect(renderer.container.querySelector('[data-testid="main"]')).toBe(mainPanel)
+    expect(sidebarPanel.scrollTop).toBe(37)
+    expect(mainPanel.dataset.dndOwner).toBe("stable")
+
+    effectOrder.length = 0
+    renderer.rerender(createElement(
+      ShellFrameView,
+      { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c3", "detail") },
+      createElement(PassiveFrameProbe, { href: "/c/channels/s1/c3" }),
+    ))
+    expect(animate).toHaveBeenCalledTimes(3)
+    expect(animate).toHaveBeenLastCalledWith([
+      { opacity: 0.92, transform: "translate3d(8px, 0, 0)" },
+      { opacity: 1, transform: "translate3d(0, 0, 0)" },
+    ], {
+      duration: 180,
+      easing: "cubic-bezier(0.22, 1, 0.36, 1)",
+    })
+    expect(effectOrder).toEqual(["animate", "passive:/c/channels/s1/c3"])
 
     vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: true })))
     renderer.rerender(createElement(
       ShellFrameView,
-      { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c3", "detail") },
-      createElement("main-content"),
+      { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c4", "detail") },
+      createElement(PassiveFrameProbe, { href: "/c/channels/s1/c4" }),
     ))
-    expect(animate).toHaveBeenCalledOnce()
+    expect(animate).toHaveBeenCalledTimes(3)
   })
 
   it("keeps pending mobile surfaces still and does not replay their expired transition", async () => {

--- a/src/web/src/components/community/shell/shell-frame-view.dom.test.ts
+++ b/src/web/src/components/community/shell/shell-frame-view.dom.test.ts
@@ -491,7 +491,7 @@ describe("ShellFrameView", () => {
     expect(animate).toHaveBeenCalledTimes(3)
   })
 
-  it("consumes real pending mobile navigation on either success or cancellation", async () => {
+  it("animates successful pending commits and consumes canceled stale targets", async () => {
     const cancel = vi.fn()
     const animate = vi.fn(() => ({ cancel }))
     Object.defineProperty(HTMLElement.prototype, "animate", {
@@ -536,14 +536,45 @@ describe("ShellFrameView", () => {
       { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c2", "detail") },
       createElement("main-content"),
     ))
-    expect(animate).not.toHaveBeenCalled()
+    expect(animate).toHaveBeenCalledOnce()
+    expect(animate).toHaveBeenLastCalledWith([
+      { opacity: 0.92, transform: "translate3d(8px, 0, 0)" },
+      { opacity: 1, transform: "translate3d(0, 0, 0)" },
+    ], {
+      duration: 180,
+      easing: "cubic-bezier(0.22, 1, 0.36, 1)",
+    })
+
+    renderer.rerender(createElement(
+      ShellFrameView,
+      {
+        ...common,
+        checkpoint: {
+          mode: "same-scope-leaf",
+          surface: "list",
+          targetHref: "/c/channels/s1",
+          rail: { kind: "keep" },
+          sidebar: { kind: "keep" },
+          main: { kind: "keep" },
+        },
+      },
+      createElement("main-content"),
+    ))
+    expect(animate).toHaveBeenCalledOnce()
 
     renderer.rerender(createElement(
       ShellFrameView,
       { ...common, checkpoint: committedCheckpoint("/c/channels/s1", "list") },
       createElement("main-content"),
     ))
-    expect(animate).toHaveBeenCalledOnce()
+    expect(animate).toHaveBeenCalledTimes(2)
+    expect(animate).toHaveBeenLastCalledWith([
+      { opacity: 0.92, transform: "translate3d(-8px, 0, 0)" },
+      { opacity: 1, transform: "translate3d(0, 0, 0)" },
+    ], {
+      duration: 180,
+      easing: "cubic-bezier(0.22, 1, 0.36, 1)",
+    })
 
     renderer.rerender(createElement(
       ShellFrameView,
@@ -560,16 +591,28 @@ describe("ShellFrameView", () => {
       },
       createElement("main-content"),
     ))
-    expect(animate).toHaveBeenCalledOnce()
-    expect(cancel).toHaveBeenCalledOnce()
+    expect(animate).toHaveBeenCalledTimes(2)
 
     renderer.rerender(createElement(
       ShellFrameView,
       { ...common, checkpoint: committedCheckpoint("/c/channels/s1", "list") },
       createElement("main-content"),
     ))
-    expect(animate).toHaveBeenCalledOnce()
-    expect(cancel).toHaveBeenCalledOnce()
+    expect(animate).toHaveBeenCalledTimes(2)
+
+    renderer.rerender(createElement(
+      ShellFrameView,
+      { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c3", "detail") },
+      createElement("main-content"),
+    ))
+    expect(animate).toHaveBeenCalledTimes(2)
+
+    renderer.rerender(createElement(
+      ShellFrameView,
+      { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c3", "detail") },
+      createElement("main-content"),
+    ))
+    expect(animate).toHaveBeenCalledTimes(2)
   })
 
   it("consumes a committed mobile target whose content suppresses entry motion", async () => {

--- a/src/web/src/components/community/shell/shell-frame-view.dom.test.ts
+++ b/src/web/src/components/community/shell/shell-frame-view.dom.test.ts
@@ -65,7 +65,10 @@ vi.mock("./shell-frame-overlays", () => ({
 vi.mock("./community-pending-frame", () => ({
   CommunityPendingFrame: (props: Record<string, unknown>) => {
     mocks.pendingProps(props)
-    return createElement("div", { "data-channel-loading-frame": "" })
+    return createElement("div", {
+      "data-channel-loading-frame": "",
+      "data-community-mobile-transition": "suppress",
+    })
   },
 }))
 vi.mock("@/components/community/channels/channel-sidebar", () => ({
@@ -383,7 +386,16 @@ describe("ShellFrameView", () => {
       useEffect(() => { effectOrder.push(`passive:${href}`) }, [href])
       return createElement("main-content")
     }
-    const sidebar = () => createElement("sidebar-content")
+    let sidebarMounts = 0
+    function StatefulSidebar() {
+      const [identity] = useState(() => ++sidebarMounts)
+      return createElement(
+        "div",
+        { "data-testid": "community-channel-sidebar-scroll" },
+        createElement("div", { "data-testid": "sidebar-dnd-owner", "data-identity": identity }),
+      )
+    }
+    const sidebar = () => createElement(StatefulSidebar)
     const common = {
       breakpoint: "mobile" as const,
       sidebar,
@@ -400,8 +412,12 @@ describe("ShellFrameView", () => {
     expect(animate).not.toHaveBeenCalled()
     const sidebarPanel = renderer.container.querySelector<HTMLElement>('[data-testid="sidebar"]')!
     const mainPanel = renderer.container.querySelector<HTMLElement>('[data-testid="main"]')!
-    sidebarPanel.scrollTop = 37
-    mainPanel.dataset.dndOwner = "stable"
+    const sidebarScroll = renderer.container.querySelector<HTMLElement>(
+      '[data-testid="community-channel-sidebar-scroll"]',
+    )!
+    const dndOwner = renderer.container.querySelector<HTMLElement>('[data-testid="sidebar-dnd-owner"]')!
+    sidebarScroll.scrollTop = 37
+    dndOwner.dataset.owner = "stable"
     effectOrder.length = 0
 
     renderer.rerender(createElement(
@@ -420,8 +436,11 @@ describe("ShellFrameView", () => {
     expect(effectOrder).toEqual(["animate", "passive:/c/channels/s1"])
     expect(renderer.container.querySelector('[data-testid="sidebar"]')).toBe(sidebarPanel)
     expect(renderer.container.querySelector('[data-testid="main"]')).toBe(mainPanel)
-    expect(sidebarPanel.scrollTop).toBe(37)
-    expect(mainPanel.dataset.dndOwner).toBe("stable")
+    expect(renderer.container.querySelector('[data-testid="community-channel-sidebar-scroll"]'))
+      .toBe(sidebarScroll)
+    expect(renderer.container.querySelector('[data-testid="sidebar-dnd-owner"]')).toBe(dndOwner)
+    expect(sidebarScroll.scrollTop).toBe(37)
+    expect(dndOwner.dataset.owner).toBe("stable")
 
     effectOrder.length = 0
     renderer.rerender(createElement(
@@ -440,8 +459,12 @@ describe("ShellFrameView", () => {
     expect(effectOrder).toEqual(["animate", "passive:/c/channels/s1/c2"])
     expect(renderer.container.querySelector('[data-testid="sidebar"]')).toBe(sidebarPanel)
     expect(renderer.container.querySelector('[data-testid="main"]')).toBe(mainPanel)
-    expect(sidebarPanel.scrollTop).toBe(37)
-    expect(mainPanel.dataset.dndOwner).toBe("stable")
+    expect(renderer.container.querySelector('[data-testid="community-channel-sidebar-scroll"]'))
+      .toBe(sidebarScroll)
+    expect(renderer.container.querySelector('[data-testid="sidebar-dnd-owner"]')).toBe(dndOwner)
+    expect(sidebarScroll.scrollTop).toBe(37)
+    expect(dndOwner.dataset.owner).toBe("stable")
+    expect(sidebarMounts).toBe(1)
 
     effectOrder.length = 0
     renderer.rerender(createElement(
@@ -468,7 +491,88 @@ describe("ShellFrameView", () => {
     expect(animate).toHaveBeenCalledTimes(3)
   })
 
-  it("keeps pending mobile surfaces still and does not replay their expired transition", async () => {
+  it("consumes real pending mobile navigation on either success or cancellation", async () => {
+    const cancel = vi.fn()
+    const animate = vi.fn(() => ({ cancel }))
+    Object.defineProperty(HTMLElement.prototype, "animate", {
+      configurable: true,
+      value: animate,
+    })
+    const common = {
+      breakpoint: "mobile" as const,
+      sidebar: () => createElement("sidebar-content"),
+      cancelPendingNavigation: vi.fn(),
+      rail,
+      profile,
+      inbox,
+    }
+    const renderer = render(createElement(
+      ShellFrameView,
+      { ...common, checkpoint: committedCheckpoint("/c/channels/s1", "list") },
+      createElement("main-content"),
+    ))
+
+    renderer.rerender(createElement(
+      ShellFrameView,
+      {
+        ...common,
+        checkpoint: {
+          mode: "same-scope-leaf",
+          surface: "detail",
+          targetHref: "/c/channels/s1/c2",
+          rail: { kind: "keep" },
+          sidebar: { kind: "keep" },
+          main: { kind: "target-skeleton", href: "/c/channels/s1/c2" },
+        },
+      },
+      createElement("main-content"),
+    ))
+    expect(animate).not.toHaveBeenCalled()
+    expect(renderer.container.querySelector('[data-community-mobile-transition="suppress"]'))
+      .not.toBeNull()
+
+    renderer.rerender(createElement(
+      ShellFrameView,
+      { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c2", "detail") },
+      createElement("main-content"),
+    ))
+    expect(animate).not.toHaveBeenCalled()
+
+    renderer.rerender(createElement(
+      ShellFrameView,
+      { ...common, checkpoint: committedCheckpoint("/c/channels/s1", "list") },
+      createElement("main-content"),
+    ))
+    expect(animate).toHaveBeenCalledOnce()
+
+    renderer.rerender(createElement(
+      ShellFrameView,
+      {
+        ...common,
+        checkpoint: {
+          mode: "same-scope-leaf",
+          surface: "detail",
+          targetHref: "/c/channels/s1/c3",
+          rail: { kind: "keep" },
+          sidebar: { kind: "keep" },
+          main: { kind: "target-skeleton", href: "/c/channels/s1/c3" },
+        },
+      },
+      createElement("main-content"),
+    ))
+    expect(animate).toHaveBeenCalledOnce()
+    expect(cancel).toHaveBeenCalledOnce()
+
+    renderer.rerender(createElement(
+      ShellFrameView,
+      { ...common, checkpoint: committedCheckpoint("/c/channels/s1", "list") },
+      createElement("main-content"),
+    ))
+    expect(animate).toHaveBeenCalledOnce()
+    expect(cancel).toHaveBeenCalledOnce()
+  })
+
+  it("consumes a committed mobile target whose content suppresses entry motion", async () => {
     const cancel = vi.fn()
     const animate = vi.fn(() => ({ cancel }))
     Object.defineProperty(HTMLElement.prototype, "animate", {
@@ -488,10 +592,6 @@ describe("ShellFrameView", () => {
       { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c1", "detail") },
       createElement("main-content"),
     ))
-    const motionSurface = renderer.container.querySelector(
-      '[data-community-mobile-surface="detail"]',
-    )!
-    const querySelector = vi.spyOn(motionSurface, "querySelector")
 
     renderer.rerender(createElement(
       ShellFrameView,
@@ -499,9 +599,6 @@ describe("ShellFrameView", () => {
       createElement("main-content", { "data-community-mobile-transition": "suppress" }),
     ))
     expect(animate).not.toHaveBeenCalled()
-    expect(querySelector).toHaveBeenLastCalledWith(
-      '[data-community-mobile-transition="suppress"]',
-    )
 
     renderer.rerender(createElement(
       ShellFrameView,
@@ -509,21 +606,6 @@ describe("ShellFrameView", () => {
       createElement("main-content"),
     ))
     expect(animate).not.toHaveBeenCalled()
-
-    renderer.rerender(createElement(
-      ShellFrameView,
-      { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c3", "detail") },
-      createElement("main-content"),
-    ))
-    expect(animate).toHaveBeenCalledOnce()
-
-    renderer.rerender(createElement(
-      ShellFrameView,
-      { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c4", "detail") },
-      createElement("main-content", { "data-community-mobile-transition": "suppress" }),
-    ))
-    expect(animate).toHaveBeenCalledOnce()
-    expect(cancel).toHaveBeenCalledOnce()
   })
 
   it("preserves child component identity across the 639 to 640 breakpoint", async () => {

--- a/src/web/src/components/community/shell/shell-frame-view.tsx
+++ b/src/web/src/components/community/shell/shell-frame-view.tsx
@@ -56,9 +56,7 @@ export function ShellFrameView({
       onNavigationIntent={cancelPendingNavigation}
       transition={{ mode: checkpoint.mode, targetHref: checkpoint.targetHref }}
       rail={<ServerRail {...rail.railProps} bottomInset={60} />}
-      sidebar={breakpoint === "mobile" && surface === "detail"
-        ? null
-        : checkpoint.sidebar.kind === "server-skeleton"
+      sidebar={checkpoint.sidebar.kind === "server-skeleton"
           ? <ChannelSidebarSkeleton targetServerId={checkpoint.sidebar.serverId} />
           : checkpoint.sidebar.kind === "me-skeleton"
             ? <DmSidebarSkeleton />

--- a/src/web/src/test/e2e-ui/38-community-navigation-checkpoint-matrix.spec.ts
+++ b/src/web/src/test/e2e-ui/38-community-navigation-checkpoint-matrix.spec.ts
@@ -28,6 +28,54 @@ function channelHeader(page: Page, name: string) {
   return page.getByRole("banner").getByText(name, { exact: true })
 }
 
+type SurfaceAnimationRecord = {
+  surface: string | null
+  opacity: number
+  transform: string
+  suppressed: boolean
+}
+
+async function installSurfaceAnimationProbe(page: Page) {
+  await page.addInitScript(() => {
+    const state = window as typeof window & {
+      __communitySurfaceAnimations?: Array<{
+        surface: string | null
+        opacity: number
+        transform: string
+        suppressed: boolean
+      }>
+    }
+    state.__communitySurfaceAnimations = []
+    const nativeAnimate = Element.prototype.animate
+    Element.prototype.animate = function (keyframes, options) {
+      if (this.hasAttribute("data-community-mobile-surface") && Array.isArray(keyframes)) {
+        const first = keyframes[0]
+        state.__communitySurfaceAnimations!.push({
+          surface: this.getAttribute("data-community-mobile-surface"),
+          opacity: Number(first?.opacity),
+          transform: String(first?.transform),
+          suppressed: this.querySelector('[data-community-mobile-transition="suppress"]') !== null,
+        })
+      }
+      return nativeAnimate.call(this, keyframes, options)
+    }
+  })
+}
+
+async function surfaceAnimations(page: Page): Promise<SurfaceAnimationRecord[]> {
+  return page.evaluate(() => (
+    window as typeof window & { __communitySurfaceAnimations?: SurfaceAnimationRecord[] }
+  ).__communitySurfaceAnimations ?? [])
+}
+
+async function clearSurfaceAnimations(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    ;(window as typeof window & {
+      __communitySurfaceAnimations?: SurfaceAnimationRecord[]
+    }).__communitySurfaceAnimations = []
+  })
+}
+
 test("community checkpoint shows target pending for detail and keeps list surfaces stable", async ({ asUser }) => {
   test.setTimeout(120_000)
   const stamp = Date.now()
@@ -94,4 +142,90 @@ test("community checkpoint shows target pending for detail and keeps list surfac
     .toBeVisible({ timeout: 30_000 })
 
   expect(mutations).toEqual([])
+})
+
+test("mobile pending commits animate once while sidebar identity survives route changes", async ({ asUser }) => {
+  test.setTimeout(120_000)
+  const stamp = Date.now()
+  const serverId = await seedServer("alice", `Mobile frame ${stamp}`)
+  const fastName = `fast-${stamp}`
+  const pendingName = `pending-${stamp}`
+  const fastChannel = await seedChannel("alice", serverId, fastName)
+  const pendingChannel = await seedChannel("alice", serverId, pendingName)
+  const { page } = await asUser("alice")
+  await page.setViewportSize({ width: 390, height: 844 })
+  await installSurfaceAnimationProbe(page)
+  await page.goto(`/c/channels/${serverId}`)
+
+  const fastRow = page.getByTestId(tid.channelRow(fastChannel))
+  const sidebarScroll = page.getByTestId(tid.channelSidebarScroll)
+  await expect(fastRow).toBeVisible({ timeout: 30_000 })
+  await sidebarScroll.evaluate((element) => {
+    ;(element as typeof element & { __e2eIdentity?: string }).__e2eIdentity = "stable"
+  })
+  await fastRow.evaluate((element) => {
+    ;(element as typeof element & { __e2eDndOwner?: string }).__e2eDndOwner = "stable"
+  })
+  await clearSurfaceAnimations(page)
+
+  await fastRow.click()
+  await expect.poll(() => new URL(page.url()).pathname)
+    .toBe(`/c/channels/${serverId}/${fastChannel}`)
+  await expect(page.getByTestId(tid.composerInput)).toBeVisible()
+  expect(await surfaceAnimations(page)).toEqual([{
+    surface: "detail",
+    opacity: 0.92,
+    transform: "translate3d(8px, 0, 0)",
+    suppressed: false,
+  }])
+  expect(await sidebarScroll.evaluate((element) => (
+    element as typeof element & { __e2eIdentity?: string }
+  ).__e2eIdentity)).toBe("stable")
+  expect(await fastRow.evaluate((element) => (
+    element as typeof element & { __e2eDndOwner?: string }
+  ).__e2eDndOwner)).toBe("stable")
+
+  await page.getByRole("banner").getByRole("button", { name: "Back" }).click()
+  await expect.poll(() => new URL(page.url()).pathname).toBe(`/c/channels/${serverId}`)
+  await expect(fastRow).toBeVisible()
+  expect(await surfaceAnimations(page)).toEqual([
+    {
+      surface: "detail",
+      opacity: 0.92,
+      transform: "translate3d(8px, 0, 0)",
+      suppressed: false,
+    },
+    {
+      surface: "list",
+      opacity: 0.92,
+      transform: "translate3d(-8px, 0, 0)",
+      suppressed: false,
+    },
+  ])
+  expect(await sidebarScroll.evaluate((element) => (
+    element as typeof element & { __e2eIdentity?: string }
+  ).__e2eIdentity)).toBe("stable")
+  expect(await fastRow.evaluate((element) => (
+    element as typeof element & { __e2eDndOwner?: string }
+  ).__e2eDndOwner)).toBe("stable")
+
+  await clearSurfaceAnimations(page)
+  await page.getByTestId(tid.channelRow(pendingChannel)).click({ noWaitAfter: true })
+  await expect(page.getByTestId(tid.pendingMain("server-conversation"))).toBeVisible()
+
+  const pendingPath = `/c/channels/${serverId}/${pendingChannel}`
+  await expect.poll(() => new URL(page.url()).pathname).toBe(pendingPath)
+  await expect(page.getByTestId(tid.composerInput)).toBeVisible({ timeout: 30_000 })
+  expect(await surfaceAnimations(page)).toEqual([{
+    surface: "detail",
+    opacity: 0.92,
+    transform: "translate3d(8px, 0, 0)",
+    suppressed: false,
+  }])
+  expect(await sidebarScroll.evaluate((element) => (
+    element as typeof element & { __e2eIdentity?: string }
+  ).__e2eIdentity)).toBe("stable")
+  expect(await fastRow.evaluate((element) => (
+    element as typeof element & { __e2eDndOwner?: string }
+  ).__e2eDndOwner)).toBe("stable")
 })


### PR DESCRIPTION
# Why we need this PR?

Mobile Community list/detail transitions began in a passive effect. The new surface could paint at its terminal state before Web Animations rewound it to the entry keyframe, producing a visible flash and reverse jump.

## What changed

- Start the existing committed mobile surface animation in a layout effect so its entry keyframe is established before paint.
- Track pending transitions by stable source/target identity: every matching successful commit animates, while cancellation or supersession consumes only a later stale commit of the abandoned target.
- Keep the real sidebar subtree mounted inside the hidden mobile detail panel so scroll and DnD ownership survive route changes.
- Preserve the current animation owner, keyframes, duration, easing, suppression, and reduced-motion behavior.
- Cover both directions, layout-before-passive ordering, successful pending commits, cancel/stale replay, cold/reduced gates, and real sidebar identity.

## Checklist

- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

Verification: focused DOM 13/13; real Chromium 390×844 route regression 1/1; repository typecheck 11/11; Web 7,138 tests; agent-driver 721 passed with 4 skipped; CI scripts 248; lint, typegrep, and Knip. Independent mobile QA passed on exact head `70806e8f6cb50884ed1666cab2f069eb11e2efc0`, including held-success motion, cancel/stale suppression, cold/reduced motion, and sidebar scroll/DnD identity. Hosted CI, all 9 UI shards, UI E2E gate, and `codecov/patch` passed.

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...
