### PR TITLE
fix(web): skip mobile signup onboarding

### DIFF
--- a/src/web/src/components/community/machines/machine-list.dom.test.ts
+++ b/src/web/src/components/community/machines/machine-list.dom.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   machines: { current: [] as unknown[] },
   onboardingState: { current: "done" as unknown },
   guideMotion: vi.fn(),
+  startOnboarding: vi.fn(),
 }))
 
 vi.mock("sonner", () => ({
@@ -91,7 +92,7 @@ vi.mock("@/stores/community", () => ({
 vi.mock("@/lib/community-onboarding", () => ({
   advanceCommunityOnboarding: vi.fn(),
   readCommunityOnboardingState: vi.fn(() => null),
-  startCommunityOnboarding: vi.fn(),
+  startCommunityOnboarding: mocks.startOnboarding,
   updateCommunityOnboardingResources: vi.fn(),
   useCommunityOnboarding: () => mocks.onboardingState.current,
 }))
@@ -132,6 +133,7 @@ describe("machine daemon update UI", () => {
     mocks.toastSuccess.mockReset()
     mocks.toastError.mockReset()
     mocks.fetchLatestDaemonVersion.mockReset()
+    mocks.startOnboarding.mockReset()
     mocks.fetchLatestDaemonVersion.mockResolvedValue({
       version: "0.1.8",
       package: "@alook/daemon",
@@ -164,6 +166,15 @@ describe("machine daemon update UI", () => {
     const renderer = render(React.createElement(MachineList))
 
     expect(renderer.getByTestId(tid.onboardingStart)).toBeInTheDocument()
+  })
+
+  it("keeps the Machines Guide me action wired to manual onboarding", () => {
+    const renderer = render(React.createElement(MachineList))
+
+    fireEvent.click(renderer.getByTestId(tid.onboardingStart))
+
+    expect(mocks.startOnboarding).toHaveBeenCalledOnce()
+    expect(mocks.startOnboarding).toHaveBeenCalledWith({ guideAvatarSeed: expect.any(String) })
   })
 
   it("loads Community update eligibility from the daemon package endpoint", async () => {

--- a/src/web/src/components/signup-tracker.test.ts
+++ b/src/web/src/components/signup-tracker.test.ts
@@ -1,18 +1,24 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-const mockSendGTMEvent = vi.fn()
-const replaceRoute = vi.fn()
-const queueCommunityOnboarding = vi.fn()
-const startCommunityOnboarding = vi.fn()
+const mocks = vi.hoisted(() => ({
+  breakpoint: { current: "desktop" as "desktop" | "mobile" | "unknown" },
+  queueCommunityOnboarding: vi.fn(),
+  replaceRoute: vi.fn(),
+  sendGTMEvent: vi.fn(),
+  startCommunityOnboarding: vi.fn(),
+}))
 vi.mock("@next/third-parties/google", () => ({
-  sendGTMEvent: (...args: unknown[]) => mockSendGTMEvent(...args),
+  sendGTMEvent: (...args: unknown[]) => mocks.sendGTMEvent(...args),
 }))
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ replace: replaceRoute }),
+  useRouter: () => ({ replace: mocks.replaceRoute }),
+}))
+vi.mock("@/hooks/use-mobile", () => ({
+  useBreakpoint: () => mocks.breakpoint.current,
 }))
 vi.mock("@/lib/community-onboarding", () => ({
-  queueCommunityOnboarding,
-  startCommunityOnboarding,
+  queueCommunityOnboarding: mocks.queueCommunityOnboarding,
+  startCommunityOnboarding: mocks.startCommunityOnboarding,
 }))
 
 vi.mock("react", () => ({
@@ -21,21 +27,27 @@ vi.mock("react", () => ({
 
 describe("SignupTracker", () => {
   let cookieValue = ""
-  let cookieSetValue = ""
+  let cookieWrites: string[] = []
   const replace = vi.fn()
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.breakpoint.current = "desktop"
     cookieValue = ""
-    cookieSetValue = ""
+    cookieWrites = []
     replace.mockReset()
-    replaceRoute.mockReset()
-    queueCommunityOnboarding.mockReset()
-    startCommunityOnboarding.mockReset()
     // @ts-expect-error stub global document
     globalThis.document = {
       get cookie() { return cookieValue },
-      set cookie(val: string) { cookieSetValue = val },
+      set cookie(value: string) {
+        cookieWrites.push(value)
+        if (value === "is_new_signup=; max-age=0; path=/") {
+          cookieValue = cookieValue
+            .split("; ")
+            .filter((cookie) => !cookie.startsWith("is_new_signup="))
+            .join("; ")
+        }
+      },
     }
     // @ts-expect-error stub global window
     globalThis.window = { location: { replace } }
@@ -48,44 +60,120 @@ describe("SignupTracker", () => {
     delete globalThis.window
   })
 
-  it("fires sign_up event and clears cookie when is_new_signup is present", async () => {
-    cookieValue = "is_new_signup=email"
-    vi.resetModules()
-    const { SignupTracker } = await import("./signup-tracker")
-    SignupTracker()
-
-    expect(mockSendGTMEvent).toHaveBeenCalledWith({ event: "sign_up", method: "email" })
-    expect(cookieSetValue).toBe("is_new_signup=; max-age=0; path=/")
-  })
-
-  it("does nothing when is_new_signup cookie is absent", async () => {
-    cookieValue = "other_cookie=value"
-    vi.resetModules()
-    const { SignupTracker } = await import("./signup-tracker")
-    SignupTracker()
-
-    expect(mockSendGTMEvent).not.toHaveBeenCalled()
-  })
-
-  it("handles github method correctly", async () => {
-    cookieValue = "session=abc; is_new_signup=github; other=xyz"
-    vi.resetModules()
-    const { SignupTracker } = await import("./signup-tracker")
-    SignupTracker()
-
-    expect(mockSendGTMEvent).toHaveBeenCalledWith({ event: "sign_up", method: "github" })
-  })
-
-  it("redirects a new signup when the host surface provides a landing", async () => {
+  it("does not consume the signup cookie while the breakpoint is unknown", async () => {
+    mocks.breakpoint.current = "unknown"
     cookieValue = "is_new_signup=email"
     vi.resetModules()
     const { SignupTracker } = await import("./signup-tracker")
     SignupTracker({ redirectTo: "/c/me/machines" })
 
-    expect(queueCommunityOnboarding).toHaveBeenCalledOnce()
-    expect(startCommunityOnboarding).toHaveBeenCalledOnce()
-    expect(replaceRoute).toHaveBeenCalledWith("/c/me/machines")
+    expect(cookieValue).toBe("is_new_signup=email")
+    expect(cookieWrites).toEqual([])
+    expect(mocks.sendGTMEvent).not.toHaveBeenCalled()
+    expect(mocks.queueCommunityOnboarding).not.toHaveBeenCalled()
+    expect(mocks.startCommunityOnboarding).not.toHaveBeenCalled()
+    expect(mocks.replaceRoute).not.toHaveBeenCalled()
+  })
+
+  it("consumes unknown to mobile once without automatic onboarding or redirect", async () => {
+    mocks.breakpoint.current = "unknown"
+    cookieValue = "is_new_signup=email"
+    vi.resetModules()
+    const { SignupTracker } = await import("./signup-tracker")
+    const props = { redirectTo: "/c/me/machines" }
+
+    SignupTracker(props)
+    mocks.breakpoint.current = "mobile"
+    SignupTracker(props)
+    mocks.breakpoint.current = "desktop"
+    SignupTracker(props)
+
+    expect(mocks.sendGTMEvent).toHaveBeenCalledOnce()
+    expect(mocks.sendGTMEvent).toHaveBeenCalledWith({ event: "sign_up", method: "email" })
+    expect(cookieWrites).toEqual(["is_new_signup=; max-age=0; path=/"])
+    expect(mocks.queueCommunityOnboarding).not.toHaveBeenCalled()
+    expect(mocks.startCommunityOnboarding).not.toHaveBeenCalled()
+    expect(mocks.replaceRoute).not.toHaveBeenCalled()
     expect(replace).not.toHaveBeenCalled()
-    expect(cookieSetValue).toBe("is_new_signup=; max-age=0; path=/")
+  })
+
+  it("consumes unknown to desktop through the existing automatic flow", async () => {
+    mocks.breakpoint.current = "unknown"
+    cookieValue = "is_new_signup=email"
+    vi.resetModules()
+    const { SignupTracker } = await import("./signup-tracker")
+    const props = { redirectTo: "/c/me/machines" }
+
+    SignupTracker(props)
+    mocks.breakpoint.current = "desktop"
+    SignupTracker(props)
+
+    expect(mocks.sendGTMEvent).toHaveBeenCalledWith({ event: "sign_up", method: "email" })
+    expect(cookieWrites).toEqual(["is_new_signup=; max-age=0; path=/"])
+    expect(mocks.queueCommunityOnboarding).toHaveBeenCalledOnce()
+    expect(mocks.startCommunityOnboarding).toHaveBeenCalledOnce()
+    expect(mocks.replaceRoute).toHaveBeenCalledWith("/c/me/machines")
+    expect(replace).not.toHaveBeenCalled()
+  })
+
+  it("handles a directly resolved mobile signup without automatic navigation", async () => {
+    mocks.breakpoint.current = "mobile"
+    cookieValue = "is_new_signup=email"
+    vi.resetModules()
+    const { SignupTracker } = await import("./signup-tracker")
+    SignupTracker({ redirectTo: "/c/me/machines" })
+
+    expect(mocks.sendGTMEvent).toHaveBeenCalledWith({ event: "sign_up", method: "email" })
+    expect(cookieWrites).toEqual(["is_new_signup=; max-age=0; path=/"])
+    expect(mocks.queueCommunityOnboarding).not.toHaveBeenCalled()
+    expect(mocks.startCommunityOnboarding).not.toHaveBeenCalled()
+    expect(mocks.replaceRoute).not.toHaveBeenCalled()
+    expect(replace).not.toHaveBeenCalled()
+  })
+
+  it("deduplicates repeated resolved renders through cookie consumption", async () => {
+    cookieValue = "is_new_signup=email"
+    vi.resetModules()
+    const { SignupTracker } = await import("./signup-tracker")
+    const props = { redirectTo: "/c/me/machines" }
+
+    SignupTracker(props)
+    SignupTracker(props)
+
+    expect(mocks.sendGTMEvent).toHaveBeenCalledOnce()
+    expect(cookieWrites).toEqual(["is_new_signup=; max-age=0; path=/"])
+    expect(mocks.queueCommunityOnboarding).toHaveBeenCalledOnce()
+    expect(mocks.startCommunityOnboarding).toHaveBeenCalledOnce()
+    expect(mocks.replaceRoute).toHaveBeenCalledOnce()
+  })
+
+  it("keeps signup method tracking intact", async () => {
+    cookieValue = "session=abc; is_new_signup=github; other=xyz"
+    vi.resetModules()
+    const { SignupTracker } = await import("./signup-tracker")
+
+    SignupTracker()
+
+    expect(mocks.sendGTMEvent).toHaveBeenCalledOnce()
+    expect(mocks.sendGTMEvent).toHaveBeenCalledWith({ event: "sign_up", method: "github" })
+    expect(cookieWrites).toEqual(["is_new_signup=; max-age=0; path=/"])
+    expect(mocks.queueCommunityOnboarding).not.toHaveBeenCalled()
+    expect(mocks.startCommunityOnboarding).not.toHaveBeenCalled()
+    expect(mocks.replaceRoute).not.toHaveBeenCalled()
+  })
+
+  it("does nothing when the signup cookie is absent", async () => {
+    cookieValue = "other_cookie=value"
+    vi.resetModules()
+    const { SignupTracker } = await import("./signup-tracker")
+
+    SignupTracker({ redirectTo: "/c/me/machines" })
+
+    expect(cookieWrites).toEqual([])
+    expect(mocks.sendGTMEvent).not.toHaveBeenCalled()
+    expect(mocks.queueCommunityOnboarding).not.toHaveBeenCalled()
+    expect(mocks.startCommunityOnboarding).not.toHaveBeenCalled()
+    expect(mocks.replaceRoute).not.toHaveBeenCalled()
+    expect(replace).not.toHaveBeenCalled()
   })
 })

--- a/src/web/src/components/signup-tracker.tsx
+++ b/src/web/src/components/signup-tracker.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react"
 import { useRouter } from "next/navigation"
+import { useBreakpoint } from "@/hooks/use-mobile"
 import { trackSignUp } from "@/lib/analytics"
 import {
   queueCommunityOnboarding,
@@ -10,13 +11,16 @@ import {
 
 export function SignupTracker({ redirectTo }: { redirectTo?: string } = {}) {
   const router = useRouter()
+  const breakpoint = useBreakpoint()
 
   useEffect(() => {
+    if (breakpoint === "unknown") return
     const match = document.cookie.match(/(?:^|; )is_new_signup=([^;]*)/)
     if (!match) return
     const method = decodeURIComponent(match[1])
     trackSignUp(method)
     document.cookie = "is_new_signup=; max-age=0; path=/"
+    if (breakpoint === "mobile") return
     if (redirectTo) {
       if (redirectTo.startsWith("/c/")) {
         queueCommunityOnboarding()
@@ -26,7 +30,7 @@ export function SignupTracker({ redirectTo }: { redirectTo?: string } = {}) {
       }
       window.location.replace(redirectTo)
     }
-  }, [redirectTo, router])
+  }, [breakpoint, redirectTo, router])
 
   return null
 }

--- a/src/web/src/test/e2e-ui/25-community-ws-reconnect-overlay.spec.ts
+++ b/src/web/src/test/e2e-ui/25-community-ws-reconnect-overlay.spec.ts
@@ -146,8 +146,21 @@ test("an active onboarding form yields focus priority during outage, then resume
       `guide-reconnect-${process.pid}-${Date.now()}@example.com`,
     )
     await page.getByRole("button", { name: "Sign in", exact: true }).click()
-    await page.waitForURL("**/c/me/machines", { waitUntil: "commit" })
-    const onboarding = page.getByRole("dialog")
+    await page.waitForURL("**/c/me", { waitUntil: "commit" })
+    await expect.poll(async () => {
+      const cookies = await page.context().cookies()
+      return cookies.some((cookie) => cookie.name === "is_new_signup")
+    }).toBe(false)
+
+    const onboarding = page.getByTestId(tid.onboardingHarnessDialog)
+    await page.waitForTimeout(250)
+    await expect(page).toHaveURL(/\/c\/me$/)
+    await expect(onboarding).toHaveCount(0)
+
+    await page.goto("/c/me/machines")
+    const startOnboarding = page.getByTestId(tid.onboardingStart)
+    await expect(startOnboarding).toBeVisible()
+    await startOnboarding.click()
     await expect(onboarding).toBeVisible()
     await expect(onboarding.getByRole("heading", { name: "Which harness do you already use?" })).toBeVisible()
 

--- a/src/web/src/test/e2e-ui/31-machine-guide-motion.spec.ts
+++ b/src/web/src/test/e2e-ui/31-machine-guide-motion.spec.ts
@@ -1,38 +1,59 @@
 import { test, expect } from "./_fixtures/community-fixture"
 import { tid } from "./_fixtures/testids"
 
-for (const viewport of [
-  { name: "mobile", width: 390, height: 844 },
-  { name: "desktop", width: 1280, height: 800 },
-]) {
-  test(`first-signup ${viewport.name} opens onboarding before the empty Machines guide`, async ({ page }) => {
-    await page.setViewportSize({ width: viewport.width, height: viewport.height })
-    await page.goto("/sign-in")
-    await page.getByRole("textbox", { name: "Email" }).fill(
-      `direct-onboarding-${viewport.name}-${process.pid}-${Date.now()}@example.com`,
-    )
-    await page.getByRole("button", { name: "Sign in", exact: true }).click()
-    await page.waitForURL("**/c/me/machines", { waitUntil: "commit" })
+test("first-signup mobile skips automatic onboarding and does not backfill it on desktop", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.goto("/sign-in")
+  await page.getByRole("textbox", { name: "Email" }).fill(
+    `direct-onboarding-mobile-${process.pid}-${Date.now()}@example.com`,
+  )
+  await page.getByRole("button", { name: "Sign in", exact: true }).click()
+  await page.waitForURL("**/c/me", { waitUntil: "commit" })
 
-    const onboarding = page.getByTestId(tid.onboardingHarnessDialog)
-    await expect(onboarding).toBeVisible()
-    await expect(
-      onboarding.getByRole("heading", { name: "Which harness do you already use?" }),
-    ).toBeVisible()
-    await expect(onboarding.getByLabel("Step 1 of 3")).toBeVisible()
-    await expect(page.getByTestId(tid.machineFirstSignupGuide)).toHaveCount(0)
+  await expect.poll(async () => {
+    const cookies = await page.context().cookies()
+    return cookies.some((cookie) => cookie.name === "is_new_signup")
+  }).toBe(false)
 
-    const grok = page.getByTestId(tid.onboardingHarnessOption("grok"))
-    await expect(grok).toBeVisible()
-    await expect(grok).toContainText("Grok Build")
-    await expect(grok.locator('[data-provider-logo="grok"]')).toBeVisible()
-    await grok.click()
-    await onboarding.getByRole("button", { name: "Continue", exact: true }).click()
+  const onboarding = page.getByTestId(tid.onboardingHarnessDialog)
+  await page.waitForTimeout(250)
+  await expect(page).toHaveURL(/\/c\/me$/)
+  await expect(onboarding).toHaveCount(0)
 
-    const machineStep = page.getByTestId(tid.onboardingMachineDialog)
-    await expect(machineStep).toBeVisible()
-    await expect(machineStep.getByRole("heading", { name: /Connect your Grok Build machine/ }))
-      .toBeVisible()
-    await expect(machineStep.locator('[data-provider-logo="grok"]')).toBeVisible()
-  })
-}
+  await page.setViewportSize({ width: 1280, height: 800 })
+  await page.waitForURL("**/c/me/friends", { waitUntil: "commit" })
+  await page.waitForTimeout(250)
+  await expect(page).toHaveURL(/\/c\/me\/friends$/)
+  await expect(onboarding).toHaveCount(0)
+})
+
+test("first-signup desktop opens onboarding before the empty Machines guide", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 })
+  await page.goto("/sign-in")
+  await page.getByRole("textbox", { name: "Email" }).fill(
+    `direct-onboarding-desktop-${process.pid}-${Date.now()}@example.com`,
+  )
+  await page.getByRole("button", { name: "Sign in", exact: true }).click()
+  await page.waitForURL("**/c/me/machines", { waitUntil: "commit" })
+
+  const onboarding = page.getByTestId(tid.onboardingHarnessDialog)
+  await expect(onboarding).toBeVisible()
+  await expect(
+    onboarding.getByRole("heading", { name: "Which harness do you already use?" }),
+  ).toBeVisible()
+  await expect(onboarding.getByLabel("Step 1 of 3")).toBeVisible()
+  await expect(page.getByTestId(tid.machineFirstSignupGuide)).toHaveCount(0)
+
+  const grok = page.getByTestId(tid.onboardingHarnessOption("grok"))
+  await expect(grok).toBeVisible()
+  await expect(grok).toContainText("Grok Build")
+  await expect(grok.locator('[data-provider-logo="grok"]')).toBeVisible()
+  await grok.click()
+  await onboarding.getByRole("button", { name: "Continue", exact: true }).click()
+
+  const machineStep = page.getByTestId(tid.onboardingMachineDialog)
+  await expect(machineStep).toBeVisible()
+  await expect(machineStep.getByRole("heading", { name: /Connect your Grok Build machine/ }))
+    .toBeVisible()
+  await expect(machineStep.locator('[data-provider-logo="grok"]')).toBeVisible()
+})


### PR DESCRIPTION
# Why we need this PR?
> Follow-up to the mobile signup onboarding behavior contract.

Mobile signups currently enter a desktop-oriented Community onboarding flow and redirect to Machines, even though that automatic walkthrough is not appropriate on the mobile layout.

## What changed
- Wait for the shared responsive breakpoint before consuming the new-signup cookie.
- Keep mobile signup analytics and cookie cleanup while skipping automatic Community onboarding and signup redirect.
- Preserve the existing desktop automatic flow and the user-initiated Machines “Guide me” action.
- Add regressions for breakpoint transitions, one-shot cookie consumption, mobile/desktop branching, manual onboarding, and reconnect-overlay focus after a deliberate manual start.

## Verification
- Focused Vitest: 19/19; breakpoint/cold-entry controls: 8/8.
- Signup Playwright: 2/2; reconnect-overlay Playwright: 2/2.
- Independent real-browser matrix: 11/11 sessions across 320/390/639/640/1280 widths, including delayed breakpoint settlement, mobile→desktop no-backfill, desktop automatic flow, no-cookie/non-new no-op, and manual Guide me.
- Root typecheck, lint, full test, changed coverage, typegrep, and knip passed. Web: 7430/7430; agent-driver: 786 pass / 4 skip; CI scripts: 257/257.
- Hosted CI run 34409489270: 20 successful checks, 4 scope skips, 0 failed/pending after one isolated rerun of an untouched delete-media navigation race; all 9 UI shards and both aggregate gates passed.
- Codecov patch: SUCCESS.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...
