### PR TITLE
fix(web): restore native image context menu

### DIFF
--- a/src/web/src/components/community/messages/image-lightbox.dom.test.ts
+++ b/src/web/src/components/community/messages/image-lightbox.dom.test.ts
@@ -95,14 +95,23 @@ describe("ImageLightbox", () => {
       aspectRatio: "800 / 450",
     })
     expect(frame.style.aspectRatio).toBe("800 / 450")
+    expect(frame).toHaveAttribute("data-native-context-menu", "true")
     expect(thumbnail).toHaveClass("absolute", "inset-0", "size-full")
-    expect(original).toHaveClass("absolute", "inset-0", "size-full", "opacity-0")
+    expect(thumbnail).toHaveClass("pointer-events-none")
+    expect(original).toHaveClass(
+      "absolute",
+      "inset-0",
+      "size-full",
+      "pointer-events-none",
+      "opacity-0",
+    )
     expect(frame.parentElement).not.toHaveClass("invisible")
     expect(renderer.getByTestId(tid.imageLightboxLoading))
       .toHaveTextContent("Loading original image")
 
     await loadThumbnail(renderer, 800, 450)
     expect(renderer.getByTestId(tid.imageLightbox).parentElement).not.toHaveClass("invisible")
+    expect(image(renderer, tid.imageLightboxThumbnail)).toHaveClass("pointer-events-auto")
 
     prepareImage(original, 800, 450, () => decodePromise)
     fireEvent.load(original)
@@ -112,8 +121,14 @@ describe("ImageLightbox", () => {
       resolveDecode()
       await decodePromise
     })
-    expect(image(renderer, tid.imageLightboxOriginal)).toHaveClass("opacity-100")
-    expect(image(renderer, tid.imageLightboxThumbnail)).toHaveClass("opacity-0")
+    expect(image(renderer, tid.imageLightboxOriginal)).toHaveClass(
+      "pointer-events-auto",
+      "opacity-100",
+    )
+    expect(image(renderer, tid.imageLightboxThumbnail)).toHaveClass(
+      "pointer-events-none",
+      "opacity-0",
+    )
     expect(previewFrameStyle({ width: 800, height: 450 })).toEqual({
       width: "min(800px, 90vw, 151.111111vh)",
       aspectRatio: "800 / 450",
@@ -133,6 +148,7 @@ describe("ImageLightbox", () => {
 
     expect(renderer.queryAllByTestId(tid.imageLightboxOriginal)).toHaveLength(0)
     expect(image(renderer, tid.imageLightboxThumbnail)).toHaveAttribute("src", "/thumbnail")
+    expect(image(renderer, tid.imageLightboxThumbnail)).toHaveClass("pointer-events-auto")
     expect(renderer.getByTestId(tid.imageLightboxError))
       .toHaveTextContent("Failed to load original image")
     expect(renderer.getByTestId(tid.imageLightboxRetry)).toHaveTextContent("Retry")

--- a/src/web/src/components/community/messages/image-lightbox.tsx
+++ b/src/web/src/components/community/messages/image-lightbox.tsx
@@ -61,6 +61,7 @@ function PreviewFrame({ image }: { image: ImagePreview }) {
     <div className="relative w-fit">
       <div
         data-testid={tid.imageLightbox}
+        data-native-context-menu="true"
         className="relative overflow-hidden rounded-lg bg-background"
         style={frameStyle}
       >
@@ -75,7 +76,7 @@ function PreviewFrame({ image }: { image: ImagePreview }) {
             alt={image.name}
             onLoad={onThumbnailLoad}
             onError={onThumbnailError}
-            className={`absolute inset-0 size-full rounded-lg object-contain transition-opacity duration-150 ease-out motion-reduce:transition-none ${thumbnailReady && !originalReady ? "opacity-100" : "opacity-0"}`}
+            className={`absolute inset-0 size-full rounded-lg object-contain transition-opacity duration-150 ease-out motion-reduce:transition-none ${thumbnailReady && !originalReady ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0"}`}
           />
         )}
         {!thumbnailReady && !originalReady && originalStatus === "pending" && (
@@ -98,7 +99,7 @@ function PreviewFrame({ image }: { image: ImagePreview }) {
             alt={image.name}
             onLoad={onOriginalLoad}
             onError={onOriginalError}
-            className={`pointer-events-none absolute inset-0 size-full rounded-lg object-contain transition-opacity duration-150 ease-out motion-reduce:transition-none ${originalReady ? "opacity-100" : "opacity-0"}`}
+            className={`absolute inset-0 size-full rounded-lg object-contain transition-opacity duration-150 ease-out motion-reduce:transition-none ${originalReady ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0"}`}
           />
         )}
       </div>

--- a/src/web/src/test/e2e-ui/20-community-attachment-thumbnails.spec.ts
+++ b/src/web/src/test/e2e-ui/20-community-attachment-thumbnails.spec.ts
@@ -11,10 +11,59 @@ const EXTREME_PORTRAIT_FIXTURE = solidPngFixture(100, 4000, [225, 91, 142])
 
 type Rect = { x: number; y: number; width: number; height: number }
 
+type NativeImageContextMenuProbe = {
+  defaultPrevented: boolean | null
+  targetSrc: string | null
+  targetTagName: string | null
+  targetTestId: string | null
+}
+
 async function boundingRect(locator: Locator): Promise<Rect> {
   const rect = await locator.boundingBox()
   expect(rect).not.toBeNull()
   return rect!
+}
+
+async function expectNativeImageContextMenu(
+  page: Page,
+  target: Locator,
+  expected: { src: string; testId: string },
+) {
+  await page.evaluate(() => {
+    const state = window as typeof window & {
+      __imageContextMenuProbe?: NativeImageContextMenuProbe
+    }
+    state.__imageContextMenuProbe = {
+      defaultPrevented: null,
+      targetSrc: null,
+      targetTagName: null,
+      targetTestId: null,
+    }
+    document.addEventListener("contextmenu", (event) => {
+      const eventTarget = event.target instanceof Element ? event.target : null
+      const imageTarget = eventTarget instanceof HTMLImageElement ? eventTarget : null
+      if (state.__imageContextMenuProbe) {
+        state.__imageContextMenuProbe.targetSrc = imageTarget?.getAttribute("src") ?? null
+        state.__imageContextMenuProbe.targetTagName = eventTarget?.tagName ?? null
+        state.__imageContextMenuProbe.targetTestId = eventTarget?.getAttribute("data-testid") ?? null
+      }
+      setTimeout(() => {
+        if (state.__imageContextMenuProbe) {
+          state.__imageContextMenuProbe.defaultPrevented = event.defaultPrevented
+        }
+      })
+    }, { capture: true, once: true })
+  })
+
+  await target.click({ button: "right" })
+  await expect.poll(() => page.evaluate(() => (
+    window as typeof window & { __imageContextMenuProbe?: NativeImageContextMenuProbe }
+  ).__imageContextMenuProbe)).toEqual({
+    defaultPrevented: false,
+    targetSrc: expected.src,
+    targetTagName: "IMG",
+    targetTestId: expected.testId,
+  })
 }
 
 function expectSameRect(actual: Rect, expected: Rect) {
@@ -166,9 +215,16 @@ test("image previews keep one frame through loading, decode, failure, retry, and
   let coldThumbnailRequests = 0
   const thumbnailPattern = "**/api/community/channels/**/attachments/**/thumbnail"
   await page.route(thumbnailPattern, async (route) => {
-    if (holdColdThumbnail && route.request().method() === "GET") {
+    if (
+      holdColdThumbnail
+      && coldThumbnailRequests === 0
+      && route.request().method() === "GET"
+    ) {
       coldThumbnailRequests++
+      const response = route.fetch()
       await coldThumbnailGate
+      await route.fulfill({ response: await response })
+      return
     }
     await route.continue()
   })
@@ -246,7 +302,12 @@ test("image previews keep one frame through loading, decode, failure, retry, and
   expectSameRect(desktopLandscapeRestored.container, desktopLandscapeLoading.container)
 
   releaseLandscape()
-  await expect(page.getByTestId(tid.imageLightboxOriginal)).toHaveClass(/opacity-100/)
+  const landscapeOriginal = page.getByTestId(tid.imageLightboxOriginal)
+  await expect(landscapeOriginal).toHaveClass(/pointer-events-auto opacity-100/)
+  await expectNativeImageContextMenu(page, landscapeOriginal, {
+    src: landscape.originalPath,
+    testId: tid.imageLightboxOriginal,
+  })
   const desktopLandscapeLoaded = await previewRects(page)
   expectSameRect(desktopLandscapeLoaded.container, desktopLandscapeRestored.container)
   await attachScreenshot(testInfo, "desktop-landscape-loaded", page)
@@ -294,7 +355,13 @@ test("image previews keep one frame through loading, decode, failure, retry, and
   await attachScreenshot(testInfo, "desktop-portrait-loading", page)
   releasePortraitFailure()
   await expect(page.getByTestId(tid.imageLightboxError)).toContainText("Failed to load original image")
-  await expect(page.getByTestId(tid.imageLightboxThumbnail)).toBeVisible()
+  const portraitThumbnail = page.getByTestId(tid.imageLightboxThumbnail)
+  await expect(portraitThumbnail).toBeVisible()
+  await expect(portraitThumbnail).toHaveClass(/pointer-events-auto/)
+  await expectNativeImageContextMenu(page, portraitThumbnail, {
+    src: portrait.thumbnailPath,
+    testId: tid.imageLightboxThumbnail,
+  })
   await waitForDialogEntrance(page)
   const desktopPortraitFailed = {
     container: await boundingRect(page.getByTestId(tid.imageLightbox)),
@@ -336,7 +403,8 @@ test("image previews keep one frame through loading, decode, failure, retry, and
   await mobilePage.setViewportSize({ width: 390, height: 844 })
   await mobilePage.goto(channelUrl)
   await mobilePage.waitForURL(new RegExp(`/c/channels/[^/]+/${channelId}$`), { waitUntil: "commit" })
-  await expect(mobilePage.getByTestId(tid.messageImage(landscape.messageId, 0))).toBeVisible()
+  await expect(mobilePage.getByTestId(tid.messageImage(landscape.messageId, 0)))
+    .toBeVisible({ timeout: 30_000 })
 
   let releaseMobileLandscape!: () => void
   const mobileLandscapeGate = new Promise<void>((resolve) => { releaseMobileLandscape = resolve })


### PR DESCRIPTION
## Summary
- restore the browser-native context menu on opened community images
- ensure only the currently visible thumbnail/original layer receives pointer events
- add component and authenticated browser regression coverage

## QA
- authenticated Chromium targeted journey passed twice
- original and failed fallback targets are real IMG nodes with defaultPrevented=false
- independent Chrome QA by Claudette passed against the 800×450 visible original
- full lint, 11/11 typecheck, pnpm test, and Impeccable detector passed locally
- image action window emitted only image GETs; no non-GET requests, community WS frames, or D1 table changes