### PR TITLE
fix(web): align share image timestamps

### DIFF
--- a/src/web/src/components/community/messages/message-share-dialog.dom.test.ts
+++ b/src/web/src/components/community/messages/message-share-dialog.dom.test.ts
@@ -20,6 +20,7 @@ import {
 } from "./message-share-dialog"
 import type { RenderMsg } from "@/lib/community/models/message"
 import { tid } from "@/lib/community/testids"
+import { formatMessageTime } from "@/lib/community/format-time"
 
 const profileState = vi.hoisted(() => ({ map: new Map<string, Record<string, unknown>>() }))
 const componentMocks = vi.hoisted(() => ({
@@ -137,6 +138,27 @@ function actionButton(testId?: string, text?: string) {
 }
 
 describe("MessageShareDialog message context", () => {
+  it("renders the live message timestamp beside the author", () => {
+    const createdAt = "2026-08-13T03:17:00.000Z"
+    const renderer = renderMessage(message({ createdAt }))
+    const timestamp = renderer.container.querySelector("[data-share-timestamp]")!
+
+    expect(timestamp.textContent).toBe(formatMessageTime(createdAt))
+    expect(timestamp.classList).toContain("text-xs")
+    expect(timestamp.classList).toContain("text-muted-foreground")
+    expect(timestamp.parentElement?.classList).toContain("items-baseline")
+    expect(timestamp.parentElement?.classList).toContain("gap-2")
+  })
+
+  it("keeps the author and timestamp collapsed for grouped follow-ups", () => {
+    const renderer = renderMessage(message({
+      grouped: true,
+      createdAt: "2026-08-13T03:18:00.000Z",
+    }))
+
+    expect(renderer.container.querySelector("[data-share-timestamp]")).toBeNull()
+  })
+
   it("passes the custom avatar URL as an image source, not as fallback copy", () => {
     renderMessage(message({ authorAvatar: "/api/community/users/u1/avatar" }))
     expect(latestCapturedProps(componentMocks.avatarProps)).toMatchObject({

--- a/src/web/src/components/community/messages/message-share-dialog.tsx
+++ b/src/web/src/components/community/messages/message-share-dialog.tsx
@@ -14,6 +14,7 @@ import { MessageBody } from "./message-body"
 import { attachmentAspectRatio } from "./attachment-layout"
 import { tid } from "@/lib/community/testids"
 import { applyHighlightToRange, clearHighlights, hasHighlights } from "@/lib/community/highlight-range"
+import { formatMessageTime } from "@/lib/community/format-time"
 import type { RenderMsg } from "@/lib/community/models/message"
 import { displayReplyContent } from "@/lib/community/reply-content"
 import { useProfilesByUserId } from "@/stores/community/ws"
@@ -525,8 +526,8 @@ type ShareCardExportFlight = {
 }
 
 // Share one OR several messages as an image. Renders a self-contained "share
-// card" that mirrors the in-app message blob(s) (avatar / name / content — NO
-// timestamp, per spec) plus an Alook brand footer, then rasterises THAT SAME
+// card" that mirrors the in-app message blob(s) (avatar / name / timestamp /
+// content) plus an Alook brand footer, then rasterises THAT SAME
 // node to PNG (WYSIWYG) via html-to-image — fully client-side, no backend. The
 // captured node has a fixed width and its own solid background so the export is
 // stable regardless of the surrounding theme surface.
@@ -756,10 +757,21 @@ export function MessageShareDialog({ m, open, onClose }: {
                   <div className="min-w-0 flex-1">
                     {!msg.grouped && (
                       <div
-                        className="mb-0.5 text-[15px] font-semibold"
-                        style={{ color: msg.color ?? "var(--foreground)" }}
+                        className="mb-0.5 flex items-baseline gap-2"
                       >
-                        {author?.name ?? msg.authorName}
+                        <span
+                          className="min-w-0 max-w-full truncate text-[15px] font-semibold"
+                          style={{ color: msg.color ?? "var(--foreground)" }}
+                        >
+                          {author?.name ?? msg.authorName}
+                        </span>
+                        <span
+                          data-share-timestamp
+                          className="shrink-0 text-xs text-muted-foreground"
+                          suppressHydrationWarning
+                        >
+                          {formatMessageTime(msg.createdAt)}
+                        </span>
                       </div>
                     )}
                     {/* Each body: clamp at 32 lines (Alli #137 — one number for

--- a/src/web/src/test/e2e-ui/51-share-image-assets.spec.ts
+++ b/src/web/src/test/e2e-ui/51-share-image-assets.spec.ts
@@ -206,6 +206,61 @@ async function holdNextAvatarRequest(page: Page) {
   }
 }
 
+test("share image timestamp matches the live row and survives both exports", async ({ asUser }) => {
+  test.setTimeout(120_000)
+  const serverId = await seedServer("alice", `Share timestamp ${Date.now()}`)
+  const channelId = await seedChannel("alice", serverId, "share-timestamp")
+  const { page } = await asUser("alice")
+  await gotoAfterUserWsAuth(page, `/c/channels/${serverId}/${channelId}`)
+
+  const seeded = await page.evaluate(async (targetId) => {
+    const response = await fetch(`/api/community/channels/${targetId}/messages`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        content: "Share timestamp parity",
+        attachments: [],
+        nonce: `e2e:${crypto.randomUUID()}`,
+      }),
+    })
+    const payload = await response.json() as {
+      message: { id: string; createdAt: string }
+    }
+    return {
+      status: response.status,
+      messageId: payload.message.id,
+      createdAt: payload.message.createdAt,
+    }
+  }, channelId)
+  expect(seeded.status).toBe(201)
+
+  const expectedTimestamp = await page.evaluate((createdAt) => (
+    new Intl.DateTimeFormat(undefined, { hour: "numeric", minute: "2-digit" })
+      .format(new Date(createdAt))
+  ), seeded.createdAt)
+  const row = page.getByTestId(tid.message(seeded.messageId))
+  await expect(row).toContainText(expectedTimestamp)
+
+  await installShareCapture(page)
+  const dialog = await openShareDialog(page, seeded.messageId)
+  const card = dialog.locator("[data-share-card]")
+  await expect(card.locator("[data-share-timestamp]")).toHaveText(expectedTimestamp)
+
+  const downloadStarted = page.waitForEvent("download")
+  await dialog.getByRole("button", { name: "Download" }).click()
+  await downloadStarted
+  await expect(dialog.getByRole("button", { name: "Copy image" })).toBeEnabled()
+  await dialog.getByRole("button", { name: "Copy image" }).click()
+  await expect(dialog.getByRole("button", { name: "Copied" })).toBeVisible()
+  await expect.poll(() => shareCaptureCounts(page)).toEqual({
+    clipboard: 1,
+    clipboardAttempts: 1,
+    download: 1,
+  })
+  await expect(card.locator("[data-share-timestamp]")).toHaveText(expectedTimestamp)
+})
+
 test("consecutive share-image exports reuse rendered avatar, attachment, and invite icon pixels", async ({ asUser }) => {
   test.setTimeout(120_000)
   const serverId = await seedServer("alice", `Share assets ${Date.now()}`)


### PR DESCRIPTION
## Summary
- add the same formatted timestamp used by live message rows to share-image cards
- keep grouped follow-up messages headerless
- cover DOM layout plus desktop and mobile export flows

## Verification
- pnpm typecheck
- pnpm test (7424 web tests; 786 agent-driver tests; 251 CI-script tests)
- focused DOM/grouping suites
- Playwright desktop and 390x844 mobile: live/share time matched; Copy and Download passed
- git diff --check and targeted ESLint

Alook task: /Alook#5620/gus-issues/#109

No backend write path changed.