### PR TITLE
fix(web): keep pending Community shell geometry aligned

### DIFF
--- a/src/web/src/components/community/shell/community-shell-layout.tsx
+++ b/src/web/src/components/community/shell/community-shell-layout.tsx
@@ -1,14 +1,14 @@
 "use client"
 
 import {
+  useCallback,
   useEffect,
   useLayoutEffect,
   useRef,
-  useState,
   type CSSProperties,
   type ReactNode,
 } from "react"
-import { useDefaultLayout } from "react-resizable-panels"
+import { useDefaultLayout, type PanelSize } from "react-resizable-panels"
 import { AppSurface } from "@/components/ui/app-surface"
 import {
   ResizableHandle,
@@ -20,6 +20,10 @@ import type { CommunitySurface } from "@/lib/community/community-route"
 import { cn } from "@/lib/utils"
 import {
   COMMUNITY_RAIL_WIDTH,
+  COMMUNITY_SIDEBAR_DEFAULT_PERCENTAGE,
+  COMMUNITY_SIDEBAR_MAX_WIDTH,
+  COMMUNITY_SIDEBAR_MIN_WIDTH,
+  desktopUserBarOverlayCssWidth,
   desktopUserBarOverlayWidth,
 } from "./shell-frame-geometry"
 import { Shell } from "./shell"
@@ -80,6 +84,7 @@ export function CommunityShellLayout({
   const hydratedClient = useHydratedClient()
   const sidebarPanelRef = useRef<HTMLDivElement>(null)
   const mainPanelRef = useRef<HTMLDivElement>(null)
+  const userBarOverlayRef = useRef<HTMLDivElement>(null)
   const previousCommittedHrefRef = useRef<string | null>(null)
   const pendingTransitionRef = useRef<{
     sourceHref: string | null
@@ -87,17 +92,16 @@ export function CommunityShellLayout({
   } | null>(null)
   const canceledTransitionTargetsRef = useRef(new Set<string>())
   const mobileSurfaceAnimationRef = useRef<Animation | null>(null)
-  const [sidebarWidth, setSidebarWidth] = useState(240)
-
-  useEffect(() => {
-    if (breakpoint !== "desktop") return
-    const element = sidebarPanelRef.current
-    if (!element) return
-    setSidebarWidth(element.offsetWidth)
-    const observer = new ResizeObserver(([entry]) => setSidebarWidth(entry!.contentRect.width))
-    observer.observe(element)
-    return () => observer.disconnect()
-  }, [breakpoint])
+  const syncDesktopUserBarWidth = useCallback((size: PanelSize) => {
+    const measuredSidebarWidth = sidebarPanelRef.current?.getBoundingClientRect().width
+    const sidebarWidth = measuredSidebarWidth && measuredSidebarWidth > 0
+      ? measuredSidebarWidth
+      : size.inPixels
+    userBarOverlayRef.current?.style.setProperty(
+      "--community-desktop-user-bar-width",
+      `${desktopUserBarOverlayWidth(sidebarWidth)}px`,
+    )
+  }, [])
 
   const isDesktop = breakpoint === "desktop"
   const isMobileList = breakpoint === "mobile" && surface === "list"
@@ -168,8 +172,14 @@ export function CommunityShellLayout({
   }, [breakpoint, surface, transitionMode, transitionTargetHref])
   useEffect(() => () => mobileSurfaceAnimationRef.current?.cancel(), [])
 
+  const sidebarPercentage = hydratedClient
+    ? defaultLayout?.sidebar ?? COMMUNITY_SIDEBAR_DEFAULT_PERCENTAGE
+    : COMMUNITY_SIDEBAR_DEFAULT_PERCENTAGE
   const initialUserBarStyle = {
-    "--community-desktop-user-bar-width": `${desktopUserBarOverlayWidth(sidebarWidth)}px`,
+    "--community-desktop-user-bar-width": desktopUserBarOverlayCssWidth(
+      sidebarPercentage,
+      hydratedClient,
+    ),
     marginLeft: -COMMUNITY_RAIL_WIDTH,
   } as CSSProperties
 
@@ -223,9 +233,10 @@ export function CommunityShellLayout({
           >
             <ResizablePanel
               id="sidebar"
-              defaultSize="24%"
-              minSize={160}
-              maxSize={360}
+              defaultSize={`${COMMUNITY_SIDEBAR_DEFAULT_PERCENTAGE}%`}
+              minSize={COMMUNITY_SIDEBAR_MIN_WIDTH}
+              maxSize={COMMUNITY_SIDEBAR_MAX_WIDTH}
+              onResize={syncDesktopUserBarWidth}
               hidden={isMobileDetail}
               data-mobile-active={sidebarMobileActive || undefined}
               data-mobile-hidden={sidebarMobileHidden || undefined}
@@ -264,19 +275,16 @@ export function CommunityShellLayout({
 
         {showUserBar && (
           <div
+            ref={userBarOverlayRef}
             data-slot="community-user-bar-overlay"
             className={cn(
               "absolute bottom-0 left-0 z-10",
+              isDesktop && "w-(--community-desktop-user-bar-width)",
               isInitial && "w-[calc(100%+3.5rem)] sm:w-(--community-desktop-user-bar-width)",
               isInitialDetail && "max-sm:hidden",
               isMobileDetail && preserveHiddenMobileModules && "hidden",
             )}
-            style={isDesktop
-              ? {
-                  width: desktopUserBarOverlayWidth(sidebarWidth),
-                  marginLeft: -COMMUNITY_RAIL_WIDTH,
-                }
-              : isMobileList ? {
+            style={isMobileList ? {
                   width: `calc(100% + ${COMMUNITY_RAIL_WIDTH}px)`,
                   marginLeft: -COMMUNITY_RAIL_WIDTH,
                 }

--- a/src/web/src/components/community/shell/shell-frame-geometry.test.ts
+++ b/src/web/src/components/community/shell/shell-frame-geometry.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest"
 import {
   COMMUNITY_RAIL_WIDTH,
+  COMMUNITY_SIDEBAR_DEFAULT_PERCENTAGE,
+  COMMUNITY_SIDEBAR_MAX_WIDTH,
+  COMMUNITY_SIDEBAR_MIN_WIDTH,
   COMMUNITY_SEPARATOR_WIDTH,
   COMMUNITY_SHELL_INSET,
+  COMMUNITY_SURFACE_BORDER_WIDTH,
   COMMUNITY_USER_BAR_BASE_HEIGHT,
   COMMUNITY_USER_BAR_HEIGHT_CSS,
+  desktopUserBarOverlayCssWidth,
   desktopUserBarOverlayWidth,
   mobileInboxAvailableHeight,
 } from "./shell-frame-geometry"
@@ -12,7 +17,10 @@ import {
 describe("desktop community shell geometry", () => {
   it("mirrors the user bar and composer around the sidebar boundary", () => {
     const sidebarWidth = 240
-    const mainStart = COMMUNITY_RAIL_WIDTH + sidebarWidth + COMMUNITY_SEPARATOR_WIDTH
+    const mainStart = COMMUNITY_RAIL_WIDTH
+      + COMMUNITY_SURFACE_BORDER_WIDTH
+      + sidebarWidth
+      + COMMUNITY_SEPARATOR_WIDTH
     const overlayLeft = COMMUNITY_RAIL_WIDTH - COMMUNITY_RAIL_WIDTH
     const userBarRight =
       overlayLeft + desktopUserBarOverlayWidth(sidebarWidth) - COMMUNITY_SHELL_INSET
@@ -20,6 +28,17 @@ describe("desktop community shell geometry", () => {
 
     expect(mainStart - userBarRight).toBe(COMMUNITY_SHELL_INSET)
     expect(composerLeft - mainStart).toBe(COMMUNITY_SHELL_INSET)
+  })
+
+  it("seeds the overlay from the same constrained percentage as the sidebar panel", () => {
+    expect(desktopUserBarOverlayCssWidth(COMMUNITY_SIDEBAR_DEFAULT_PERCENTAGE, true)).toBe(
+      `calc(clamp(${COMMUNITY_SIDEBAR_MIN_WIDTH}px, calc(24% - 0.48px), ${COMMUNITY_SIDEBAR_MAX_WIDTH}px) + 58px)`,
+    )
+    expect(desktopUserBarOverlayCssWidth(COMMUNITY_SIDEBAR_DEFAULT_PERCENTAGE, false)).toBe(
+      "calc(calc(24% - 0.24px) + 57px)",
+    )
+    expect(desktopUserBarOverlayCssWidth(-20, false)).toContain("0%")
+    expect(desktopUserBarOverlayCssWidth(120, false)).toContain("100%")
   })
 })
 

--- a/src/web/src/components/community/shell/shell-frame-geometry.ts
+++ b/src/web/src/components/community/shell/shell-frame-geometry.ts
@@ -1,6 +1,10 @@
 export const COMMUNITY_RAIL_WIDTH = 56
+export const COMMUNITY_SURFACE_BORDER_WIDTH = 1
 export const COMMUNITY_SEPARATOR_WIDTH = 1
 export const COMMUNITY_SHELL_INSET = 12
+export const COMMUNITY_SIDEBAR_DEFAULT_PERCENTAGE = 24
+export const COMMUNITY_SIDEBAR_MIN_WIDTH = 160
+export const COMMUNITY_SIDEBAR_MAX_WIDTH = 360
 export const COMMUNITY_USER_BAR_BASE_HEIGHT = 60
 export const COMMUNITY_USER_BAR_HEIGHT_CSS =
   `calc(${COMMUNITY_USER_BAR_BASE_HEIGHT}px + var(--app-safe-area-bottom))`
@@ -20,5 +24,28 @@ export function mobileInboxAvailableHeight(
 }
 
 export function desktopUserBarOverlayWidth(sidebarWidth: number) {
-  return sidebarWidth + COMMUNITY_RAIL_WIDTH + COMMUNITY_SEPARATOR_WIDTH
+  return sidebarWidth
+    + COMMUNITY_RAIL_WIDTH
+    + COMMUNITY_SURFACE_BORDER_WIDTH
+    + COMMUNITY_SEPARATOR_WIDTH
+}
+
+export function desktopUserBarOverlayCssWidth(
+  sidebarPercentage: number,
+  constrainToPanelBounds: boolean,
+) {
+  const percentage = Math.min(100, Math.max(0, sidebarPercentage))
+  const panelTrackInset = COMMUNITY_SURFACE_BORDER_WIDTH
+    + (constrainToPanelBounds ? COMMUNITY_SEPARATOR_WIDTH : 0)
+  const percentageTrackCorrection = Number(
+    (percentage * panelTrackInset / 100).toFixed(6),
+  )
+  const percentageWidth = `calc(${percentage}% - ${percentageTrackCorrection}px)`
+  const sidebarWidth = constrainToPanelBounds
+    ? `clamp(${COMMUNITY_SIDEBAR_MIN_WIDTH}px, ${percentageWidth}, ${COMMUNITY_SIDEBAR_MAX_WIDTH}px)`
+    : percentageWidth
+  const fixedWidth = COMMUNITY_RAIL_WIDTH
+    + COMMUNITY_SURFACE_BORDER_WIDTH
+    + (constrainToPanelBounds ? COMMUNITY_SEPARATOR_WIDTH : 0)
+  return `calc(${sidebarWidth} + ${fixedWidth}px)`
 }

--- a/src/web/src/components/community/shell/shell-frame-view.dom.test.ts
+++ b/src/web/src/components/community/shell/shell-frame-view.dom.test.ts
@@ -5,10 +5,8 @@ import { ShellFrameView } from "./shell-frame-view"
 import type { CommunityCheckpointPlan, CommunitySurface } from "@/lib/community/community-route"
 
 const mocks = vi.hoisted(() => ({
-  observe: vi.fn(),
-  disconnect: vi.fn(),
   onLayoutChanged: vi.fn(),
-  resizeCallback: { current: undefined as undefined | ((entries: Array<{ contentRect: { width: number } }>) => void) },
+  defaultLayout: { current: { sidebar: 24, main: 76 } },
   groupProps: vi.fn(),
   panelProps: vi.fn(),
   railProps: vi.fn(),
@@ -18,7 +16,10 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock("react-resizable-panels", () => ({
-  useDefaultLayout: () => ({ defaultLayout: { sidebar: 24, main: 76 }, onLayoutChanged: mocks.onLayoutChanged }),
+  useDefaultLayout: () => ({
+    defaultLayout: mocks.defaultLayout.current,
+    onLayoutChanged: mocks.onLayoutChanged,
+  }),
 }))
 vi.mock("@/components/ui/resizable", () => ({
   ResizablePanelGroup: ({ children, ...props }: Record<string, unknown>) => {
@@ -133,44 +134,23 @@ const inbox = {
   onOpenChange: vi.fn(),
 } as never
 
-let offsetWidthDescriptor: PropertyDescriptor | undefined
 let animateDescriptor: PropertyDescriptor | undefined
 
 describe("ShellFrameView", () => {
   beforeEach(() => {
     vi.unstubAllGlobals()
-    mocks.observe.mockClear()
-    mocks.disconnect.mockClear()
     mocks.groupProps.mockClear()
     mocks.panelProps.mockClear()
     mocks.railProps.mockClear()
     mocks.overlayProps.mockClear()
     mocks.pendingProps.mockClear()
     mocks.channelSkeletonProps.mockClear()
-    mocks.resizeCallback.current = undefined
-    offsetWidthDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetWidth")
+    mocks.defaultLayout.current = { sidebar: 24, main: 76 }
     animateDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "animate")
-    Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
-      configurable: true,
-      get: () => 240,
-    })
-    class ResizeObserverMock {
-      constructor(callback: (entries: Array<{ contentRect: { width: number } }>) => void) {
-        mocks.resizeCallback.current = callback
-      }
-      observe = mocks.observe
-      disconnect = mocks.disconnect
-    }
-    vi.stubGlobal("ResizeObserver", ResizeObserverMock)
     vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: false })))
   })
 
   afterEach(() => {
-    if (offsetWidthDescriptor) {
-      Object.defineProperty(HTMLElement.prototype, "offsetWidth", offsetWidthDescriptor)
-    } else {
-      delete (HTMLElement.prototype as unknown as Record<string, unknown>).offsetWidth
-    }
     if (animateDescriptor) Object.defineProperty(HTMLElement.prototype, "animate", animateDescriptor)
     else delete (HTMLElement.prototype as unknown as Record<string, unknown>).animate
     vi.restoreAllMocks()
@@ -267,18 +247,59 @@ describe("ShellFrameView", () => {
     expect(mainPanel).toMatchObject({ id: "main", defaultSize: "76%" })
     expect("profileStatusSeeds" in latestProps(mocks.overlayProps)).toBe(false)
     expect(sidebar).toHaveBeenCalledWith()
-    expect(mocks.observe).toHaveBeenCalledTimes(1)
     const userBarOverlay = renderer.container.querySelector<HTMLElement>(
       '[data-slot="community-user-bar-overlay"]',
     )!
-    expect(userBarOverlay.style.width).toBe("297px")
+    expect(userBarOverlay.style.getPropertyValue("--community-desktop-user-bar-width")).toBe(
+      "calc(clamp(160px, calc(24% - 0.48px), 360px) + 58px)",
+    )
     await act(async () => {
-      mocks.resizeCallback.current?.([{ contentRect: { width: 300 } }])
+      const onResize = latestProps(mocks.panelProps, "sidebar").onResize as (
+        size: { asPercentage: number; inPixels: number },
+      ) => void
+      onResize({ asPercentage: 30, inPixels: 300 })
     })
-    expect(userBarOverlay.style.width).toBe("357px")
+    expect(userBarOverlay.style.getPropertyValue("--community-desktop-user-bar-width"))
+      .toBe("358px")
+
+    const renderedSidebar = renderer.container.querySelector<HTMLElement>(
+      '[data-slot="resizable-panel"][data-testid="sidebar"] > div',
+    )!
+    vi.spyOn(renderedSidebar, "getBoundingClientRect").mockReturnValue({
+      ...renderedSidebar.getBoundingClientRect(),
+      width: 299.25,
+    })
+    await act(async () => {
+      const onResize = latestProps(mocks.panelProps, "sidebar").onResize as (
+        size: { asPercentage: number; inPixels: number },
+      ) => void
+      onResize({ asPercentage: 30, inPixels: 300 })
+    })
+    expect(userBarOverlay.style.getPropertyValue("--community-desktop-user-bar-width"))
+      .toBe("357.25px")
 
     renderer.unmount()
-    expect(mocks.disconnect).toHaveBeenCalledTimes(1)
+  })
+
+  it("seeds the User bar from the persisted panel percentage before pixel sizing", () => {
+    mocks.defaultLayout.current = { sidebar: 18.75, main: 81.25 }
+    const renderer = render(createElement(ShellFrameView, {
+      breakpoint: "desktop",
+      checkpoint: committedCheckpoint("/c/me", "list"),
+      sidebar: () => createElement("sidebar-content"),
+      cancelPendingNavigation: vi.fn(),
+      rail,
+      profile,
+      inbox,
+    }, createElement("main-content")))
+
+    const group = latestProps(mocks.groupProps)
+    expect(group.defaultLayout).toEqual({ sidebar: 18.75, main: 81.25 })
+    expect(renderer.container.querySelector<HTMLElement>(
+      '[data-slot="community-user-bar-overlay"]',
+    )!.style.getPropertyValue("--community-desktop-user-bar-width")).toBe(
+      "calc(clamp(160px, calc(18.75% - 0.375px), 360px) + 58px)",
+    )
   })
 
   it("composes the server-root list surface with desktop rail, sidebar, and landing content", async () => {
@@ -683,7 +704,7 @@ describe("ShellFrameView", () => {
     expect(mounts).toBe(1)
   })
 
-  it("disconnects and re-subscribes sidebar observation across breakpoint changes", async () => {
+  it("keeps one panel-owned resize callback across breakpoint changes", async () => {
     const sidebar = vi.fn(() => createElement("sidebar-content"))
     const common = {
       checkpoint: committedCheckpoint("/c/me", "list"),
@@ -696,25 +717,24 @@ describe("ShellFrameView", () => {
     const renderer = render(
       createElement(ShellFrameView, { ...common, breakpoint: "desktop" }, createElement("main-content")),
     )
-    expect(mocks.observe).toHaveBeenCalledTimes(1)
+    const onResize = latestProps(mocks.panelProps, "sidebar").onResize
+    expect(onResize).toBeTypeOf("function")
 
     renderer.rerender(createElement(
       ShellFrameView,
       { ...common, breakpoint: "mobile" },
       createElement("main-content"),
     ))
-    expect(mocks.disconnect).toHaveBeenCalledTimes(1)
-    expect(mocks.observe).toHaveBeenCalledTimes(1)
+    expect(latestProps(mocks.panelProps, "sidebar").onResize).toBe(onResize)
 
     renderer.rerender(createElement(
       ShellFrameView,
       { ...common, breakpoint: "desktop" },
       createElement("main-content"),
     ))
-    expect(mocks.observe).toHaveBeenCalledTimes(2)
+    expect(latestProps(mocks.panelProps, "sidebar").onResize).toBe(onResize)
 
     renderer.unmount()
-    expect(mocks.disconnect).toHaveBeenCalledTimes(2)
   })
 
   it("keeps committed content mounted while same-scope navigation is pending", async () => {

--- a/src/web/src/test/e2e-ui/46-community-loading-geometry-dark.spec.ts
+++ b/src/web/src/test/e2e-ui/46-community-loading-geometry-dark.spec.ts
@@ -1,5 +1,6 @@
 import { test } from "./_fixtures/community-fixture"
 import {
+  runDesktopPersistedPendingGeometry,
   runNeutralRootGeometry,
   runRouteLoadingGeometry,
   seedGeometryRoutes,
@@ -15,6 +16,11 @@ test.describe.serial("community dark loading geometry", () => {
 
   test("dark: neutral root owns two viewport cold restores", async ({ asUser }, testInfo) => {
     await runNeutralRootGeometry("dark", asUser, testInfo)
+  })
+
+  test("dark: persisted desktop sidebars keep every pending-frame boundary aligned", async ({ asUser }) => {
+    test.setTimeout(240_000)
+    await runDesktopPersistedPendingGeometry("dark", asUser)
   })
 
   test("dark: 18 route × viewport pending→loaded pairs keep shell CLS at zero", async ({ asUser }, testInfo) => {

--- a/src/web/src/test/e2e-ui/46-community-loading-geometry-light.spec.ts
+++ b/src/web/src/test/e2e-ui/46-community-loading-geometry-light.spec.ts
@@ -1,5 +1,6 @@
 import { test } from "./_fixtures/community-fixture"
 import {
+  runDesktopPersistedPendingGeometry,
   runNeutralRootGeometry,
   runRouteLoadingGeometry,
   seedGeometryRoutes,
@@ -15,6 +16,11 @@ test.describe.serial("community light loading geometry", () => {
 
   test("light: neutral root owns two viewport cold restores", async ({ asUser }, testInfo) => {
     await runNeutralRootGeometry("light", asUser, testInfo)
+  })
+
+  test("light: persisted desktop sidebars keep every pending-frame boundary aligned", async ({ asUser }) => {
+    test.setTimeout(240_000)
+    await runDesktopPersistedPendingGeometry("light", asUser)
   })
 
   test("light: 18 route × viewport pending→loaded pairs keep shell CLS at zero", async ({ asUser }, testInfo) => {

--- a/src/web/src/test/e2e-ui/_fixtures/community-loading-geometry.ts
+++ b/src/web/src/test/e2e-ui/_fixtures/community-loading-geometry.ts
@@ -8,6 +8,11 @@ import type {
 } from "@playwright/test"
 import { expect, sessionCookie, userId } from "./community-fixture"
 import {
+  COMMUNITY_RAIL_WIDTH,
+  COMMUNITY_SEPARATOR_WIDTH,
+  COMMUNITY_SURFACE_BORDER_WIDTH,
+} from "@/components/community/shell/shell-frame-geometry"
+import {
   seedChannel,
   seedDm,
   seedForumThread,
@@ -25,8 +30,11 @@ type CommunityAsUser = (
   options?: Omit<BrowserContextOptions, "storageState">,
 ) => Promise<{ context: BrowserContext; page: Page }>
 type MobileWidth = 320 | 390 | 639
+type DesktopWidth = 640 | 768 | 1024 | 1280
+type PersistedSidebarWidth = 160 | 240 | 350 | 360
 const RAIL_OVERFLOW_SERVER_COUNT = 20
 const ISOLATED_GEOMETRY_USER: UserKey = "dave"
+const DESKTOP_DENSITY_SCALES = [1, 1.25] as const
 const ANDROID_USER_AGENTS = {
   chrome: "Mozilla/5.0 (Linux; Android 15; Pixel 9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Mobile Safari/537.36",
   webview: "Mozilla/5.0 (Linux; Android 15; Pixel 9 Build/AP3A.240905.015; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/140.0.0.0 Mobile Safari/537.36",
@@ -185,6 +193,14 @@ type FirstFrameSample = {
   geometry: Geometry
 }
 
+type DesktopPendingFrameSample = {
+  overflow: number
+  sidebarWidth: number
+  sidebarRight: number
+  mainLeft: number
+  userBarRight: number
+}
+
 async function installFirstFrameProbe(page: Page, surface: "list" | "detail") {
   await page.addInitScript((expectedSurface) => {
     const samples: FirstFrameSample[] = []
@@ -224,6 +240,70 @@ async function firstFrameSamples(page: Page): Promise<FirstFrameSample[]> {
   return page.evaluate(() => (
     Reflect.get(window, "__communityFirstFrameSamples") as FirstFrameSample[]
   ))
+}
+
+function desktopPanelTrackWidth(viewportWidth: DesktopWidth) {
+  return viewportWidth
+    - COMMUNITY_RAIL_WIDTH
+    - COMMUNITY_SURFACE_BORDER_WIDTH
+    - COMMUNITY_SEPARATOR_WIDTH
+}
+
+async function installDesktopPendingFrameProbe(
+  page: Page,
+  viewportWidth: DesktopWidth,
+  sidebarWidth: PersistedSidebarWidth | null,
+) {
+  const panelTrackWidth = desktopPanelTrackWidth(viewportWidth)
+  await page.addInitScript(({ initialFrameTestId, layoutStorageKey, persistedLayout }) => {
+    if (persistedLayout) {
+      localStorage.setItem(layoutStorageKey, JSON.stringify(persistedLayout))
+    } else {
+      localStorage.removeItem(layoutStorageKey)
+    }
+    const samples: DesktopPendingFrameSample[] = []
+    Reflect.set(window, "__communityDesktopPendingFrameSamples", samples)
+
+    const sample = () => {
+      const frame = document.querySelector(`[data-testid="${initialFrameTestId}"]`)
+      const panels = frame?.querySelectorAll<HTMLElement>('[data-slot="resizable-panel"]')
+      const sidebar = panels?.[0]
+      const main = panels?.[1]
+      const userBar = document.querySelector<HTMLElement>(
+        '[data-slot="community-user-bar-overlay"]',
+      )
+      if (frame && sidebar && main && userBar) {
+        const sidebarRect = sidebar.getBoundingClientRect()
+        const mainRect = main.getBoundingClientRect()
+        const userBarRect = userBar.getBoundingClientRect()
+        samples.push({
+          overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+          sidebarWidth: sidebarRect.width,
+          sidebarRight: sidebarRect.right,
+          mainLeft: mainRect.left,
+          userBarRight: userBarRect.right,
+        })
+      }
+      if (performance.now() < 5_000) requestAnimationFrame(sample)
+    }
+    requestAnimationFrame(sample)
+  }, {
+    initialFrameTestId: tid.initialFrame,
+    layoutStorageKey: "react-resizable-panels:community-shell",
+    persistedLayout: sidebarWidth === null
+      ? null
+      : {
+          sidebar: sidebarWidth / panelTrackWidth * 100,
+          main: 100 - sidebarWidth / panelTrackWidth * 100,
+        },
+  })
+}
+
+async function desktopPendingFrameSamples(page: Page): Promise<DesktopPendingFrameSample[]> {
+  return page.evaluate(() => Reflect.get(
+    window,
+    "__communityDesktopPendingFrameSamples",
+  ) as DesktopPendingFrameSample[])
 }
 
 function expectMobileGeometry(
@@ -433,6 +513,60 @@ export async function runAndroidLoadingGeometry(asUser: CommunityAsUser) {
         }
       }
     }
+}
+
+export async function runDesktopPersistedPendingGeometry(
+  theme: Theme,
+  asUser: CommunityAsUser,
+) {
+  for (const viewportWidth of [640, 768, 1024, 1280] as const) {
+    for (const sidebarWidth of [null, 160, 240, 350, 360] as const) {
+      for (const deviceScaleFactor of DESKTOP_DENSITY_SCALES) {
+        const caseLabel = `${viewportWidth}px @${deviceScaleFactor}x, sidebar ${sidebarWidth ?? "default"}`
+        const { context, page } = await asUser(ISOLATED_GEOMETRY_USER, {
+          deviceScaleFactor,
+        })
+        await page.setViewportSize({ width: viewportWidth, height: 900 })
+        await page.emulateMedia({ colorScheme: theme })
+        await installDesktopPendingFrameProbe(page, viewportWidth, sidebarWidth)
+        const session = await holdSession(page)
+        await page.goto("/c/me/machines", { waitUntil: "commit" })
+        await expect.poll(session.hits).toBeGreaterThan(0)
+        await expect(page.getByTestId(tid.initialFrame)).toBeVisible()
+        await page.waitForTimeout(250)
+
+        const samples = await desktopPendingFrameSamples(page)
+        expect(samples.length, caseLabel).toBeGreaterThan(0)
+        for (const [index, sample] of samples.entries()) {
+          expect(sample.overflow, `${caseLabel}, frame ${index} horizontal overflow`).toBe(0)
+          expect(
+            Math.abs(sample.userBarRight - sample.mainLeft),
+            `${caseLabel}, frame ${index} User bar/main boundary: ${JSON.stringify(sample)}`,
+          ).toBeLessThanOrEqual(1)
+          const separatorWidth = sample.mainLeft - sample.sidebarRight
+          expect(
+            separatorWidth,
+            `${caseLabel}, frame ${index} separator width: ${JSON.stringify(sample)}`,
+          ).toBeGreaterThanOrEqual(0)
+          expect(
+            separatorWidth,
+            `${caseLabel}, frame ${index} separator width: ${JSON.stringify(sample)}`,
+          ).toBeLessThanOrEqual(1)
+        }
+        const expectedSidebarWidth = sidebarWidth ?? Math.min(
+          360,
+          Math.max(160, desktopPanelTrackWidth(viewportWidth) * 0.24),
+        )
+        expect(
+          Math.abs(samples.at(-1)!.sidebarWidth - expectedSidebarWidth),
+          `${caseLabel}, final sidebar width: ${JSON.stringify(samples.at(-1))}`,
+        ).toBeLessThanOrEqual(1)
+
+        session.release()
+        await context.close()
+      }
+    }
+  }
 }
 
 export async function runSkeletonLoadingMotion(asUser: CommunityAsUser) {


### PR DESCRIPTION
# Why we need this PR?

Cold desktop Community routes seeded the sidebar through react-resizable-panels while the User bar followed an independent passive ResizeObserver. That let the first visible pending frame show a split boundary, especially with persisted sidebar layouts and fractional device geometry.

## What changed

- make CommunityShellLayout the single owner of sidebar/User bar desktop geometry
- seed the User bar from the same persisted/default percentage and 160–360px constraints as the sidebar panel
- update the User bar from the panel resize callback using the exact rendered width, removing the passive observer frame
- add document-start light/dark regression coverage for 80 persisted-layout, viewport, and density combinations
- retain the existing mobile geometry contract

## Verification

- focused unit/DOM: 3 files, 26 tests
- pending desktop matrix: 40 light + 40 dark cases
- Android geometry regression: 2 tests across Chrome/WebView, 320/390/639, and reduced motion
- full pnpm test
- pnpm lint
- pnpm typecheck
- pnpm build
- commit hooks, including knip and boundary checks

## Checklist

- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (@alook/shared)
- [x] Web app (@alook/web)
- [ ] CLI (@alook/cli)
- [ ] Email Worker (@alook/email-worker)
- [ ] WebSocket DO (@alook/ws-do)
- [ ] CI/CD
- [ ] Other

