### PR TITLE
fix(mobile): sync iOS and Android system chrome with theme

### DIFF
--- a/scripts/ci/native-shell-theme-colors.test.ts
+++ b/scripts/ci/native-shell-theme-colors.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
+import { runInNewContext } from "node:vm"
 import { describe, expect, it } from "vitest"
 
 const repositoryRoot = resolve(import.meta.dirname, "../..")
@@ -30,6 +31,72 @@ const androidDarkSplash = readFileSync(
   resolve(desktopRoot, "gen/android/app/src/main/res/values-night/themes.xml"),
   "utf8",
 )
+const androidThemeObserver = androidRuntime.match(
+  /const val THEME_OBSERVER_SCRIPT = """([\s\S]*?)"""/,
+)?.[1]
+const iosThemeObserver = iosRuntime
+  .match(/static NSString \*const kThemeObserverScript =([\s\S]*?);\n\n@interface/)?.[1]
+  .match(/@?"([^"]*)"/g)
+  ?.map((literal) => literal.replace(/^@?"/, "").slice(0, -1))
+  .join("")
+
+function driveAndroidThemeObserver(initial: Array<"light" | "dark"> = []) {
+  const classes = new Set<string>(initial)
+  const updates: boolean[] = []
+  let notify = () => {}
+  const documentElement = {
+    classList: { contains: (name: string) => classes.has(name) },
+  }
+  class MutationObserver {
+    constructor(callback: () => void) { notify = callback }
+    observe() {}
+  }
+  runInNewContext(androidThemeObserver ?? "", {
+    document: { documentElement },
+    MutationObserver,
+    window: { AlookNative: { setWindowTheme: (dark: boolean) => updates.push(dark) } },
+  })
+  return {
+    updates,
+    apply(theme: "light" | "dark") {
+      classes.clear()
+      classes.add(theme)
+      notify()
+    },
+  }
+}
+
+function driveIosThemeObserver(initial: Array<"light" | "dark"> = []) {
+  const classes = new Set<string>(initial)
+  const updates: string[] = []
+  let notify = () => {}
+  const documentElement = {
+    classList: { contains: (name: string) => classes.has(name) },
+  }
+  class MutationObserver {
+    constructor(callback: () => void) { notify = callback }
+    observe() {}
+  }
+  runInNewContext(iosThemeObserver ?? "", {
+    document: { documentElement },
+    MutationObserver,
+    window: {
+      webkit: {
+        messageHandlers: {
+          alookTheme: { postMessage: (theme: string) => updates.push(theme) },
+        },
+      },
+    },
+  })
+  return {
+    updates,
+    apply(theme: "light" | "dark") {
+      classes.clear()
+      classes.add(theme)
+      notify()
+    },
+  }
+}
 
 describe("native shell theme color contract", () => {
   it("uses white light chrome and preserves dark chrome on macOS", () => {
@@ -48,6 +115,41 @@ describe("native shell theme color contract", () => {
     )
     expect(light?.color.components).toMatchObject({ red: "1.000", green: "1.000", blue: "1.000" })
     expect(dark?.color.components).toMatchObject({ red: "0.063", green: "0.051", blue: "0.039" })
+  })
+
+  it("synchronizes iOS safe-area chrome and status-bar contrast from system and Web themes", () => {
+    expect(iosRuntime).toContain("alookEffectiveDarkTheme(self)")
+    expect(iosRuntime).toContain("viewController.traitCollection.userInterfaceStyle")
+    expect(iosRuntime).toContain("kAlookWebDarkThemeKey")
+    expect(iosRuntime).toContain("statusBarNeedsUpdate")
+    expect(iosRuntime).toContain("alookApplyTheme(viewController, isDark)")
+    expect(iosRuntime).toContain("viewController.view.backgroundColor")
+    expect(iosRuntime).toContain("setNeedsStatusBarAppearanceUpdate")
+    expect(iosRuntime).toContain("preferredStatusBarStyle")
+    expect(iosRuntime).toContain("UIStatusBarStyleLightContent")
+    expect(iosRuntime).toContain("UIStatusBarStyleDarkContent")
+  })
+
+  it("keeps the restored iOS Web theme authoritative across later layout passes", () => {
+    expect(iosRuntime.indexOf("webTheme != nil")).toBeLessThan(
+      iosRuntime.indexOf("traitCollection.userInterfaceStyle"),
+    )
+    expect(iosRuntime).toContain("objc_setAssociatedObject(")
+    expect(iosRuntime).toContain("objc_getAssociatedObject(")
+    expect(iosRuntime).toContain("bounds.size.height - insets.top - insets.bottom")
+    expect(iosRuntime).not.toContain("prefersHomeIndicatorAutoHidden")
+  })
+
+  it("leaves the native iOS system theme in place until Web theme resolution", () => {
+    const pending = driveIosThemeObserver()
+    expect(pending.updates).toEqual([])
+
+    pending.apply("dark")
+    pending.apply("light")
+
+    expect(pending.updates).toEqual(["dark", "light"])
+    expect(driveIosThemeObserver(["dark"]).updates).toEqual(["dark"])
+    expect(driveIosThemeObserver(["light"]).updates).toEqual(["light"])
   })
 
   it("uses white light chrome and preserves dark chrome at Android launch and runtime", () => {
@@ -77,6 +179,18 @@ describe("native shell theme color contract", () => {
     expect(androidRuntime).toContain("isAppearanceLightStatusBars = !dark")
     expect(androidRuntime).toContain("isAppearanceLightNavigationBars = !dark")
     expect(androidRuntime).toContain("activity.applyWindowTheme(dark)")
+  })
+
+  it("leaves native DayNight bars in place until Web theme resolution", () => {
+    const pending = driveAndroidThemeObserver()
+    expect(pending.updates).toEqual([])
+
+    pending.apply("dark")
+    pending.apply("light")
+
+    expect(pending.updates).toEqual([true, false])
+    expect(driveAndroidThemeObserver(["dark"]).updates).toEqual([true])
+    expect(driveAndroidThemeObserver(["light"]).updates).toEqual([false])
   })
 
   it("keeps Android system-bar and IME inset ownership unchanged", () => {

--- a/scripts/ci/native-shell-theme-colors.test.ts
+++ b/scripts/ci/native-shell-theme-colors.test.ts
@@ -55,6 +55,46 @@ describe("native shell theme color contract", () => {
     expect(androidRuntime).toContain('const val COLOR_DARK = "#100D0A"')
     expect(androidLightSplash).toContain("<item name=\"windowSplashScreenBackground\">#FFFFFF</item>")
     expect(androidDarkSplash).toContain("<item name=\"windowSplashScreenBackground\">#100D0A</item>")
+    expect(androidLightSplash).toContain("<item name=\"android:statusBarColor\">#FFFFFF</item>")
+    expect(androidLightSplash).toContain("<item name=\"android:navigationBarColor\">#FFFFFF</item>")
+    expect(androidLightSplash).toContain("<item name=\"android:windowLightStatusBar\">true</item>")
+    expect(androidLightSplash).toContain("<item name=\"android:windowLightNavigationBar\">true</item>")
+    expect(androidDarkSplash).toContain("<item name=\"android:statusBarColor\">#100D0A</item>")
+    expect(androidDarkSplash).toContain("<item name=\"android:navigationBarColor\">#100D0A</item>")
+    expect(androidDarkSplash).toContain("<item name=\"android:windowLightStatusBar\">false</item>")
+    expect(androidDarkSplash).toContain("<item name=\"android:windowLightNavigationBar\">false</item>")
+  })
+
+  it("synchronizes Android root, system bars, and icon contrast at creation and from the Web bridge", () => {
+    expect(androidRuntime).toContain("applyWindowTheme(isDark)")
+    expect(androidRuntime.indexOf("applyWindowTheme(isDark)")).toBeLessThan(
+      androidRuntime.indexOf("ViewCompat.setOnApplyWindowInsetsListener"),
+    )
+    expect(androidRuntime).toContain("rootView.setBackgroundColor(color)")
+    expect(androidRuntime).toContain("window.statusBarColor = color")
+    expect(androidRuntime).toContain("window.navigationBarColor = color")
+    expect(androidRuntime).toContain("WindowCompat.getInsetsController(window, rootView)")
+    expect(androidRuntime).toContain("isAppearanceLightStatusBars = !dark")
+    expect(androidRuntime).toContain("isAppearanceLightNavigationBars = !dark")
+    expect(androidRuntime).toContain("activity.applyWindowTheme(dark)")
+  })
+
+  it("keeps Android system-bar and IME inset ownership unchanged", () => {
+    expect(androidRuntime).toContain(
+      "insets.getInsets(WindowInsetsCompat.Type.systemBars())",
+    )
+    expect(androidRuntime).toContain(
+      "insets.isVisible(WindowInsetsCompat.Type.ime())",
+    )
+    expect(androidRuntime).toContain(
+      "insets.getInsets(WindowInsetsCompat.Type.ime()).bottom",
+    )
+    expect(androidRuntime).toContain(
+      "if (imeVisible) imeHeight else systemBars.bottom",
+    )
+    expect(androidRuntime).toContain(
+      "v.setPadding(systemBars.left, systemBars.top, systemBars.right, bottomPadding)",
+    )
   })
 
   it("retains runtime theme bridges and removes the legacy light color from native owners", () => {

--- a/src/desktop/src-tauri/gen/android/app/src/main/java/ai/alook/android/MainActivity.kt
+++ b/src/desktop/src-tauri/gen/android/app/src/main/java/ai/alook/android/MainActivity.kt
@@ -28,7 +28,9 @@ class MainActivity : TauriActivity() {
                 if (window.__alookThemeObserverInstalled) return;
                 window.__alookThemeObserverInstalled = true;
                 function sync() {
-                    var dark = document.documentElement.classList.contains('dark');
+                    var root = document.documentElement;
+                    var dark = root.classList.contains('dark');
+                    if (!dark && !root.classList.contains('light')) return;
                     if (window.AlookNative) window.AlookNative.setWindowTheme(dark);
                 }
                 sync();

--- a/src/desktop/src-tauri/gen/android/app/src/main/java/ai/alook/android/MainActivity.kt
+++ b/src/desktop/src-tauri/gen/android/app/src/main/java/ai/alook/android/MainActivity.kt
@@ -11,6 +11,7 @@ import android.webkit.WebView
 import androidx.activity.enableEdgeToEdge
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
@@ -50,8 +51,7 @@ class MainActivity : TauriActivity() {
         val rootView: View = findViewById(android.R.id.content)
 
         val isDark = (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
-        val bgColor = if (isDark) Color.parseColor(COLOR_DARK) else Color.parseColor(COLOR_LIGHT)
-        rootView.setBackgroundColor(bgColor)
+        applyWindowTheme(isDark)
 
         ViewCompat.setOnApplyWindowInsetsListener(rootView) { v, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
@@ -73,18 +73,24 @@ class MainActivity : TauriActivity() {
         }
     }
 
-    fun setTheme(dark: Boolean) {
-        val rootView: View = findViewById(android.R.id.content)
+    private fun applyWindowTheme(dark: Boolean) {
         val color = if (dark) Color.parseColor(COLOR_DARK) else Color.parseColor(COLOR_LIGHT)
         runOnUiThread {
+            val rootView: View = findViewById(android.R.id.content)
             rootView.setBackgroundColor(color)
+            window.statusBarColor = color
+            window.navigationBarColor = color
+            WindowCompat.getInsetsController(window, rootView).apply {
+                isAppearanceLightStatusBars = !dark
+                isAppearanceLightNavigationBars = !dark
+            }
         }
     }
 
     class ThemeBridge(private val activity: MainActivity) {
         @JavascriptInterface
         fun setWindowTheme(dark: Boolean) {
-            activity.setTheme(dark)
+            activity.applyWindowTheme(dark)
         }
     }
 }

--- a/src/desktop/src-tauri/gen/android/app/src/main/res/values-night/themes.xml
+++ b/src/desktop/src-tauri/gen/android/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,10 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Theme.alook_desktop" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:statusBarColor">#100D0A</item>
+        <item name="android:navigationBarColor">#100D0A</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
     </style>
     <!-- Splash screen theme (dark) -->
     <style name="Theme.alook_desktop.Splash" parent="Theme.SplashScreen">

--- a/src/desktop/src-tauri/gen/android/app/src/main/res/values/themes.xml
+++ b/src/desktop/src-tauri/gen/android/app/src/main/res/values/themes.xml
@@ -1,6 +1,10 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Theme.alook_desktop" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:statusBarColor">#FFFFFF</item>
+        <item name="android:navigationBarColor">#FFFFFF</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar">true</item>
     </style>
     <!-- Splash screen theme -->
     <style name="Theme.alook_desktop.Splash" parent="Theme.SplashScreen">

--- a/src/desktop/src-tauri/gen/apple/Sources/alook-desktop/main.mm
+++ b/src/desktop/src-tauri/gen/apple/Sources/alook-desktop/main.mm
@@ -11,11 +11,35 @@ static UIColor *alookDarkColor(void) {
     return [UIColor colorWithRed:0.063 green:0.051 blue:0.039 alpha:1.0];
 }
 
+static const void *kAlookResolvedDarkThemeKey = &kAlookResolvedDarkThemeKey;
+static const void *kAlookWebDarkThemeKey = &kAlookWebDarkThemeKey;
+
+static BOOL alookEffectiveDarkTheme(UIViewController *viewController) {
+    NSNumber *webTheme = objc_getAssociatedObject(viewController, kAlookWebDarkThemeKey);
+    if (webTheme != nil) return webTheme.boolValue;
+    return viewController.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark;
+}
+
+static void alookApplyTheme(UIViewController *viewController, BOOL isDark) {
+    NSNumber *resolvedTheme = objc_getAssociatedObject(viewController, kAlookResolvedDarkThemeKey);
+    BOOL statusBarNeedsUpdate = resolvedTheme == nil || resolvedTheme.boolValue != isDark;
+    objc_setAssociatedObject(
+        viewController,
+        kAlookResolvedDarkThemeKey,
+        @(isDark),
+        OBJC_ASSOCIATION_RETAIN_NONATOMIC
+    );
+    viewController.view.backgroundColor = isDark ? alookDarkColor() : alookLightColor();
+    if (statusBarNeedsUpdate) [viewController setNeedsStatusBarAppearanceUpdate];
+}
+
 static NSString *const kThemeObserverScript =
     @"(function(){"
     "if(window.__alookThemeObserverInstalled)return;"
     "window.__alookThemeObserverInstalled=true;"
-    "function sync(){var d=document.documentElement.classList.contains('dark');"
+    "function sync(){var r=document.documentElement;"
+    "var d=r.classList.contains('dark');"
+    "if(!d&&!r.classList.contains('light'))return;"
     "window.webkit.messageHandlers.alookTheme.postMessage(d?'dark':'light');}"
     "sync();"
     "new MutationObserver(sync).observe(document.documentElement,"
@@ -34,7 +58,15 @@ static NSString *const kThemeObserverScript =
     NSString *theme = message.body;
     BOOL isDark = [theme isEqualToString:@"dark"];
     dispatch_async(dispatch_get_main_queue(), ^{
-        self.viewController.view.backgroundColor = isDark ? alookDarkColor() : alookLightColor();
+        UIViewController *viewController = self.viewController;
+        if (viewController == nil) return;
+        objc_setAssociatedObject(
+            viewController,
+            kAlookWebDarkThemeKey,
+            @(isDark),
+            OBJC_ASSOCIATION_RETAIN_NONATOMIC
+        );
+        alookApplyTheme(viewController, isDark);
     });
 }
 
@@ -48,7 +80,17 @@ static NSString *const kThemeObserverScript =
         Method original = class_getInstanceMethod(self, @selector(viewDidLayoutSubviews));
         Method swizzled = class_getInstanceMethod(self, @selector(alook_viewDidLayoutSubviews));
         method_exchangeImplementations(original, swizzled);
+
+        Method originalStatusBar = class_getInstanceMethod(self, @selector(preferredStatusBarStyle));
+        Method swizzledStatusBar = class_getInstanceMethod(self, @selector(alook_preferredStatusBarStyle));
+        method_exchangeImplementations(originalStatusBar, swizzledStatusBar);
     });
+}
+
+- (UIStatusBarStyle)alook_preferredStatusBarStyle {
+    NSNumber *resolvedTheme = objc_getAssociatedObject(self, kAlookResolvedDarkThemeKey);
+    if (resolvedTheme == nil) return [self alook_preferredStatusBarStyle];
+    return resolvedTheme.boolValue ? UIStatusBarStyleLightContent : UIStatusBarStyleDarkContent;
 }
 
 - (void)alook_viewDidLayoutSubviews {
@@ -78,8 +120,7 @@ static NSString *const kThemeObserverScript =
                 [webView.configuration.userContentController addUserScript:script];
             });
 
-            BOOL isDark = (self.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark);
-            self.view.backgroundColor = isDark ? alookDarkColor() : alookLightColor();
+            alookApplyTheme(self, alookEffectiveDarkTheme(self));
         }
     }
 }


### PR DESCRIPTION
# Why we need this PR?
> Prevent iOS and Android system chrome from flashing or retaining the wrong color/icon contrast while the native splash hands off to the restored Web theme.

## What changed
- Keep native system light/dark chrome authoritative until the Web document exposes an explicit `light` or `dark` class.
- On Android, update the root background, status/navigation bar surfaces, and their icon contrast together while preserving existing system-bar and IME inset ownership.
- On iOS, keep the safe-area background and status-bar style on one resolved theme source; once Web resolves, later layout and trait passes cannot overwrite a fixed user theme.
- Leave the iOS Home Indicator under system ownership; only its surrounding safe-area surface follows the resolved theme.
- Add executable observer coverage for unresolved, light, dark, and transition states on both platforms, plus native-shell contract coverage.

## Checklist
- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [x] Other: iOS and Android native shells
