### PR TITLE
fix(desktop): retry recovery on lifecycle signals

### DIFF
--- a/scripts/ci/webview-recovery.test.ts
+++ b/scripts/ci/webview-recovery.test.ts
@@ -1,0 +1,263 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { runInNewContext } from "node:vm"
+import { describe, expect, it, vi } from "vitest"
+
+type TestEvent = {
+  defaultPrevented?: boolean
+  key?: string
+  preventDefault?: () => void
+}
+
+type Listener = (event: TestEvent) => void
+
+class FakeEventTarget {
+  private readonly listeners = new Map<string, Set<Listener>>()
+
+  addEventListener(type: string, listener: Listener) {
+    const listeners = this.listeners.get(type) ?? new Set<Listener>()
+    listeners.add(listener)
+    this.listeners.set(type, listeners)
+  }
+
+  removeEventListener(type: string, listener: Listener) {
+    const listeners = this.listeners.get(type)
+    listeners?.delete(listener)
+    if (listeners?.size === 0) this.listeners.delete(type)
+  }
+
+  dispatch(type: string, event: TestEvent = {}) {
+    for (const listener of [...(this.listeners.get(type) ?? [])]) listener(event)
+    return event
+  }
+
+  listenerCount(type: string) {
+    return this.listeners.get(type)?.size ?? 0
+  }
+}
+
+class FakeElement extends FakeEventTarget {
+  readonly attributes = new Map<string, string>()
+  focusCalls = 0
+  textContent: string
+
+  constructor(textContent = "") {
+    super()
+    this.textContent = textContent
+  }
+
+  focus() {
+    this.focusCalls += 1
+  }
+
+  setAttribute(name: string, value: string) {
+    this.attributes.set(name, value)
+  }
+}
+
+class FakeDocument extends FakeEventTarget {
+  hidden = false
+
+  constructor(
+    private readonly surface: FakeElement,
+    private readonly message: FakeElement,
+  ) {
+    super()
+  }
+
+  querySelector(selector: string) {
+    if (selector === '[data-testid="webview-recovery"]') return this.surface
+    if (selector === '[data-testid="recovery-message"]') return this.message
+    return null
+  }
+}
+
+const repositoryRoot = resolve(import.meta.dirname, "../..")
+const rustSource = readFileSync(
+  resolve(repositoryRoot, "src/desktop/src-tauri/src/webview_recovery.rs"),
+  "utf8",
+)
+const recoveryHtml = rustSource.match(
+  /fn recovery_html\(\) -> &'static str \{\s*r##"([\s\S]*?)"##\s*\}/,
+)?.[1]
+
+if (!recoveryHtml) throw new Error("recovery HTML not found")
+
+const recoveryScript = recoveryHtml.match(/<script>\s*([\s\S]*?)\s*<\/script>/)?.[1]
+
+if (!recoveryScript) throw new Error("recovery script not found")
+
+const defaultMessage = "Network connection failed. Click to refresh"
+
+const createHarness = (
+  target = "https://alook.ai/c/channel?after=%23one&view=all#message-7",
+  replace = vi.fn(),
+) => {
+  const surface = new FakeElement()
+  const message = new FakeElement(defaultMessage)
+  const document = new FakeDocument(surface, message)
+  const window = new FakeEventTarget()
+  const location = {
+    hash: `#${new URLSearchParams({ target }).toString()}`,
+    replace,
+  }
+
+  runInNewContext(recoveryScript, {
+    URL,
+    URLSearchParams,
+    document,
+    location,
+    window,
+  })
+
+  return { document, location, message, replace, surface, window }
+}
+
+describe("WebView recovery document", () => {
+  it("does not focus on load and confines the keyboard ring to the refresh icon", () => {
+    const { surface } = createHarness()
+
+    expect(surface.focusCalls).toBe(0)
+    expect(recoveryHtml).toContain(
+      "main:focus-visible svg{outline:3px solid var(--ring);outline-offset:4px",
+    )
+    expect(recoveryHtml).not.toContain("autofocus")
+    expect(recoveryHtml).not.toMatch(/main:focus-visible\{[^}]*outline:3px/)
+  })
+
+  it("retries the exact target once on online", () => {
+    const harness = createHarness()
+
+    harness.window.dispatch("online")
+    harness.window.dispatch("online")
+
+    expect(harness.replace).toHaveBeenCalledOnce()
+    expect(harness.replace).toHaveBeenCalledWith(
+      "https://alook.ai/c/channel?after=%23one&view=all#message-7",
+    )
+  })
+
+  it("retries only after blur is followed by focus", () => {
+    const harness = createHarness()
+
+    harness.window.dispatch("focus")
+    expect(harness.replace).not.toHaveBeenCalled()
+
+    harness.window.dispatch("blur")
+    harness.window.dispatch("focus")
+    harness.window.dispatch("focus")
+
+    expect(harness.replace).toHaveBeenCalledOnce()
+  })
+
+  it("retries only after hidden is followed by visible", () => {
+    const harness = createHarness()
+
+    harness.document.dispatch("visibilitychange")
+    expect(harness.replace).not.toHaveBeenCalled()
+
+    harness.document.hidden = true
+    harness.document.dispatch("visibilitychange")
+    harness.document.hidden = false
+    harness.document.dispatch("visibilitychange")
+    harness.document.dispatch("visibilitychange")
+
+    expect(harness.replace).toHaveBeenCalledOnce()
+  })
+
+  it("deduplicates concurrent manual and lifecycle retries", () => {
+    const harness = createHarness()
+    const keyEvent: TestEvent = {
+      key: "Enter",
+      preventDefault() {
+        this.defaultPrevented = true
+      },
+    }
+
+    harness.surface.dispatch("click")
+    harness.surface.dispatch("keydown", keyEvent)
+    harness.window.dispatch("online")
+    harness.window.dispatch("blur")
+    harness.window.dispatch("focus")
+    harness.document.hidden = true
+    harness.document.dispatch("visibilitychange")
+    harness.document.hidden = false
+    harness.document.dispatch("visibilitychange")
+
+    expect(keyEvent.defaultPrevented).toBe(true)
+    expect(harness.replace).toHaveBeenCalledOnce()
+    expect(harness.message.textContent).toBe("Retrying…")
+  })
+
+  it.each(["Enter", " "])("supports the %j manual retry key", (key) => {
+    const harness = createHarness()
+    const event: TestEvent = {
+      key,
+      preventDefault() {
+        this.defaultPrevented = true
+      },
+    }
+
+    harness.surface.dispatch("keydown", event)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(harness.replace).toHaveBeenCalledOnce()
+  })
+
+  it("restores the recovery state after a synchronous navigation failure", () => {
+    const replace = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error("navigation rejected")
+      })
+      .mockImplementationOnce(() => undefined)
+    const harness = createHarness(undefined, replace)
+
+    harness.surface.dispatch("click")
+
+    expect(harness.surface.attributes.get("aria-disabled")).toBe("false")
+    expect(harness.message.textContent).toBe(defaultMessage)
+
+    harness.window.dispatch("online")
+
+    expect(replace).toHaveBeenCalledTimes(2)
+    expect(harness.message.textContent).toBe("Retrying…")
+  })
+
+  it("fails closed for invalid targets", () => {
+    const harness = createHarness("javascript:alert(1)")
+
+    harness.surface.dispatch("click")
+    harness.window.dispatch("online")
+
+    expect(harness.surface.attributes.get("aria-disabled")).toBe("true")
+    expect(harness.replace).not.toHaveBeenCalled()
+  })
+
+  it("removes all listeners on pagehide", () => {
+    const harness = createHarness()
+
+    expect(harness.window.listenerCount("pagehide")).toBe(1)
+    harness.window.dispatch("pagehide")
+
+    for (const type of ["online", "blur", "focus", "pagehide"]) {
+      expect(harness.window.listenerCount(type)).toBe(0)
+    }
+    expect(harness.document.listenerCount("visibilitychange")).toBe(0)
+    expect(harness.surface.listenerCount("click")).toBe(0)
+    expect(harness.surface.listenerCount("keydown")).toBe(0)
+
+    harness.surface.dispatch("click")
+    harness.window.dispatch("online")
+    expect(harness.replace).not.toHaveBeenCalled()
+  })
+
+  it("has no polling or reload loop and does not claim connectivity succeeded", () => {
+    expect(recoveryScript).not.toContain("setTimeout")
+    expect(recoveryScript).not.toContain("setInterval")
+    expect(recoveryScript).not.toContain("location.reload")
+    expect(recoveryScript).not.toContain("navigator.onLine")
+    expect(recoveryHtml).not.toContain("Back online")
+    expect(recoveryHtml).not.toContain("Connected")
+  })
+})

--- a/src/desktop/src-tauri/src/webview_recovery.rs
+++ b/src/desktop/src-tauri/src/webview_recovery.rs
@@ -447,7 +447,7 @@ fn recovery_html() -> &'static str {
     *{box-sizing:border-box}
     body{min-height:100vh;margin:0;background:var(--background)}
     main{width:100%;min-height:100vh;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:18px;padding:max(24px,env(safe-area-inset-top)) max(24px,env(safe-area-inset-right)) max(24px,env(safe-area-inset-bottom)) max(24px,env(safe-area-inset-left));text-align:center;cursor:pointer;outline:none;-webkit-user-select:none;user-select:none}
-    main:focus-visible{outline:3px solid var(--ring);outline-offset:-4px}
+    main:focus-visible svg{outline:3px solid var(--ring);outline-offset:4px;border-radius:50%}
     svg{width:48px;height:48px;color:var(--foreground)}
     p{margin:0;color:var(--muted-foreground);font-size:16px;line-height:1.55}
     main[aria-disabled="true"]{cursor:wait}
@@ -465,14 +465,28 @@ fn recovery_html() -> &'static str {
     const candidate=params.get("target")||"";
     const surface=document.querySelector('[data-testid="webview-recovery"]');
     const message=document.querySelector('[data-testid="recovery-message"]');
+    const originalMessage=message.textContent;
     let target="";
     let retrying=false;
+    let blurred=false;
+    let hidden=document.hidden;
     try{const parsed=new URL(candidate);if((parsed.protocol==="http:"||parsed.protocol==="https:")&&parsed.hostname!=="alook-recovery.localhost")target=candidate}catch(_error){}
     if(!target)surface.setAttribute("aria-disabled","true");
-    const refresh=()=>{if(retrying||!target)return;retrying=true;surface.setAttribute("aria-disabled","true");message.textContent="Retrying…";location.replace(target)};
-    surface.addEventListener("click",refresh);
-    surface.addEventListener("keydown",event=>{if(event.key==="Enter"||event.key===" "){event.preventDefault();refresh()}});
-    surface.focus();
+    const refresh=()=>{if(retrying||!target)return;retrying=true;surface.setAttribute("aria-disabled","true");message.textContent="Retrying…";try{location.replace(target)}catch(_error){retrying=false;surface.setAttribute("aria-disabled","false");message.textContent=originalMessage}};
+    const onKeydown=event=>{if(event.key==="Enter"||event.key===" "){event.preventDefault();refresh()}};
+    const onBlur=()=>{blurred=true};
+    const onFocus=()=>{if(!blurred)return;blurred=false;refresh()};
+    const onVisibilityChange=()=>{if(document.hidden){hidden=true;return}if(!hidden)return;hidden=false;refresh()};
+    const listeners=[];
+    const listen=(owner,type,handler)=>{owner.addEventListener(type,handler);listeners.push([owner,type,handler])};
+    const cleanup=()=>{while(listeners.length){const [owner,type,handler]=listeners.pop();owner.removeEventListener(type,handler)}};
+    listen(surface,"click",refresh);
+    listen(surface,"keydown",onKeydown);
+    listen(window,"online",refresh);
+    listen(window,"blur",onBlur);
+    listen(window,"focus",onFocus);
+    listen(document,"visibilitychange",onVisibilityChange);
+    listen(window,"pagehide",cleanup);
     if(window.__TAURI_INTERNALS__)window.__TAURI_INTERNALS__.invoke("close_splashscreen").catch(()=>{});
   </script>
 </body>
@@ -576,7 +590,7 @@ mod tests {
     }
 
     #[test]
-    fn recovery_document_has_stable_test_seams_and_only_explicit_retry() {
+    fn recovery_document_has_stable_test_seams_and_lifecycle_retry() {
         let html = recovery_html();
         for test_id in [
             "webview-recovery",
@@ -589,13 +603,22 @@ mod tests {
         assert!(html.contains("location.replace(target)"));
         assert!(html.contains("event.key===\"Enter\"||event.key===\" \""));
         assert!(html.contains("color:var(--foreground)"));
-        assert!(html.contains("outline:3px solid var(--ring)"));
+        assert!(html.contains("main:focus-visible svg{outline:3px solid var(--ring)"));
         assert!(html.contains("Network connection failed. Click to refresh"));
         assert!(html.contains("message.textContent=\"Retrying…\""));
         assert!(!html.contains("textContent=target"));
+        assert!(!html.contains("autofocus"));
+        assert!(!html.contains("surface.focus()"));
         assert!(!html.contains("location.reload"));
         assert!(!html.contains("setTimeout"));
-        assert!(!html.contains("addEventListener(\"online\""));
+        assert!(!html.contains("setInterval"));
+        for lifecycle_event in ["online", "blur", "focus", "visibilitychange", "pagehide"] {
+            assert!(
+                html.contains(&format!("listen(window,\"{lifecycle_event}\""))
+                    || html.contains(&format!("listen(document,\"{lifecycle_event}\""))
+            );
+        }
+        assert!(html.contains("removeEventListener(type,handler)"));
         assert!(!html.contains("transition:"));
         assert!(!html.contains("linear-gradient"));
         assert!(!html.contains("box-shadow"));


### PR DESCRIPTION
# Why we need this PR?
> Follow-up to #737

The desktop recovery page takes keyboard focus on load, which makes the full-window focus outline look like a border, and it requires a manual retry even when WebView lifecycle signals indicate another attempt is appropriate.

## What changed
- Remove initial focus and render keyboard focus only around the refresh icon while preserving the full-page click and keyboard control.
- Route `online`, blur→focus, hidden→visible, click, and Enter/Space through one exact-target, per-document retry guard.
- Restore the same recovery UI when navigation throws synchronously, clean up every listener on `pagehide`, and retain the existing native platform failure hooks.
- Add behavior coverage for lifecycle transitions, de-duplication, exact URL preservation, failure fallback, listener cleanup, invalid targets, manual input, and the no-polling contract.

## Verification
- Desktop recovery Rust tests: 15/15 passed.
- Recovery document behavior tests: 11/11 passed.
- Independent real-browser QA of the exact embedded recovery HTML: 4/4 scenarios passed at desktop and mobile widths.
- `pnpm typecheck` and `pnpm test` passed.
- Hosted CI: 24/24 checks passed, including Codecov patch.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [ ] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [x] Other: Desktop app (`@alook/desktop`)
