### PR TITLE
feat(app): align user bar theme, safe areas, and reconciliation

### DIFF
--- a/scripts/ci/native-shell-theme-colors.test.ts
+++ b/scripts/ci/native-shell-theme-colors.test.ts
@@ -193,22 +193,31 @@ describe("native shell theme color contract", () => {
     expect(driveAndroidThemeObserver(["light"]).updates).toEqual([false])
   })
 
-  it("keeps Android system-bar and IME inset ownership unchanged", () => {
+  it("keeps Android inset ownership native and zeroes handled edges for WebView", () => {
     expect(androidRuntime).toContain(
-      "insets.getInsets(WindowInsetsCompat.Type.systemBars())",
+      "WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()",
     )
     expect(androidRuntime).toContain(
-      "insets.isVisible(WindowInsetsCompat.Type.ime())",
+      "val chromeInsets = insets.getInsets(chromeTypes)",
     )
     expect(androidRuntime).toContain(
-      "insets.getInsets(WindowInsetsCompat.Type.ime()).bottom",
+      "val imeInsets = insets.getInsets(imeType)",
     )
     expect(androidRuntime).toContain(
-      "if (imeVisible) imeHeight else systemBars.bottom",
+      "val imeVisible = insets.isVisible(imeType)",
     )
     expect(androidRuntime).toContain(
-      "v.setPadding(systemBars.left, systemBars.top, systemBars.right, bottomPadding)",
+      "if (imeVisible) imeInsets.bottom else chromeInsets.bottom",
     )
+    expect(androidRuntime).toContain(
+      "v.setPadding(chromeInsets.left, chromeInsets.top, chromeInsets.right, bottomPadding)",
+    )
+    expect(androidRuntime).toContain("WindowInsetsCompat.Builder(insets)")
+    expect(androidRuntime).toContain(".setInsets(chromeTypes, Insets.NONE)")
+    expect(androidRuntime).toContain(
+      ".setInsets(imeType, Insets.of(imeInsets.left, imeInsets.top, imeInsets.right, 0))",
+    )
+    expect(androidRuntime).not.toContain("WindowInsetsCompat.CONSUMED")
   })
 
   it("retains runtime theme bridges and removes the legacy light color from native owners", () => {

--- a/src/desktop/src-tauri/gen/android/app/src/main/java/ai/alook/android/MainActivity.kt
+++ b/src/desktop/src-tauri/gen/android/app/src/main/java/ai/alook/android/MainActivity.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import androidx.activity.enableEdgeToEdge
+import androidx.core.graphics.Insets
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
@@ -56,13 +57,18 @@ class MainActivity : TauriActivity() {
         applyWindowTheme(isDark)
 
         ViewCompat.setOnApplyWindowInsetsListener(rootView) { v, insets ->
-            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            val imeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
-            val imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
-            val bottomPadding = if (imeVisible) imeHeight else systemBars.bottom
+            val chromeTypes = WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+            val chromeInsets = insets.getInsets(chromeTypes)
+            val imeType = WindowInsetsCompat.Type.ime()
+            val imeInsets = insets.getInsets(imeType)
+            val imeVisible = insets.isVisible(imeType)
+            val bottomPadding = if (imeVisible) imeInsets.bottom else chromeInsets.bottom
 
-            v.setPadding(systemBars.left, systemBars.top, systemBars.right, bottomPadding)
-            insets
+            v.setPadding(chromeInsets.left, chromeInsets.top, chromeInsets.right, bottomPadding)
+            WindowInsetsCompat.Builder(insets)
+                .setInsets(chromeTypes, Insets.NONE)
+                .setInsets(imeType, Insets.of(imeInsets.left, imeInsets.top, imeInsets.right, 0))
+                .build()
         }
     }
 

--- a/src/web/src/app/c/QueryProvider.dom.test.ts
+++ b/src/web/src/app/c/QueryProvider.dom.test.ts
@@ -141,6 +141,8 @@ describe("QueryProvider profile account lifecycle", () => {
     expect(detailPredicate({ queryKey: communityKeys.server("server-1") })).toBe(true)
     expect(detailPredicate({ queryKey: communityKeys.members("server-1") })).toBe(false)
     expect(detailPredicate({ queryKey: communityKeys.channelRefDirectory() })).toBe(false)
+    expect(detailPredicate({ queryKey: communityKeys.server("__none__") })).toBe(false)
+    expect(detailPredicate({ queryKey: communityKeys.server("__pending__") })).toBe(false)
     act(() => renderer.unmount())
   })
 })

--- a/src/web/src/app/c/QueryProvider.tsx
+++ b/src/web/src/app/c/QueryProvider.tsx
@@ -18,7 +18,10 @@ import {
   disposeAccountUnreadProjection,
   getAccountUnreadProjection,
 } from "@/hooks/community/account-unread-projection"
-import { communityKeys } from "@/lib/query-keys"
+import {
+  communityKeys,
+  isCommunityServerDetailQueryKey,
+} from "@/lib/query-keys"
 import { installStructuralSnapshotProjection } from "@/hooks/community/use-structural-snapshot"
 
 /**
@@ -64,12 +67,7 @@ export function QueryProvider({
       void queryClient.invalidateQueries({ queryKey: communityKeys.dms(), exact: true })
       void queryClient.invalidateQueries({ queryKey: communityKeys.servers(), exact: true })
       void queryClient.invalidateQueries({
-        predicate: ({ queryKey }) => (
-          queryKey.length === 3
-          && queryKey[0] === communityKeys.all[0]
-          && queryKey[1] === communityKeys.servers()[1]
-          && queryKey[2] !== communityKeys.channelRefDirectory()[2]
-        ),
+        predicate: ({ queryKey }) => isCommunityServerDetailQueryKey(queryKey),
       })
     })
     return () => unreadProjection.setReconcileScheduler(null)

--- a/src/web/src/components/community/shell/community-session-pending-frame.dom.test.ts
+++ b/src/web/src/components/community/shell/community-session-pending-frame.dom.test.ts
@@ -66,6 +66,16 @@ describe("CommunitySessionPendingFrame", () => {
     expect(screen.getByTestId(sidebar)).toBeInTheDocument()
     expect(screen.getByTestId("pending-main")).toHaveAttribute("data-main-kind", main)
     expect(screen.getByTestId("user-bar-skeleton")).toBeInTheDocument()
+    const userBarUnderlay = renderer.container.querySelector<HTMLElement>(
+      '[data-slot="community-user-bar-underlay"]',
+    )!
+    expect(userBarUnderlay).toHaveAttribute("aria-hidden", "true")
+    expect(userBarUnderlay.className).toContain("pointer-events-none")
+    expect(userBarUnderlay.className).toContain("from-(--app-bg)")
+    expect(userBarUnderlay.className).toContain("to-transparent")
+    expect(userBarUnderlay.style.height).toBe(
+      "calc(60px + var(--app-safe-area-bottom))",
+    )
     expect(renderer.container.querySelectorAll('[data-testid="skeleton"]').length)
       .toBeGreaterThanOrEqual(2)
     expect(renderer.container.querySelectorAll("button, a")).toHaveLength(0)
@@ -77,6 +87,7 @@ describe("CommunitySessionPendingFrame", () => {
     expect(screen.queryByTestId("me-sidebar")).not.toBeInTheDocument()
     expect(screen.queryByTestId("server-sidebar")).not.toBeInTheDocument()
     expect(screen.queryByTestId("user-bar-skeleton")).not.toBeInTheDocument()
+    expect(document.querySelector('[data-slot="community-user-bar-underlay"]')).toBeNull()
     expect(screen.getByTestId("pending-main")).toHaveAttribute("data-main-kind", "route-resolution")
   })
 
@@ -88,6 +99,7 @@ describe("CommunitySessionPendingFrame", () => {
     expect(screen.queryByTestId("me-sidebar")).not.toBeInTheDocument()
     expect(screen.queryByTestId("server-sidebar")).not.toBeInTheDocument()
     expect(screen.queryByTestId("user-bar-skeleton")).not.toBeInTheDocument()
+    expect(document.querySelector('[data-slot="community-user-bar-underlay"]')).toBeNull()
     expect(screen.getByTestId("pending-main")).toHaveAttribute("data-main-kind", "route-resolution")
   })
 
@@ -98,5 +110,6 @@ describe("CommunitySessionPendingFrame", () => {
     expect(screen.queryByTestId("server-sidebar")).not.toBeInTheDocument()
     expect(screen.queryByTestId("pending-main")).not.toBeInTheDocument()
     expect(screen.queryByTestId("user-bar-skeleton")).not.toBeInTheDocument()
+    expect(document.querySelector('[data-slot="community-user-bar-underlay"]')).toBeNull()
   })
 })

--- a/src/web/src/components/community/shell/community-shell-layout.tsx
+++ b/src/web/src/components/community/shell/community-shell-layout.tsx
@@ -23,6 +23,7 @@ import {
   COMMUNITY_SIDEBAR_DEFAULT_PERCENTAGE,
   COMMUNITY_SIDEBAR_MAX_WIDTH,
   COMMUNITY_SIDEBAR_MIN_WIDTH,
+  COMMUNITY_USER_BAR_HEIGHT_CSS,
   desktopUserBarOverlayCssWidth,
   desktopUserBarOverlayWidth,
 } from "./shell-frame-geometry"
@@ -290,6 +291,12 @@ export function CommunityShellLayout({
                 }
               : initialUserBarStyle}
           >
+            <div
+              data-slot="community-user-bar-underlay"
+              aria-hidden
+              className="pointer-events-none absolute inset-x-0 bottom-0 -z-10 bg-linear-to-t from-(--app-bg) to-transparent"
+              style={{ height: COMMUNITY_USER_BAR_HEIGHT_CSS }}
+            />
             {userBar}
           </div>
         )}

--- a/src/web/src/components/community/shell/shell-frame-view.dom.test.ts
+++ b/src/web/src/components/community/shell/shell-frame-view.dom.test.ts
@@ -261,6 +261,23 @@ describe("ShellFrameView", () => {
     const userBarOverlay = renderer.container.querySelector<HTMLElement>(
       '[data-slot="community-user-bar-overlay"]',
     )!
+    const userBarUnderlay = userBarOverlay.querySelector<HTMLElement>(
+      '[data-slot="community-user-bar-underlay"]',
+    )!
+    expect(userBarUnderlay).toHaveAttribute("aria-hidden", "true")
+    expect(userBarUnderlay.className.split(" ")).toEqual(expect.arrayContaining([
+      "pointer-events-none",
+      "absolute",
+      "inset-x-0",
+      "bottom-0",
+      "-z-10",
+      "bg-linear-to-t",
+      "from-(--app-bg)",
+      "to-transparent",
+    ]))
+    expect(userBarUnderlay.style.height).toBe(
+      "calc(60px + var(--app-safe-area-bottom))",
+    )
     expect(userBarOverlay.style.getPropertyValue("--community-desktop-user-bar-width")).toBe(
       "calc(clamp(160px, calc(24% - 0.48px), 360px) + 58px)",
     )
@@ -357,6 +374,9 @@ describe("ShellFrameView", () => {
     const mobileUserBarOverlay = renderer.container.querySelector<HTMLElement>(
       '[data-slot="community-user-bar-overlay"]',
     )!
+    expect(mobileUserBarOverlay.querySelectorAll(
+      '[data-slot="community-user-bar-underlay"]',
+    )).toHaveLength(1)
     expect(mobileUserBarOverlay.style.width).toBe("calc(100% + 56px)")
     expect(mobileUserBarOverlay.style.marginLeft).toBe("-56px")
     const mobileSurface = renderer.container.querySelector("[data-app-surface]")!
@@ -393,6 +413,7 @@ describe("ShellFrameView", () => {
     expect(renderer.container.querySelectorAll("[data-server-rail]")).toHaveLength(0)
     expect(renderer.container.querySelectorAll("[data-user-bar]")).toHaveLength(0)
     expect(renderer.container.querySelectorAll('[data-slot="community-user-bar-overlay"]')).toHaveLength(0)
+    expect(renderer.container.querySelectorAll('[data-slot="community-user-bar-underlay"]')).toHaveLength(0)
     expect(renderer.container.querySelectorAll("[data-app-surface]")).toHaveLength(1)
     expect(renderer.container.querySelector("[data-app-surface]")?.className).toContain("rounded-none")
     expect(renderer.container.querySelectorAll("main-content")).toHaveLength(1)

--- a/src/web/src/components/community/shell/user-bar-extension-slot.dom.test.tsx
+++ b/src/web/src/components/community/shell/user-bar-extension-slot.dom.test.tsx
@@ -74,6 +74,12 @@ describe("UserBarExtensionSlot", () => {
 
     expect(renderer.getByText("Machine update available")).toBeInTheDocument()
     expect(renderer.getByText(description)).toBeInTheDocument()
+    const action = renderer.getByTestId(tid.daemonUpdateAction)
+    expect(action.className).toContain("h-11")
+    expect(action.className).toContain("px-3")
+    expect(action.className).toContain("sm:h-9")
+    expect(action.className).toContain("sm:px-2")
+    expect(action.className).not.toContain("min-h-")
     expect(renderer.queryByRole("button", { name: "Dismiss Machine update" })).not.toBeInTheDocument()
   })
 
@@ -109,6 +115,10 @@ describe("UserBarExtensionSlot", () => {
     expect(renderer.getByText("1 machine is updating. 1 update request failed.")).toBeInTheDocument()
     const action = renderer.getByTestId(tid.daemonUpdateAction)
     expect(action).toHaveTextContent("Retry")
+    expect(action.className).toContain("h-11")
+    expect(action.className).toContain("px-3")
+    expect(action.className).toContain("sm:h-9")
+    expect(action.className).toContain("sm:px-2")
     await act(async () => action.click())
     expect(onRequestUpdate).toHaveBeenCalledOnce()
   })

--- a/src/web/src/components/community/shell/user-bar-extension-slot.tsx
+++ b/src/web/src/components/community/shell/user-bar-extension-slot.tsx
@@ -186,7 +186,7 @@ function DaemonUpdateExtension({
         <Button
           type="button"
           data-testid={tid.daemonUpdateAction}
-          className="min-h-11 self-end sm:min-h-9"
+          className="h-11 self-end px-3 sm:h-9 sm:px-2"
           onClick={onRequestUpdate}
         >
           {retry ? "Retry" : "Update"}

--- a/src/web/src/hooks/community/community-ws/read-state-reconciliation.test.ts
+++ b/src/web/src/hooks/community/community-ws/read-state-reconciliation.test.ts
@@ -119,21 +119,57 @@ describe("account read-state reconciliation", () => {
       .toMatchObject({ lastReadMessageId: "m3", lastReadSeq: 3 })
   })
 
-  it("invalidates every cached concrete server detail after applying a snapshot", async () => {
+  it("refetches cached server details without refetching the channel-ref directory", async () => {
     queryClient.setQueryData(communityKeys.accountReadStateSnapshot(), {
       revision: 1,
       readStates: [],
     })
-    queryClient.setQueryData(communityKeys.server("server-1"), { id: "server-1" })
+    let serverFetches = 0
+    let directoryFetches = 0
+    const serverObserver = new QueryObserver(queryClient, {
+      queryKey: communityKeys.server("server-1"),
+      queryFn: async () => {
+        serverFetches += 1
+        return { id: "server-1" }
+      },
+      staleTime: Infinity,
+    })
+    const directoryObserver = new QueryObserver(queryClient, {
+      queryKey: communityKeys.channelRefDirectory(),
+      queryFn: async () => {
+        directoryFetches += 1
+        return { servers: [] }
+      },
+      staleTime: Infinity,
+    })
+    const unsubscribeServer = serverObserver.subscribe(() => {})
+    const unsubscribeDirectory = directoryObserver.subscribe(() => {})
+    await vi.waitFor(() => {
+      expect(serverFetches).toBe(1)
+      expect(directoryFetches).toBe(1)
+    })
+    queryClient.setQueryData(communityKeys.server("__none__"), { id: "__none__" })
     apiFetch.mockResolvedValue({ revision: 2, readStates: [] })
     const invalidate = vi.spyOn(queryClient, "invalidateQueries")
 
     await reconcileAccountReadState(queryClient, { targetRevision: 2 })
 
+    expect(serverFetches).toBe(2)
+    expect(directoryFetches).toBe(1)
     expect(invalidate).toHaveBeenCalledWith(
       { queryKey: communityKeys.server("server-1"), exact: true, refetchType: "active" },
       { throwOnError: true, cancelRefetch: true },
     )
+    expect(invalidate).not.toHaveBeenCalledWith(
+      { queryKey: communityKeys.channelRefDirectory(), exact: true, refetchType: "active" },
+      expect.anything(),
+    )
+    expect(invalidate).not.toHaveBeenCalledWith(
+      { queryKey: communityKeys.server("__none__"), exact: true, refetchType: "active" },
+      expect.anything(),
+    )
+    unsubscribeDirectory()
+    unsubscribeServer()
   })
 
   it("deduplicates concurrent lifecycle and gap reconciliations per query client", async () => {

--- a/src/web/src/hooks/community/community-ws/read-state-reconciliation.ts
+++ b/src/web/src/hooks/community/community-ws/read-state-reconciliation.ts
@@ -1,6 +1,9 @@
 import { notifyManager, type QueryClient, type QueryKey } from "@tanstack/react-query"
 import { apiFetch } from "@/lib/api/client"
-import { communityKeys } from "@/lib/query-keys"
+import {
+  communityKeys,
+  isCommunityServerDetailQueryKey,
+} from "@/lib/query-keys"
 import { projectReadCoordinatorSnapshot } from "@/hooks/community/read-coordinator-snapshot-projection"
 import { acceptAccountUnreadPrimarySnapshot } from "@/hooks/community/account-unread-projection"
 
@@ -132,13 +135,7 @@ async function invalidateServerSurfaces(queryClient: QueryClient) {
   const serverIds = new Set<string>()
   for (const query of queryClient.getQueryCache().getAll()) {
     const key = query.queryKey
-    if (
-      key[0] === "community"
-      && key[1] === "servers"
-      && typeof key[2] === "string"
-      && key[2] !== "__none__"
-      && key.length === 3
-    ) serverIds.add(key[2])
+    if (isCommunityServerDetailQueryKey(key)) serverIds.add(key[2])
   }
   const refetchOptions = { throwOnError: true, cancelRefetch: true }
   const settled = await Promise.allSettled([

--- a/src/web/src/hooks/community/community-ws/reconnect.test.ts
+++ b/src/web/src/hooks/community/community-ws/reconnect.test.ts
@@ -454,9 +454,21 @@ describe("useCommunityWs — resyncs machines on WS reconnect", () => {
 
   it("reconciles every recognized cached server snapshot and ignores sentinel or unknown tuples", async () => {
     await mountHook()
+    let directoryFetches = 0
+    const directoryObserver = new QueryObserver(capturedQueryClient, {
+      queryKey: communityKeys.channelRefDirectory(),
+      queryFn: async () => {
+        directoryFetches += 1
+        return { servers: [] }
+      },
+      staleTime: Infinity,
+    })
+    const unsubscribeDirectory = directoryObserver.subscribe(() => {})
+    await vi.waitFor(() => expect(directoryFetches).toBe(1))
     capturedQueryClient.setQueryData(communityKeys.server("srv_a"), { id: "srv_a" })
     capturedQueryClient.setQueryData(communityKeys.members("srv_b"), { pages: [] })
     capturedQueryClient.setQueryData(communityKeys.server("__none__"), { id: "__none__" })
+    capturedQueryClient.setQueryData(communityKeys.server("__pending__"), { id: "__pending__" })
     capturedQueryClient.setQueryData(["community", "servers", "srv_ghost", "unknown-family"], {})
     capturedQueryClient.setQueryData(["community", "servers", "srv_ghost", "members", "unexpected"], {})
     const invalidDerivedTuples = [
@@ -478,6 +490,8 @@ describe("useCommunityWs — resyncs machines on WS reconnect", () => {
 
     await capturedOnReconnect!({ reconnectDurationMs: 250 })
 
+    expect(directoryFetches).toBe(1)
+    expect(capturedQueryClient.getQueryState(communityKeys.channelRefDirectory())?.isInvalidated).toBe(false)
     const calls = spy.mock.calls.map(([filters]) => filters)
     for (const serverId of ["srv_a", "srv_b"]) {
       for (const queryKey of [
@@ -500,6 +514,8 @@ describe("useCommunityWs — resyncs machines on WS reconnect", () => {
       }
     }
     expect(calls.some(({ queryKey }) => queryKey?.includes("__none__"))).toBe(false)
+    expect(calls.some(({ queryKey }) => queryKey?.includes("__pending__"))).toBe(false)
+    expect(calls.some(({ queryKey }) => queryKey?.includes("channel-ref-directory"))).toBe(false)
     expect(calls.some(({ queryKey }) => queryKey?.includes("srv_ghost"))).toBe(false)
     for (const queryKey of invalidDerivedTuples) {
       expect(capturedQueryClient.getQueryData(queryKey)).toEqual({ sentinel: true })
@@ -507,6 +523,7 @@ describe("useCommunityWs — resyncs machines on WS reconnect", () => {
     expect(calls.filter(({ queryKey, exact }) => (
       exact === true && JSON.stringify(queryKey) === JSON.stringify(communityKeys.servers())
     ))).toHaveLength(1)
+    unsubscribeDirectory()
   })
 
   it("isolates one cached-server rejection while completing every other policy", async () => {

--- a/src/web/src/hooks/community/community-ws/reconnect.ts
+++ b/src/web/src/hooks/community/community-ws/reconnect.ts
@@ -1,5 +1,9 @@
 import type { QueryClient, QueryKey } from "@tanstack/react-query"
-import { communityKeys } from "@/lib/query-keys"
+import {
+  communityKeys,
+  isCommunityServerDetailQueryKey,
+  isCommunityServerIdSegment,
+} from "@/lib/query-keys"
 import { useCommunityStore } from "@/stores/community"
 import { useCommunityWsStore } from "@/stores/community/ws"
 import { invalidateForumSidebarBaseExact } from "@/hooks/community/use-forum-sidebar-threads"
@@ -50,14 +54,13 @@ type ServerQueryKey = readonly ["community", "servers", string, ...unknown[]]
 function isServerQueryPrefix(key: QueryKey, serverId?: string): key is ServerQueryKey {
   return key[0] === "community"
     && key[1] === "servers"
-    && typeof key[2] === "string"
-    && key[2] !== "__none__"
+    && isCommunityServerIdSegment(key[2])
     && (serverId === undefined || key[2] === serverId)
 }
 
 function isRecognizedServerQueryKey(key: QueryKey): key is ServerQueryKey {
+  if (isCommunityServerDetailQueryKey(key)) return true
   if (!isServerQueryPrefix(key)) return false
-  if (key.length === 3) return true
   if (key.length === 4) {
     return typeof key[3] === "string" && EXACT_SERVER_QUERY_FAMILIES.has(key[3])
   }

--- a/src/web/src/hooks/community/use-structural-snapshot.test.ts
+++ b/src/web/src/hooks/community/use-structural-snapshot.test.ts
@@ -257,6 +257,25 @@ describe("installStructuralSnapshotProjection", () => {
     })
   })
 
+  it("does not project reserved server query keys as server trees", async () => {
+    await queryClient.fetchQuery({
+      queryKey: communityKeys.servers(),
+      queryFn: () => Promise.resolve(servers()),
+    })
+    const snapshot = queryClient.getQueryData(communityKeys.structuralSnapshot())
+
+    await queryClient.fetchQuery({
+      queryKey: communityKeys.channelRefDirectory(),
+      queryFn: () => Promise.resolve({ servers: [] }),
+    })
+    await queryClient.fetchQuery({
+      queryKey: communityKeys.server("__none__"),
+      queryFn: () => Promise.resolve({ sentinel: true }),
+    })
+
+    expect(queryClient.getQueryData(communityKeys.structuralSnapshot())).toEqual(snapshot)
+  })
+
   it("removes an archived child receipt from the structural snapshot", async () => {
     await queryClient.fetchQuery({
       queryKey: communityKeys.servers(),

--- a/src/web/src/hooks/community/use-structural-snapshot.ts
+++ b/src/web/src/hooks/community/use-structural-snapshot.ts
@@ -2,7 +2,10 @@
 
 import { useCallback, useMemo, useSyncExternalStore } from "react"
 import { useQueryClient, type QueryClient, type QueryKey } from "@tanstack/react-query"
-import { communityKeys } from "@/lib/query-keys"
+import {
+  communityKeys,
+  isCommunityServerDetailQueryKey,
+} from "@/lib/query-keys"
 import {
   parseStructuralSnapshot,
   projectServerDetailTree,
@@ -74,9 +77,8 @@ function projectLiveStructuralQuery(
     })
     return
   }
-  if (key.length === 3 && key[0] === "community" && key[1] === "servers") {
-    const serverId = String(key[2])
-    if (serverId === "__none__" || serverId === "channel-ref-directory") return
+  if (isCommunityServerDetailQueryKey(key)) {
+    const serverId = key[2]
     const tree = projectServerDetailTree(data as ServerDetail)
     updateStructuralSnapshot(queryClient, {
       type: "replaceServerTree",

--- a/src/web/src/lib/query-keys.test.ts
+++ b/src/web/src/lib/query-keys.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { communityKeys } from "./query-keys"
+import {
+  communityKeys,
+  isCommunityServerDetailQueryKey,
+  isCommunityServerIdSegment,
+} from "./query-keys"
 
 /**
  * These tests exist so that segment order and prefix nesting of the query-key
@@ -52,6 +56,22 @@ describe("communityKeys", () => {
     expect(communityKeys.forumSidebarUnreadFallbacks("s1")).toEqual([
       ...server, "forum-sidebar-unread-fallbacks",
     ])
+  })
+
+  it("recognizes only real server-detail keys and server-id segments", () => {
+    expect(isCommunityServerIdSegment("server-1")).toBe(true)
+    expect(isCommunityServerDetailQueryKey(communityKeys.server("server-1"))).toBe(true)
+
+    for (const queryKey of [
+      communityKeys.channelRefDirectory(),
+      communityKeys.server("__none__"),
+      communityKeys.server("__pending__"),
+      communityKeys.server(""),
+      communityKeys.members("server-1"),
+      communityKeys.servers(),
+    ]) {
+      expect(isCommunityServerDetailQueryKey(queryKey)).toBe(false)
+    }
   })
 
   it("nests channel-scoped keys under a stable channel prefix", () => {

--- a/src/web/src/lib/query-keys.ts
+++ b/src/web/src/lib/query-keys.ts
@@ -162,3 +162,25 @@ export const communityKeys = {
   profile: (userId: string) =>
     [...communityKeys.all, "profile", userId] as const,
 } as const
+
+const reservedServerIdSegments = new Set<string>([
+  communityKeys.channelRefDirectory()[2],
+])
+
+export type CommunityServerDetailQueryKey = ReturnType<typeof communityKeys.server>
+
+export function isCommunityServerIdSegment(value: unknown): value is string {
+  return typeof value === "string"
+    && value.length > 0
+    && !value.startsWith("__")
+    && !reservedServerIdSegments.has(value)
+}
+
+export function isCommunityServerDetailQueryKey(
+  queryKey: readonly unknown[],
+): queryKey is CommunityServerDetailQueryKey {
+  return queryKey.length === 3
+    && queryKey[0] === communityKeys.all[0]
+    && queryKey[1] === communityKeys.servers()[1]
+    && isCommunityServerIdSegment(queryKey[2])
+}

--- a/src/web/src/test/e2e-ui/50-daemon-update-notice.spec.ts
+++ b/src/web/src/test/e2e-ui/50-daemon-update-notice.spec.ts
@@ -80,6 +80,36 @@ function observeWrites(page: Page) {
   return { writes, stop: () => page.off("request", listener) }
 }
 
+async function expectUpdateActionGeometry(
+  page: Page,
+  expected: { height: number; horizontalPadding: number },
+) {
+  const notice = page.getByTestId(tid.daemonUpdateNotice)
+  const action = page.getByTestId(tid.daemonUpdateAction)
+  await expect.poll(() => action.evaluate((element) => {
+    const style = getComputedStyle(element)
+    return {
+      height: Number.parseFloat(style.height),
+      paddingLeft: Number.parseFloat(style.paddingLeft),
+      paddingRight: Number.parseFloat(style.paddingRight),
+    }
+  })).toEqual({
+    height: expected.height,
+    paddingLeft: expected.horizontalPadding,
+    paddingRight: expected.horizontalPadding,
+  })
+  const [noticeBox, actionBox] = await Promise.all([
+    notice.boundingBox(),
+    action.boundingBox(),
+  ])
+  expect(noticeBox).not.toBeNull()
+  expect(actionBox).not.toBeNull()
+  expect(Math.abs(noticeBox!.x + noticeBox!.width - actionBox!.x - actionBox!.width - 20))
+    .toBeLessThanOrEqual(1)
+  expect(Math.abs(noticeBox!.y + noticeBox!.height - actionBox!.y - actionBox!.height - 20))
+    .toBeLessThanOrEqual(1)
+}
+
 test("Update, Inbox, and viewer Profile share one persistent User Bar extension", async ({ asUser }) => {
   const { page } = await asUser("alice")
   const requests = await serveMachines(page)
@@ -95,6 +125,7 @@ test("Update, Inbox, and viewer Profile share one persistent User Bar extension"
   await expect(slot).toContainText("Machine update available")
   await expect(slot).toContainText("You can update your machine to get more features.")
   await expect(page.getByTestId(tid.daemonUpdateAction)).toHaveText("Update")
+  await expectUpdateActionGeometry(page, { height: 36, horizontalPadding: 8 })
   await expect(page.getByTestId(tid.daemonUpdateBadge)).toHaveCount(0)
   await expect(slot.getByRole("button", { name: /^Dismiss / })).toHaveCount(0)
   await expect(slot).toHaveCSS("animation-name", "none")
@@ -225,9 +256,11 @@ test("partial dispatch retries only failed eligible Machines and clears from liv
   const slot = page.getByTestId(tid.userBarExtension)
   await expect(slot).toContainText("You can update your machines to get more features.")
   await expect(page.getByTestId(tid.daemonUpdateBadge)).toHaveCount(0)
+  await expectUpdateActionGeometry(page, { height: 44, horizontalPadding: 12 })
   await page.getByTestId(tid.daemonUpdateAction).click()
   await expect(slot).toContainText("1 machine is updating. 1 update request failed.")
   await expect(page.getByTestId(tid.daemonUpdateAction)).toHaveText("Retry")
+  await expectUpdateActionGeometry(page, { height: 44, horizontalPadding: 12 })
   await expect.poll(() => requests.updateRequests()).toEqual([
     outdatedMachine.id,
     secondMachine.id,


### PR DESCRIPTION
# Why we need this PR?

The floating User Bar needs a theme-aware fade that remains stable across extension and pending states. Mobile native shells must own system insets exactly once, the Update action needs balanced responsive geometry, and reconciliation must not treat the channel-ref directory or sentinels as server details.

## What changed

- Added one inert, bottom-pinned underlay that fades from the existing `--app-bg` token to transparent at the shared User Bar height.
- Kept Android system-bar, cutout, and IME avoidance native while zeroing only the handled inset edges before they reach WebView; iOS and Web CSS behavior remain unchanged.
- Set Update and Retry actions to `44px`/`12px` padding on mobile and `36px`/`8px` on desktop without changing the extension card.
- Centralized real server-detail query recognition across read-state, reconnect, structural snapshot, and profile lifecycle reconciliation so directory and sentinel keys stay untouched.
- Added DOM, query-cache, native contract, and responsive browser regressions for the combined behavior.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [x] Other: Android native shell
