### PR TITLE
fix(web): require touch movement before rail drag

### DIFF
--- a/src/web/src/components/community/shell/server-rail-pdd-contract.test.ts
+++ b/src/web/src/components/community/shell/server-rail-pdd-contract.test.ts
@@ -45,7 +45,8 @@ describe("server rail PDD component contract", () => {
     const rail = read("./server-rail.tsx")
     const server = read("./sortable-server.tsx")
     const folder = read("./rail-folder.tsx")
-    expect(adapter).toContain("SERVER_RAIL_TOUCH_HOLD_MS = 450")
+    expect(adapter).toContain("SERVER_RAIL_TOUCH_HOLD_MS = 650")
+    expect(adapter).toContain("SERVER_RAIL_TOUCH_DRAG_PX = 8")
     expect(adapter).toContain("SERVER_RAIL_TOUCH_DRIFT_PX = 10")
     const touchStart = adapter.slice(
       adapter.indexOf("const onTouchStart"),
@@ -78,7 +79,7 @@ describe("server rail PDD component contract", () => {
     expect(adapter).toContain("positionTouchDragPreview")
     expect(adapter).toContain("document.body.appendChild(element)")
     expect(adapter).toContain("requestAnimationFrame(runTouchFrame)")
-    expect(adapter).toContain('begin(entity, "touch")')
+    expect(adapter).toContain('!begin(entity, "touch")')
     expect(adapter).not.toContain('new MouseEvent("contextmenu"')
     expect(adapter).not.toContain("matchMedia")
     expect(rail).toContain("Press Space to pick up a server or group")

--- a/src/web/src/components/community/shell/use-server-rail-pdd.behavior.dom.test.ts
+++ b/src/web/src/components/community/shell/use-server-rail-pdd.behavior.dom.test.ts
@@ -524,6 +524,7 @@ describe("useServerRailPdd behavior", () => {
   it("separates taps, scroll, context menu, multi-touch, and cancellation", async () => {
     const hook = await renderHook()
     const a = register(hook.current, { kind: "server", id: "a" }, rect(0, 40))
+    register(hook.current, { kind: "server", id: "b" }, rect(80, 120))
     const desktopContext = a.handle.dispatch("contextmenu", testEvent("contextmenu"))
     expect(desktopContext.defaultPrevented).toBe(false)
     expect(desktopContext.propagationStopped).toBe(false)
@@ -557,6 +558,7 @@ describe("useServerRailPdd behavior", () => {
     touch(a.handle, "touchcancel", [])
 
     const dragStartCount = hook.callbacks.onDragStart.mock.calls.length
+    const longClickCount = a.handle.clickCount
     touch(a.handle, "touchstart", [point(9, 10, 10)])
     await act(async () => vi.advanceTimersByTime(SERVER_RAIL_TOUCH_HOLD_MS - 1))
     expect(hook.callbacks.onDragStart).toHaveBeenCalledTimes(dragStartCount)
@@ -565,6 +567,23 @@ describe("useServerRailPdd behavior", () => {
     expect(context.defaultPrevented).toBe(true)
     expect(context.propagationStopped).toBe(true)
     await act(async () => vi.advanceTimersByTime(1))
+    expect(hook.callbacks.onDragStart).toHaveBeenCalledTimes(dragStartCount)
+    expect(fakeDocument.body.children).toHaveLength(0)
+    expect(fakeDocument.documentElement.style.userSelect).toBe("text")
+    touch(a.handle, "touchend", [], [point(9, 10, 10)])
+    expect(a.handle.clickCount).toBe(longClickCount + 1)
+
+    touch(a.handle, "touchstart", [point(91, 10, 10)])
+    await act(async () => vi.advanceTimersByTime(SERVER_RAIL_TOUCH_HOLD_MS - 1))
+    const preArmMove = touch(a.handle, "touchmove", [point(91, 17, 10)])
+    expect(preArmMove.defaultPrevented).toBe(false)
+    await act(async () => vi.advanceTimersByTime(1))
+    const sevenPixelMove = touch(a.handle, "touchmove", [point(91, 24, 10)])
+    expect(sevenPixelMove.defaultPrevented).toBe(false)
+    expect(hook.callbacks.onDragStart).toHaveBeenCalledTimes(dragStartCount)
+    expect(fakeDocument.body.children).toHaveLength(0)
+    const eightPixelMove = touch(a.handle, "touchmove", [point(91, 25, 10)])
+    expect(eightPixelMove.defaultPrevented).toBe(true)
     expect(hook.callbacks.onDragStart).toHaveBeenCalledTimes(dragStartCount + 1)
     expect(hook.callbacks.onDragStart).toHaveBeenLastCalledWith(a.entity)
     expect(fakeDocument.documentElement.style.userSelect).toBe("none")
@@ -576,12 +595,12 @@ describe("useServerRailPdd behavior", () => {
     expect(floating.style.width).toBe("40px")
     expect(floating.style.height).toBe("40px")
     expect(floating.style.pointerEvents).toBe("none")
-    expect(floating.style.transform).toBe("translate3d(-10px, -10px, 0)")
-    const dragMove = touch(a.handle, "touchmove", [point(9, 30, 50)])
+    expect(floating.style.transform).toBe("translate3d(5px, -10px, 0)")
+    const dragMove = touch(a.handle, "touchmove", [point(91, 30, 50)])
     expect(dragMove.defaultPrevented).toBe(true)
     expect(floating.style.transform).toBe("translate3d(10px, 30px, 0)")
     const clickCount = a.handle.clickCount
-    touch(a.handle, "touchend", [], [point(9, 30, 50)])
+    touch(a.handle, "touchend", [], [point(91, 30, 50)])
     expect(a.handle.clickCount).toBe(clickCount)
     expect(floating.removed).toBe(true)
     expect(fakeDocument.documentElement.style.userSelect).toBe("text")
@@ -600,9 +619,35 @@ describe("useServerRailPdd behavior", () => {
     touch(a.handle, "touchstart", [point(10, 10, 10)])
     hook.callbacks.canStart.mockReturnValue(false)
     await act(async () => vi.advanceTimersByTime(SERVER_RAIL_TOUCH_HOLD_MS))
+    touch(a.handle, "touchmove", [point(10, 18, 10)])
     expect(hook.callbacks.onAnnounce).toHaveBeenCalledWith(
       "A server rail move is already being saved",
     )
+  })
+
+  it("does not arm touch drag when the source has no legal registered target", async () => {
+    const hook = await renderHook({
+      getState: () => ({
+        serverOrder: ["a"],
+        folderOrder: [],
+        folders: {},
+        expanded: [],
+      }),
+    })
+    const a = register(hook.current, { kind: "server", id: "a" }, rect(0, 40))
+
+    touch(a.handle, "touchstart", [point(1, 10, 10)])
+    await act(async () => vi.advanceTimersByTime(SERVER_RAIL_TOUCH_HOLD_MS))
+    const move = touch(a.handle, "touchmove", [point(1, 30, 10)])
+    const end = touch(a.handle, "touchend", [], [point(1, 30, 10)])
+    expect(move.defaultPrevented).toBe(false)
+    expect(end.defaultPrevented).toBe(false)
+    expect(hook.callbacks.onDragStart).not.toHaveBeenCalled()
+    expect(fakeDocument.body.children).toHaveLength(0)
+
+    a.handle.click()
+    expect(a.handle.clickCount).toBe(1)
+    expect(a.handle.lastClickEvent?.defaultPrevented).toBe(false)
   })
 
   it("drags by touch through every hit region and owns edge scroll only after hold", async () => {
@@ -624,14 +669,14 @@ describe("useServerRailPdd behavior", () => {
     ) {
       touch(source.handle, "touchstart", [point(identifier, 20, startY)])
       await act(async () => vi.advanceTimersByTime(SERVER_RAIL_TOUCH_HOLD_MS))
+      expect(fakeDocument.body.children.filter((element) => !element.removed)).toHaveLength(0)
+      fakeDocument.points = [target.element]
+      const move = touch(source.handle, "touchmove", [point(identifier, 20, endY)])
+      expect(move.defaultPrevented).toBe(true)
       const floating = fakeDocument.body.children.at(-1)!
       expect(floating.attributes.get("data-rail-floating-preview")).toBe(source.entity.kind)
       expect(floating.style.width).toBe("40px")
       expect(floating.style.height).toBe("40px")
-      expect(floating.style.transform).toBe(`translate3d(0px, ${startY - 20}px, 0)`)
-      fakeDocument.points = [target.element]
-      const move = touch(source.handle, "touchmove", [point(identifier, 20, endY)])
-      expect(move.defaultPrevented).toBe(true)
       expect(floating.style.transform).toBe(`translate3d(0px, ${endY - 20}px, 0)`)
       touch(source.handle, "touchmove", [point(identifier, 20, endY)])
       flushAnimationFrame()
@@ -688,5 +733,27 @@ describe("useServerRailPdd behavior", () => {
     expect(hook.callbacks.onCancel).toHaveBeenCalledTimes(1)
     expect(adapters.cleanupTarget).toHaveBeenCalledTimes(2)
     expect(adapters.cleanupDraggable).toHaveBeenCalledTimes(2)
+  })
+
+  it("cleans armed touch state on cancellation and source unmount", async () => {
+    const hook = await renderHook()
+    const a = register(hook.current, { kind: "server", id: "a" }, rect(0, 40))
+    register(hook.current, { kind: "server", id: "b" }, rect(80, 120))
+
+    touch(a.handle, "touchstart", [point(1, 10, 10)])
+    await act(async () => vi.advanceTimersByTime(SERVER_RAIL_TOUCH_HOLD_MS))
+    expect(hook.callbacks.onDragStart).not.toHaveBeenCalled()
+    expect(fakeDocument.body.children).toHaveLength(0)
+    touch(a.handle, "touchcancel", [])
+    expect(hook.callbacks.onCancel).toHaveBeenCalledTimes(1)
+
+    touch(a.handle, "touchstart", [point(2, 10, 10)])
+    await act(async () => vi.advanceTimersByTime(SERVER_RAIL_TOUCH_HOLD_MS))
+    a.dispose()
+    await act(async () => Promise.resolve())
+    touch(a.handle, "touchmove", [point(2, 18, 10)])
+    expect(hook.callbacks.onCancel).toHaveBeenCalledTimes(2)
+    expect(hook.callbacks.onDragStart).not.toHaveBeenCalled()
+    expect(fakeDocument.body.children).toHaveLength(0)
   })
 })

--- a/src/web/src/components/community/shell/use-server-rail-pdd.test.ts
+++ b/src/web/src/components/community/shell/use-server-rail-pdd.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest"
 import { attachInstruction } from "@atlaskit/pragmatic-drag-and-drop-hitbox/list-item"
 import {
+  railEntityHasAvailableTarget,
   railEntityFromData,
   railInstructionFromRecords,
   railTouchMoveIntent,
+  SERVER_RAIL_TOUCH_DRAG_PX,
   SERVER_RAIL_TOUCH_DRIFT_PX,
   SERVER_RAIL_TOUCH_HOLD_MS,
 } from "./use-server-rail-pdd"
@@ -47,28 +49,86 @@ describe("server rail PDD record adapter", () => {
     expect(railInstructionFromRecords({ railKind: "server", railId: "one" }, [])).toBeNull()
   })
 
-  it("keeps ordinary scroll outside the 450ms/10px drag intent", () => {
-    expect(SERVER_RAIL_TOUCH_HOLD_MS).toBe(450)
+  it("requires the 650ms arm before the 8px drag threshold", () => {
+    expect(SERVER_RAIL_TOUCH_HOLD_MS).toBe(650)
+    expect(SERVER_RAIL_TOUCH_DRAG_PX).toBe(8)
     expect(SERVER_RAIL_TOUCH_DRIFT_PX).toBe(10)
     expect(railTouchMoveIntent({
+      armed: false,
       dragging: false,
       distance: 10,
       touchCount: 1,
     })).toBe("wait")
     expect(railTouchMoveIntent({
+      armed: false,
       dragging: false,
       distance: 10.1,
       touchCount: 1,
     })).toBe("scroll")
     expect(railTouchMoveIntent({
+      armed: true,
+      dragging: false,
+      distance: 7,
+      touchCount: 1,
+    })).toBe("wait")
+    expect(railTouchMoveIntent({
+      armed: true,
+      dragging: false,
+      distance: 8,
+      touchCount: 1,
+    })).toBe("drag")
+    expect(railTouchMoveIntent({
+      armed: true,
       dragging: true,
       distance: 30,
       touchCount: 1,
     })).toBe("drag")
     expect(railTouchMoveIntent({
+      armed: true,
       dragging: true,
       distance: 30,
       touchCount: 2,
     })).toBe("cancel")
+  })
+
+  it("arms touch only when the source has a legal registered target", () => {
+    expect(railEntityHasAvailableTarget({
+      serverOrder: ["a"],
+      folderOrder: [],
+      folders: {},
+      expanded: [],
+    }, { kind: "server", id: "a" }, [
+      { kind: "server", id: "a" },
+    ])).toBe(false)
+
+    expect(railEntityHasAvailableTarget({
+      serverOrder: ["a", "b"],
+      folderOrder: [],
+      folders: {},
+      expanded: [],
+    }, { kind: "server", id: "a" }, [
+      { kind: "server", id: "a" },
+      { kind: "server", id: "b" },
+    ])).toBe(true)
+
+    expect(railEntityHasAvailableTarget({
+      serverOrder: ["a", "b"],
+      folderOrder: ["f"],
+      folders: { f: ["a"] },
+      expanded: ["f"],
+    }, { kind: "server", id: "a" }, [
+      { kind: "server", id: "a" },
+      { kind: "server", id: "b" },
+    ])).toBe(true)
+
+    expect(railEntityHasAvailableTarget({
+      serverOrder: ["a"],
+      folderOrder: ["f"],
+      folders: { f: ["a"] },
+      expanded: ["f"],
+    }, { kind: "folder", id: "f" }, [
+      { kind: "folder", id: "f" },
+      { kind: "server", id: "a" },
+    ])).toBe(false)
   })
 })

--- a/src/web/src/components/community/shell/use-server-rail-pdd.ts
+++ b/src/web/src/components/community/shell/use-server-rail-pdd.ts
@@ -23,7 +23,8 @@ import {
 
 type RailData = Record<string | symbol, unknown>
 
-export const SERVER_RAIL_TOUCH_HOLD_MS = 450
+export const SERVER_RAIL_TOUCH_HOLD_MS = 650
+export const SERVER_RAIL_TOUCH_DRAG_PX = 8
 export const SERVER_RAIL_TOUCH_DRIFT_PX = 10
 const TOUCH_DRAG_PREVIEW_SELECTOR = "[data-rail-drag-preview]"
 
@@ -73,21 +74,36 @@ function createTouchDragPreview(
 }
 
 export function railTouchMoveIntent({
+  armed,
   dragging,
   distance,
   touchCount,
 }: {
+  armed: boolean
   dragging: boolean
   distance: number
   touchCount: number
 }): "wait" | "scroll" | "drag" | "cancel" {
   if (touchCount !== 1) return "cancel"
   if (dragging) return "drag"
+  if (armed) return distance >= SERVER_RAIL_TOUCH_DRAG_PX ? "drag" : "wait"
   return distance > SERVER_RAIL_TOUCH_DRIFT_PX ? "scroll" : "wait"
 }
 
 function sameEntity(left: RailEntity | null, right: RailEntity | null): boolean {
   return left?.kind === right?.kind && left?.id === right?.id
+}
+
+export function railEntityHasAvailableTarget(
+  state: RailState,
+  source: RailEntity,
+  targets: readonly RailEntity[],
+): boolean {
+  return targets.some((target) => {
+    if (sameEntity(source, target)) return false
+    const availability = railOperationAvailability(state, source, target)
+    return availability["reorder-before"] || availability["reorder-after"] || availability.combine
+  })
 }
 
 export function railEntityFromData(data: RailData): RailEntity | null {
@@ -190,6 +206,9 @@ export function useServerRailPdd({
     startY: number
     clientX: number
     clientY: number
+    armX: number
+    armY: number
+    armed: boolean
     dragging: boolean
     timer: ReturnType<typeof setTimeout> | null
     frame: number | null
@@ -441,7 +460,7 @@ export function useServerRailPdd({
     const suppressTouchMenu = (event: TouchEvent) => {
       // Base UI owns a separate 500 ms touch timer on ContextMenuTrigger.
       // Keep the event native (and therefore scrollable), but do not let it
-      // reach that trigger: the rail's 450 ms hold is exclusively drag pickup.
+      // reach that trigger: the rail owns its 650 ms touch intent timer.
       event.stopPropagation()
     }
     const onTouchStart = (event: TouchEvent) => {
@@ -450,8 +469,10 @@ export function useServerRailPdd({
         return
       }
       if (touchRef.current || activeRef.current) return
-      if (!handlersRef.current.canStart()) return
       suppressClickUntilRef.current = 0
+      if (!handlersRef.current.canStart()) return
+      const targets = [...itemsRef.current.values()].map((item) => item.entity)
+      if (!railEntityHasAvailableTarget(handlersRef.current.getState(), entity, targets)) return
       const touch = event.touches[0]!
       const pending = {
         entity,
@@ -460,6 +481,9 @@ export function useServerRailPdd({
         startY: touch.clientY,
         clientX: touch.clientX,
         clientY: touch.clientY,
+        armX: touch.clientX,
+        armY: touch.clientY,
+        armed: false,
         dragging: false,
         timer: null as ReturnType<typeof setTimeout> | null,
         frame: null as number | null,
@@ -468,21 +492,9 @@ export function useServerRailPdd({
       pending.timer = setTimeout(() => {
         if (touchRef.current !== pending) return
         pending.timer = null
-        if (!begin(entity, "touch")) {
-          clearTouch()
-          return
-        }
-        pending.dragging = true
-        pending.preview = createTouchDragPreview(
-          dragHandle,
-          entity,
-          pending.clientX,
-          pending.clientY,
-        )
-        selectionStyleRef.current = document.documentElement.style.userSelect
-        document.documentElement.style.userSelect = "none"
-        document.getSelection()?.removeAllRanges()
-        pending.frame = requestAnimationFrame(runTouchFrame)
+        pending.armX = pending.clientX
+        pending.armY = pending.clientY
+        pending.armed = true
       }, SERVER_RAIL_TOUCH_HOLD_MS)
       touchRef.current = pending
     }
@@ -503,8 +515,11 @@ export function useServerRailPdd({
       if (pending.preview) {
         positionTouchDragPreview(pending.preview, touch.clientX, touch.clientY)
       }
-      const exactDistance = Math.hypot(touch.clientX - pending.startX, touch.clientY - pending.startY)
+      const originX = pending.armed ? pending.armX : pending.startX
+      const originY = pending.armed ? pending.armY : pending.startY
+      const exactDistance = Math.hypot(touch.clientX - originX, touch.clientY - originY)
       const exactIntent = railTouchMoveIntent({
+        armed: pending.armed,
         dragging: pending.dragging,
         distance: exactDistance,
         touchCount: event.touches.length,
@@ -514,6 +529,27 @@ export function useServerRailPdd({
         return
       }
       if (exactIntent === "wait") return
+      if (!pending.dragging) {
+        const targets = [...itemsRef.current.values()].map((item) => item.entity)
+        if (
+          !railEntityHasAvailableTarget(handlersRef.current.getState(), entity, targets)
+          || !begin(entity, "touch")
+        ) {
+          clearTouch()
+          return
+        }
+        pending.dragging = true
+        pending.preview = createTouchDragPreview(
+          dragHandle,
+          entity,
+          pending.clientX,
+          pending.clientY,
+        )
+        selectionStyleRef.current = document.documentElement.style.userSelect
+        document.documentElement.style.userSelect = "none"
+        document.getSelection()?.removeAllRanges()
+        pending.frame = requestAnimationFrame(runTouchFrame)
+      }
       event.preventDefault()
       setPreview(itemAtPoint(entity, touch.clientX, touch.clientY))
     }
@@ -536,14 +572,20 @@ export function useServerRailPdd({
     const onTouchCancel = () => cancelActive()
     const onContextMenu = (event: MouseEvent) => {
       const pending = touchRef.current
+      const pendingMatches = !!pending && sameEntity(pending.entity, entity)
+      const draggingMatches = activeRef.current?.sensor === "touch"
+        && sameEntity(activeRef.current.source, entity)
+      const clickSuppressed = Date.now() < suppressClickUntilRef.current
       if (
-        (pending && sameEntity(pending.entity, entity))
-        || (activeRef.current?.sensor === "touch" && sameEntity(activeRef.current.source, entity))
-        || Date.now() < suppressClickUntilRef.current
+        pendingMatches
+        || draggingMatches
+        || clickSuppressed
       ) {
         event.preventDefault()
         event.stopPropagation()
-        suppressClickUntilRef.current = Date.now() + 800
+        if (draggingMatches || clickSuppressed) {
+          suppressClickUntilRef.current = Date.now() + 800
+        }
       }
     }
     const onClickCapture = (event: MouseEvent) => {

--- a/src/web/src/test/e2e-ui/37-server-rail-pdd.spec.ts
+++ b/src/web/src/test/e2e-ui/37-server-rail-pdd.spec.ts
@@ -639,6 +639,8 @@ test("short server rail keeps Add adjacent and desktop geometry stable", async (
     }
   })
   await page.setViewportSize({ width: 390, height: 844 })
+  await page.getByRole("banner").getByRole("button", { name: "Back" }).click()
+  await expect.poll(() => new URL(page.url()).pathname).toBe(`/c/channels/${serverId}`)
   const onlyServer = page.getByTestId(tid.serverIcon(serverId))
   await expect(onlyServer).toBeVisible()
   await onlyServer.evaluate((element) => {

--- a/src/web/src/test/e2e-ui/37-server-rail-pdd.spec.ts
+++ b/src/web/src/test/e2e-ui/37-server-rail-pdd.spec.ts
@@ -223,7 +223,7 @@ async function touchDrag(
     source,
     { x: sourceBox.x + sourceBox.width / 2, y: sourceBox.y + sourceBox.height / 2 },
     { x: targetBox.x + targetBox.width / 2, y: targetBox.y + targetBox.height * targetRatio },
-    460,
+    660,
     { source, target },
     targetRatio,
     previewScreenshotPath,
@@ -251,7 +251,7 @@ async function startStationaryTouch(page: Page, origin: Locator) {
       screenX: args.point.x,
       screenY: args.point.y,
     })
-    element.dispatchEvent(new TouchEvent(args.type, {
+    const allowed = element.dispatchEvent(new TouchEvent(args.type, {
       bubbles: true,
       cancelable: true,
       composed: true,
@@ -259,6 +259,9 @@ async function startStationaryTouch(page: Page, origin: Locator) {
       targetTouches: args.type === "touchend" ? [] : [touch],
       changedTouches: [touch],
     }))
+    // Synthetic TouchEvents do not synthesize the browser's trailing click.
+    // Mirror that default only when the production handler did not cancel it.
+    if (args.type === "touchend" && allowed) (element as HTMLElement).click()
   }, { type, point })
   await dispatch("touchstart")
   return () => dispatch("touchend")
@@ -521,18 +524,30 @@ test("server rail keeps scroll separate from native, touch, and keyboard drag", 
   await expect(page.getByTestId(tid.serverIcon(second))).toBeVisible()
   const beforeLongPress = railRequests.length
   await firstFolder.scrollIntoViewIfNeeded()
+  await firstFolder.evaluate((element) => {
+    Reflect.set(window, "__railStationaryClicks", 0)
+    element.addEventListener("click", () => {
+      Reflect.set(
+        window,
+        "__railStationaryClicks",
+        Number(Reflect.get(window, "__railStationaryClicks")) + 1,
+      )
+    })
+  })
   const endLongPress = await startStationaryTouch(page, firstFolder)
-  await expect(firstFolder).toHaveAttribute("data-dragging", "true")
-  const stationaryFolderPreview = page.locator('[data-rail-floating-preview="folder"]')
-  await expect(stationaryFolderPreview).toHaveCount(1)
-  expect(await stationaryFolderPreview.boundingBox()).toMatchObject({ width: 40, height: 40 })
   await page.waitForTimeout(700)
+  await expect(firstFolder).not.toHaveAttribute("data-dragging", "true")
+  const stationaryFolderPreview = page.locator('[data-rail-floating-preview="folder"]')
+  await expect(stationaryFolderPreview).toHaveCount(0)
   await expect(page.getByRole("menuitem", { name: "Ungroup" })).toHaveCount(0)
   await expect(page.getByRole("menuitem", { name: "Move…" })).toHaveCount(0)
   await expect(page.getByRole("menuitem", { name: "Create group" })).toHaveCount(0)
   await endLongPress()
   await expect(stationaryFolderPreview).toHaveCount(0)
+  await expect.poll(() => page.evaluate(() => Reflect.get(window, "__railStationaryClicks")))
+    .toBe(1)
   expect(railRequests).toHaveLength(beforeLongPress)
+  await firstFolder.click()
   await page.getByTestId(tid.serverIcon(tail)).scrollIntoViewIfNeeded()
   await expect.poll(async () => (await railGeometry(page, tail)).targetOwnsCenter)
     .toBe(true)
@@ -616,4 +631,34 @@ test("short server rail keeps Add adjacent and desktop geometry stable", async (
   expect(desktop.target).toEqual(mobile.target)
   expect(desktop.add).toEqual(mobile.add)
   expect(desktop.targetOwnsCenter).toBe(true)
+
+  let railPatchCount = 0
+  page.on("request", (request) => {
+    if (request.method() === "PATCH" && new URL(request.url()).pathname === RAIL_ENDPOINT) {
+      railPatchCount += 1
+    }
+  })
+  await page.setViewportSize({ width: 390, height: 844 })
+  const onlyServer = page.getByTestId(tid.serverIcon(serverId))
+  await expect(onlyServer).toBeVisible()
+  await onlyServer.evaluate((element) => {
+    Reflect.set(window, "__railOnlyServerClicks", 0)
+    element.addEventListener("click", () => {
+      Reflect.set(
+        window,
+        "__railOnlyServerClicks",
+        Number(Reflect.get(window, "__railOnlyServerClicks")) + 1,
+      )
+    })
+  })
+
+  const endLongPress = await startStationaryTouch(page, onlyServer)
+  await page.waitForTimeout(700)
+  await expect(onlyServer).not.toHaveAttribute("data-dragging", "true")
+  await expect(page.locator("[data-rail-floating-preview]")).toHaveCount(0)
+  await endLongPress()
+  await expect.poll(() => page.evaluate(() => Reflect.get(window, "__railOnlyServerClicks")))
+    .toBe(1)
+  expect(new URL(page.url()).pathname).toBe(`/c/channels/${serverId}`)
+  expect(railPatchCount).toBe(0)
 })


### PR DESCRIPTION
# Why we need this PR?
> Follow-up to the mobile server-rail touch drag contract.

A stationary 450 ms touch currently starts dragging immediately, fading the source and suppressing the trailing click even when the item has nowhere valid to move.

## What changed
- Require a currently registered legal reorder, combine, or ungroup target before arming touch drag.
- Arm after 650 ms without visual or click side effects, then require 8 px of post-arm movement before pickup.
- Preserve the existing 10 px pre-arm scroll threshold and the native pointer, keyboard, folder, and persistence paths.
- Expand unit, DOM, contract, and Playwright coverage for touch thresholds, cleanup, stationary clicks, and valid drag operations.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...
