### PR TITLE
fix(web): center native oauth status actions

### DIFF
--- a/src/web/src/app/(auth)/sign-in/social-sign-in.dom.test.ts
+++ b/src/web/src/app/(auth)/sign-in/social-sign-in.dom.test.ts
@@ -52,6 +52,14 @@ function button(id: string): HTMLButtonElement {
   return screen.getByTestId(id) as HTMLButtonElement
 }
 
+const attempt = {
+  attemptId: "opaque-id",
+  provider: "google" as const,
+  redirectPath: "/c/me",
+  expiresAt: Date.now() + 600_000,
+  waiting: true,
+}
+
 describe("social sign-in native boundary", () => {
   it("preserves normal browser social login and callback destination", async () => {
     const user = setupUser()
@@ -209,14 +217,6 @@ describe("social sign-in native boundary", () => {
     const user = setupUser()
     mocks.tauri = true
     render(createElement(SocialSignIn, { postLoginUrl: "/c/me" }))
-    const attempt = {
-      attemptId: "opaque-id",
-      provider: "google" as const,
-      redirectPath: "/c/me",
-      expiresAt: Date.now() + 600_000,
-      waiting: true,
-    }
-
     act(() => mocks.emit!({ phase: "exchanging", attempt }))
     expect(button("native-oauth-retry")).toBeDisabled()
     expect(button("native-oauth-cancel")).toBeEnabled()
@@ -229,5 +229,71 @@ describe("social sign-in native boundary", () => {
 
     expect(mocks.start).toHaveBeenCalledWith("google", "/c/me")
     expect(document.body).not.toHaveTextContent("opaque-id")
+  })
+
+  it.each([
+    {
+      name: "preparing",
+      view: { phase: "preparing", attempt: null } as NativeOauthView,
+      copy: "Opening sign-in in your browser…",
+      role: "status",
+      retryDisabled: true,
+    },
+    {
+      name: "waiting",
+      view: { phase: "waiting", attempt } as NativeOauthView,
+      copy: "Finish signing in in your browser.",
+      role: "status",
+      retryDisabled: false,
+    },
+    {
+      name: "error",
+      view: { phase: "error", message: "retry_required", attempt } as NativeOauthView,
+      copy: "Couldn't confirm sign-in. Try again to start a new attempt.",
+      role: "alert",
+      retryDisabled: false,
+    },
+  ])("centers the $name state with responsive text-only actions", ({
+    view,
+    copy,
+    role,
+    retryDisabled,
+  }) => {
+    mocks.tauri = true
+    render(createElement(SocialSignIn, { postLoginUrl: "/c/me" }))
+
+    act(() => mocks.emit!(view))
+
+    const status = screen.getByTestId("native-oauth-status")
+    expect(status).toHaveAttribute("role", role)
+    expect(status).toHaveTextContent(copy)
+    expect(status).toHaveClass("text-center")
+    expect(status.nextElementSibling).toHaveClass(
+      "flex",
+      "justify-center",
+      "gap-2",
+    )
+
+    const cancel = button("native-oauth-cancel")
+    const retry = button("native-oauth-retry")
+    for (const action of [cancel, retry]) {
+      expect(action).toHaveClass(
+        "h-11",
+        "px-3",
+        "sm:h-8",
+        "text-primary",
+        "underline-offset-4",
+      )
+      expect(action).not.toHaveClass(
+        "border-border",
+        "bg-background",
+        "bg-primary",
+        "bg-secondary",
+      )
+      action.focus()
+      expect(action).toHaveFocus()
+    }
+    expect(retry.disabled).toBe(retryDisabled)
+    expect(cancel).toBeEnabled()
   })
 })

--- a/src/web/src/app/(auth)/sign-in/social-sign-in.tsx
+++ b/src/web/src/app/(auth)/sign-in/social-sign-in.tsx
@@ -118,11 +118,11 @@ export function SocialSignIn({
           </Button>
         ) : null}
       </Field>
-      {text && <p role={native?.phase === "error" || unsupported ? "alert" : "status"} className="text-sm text-muted-foreground" data-testid="native-oauth-status">{text}</p>}
+      {text && <p role={native?.phase === "error" || unsupported ? "alert" : "status"} className="text-center text-sm text-muted-foreground" data-testid="native-oauth-status">{text}</p>}
       {!unsupported && !appleUpdateRequired && native && (native.attempt || native.phase === "error" || native.phase === "preparing") && (
-        <div className="flex gap-2">
-          {(native.attempt || native.phase === "preparing") && <Button type="button" variant="ghost" data-testid="native-oauth-cancel" onClick={() => { void controller.current?.cancel() }}>Cancel</Button>}
-          <Button type="button" variant="outline" disabled={busy} data-testid="native-oauth-retry" onClick={() => begin(native.attempt?.provider ?? lastProvider.current)}>Try again</Button>
+        <div className="flex justify-center gap-2">
+          {(native.attempt || native.phase === "preparing") && <Button type="button" variant="link" className="h-11 px-3 sm:h-8" data-testid="native-oauth-cancel" onClick={() => { void controller.current?.cancel() }}>Cancel</Button>}
+          <Button type="button" variant="link" className="h-11 px-3 sm:h-8" disabled={busy} data-testid="native-oauth-retry" onClick={() => begin(native.attempt?.provider ?? lastProvider.current)}>Try again</Button>
         </div>
       )}
     </>

--- a/src/web/src/test/e2e-ui/01-auth.spec.ts
+++ b/src/web/src/test/e2e-ui/01-auth.spec.ts
@@ -3,6 +3,7 @@ import {
   test as browserTest,
   expect as browserExpect,
   type Locator,
+  type Page,
 } from "@playwright/test"
 
 async function expectSameHorizontalCenter(first: Locator, second: Locator) {
@@ -26,6 +27,57 @@ async function expectSameWidth(first: Locator, second: Locator) {
   browserExpect(firstBox).not.toBeNull()
   browserExpect(secondBox).not.toBeNull()
   browserExpect(Math.abs(firstBox!.width - secondBox!.width)).toBeLessThanOrEqual(1)
+}
+
+async function expectCenteredNativeOauthState(
+  page: Page,
+  {
+    copy,
+    role,
+    cancel,
+    retryDisabled,
+  }: {
+    copy: string
+    role: "alert" | "status"
+    cancel: boolean
+    retryDisabled: boolean
+  },
+) {
+  const status = page.getByRole(role).filter({ hasText: copy })
+  const retry = page.getByRole("button", { name: "Try again" })
+  const actions = retry.locator("..")
+  const authPane = page.locator('[data-slot="card-content"] > div').first()
+  await browserExpect(status).toHaveRole(role)
+  await browserExpect(status).toHaveText(copy)
+  await browserExpect(status).toHaveClass(/text-center/)
+  await browserExpect(actions).toHaveClass(/justify-center/)
+  await expectSameHorizontalCenter(status, authPane)
+  await expectSameHorizontalCenter(actions, authPane)
+
+  await browserExpect(retry).toHaveText("Try again")
+  await browserExpect(retry).toHaveClass(/h-11/)
+  await browserExpect(retry).toHaveClass(/sm:h-8/)
+  await browserExpect(retry).toHaveClass(/text-primary/)
+  await browserExpect(retry).not.toHaveClass(/border-border|bg-background|bg-primary|bg-secondary/)
+  if (retryDisabled) await browserExpect(retry).toBeDisabled()
+  else {
+    await browserExpect(retry).toBeEnabled()
+    await retry.focus()
+    await browserExpect(retry).toBeFocused()
+  }
+
+  const cancelAction = page.getByRole("button", { name: "Cancel" })
+  if (!cancel) {
+    await browserExpect(cancelAction).toHaveCount(0)
+    return
+  }
+  await browserExpect(cancelAction).toHaveText("Cancel")
+  await browserExpect(cancelAction).toHaveClass(/h-11/)
+  await browserExpect(cancelAction).toHaveClass(/sm:h-8/)
+  await browserExpect(cancelAction).toHaveClass(/text-primary/)
+  await browserExpect(cancelAction).not.toHaveClass(/border-border|bg-background|bg-primary|bg-secondary/)
+  await cancelAction.focus()
+  await browserExpect(cancelAction).toBeFocused()
 }
 
 // Journey 1 — login & first screen. storageState is established in
@@ -204,5 +256,138 @@ browserTest.describe("production OTP error placement", () => {
     await browserExpect(page.getByRole("button", { name: /Wait \d+s/ })).toBeDisabled()
     await browserExpect(page.getByRole("button", { name: "GitHub" })).toBeVisible()
     await browserExpect(page.getByRole("button", { name: "Google" })).toBeVisible()
+  })
+})
+
+browserTest.describe("native OAuth status actions", () => {
+  browserTest("centers responsive preparing, waiting, and error states with text-only actions", async ({ page }) => {
+    const attempt = {
+      attemptId: "attempt_1234567890123456",
+      provider: "github" as const,
+      redirectPath: "/c/me",
+      expiresAt: Date.now() + 600_000,
+      waiting: false,
+    }
+    const registration = {
+      attemptId: attempt.attemptId,
+      stateHash: "a".repeat(64),
+      codeChallenge: "b".repeat(43),
+      instanceKeyHash: "c".repeat(64),
+      platform: "macos",
+      provider: "github",
+      redirectPath: "/c/me",
+    }
+    let snapshot: typeof attempt | null = null
+    let failPrepare = false
+    let releasePrepare!: () => void
+    const prepareGate = new Promise<void>((resolve) => { releasePrepare = resolve })
+
+    await page.exposeFunction("__testNativeOauthInvoke", async (command: string) => {
+      if (command === "native_oauth_snapshot") return snapshot
+      if (command === "native_oauth_pending_exchange") return null
+      if (command === "native_oauth_prepare") {
+        if (failPrepare) throw new Error("start failed")
+        await prepareGate
+        snapshot = attempt
+        return registration
+      }
+      if (command === "native_oauth_open_start") {
+        snapshot = { ...attempt, waiting: true }
+        return null
+      }
+      if (command === "native_oauth_cancel") {
+        snapshot = null
+        return null
+      }
+      return null
+    })
+    await page.addInitScript(() => {
+      const bridge = window as typeof window & {
+        __testNativeOauthInvoke: (command: string, args?: Record<string, unknown>) => Promise<unknown>
+        __TAURI__: {
+          core: {
+            Channel: new () => { onmessage: () => void }
+            invoke: (command: string, args?: Record<string, unknown>) => Promise<unknown>
+          }
+        }
+      }
+      class Channel {
+        onmessage = () => {}
+      }
+      bridge.__TAURI__ = {
+        core: {
+          Channel,
+          invoke: (command, args) => command === "native_oauth_listen"
+            ? Promise.resolve(1)
+            : bridge.__testNativeOauthInvoke(command, args),
+        },
+      }
+    })
+    await page.route("**/api/auth/native/attempt", (route) => route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ startUrl: "https://github.com/login/oauth/authorize" }),
+    }))
+
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto("/sign-in")
+    await browserExpect(page.getByRole("button", { name: "GitHub" })).toBeEnabled()
+    await page.getByRole("button", { name: "GitHub" }).click()
+    await expectCenteredNativeOauthState(page, {
+      copy: "Opening sign-in in your browser…",
+      role: "status",
+      cancel: true,
+      retryDisabled: true,
+    })
+    await browserExpect.poll(async () => (
+      await page.getByRole("button", { name: "Cancel" }).boundingBox()
+    )?.height ?? 0).toBeGreaterThanOrEqual(44)
+
+    await page.setViewportSize({ width: 1280, height: 800 })
+    await expectCenteredNativeOauthState(page, {
+      copy: "Opening sign-in in your browser…",
+      role: "status",
+      cancel: true,
+      retryDisabled: true,
+    })
+
+    releasePrepare()
+    await expectCenteredNativeOauthState(page, {
+      copy: "Finish signing in in your browser.",
+      role: "status",
+      cancel: true,
+      retryDisabled: false,
+    })
+
+    await page.setViewportSize({ width: 390, height: 844 })
+    await expectCenteredNativeOauthState(page, {
+      copy: "Finish signing in in your browser.",
+      role: "status",
+      cancel: true,
+      retryDisabled: false,
+    })
+    await browserExpect.poll(async () => (
+      await page.getByRole("button", { name: "Try again" }).boundingBox()
+    )?.height ?? 0).toBeGreaterThanOrEqual(44)
+
+    failPrepare = true
+    await page.getByRole("button", { name: "Try again" }).click()
+    await expectCenteredNativeOauthState(page, {
+      copy: "Couldn't open sign-in. Try again.",
+      role: "alert",
+      cancel: false,
+      retryDisabled: false,
+    })
+    await browserExpect.poll(async () => (
+      await page.getByRole("button", { name: "Try again" }).boundingBox()
+    )?.height ?? 0).toBeGreaterThanOrEqual(44)
+
+    await page.setViewportSize({ width: 1280, height: 800 })
+    await expectCenteredNativeOauthState(page, {
+      copy: "Couldn't open sign-in. Try again.",
+      role: "alert",
+      cancel: false,
+      retryDisabled: false,
+    })
   })
 })


### PR DESCRIPTION
# Why we need this PR?
> Native desktop OAuth startup, waiting, and recovery states need clearer alignment and touch-safe secondary actions without changing provider sign-in behavior.

## What changed
- Center native OAuth status/error copy and its action row.
- Render Cancel and Try again as text-only actions with 44px mobile targets and compact desktop sizing.
- Preserve keyboard focus, disabled behavior, status/alert semantics, provider buttons, and the existing OAuth controller flow.
- Add DOM and Chromium regression coverage for preparing, waiting, and error states at mobile and desktop sizes.

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- Focused native OAuth DOM/client tests: 58 passed
- Focused Chromium OAuth-state journey: 1 passed

## Checklist
- [x] Tests added/updated as needed
- [ ] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...
