### PR TITLE
feat: add official server badges and fix bot log sizing and read scheduling

### DIFF
--- a/scripts/ci/verify-coverage-plan.mjs
+++ b/scripts/ci/verify-coverage-plan.mjs
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs"
 import { isAbsolute, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
+import ts from "typescript"
 import {
   loadScopeManifest,
   validateExecutionPlan,
@@ -23,6 +24,18 @@ function statementCounts(file) {
   }
 }
 
+function isTypeOnlySource(path) {
+  if (!/\.[cm]?tsx?$/.test(path)) return false
+  const source = ts.createSourceFile(path, readFileSync(path, "utf8"), ts.ScriptTarget.Latest, true)
+  if (source.parseDiagnostics.length > 0 || source.statements.length === 0) return false
+  return source.statements.every((statement) => (
+    ts.isTypeAliasDeclaration(statement)
+    || ts.isInterfaceDeclaration(statement)
+    || (ts.isImportDeclaration(statement) && statement.importClause?.isTypeOnly === true)
+    || (ts.isExportDeclaration(statement) && statement.isTypeOnly)
+  ))
+}
+
 export function verifyCoveragePlan(plan, report, options = {}) {
   const root = options.root || ROOT
   const manifest = options.manifest || loadScopeManifest()
@@ -33,12 +46,17 @@ export function verifyCoveragePlan(plan, report, options = {}) {
     coverage: value,
   }))
   const reportPaths = new Set(files.map((entry) => entry.path))
+  const typeOnlyChangedFiles = []
 
   for (const path of plan.coverage.required_changed_files) {
     if (!existsSync(resolve(root, path))) {
       throw new Error(`required changed coverage file does not exist at head: ${path}`)
     }
     if (!reportPaths.has(path)) {
+      if (isTypeOnlySource(resolve(root, path))) {
+        typeOnlyChangedFiles.push(path)
+        continue
+      }
       throw new Error(`required changed coverage file is missing from merged report: ${path}`)
     }
   }
@@ -81,6 +99,7 @@ export function verifyCoveragePlan(plan, report, options = {}) {
     plan_hash: plan.plan_hash,
     include_roots: plan.coverage.include_roots,
     required_changed_files: plan.coverage.required_changed_files,
+    type_only_changed_files: typeOnlyChangedFiles,
     report_files: [...reportPaths].sort(),
     targets,
   }

--- a/scripts/ci/verify-coverage-plan.test.ts
+++ b/scripts/ci/verify-coverage-plan.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto"
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { describe, expect, it } from "vitest"
@@ -30,6 +30,43 @@ function resignPlan(value) {
 }
 
 describe("verifyCoveragePlan", () => {
+  it("audits the type-only navigation model without waiving the project denominator", () => {
+    const changed = "src/web/src/lib/community/models/navigation.ts"
+    const runtime = "src/web/src/lib/config.ts"
+    const plan = buildExecutionPlan([{ status: "M", path: changed }], { baseSha, headSha })
+    expect(verifyCoveragePlan(plan, { [runtime]: coveredFile(runtime) }))
+      .toMatchObject({ type_only_changed_files: [changed] })
+    expect(() => verifyCoveragePlan(plan, {})).toThrow("nonempty denominator")
+  })
+
+  it.each([
+    ["extra empty statement", "import type { Foo } from './foo'; export type Bar = Foo; export interface Item { id: string };", false],
+    ["type exports", "export type { Foo } from './foo'; export type * from './bar';", true],
+    ["types and interfaces", "import type { Foo } from './foo'; export type Bar = Foo; export interface Item { id: string }", true],
+    ["runtime value", "export type Foo = string; export const value = 1;", false],
+    ["side-effect import", "import './setup'; export type Foo = string;", false],
+    ["value import", "import { Foo } from './foo'; export type Bar = Foo;", false],
+    ["value re-export", "export { Foo } from './foo';", false],
+    ["enum", "export enum Foo { Bar }", false],
+    ["namespace", "export namespace Foo { export const bar = 1 }", false],
+    ["invalid syntax", "export type Foo = ;", false],
+    ["empty source", "", false],
+  ])("handles %s conservatively", (_name, source, typeOnly) => {
+    const root = mkdtempSync(join(tmpdir(), "alook-coverage-types-"))
+    const changed = "src/web/src/types.ts"
+    const runtime = "src/web/src/lib/config.ts"
+    const plan = buildExecutionPlan([{ status: "M", path: changed }], { baseSha, headSha })
+    try {
+      mkdirSync(join(root, "src/web/src"), { recursive: true })
+      writeFileSync(join(root, changed), source)
+      const verify = () => verifyCoveragePlan(plan, { [runtime]: coveredFile(runtime) }, { root })
+      if (typeOnly) expect(verify().type_only_changed_files).toEqual([changed])
+      else expect(verify).toThrow(`required changed coverage file is missing from merged report: ${changed}`)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it("permits an excluded E2E fixture without hiding missing product coverage", () => {
     const fixture = "src/web/src/test/e2e-ui/_fixtures/community-notification-requests.ts"
     const product = "src/web/src/lib/community/message-dispatcher.ts"

--- a/src/shared/src/db/community-schema.ts
+++ b/src/shared/src/db/community-schema.ts
@@ -25,6 +25,7 @@ export const communityServer = sqliteTable(
     discriminator: text("discriminator").notNull().default("0000"),
     description: text("description").default(""),
     icon: text("icon"),
+    official: integer("official", { mode: "boolean" }).notNull().default(false),
     ownerId: text("owner_id")
       .notNull()
       .references(() => user.id, { onDelete: "restrict" }),

--- a/src/shared/src/db/queries/community/server.ts
+++ b/src/shared/src/db/queries/community/server.ts
@@ -259,6 +259,7 @@ export async function listUserServers(db: Database, userId: string) {
       discriminator: communityServer.discriminator,
       description: communityServer.description,
       icon: communityServer.icon,
+      official: communityServer.official,
       ownerId: communityServer.ownerId,
       createdAt: communityServer.createdAt,
       role: communityServerMember.role,

--- a/src/shared/test/migrations/community-server-official.test.ts
+++ b/src/shared/test/migrations/community-server-official.test.ts
@@ -1,0 +1,46 @@
+import Sqlite from "better-sqlite3"
+import { drizzle } from "drizzle-orm/better-sqlite3"
+import { readFileSync } from "node:fs"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import type { Database } from "../../src/db"
+import { getServer } from "../../src/db/queries/community/server"
+
+const migration = readFileSync(new URL("../../../web/migrations/0100_community_server_official.sql", import.meta.url), "utf8")
+
+describe("official server migration and reads", () => {
+  let sqlite: Sqlite.Database
+  let db: Database
+
+  beforeEach(() => {
+    sqlite = new Sqlite(":memory:")
+    sqlite.exec(`
+      CREATE TABLE community_server (
+        id TEXT PRIMARY KEY, name TEXT NOT NULL, discriminator TEXT NOT NULL DEFAULT '0000',
+        description TEXT DEFAULT '', icon TEXT, owner_id TEXT NOT NULL, created_at TEXT NOT NULL
+      );
+      INSERT INTO community_server (id, name, owner_id, created_at) VALUES ('existing', 'Alook', 'owner', '2026-09-10');
+    `)
+    sqlite.exec(migration)
+    db = drizzle(sqlite) as unknown as Database
+  })
+
+  afterEach(() => sqlite.close())
+
+  it("keeps existing and newly inserted servers unofficial by default", async () => {
+    sqlite.exec("INSERT INTO community_server (id, name, owner_id, created_at) VALUES ('new', 'New', 'owner', '2026-09-10')")
+    expect((await getServer(db, "existing"))?.official).toBe(false)
+    expect((await getServer(db, "new"))?.official).toBe(false)
+  })
+
+  it("reads manual admin updates as booleans and supports removing official status", async () => {
+    sqlite.exec("UPDATE community_server SET official = 1 WHERE id = 'existing'")
+    expect((await getServer(db, "existing"))?.official).toBe(true)
+    sqlite.exec("UPDATE community_server SET official = 0 WHERE id = 'existing'")
+    expect((await getServer(db, "existing"))?.official).toBe(false)
+  })
+
+  it("rejects null and invalid flags", () => {
+    expect(() => sqlite.exec("UPDATE community_server SET official = NULL")).toThrow()
+    expect(() => sqlite.exec("UPDATE community_server SET official = 2")).toThrow()
+  })
+})

--- a/src/shared/test/queries/community-notification-cursor-clear.test.ts
+++ b/src/shared/test/queries/community-notification-cursor-clear.test.ts
@@ -54,6 +54,7 @@ describe("notification setting read-state isolation contract", () => {
         ('u', 'Bot', '0001'),
         ('author', 'Human', '0002');
       CREATE TABLE community_server (
+        official INTEGER NOT NULL DEFAULT 0,
         id TEXT PRIMARY KEY,
         name TEXT NOT NULL,
         discriminator TEXT NOT NULL DEFAULT '0000',

--- a/src/shared/test/queries/server.test.ts
+++ b/src/shared/test/queries/server.test.ts
@@ -419,6 +419,7 @@ describe("listUserServers — mention aggregate for the rail badge", () => {
     await serverQueries.listUserServers(db, "u_1");
     const outer = selectChains[1];
     expect(outer.from).toBe(communityServer);
+    expect(outer.fields.official).toBe(communityServer.official);
     // Inner join to member (the "am I in this server" pin) MUST stay — the
     // mention aggregate is a badge on the rail, not a public feed.
     expect(outer.innerJoins).toHaveLength(1);

--- a/src/web/migrations/0100_community_server_official.sql
+++ b/src/web/migrations/0100_community_server_official.sql
@@ -1,0 +1,1 @@
+ALTER TABLE community_server ADD COLUMN official INTEGER NOT NULL DEFAULT 0 CHECK (official IN (0, 1));

--- a/src/web/public/official-server-badge-flat.svg
+++ b/src/web/public/official-server-badge-flat.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+<metadata>Geometry: Lucide BadgeCheck. Flat treatment: Alook.
+ISC License
+
+Copyright (c) 2026 Lucide Icons and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+</metadata>
+<path d="M3.85 8.62a4 4 0 0 1 4.78-4.77 4 4 0 0 1 6.74 0 4 4 0 0 1 4.78 4.78 4 4 0 0 1 0 6.74 4 4 0 0 1-4.77 4.78 4 4 0 0 1-6.75 0 4 4 0 0 1-4.78-4.77 4 4 0 0 1 0-6.76Z" fill="#F2C94C" stroke="#17130D" stroke-width="2" stroke-linejoin="round"/>
+<path d="m8.5 12 2.5 2.5 4.5-4.5" stroke="#17130D" stroke-width="2.6" stroke-linecap="square" stroke-linejoin="miter"/>
+</svg>

--- a/src/web/src/app/api/community/servers/[id]/route.test.ts
+++ b/src/web/src/app/api/community/servers/[id]/route.test.ts
@@ -101,6 +101,19 @@ describe("PATCH /api/community/servers/[id]", () => {
     mockFanOut.mockResolvedValue(undefined)
   })
 
+  it("does not allow an owner to promote a server to official", async () => {
+    const res = await PATCH(patchReq({ official: true }), ctx)
+    expect(res.status).toBe(400)
+    expect(mockUpdateServer).not.toHaveBeenCalled()
+  })
+
+  it("ignores official when updating an allowed field", async () => {
+    mockUpdateServer.mockResolvedValue({ id: "s1", name: "Renamed", official: false })
+    const res = await PATCH(patchReq({ name: "Renamed", official: true }), ctx)
+    expect(res.status).toBe(200)
+    expect(mockUpdateServer).toHaveBeenCalledWith(expect.anything(), "s1", { name: "Renamed" })
+  })
+
   it("normalizes a spaced rename via slugify before calling updateServer", async () => {
     mockUpdateServer.mockResolvedValue({ id: "s1", name: "My-Home" })
 

--- a/src/web/src/app/api/community/servers/route.test.ts
+++ b/src/web/src/app/api/community/servers/route.test.ts
@@ -62,6 +62,18 @@ describe("POST /api/community/servers", () => {
     fanOut.mockResolvedValue(undefined)
   })
 
+  it("does not accept official status when creating a server", async () => {
+    createServer.mockResolvedValue({
+      server: { id: "srv_1", name: "New", ownerId: "u1", official: false },
+      ownerMember: { id: "mem_1", userId: "u1", joinedAt, userName: "Alice" },
+    })
+    const res = await POST(postReq({ name: "New", official: true }))
+    expect(res.status).toBe(201)
+    expect(createServer).toHaveBeenCalledWith(expect.anything(), {
+      name: "New", description: undefined, ownerId: "u1",
+    })
+  })
+
   it("fires MEMBER_JOIN with byte-identical payload sourced from createServer's ownerMember", async () => {
     createServer.mockResolvedValue({
       server: { id: "srv_1", name: "My Server", ownerId: "u1" },

--- a/src/web/src/app/c/channels/layout.tsx
+++ b/src/web/src/app/c/channels/layout.tsx
@@ -390,6 +390,7 @@ export default function ServerLayout({ children }: { children: ReactNode }) {
     tree: channelTree,
     serverName: currentServer?.name ?? structuralServer?.name ?? "",
     serverIcon: currentServer?.icon ?? structuralServer?.icon ?? null,
+    official: currentServer?.official ?? false,
     activeChannel: currentChannelMeta?.parentChannelId ?? currentChannelId ?? "",
     isAdmin,
     currentUserId: currentUser.id,

--- a/src/web/src/components/community/channels/channel-sidebar.tsx
+++ b/src/web/src/components/community/channels/channel-sidebar.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { OfficialServerBadge } from "../official-server-badge"
 import { Fragment, memo, useRef, useState } from "react"
 import { Settings, Users, Link2, Bell, ChevronDown, UserPlus } from "lucide-react"
 import {
@@ -53,7 +54,7 @@ const channelSidebarCollisionDetection: CollisionDetection = (args) => {
 // right-click) creates; channels right-click to edit/delete. A private category only
 // lets admins create channels — non-admins are blocked via onBlockedCreate.
 export const ChannelSidebar = memo(function ChannelSidebar({
-  tree, serverName, activeChannel, setActiveChannel, prefetchChannel, noHeader, onOpenSettings,
+  tree, serverName, official, activeChannel, setActiveChannel, prefetchChannel, noHeader, onOpenSettings,
   isAdmin = true, currentUserId, onBlockedCreate, mutedChannels, loading,
   onCreateChannel, onCreateCategory, onDeleteChannel, onDeleteCategory,
   onUpdateCategory, onRenameChannel, onReorderCategories, onReorderChannels,
@@ -63,6 +64,7 @@ export const ChannelSidebar = memo(function ChannelSidebar({
 }: {
   tree: ChannelTree
   serverName: string
+  official?: boolean
   serverIcon?: string | null
   activeChannel: string
   setActiveChannel: (id: string) => void
@@ -323,7 +325,8 @@ export const ChannelSidebar = memo(function ChannelSidebar({
   return (
     <aside className="flex min-h-0 min-w-0 flex-1 flex-col">
       {!noHeader && (
-        <header className="flex h-12 items-center gap-1 border-b border-border/40 px-2">
+        <header className="relative flex h-12 items-center gap-1 border-b border-border/40 px-2">
+          <OfficialServerBadge official={official} className="absolute left-1 top-0.5 z-1" />
           {serverName && onOpenSettings ? (
             <DropdownMenu>
               <DropdownMenuTrigger className="flex h-11 min-w-0 max-w-full items-center gap-2 rounded-md px-2 hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none sm:h-auto sm:py-1">

--- a/src/web/src/components/community/official-server-badge.dom.test.ts
+++ b/src/web/src/components/community/official-server-badge.dom.test.ts
@@ -1,0 +1,18 @@
+import { resolve } from "node:path"
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+describe("official server badge asset", () => {
+  it("loads as a standalone SVG without reflective effects", () => {
+    const asset = readFileSync(resolve(
+      process.cwd(),
+      process.cwd().endsWith("/src/web") ? "" : "src/web",
+      "public/official-server-badge-flat.svg",
+    ), "utf8")
+    const document = new DOMParser().parseFromString(asset, "image/svg+xml")
+    expect(document.querySelector("parsererror")).toBeNull()
+    expect(document.documentElement.localName).toBe("svg")
+    expect(document.documentElement.getAttribute("viewBox")).toBe("0 0 24 24")
+    expect(document.querySelector("linearGradient, radialGradient, filter")).toBeNull()
+  })
+})

--- a/src/web/src/components/community/official-server-badge.dom.test.ts
+++ b/src/web/src/components/community/official-server-badge.dom.test.ts
@@ -1,13 +1,19 @@
 import { resolve } from "node:path"
 import { readFileSync } from "node:fs"
+import { createElement } from "react"
 import { describe, expect, it } from "vitest"
+import { render, screen } from "@/test/react-dom-harness"
+import { OfficialServerBadge } from "./official-server-badge"
 
 describe("official server badge asset", () => {
   it("loads as a standalone SVG without reflective effects", () => {
+    render(createElement(OfficialServerBadge, { official: true }))
+    const badge = screen.getByRole("img", { name: "Official server" })
+    expect(badge).toHaveAttribute("src", "/official-server-badge-flat.svg")
     const asset = readFileSync(resolve(
-      process.cwd(),
-      process.cwd().endsWith("/src/web") ? "" : "src/web",
-      "public/official-server-badge-flat.svg",
+      import.meta.dirname,
+      "../../../public",
+      badge.getAttribute("src")!.slice(1),
     ), "utf8")
     const document = new DOMParser().parseFromString(asset, "image/svg+xml")
     expect(document.querySelector("parsererror")).toBeNull()

--- a/src/web/src/components/community/official-server-badge.test.ts
+++ b/src/web/src/components/community/official-server-badge.test.ts
@@ -1,0 +1,20 @@
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import { OfficialServerBadge } from "./official-server-badge"
+
+describe("OfficialServerBadge", () => {
+  it.each([false, undefined])("does not render for unofficial or older cached servers (%s)", (official) => {
+    expect(renderToStaticMarkup(createElement(OfficialServerBadge, { official }))).toBe("")
+  })
+
+  it("renders the shared flat asset with accessible identity and fixed size", () => {
+    const html = renderToStaticMarkup(createElement(OfficialServerBadge, { official: true, className: "absolute" }))
+    expect(html).toContain('alt="Official server"')
+    expect(html).toContain('src="/official-server-badge-flat.svg"')
+    expect(html).toContain('width="20"')
+    expect(html).toContain('height="20"')
+    expect(html).toContain('draggable="false"')
+    expect(html).toContain("absolute")
+  })
+})

--- a/src/web/src/components/community/official-server-badge.tsx
+++ b/src/web/src/components/community/official-server-badge.tsx
@@ -1,0 +1,21 @@
+import Image from "next/image"
+import { cn } from "@/lib/utils"
+
+export function OfficialServerBadge({ official, className }: {
+  official?: boolean
+  className?: string
+}) {
+  if (!official) return null
+  return (
+    <Image
+      src="/official-server-badge-flat.svg"
+      alt="Official server"
+      title="Official server"
+      width={20}
+      height={20}
+      unoptimized
+      draggable={false}
+      className={cn("pointer-events-none size-5 shrink-0", className)}
+    />
+  )
+}

--- a/src/web/src/components/community/shell/sortable-server.focus.dom.test.ts
+++ b/src/web/src/components/community/shell/sortable-server.focus.dom.test.ts
@@ -32,9 +32,9 @@ const server = {
   mentions: 0,
 }
 
-function renderServer(active = false, mentions = 0) {
+function renderServer(active = false, mentions = 0, official = false) {
   const renderer = render(createElement(SortableServer, {
-    server: { ...server, mentions },
+    server: { ...server, mentions, official },
     active,
     onClick: vi.fn(),
     dragDescriptionId: "rail-help",
@@ -46,6 +46,13 @@ function renderServer(active = false, mentions = 0) {
 
 describe("SortableServer lazy menu focus", () => {
   afterEach(() => vi.restoreAllMocks())
+
+  it("announces official status without changing ordinary server labels", () => {
+    const ordinary = renderServer()
+    expect(ordinary.button()).toHaveAccessibleName("A")
+    const official = renderServer(false, 0, true)
+    expect(official.button()).toHaveAccessibleName("A, Official server")
+  })
 
   it("refocuses the icon after first focus activates and replaces its menu wrapper", () => {
     const focus = vi.spyOn(HTMLElement.prototype, "focus")

--- a/src/web/src/components/community/shell/sortable-server.tsx
+++ b/src/web/src/components/community/shell/sortable-server.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { OfficialServerBadge } from "../official-server-badge";
+
 import { memo, useLayoutEffect, useRef, useState } from "react";
 import {
   ContextMenu,
@@ -123,7 +125,7 @@ function SortableServerImpl({
           data-testid={tid.serverIcon(server.id)}
           data-dragging={isDragActive || undefined}
           data-rail-preview={preview ?? undefined}
-          aria-label={server.name}
+          aria-label={server.official ? `${server.name}, Official server` : server.name}
           aria-describedby={dragDescriptionId}
           aria-keyshortcuts="Space ArrowUp ArrowDown ArrowLeft ArrowRight Escape"
           onClick={active ? undefined : onClick}
@@ -151,6 +153,7 @@ function SortableServerImpl({
               : "text-white [text-shadow:0_1px_2px_rgb(0_0_0/0.35)] group-hover/server:brightness-110",
           ].join(" ")}
           />
+          <OfficialServerBadge official={server.official} className="absolute -left-1 -top-1 z-2" />
         </button>
         {server.mentions > 0 && (
           <span
@@ -248,6 +251,7 @@ export function serverPropsEqual(prev: SortableServerProps, next: SortableServer
     a.name === b.name &&
     a.initial === b.initial &&
     a.icon === b.icon &&
+    a.official === b.official &&
     a.unread === b.unread &&
     a.mentions === b.mentions &&
     a.isOwner === b.isOwner &&

--- a/src/web/src/components/community/shell/sortable-server.unread.test.ts
+++ b/src/web/src/components/community/shell/sortable-server.unread.test.ts
@@ -15,6 +15,13 @@ const base = {
 }
 
 describe("SortableServer unread memo boundary", () => {
+  it("rerenders when official status changes", () => {
+    const official = { ...base, server: { ...base.server, official: true } }
+    expect(serverPropsEqual(base, official)).toBe(false)
+    expect(serverPropsEqual(official, base)).toBe(false)
+    expect(serverPropsEqual(official, { ...official, onClick: vi.fn() })).toBe(true)
+  })
+
   it("rerenders for owned unread changes while ignoring callback identity", () => {
     expect(serverPropsEqual(base, { ...base, onClick: vi.fn() })).toBe(true)
     expect(serverPropsEqual(base, {

--- a/src/web/src/components/community/social/bot-mark-sticker.dom.test.ts
+++ b/src/web/src/components/community/social/bot-mark-sticker.dom.test.ts
@@ -382,7 +382,7 @@ describe("BotMarkSticker", () => {
     expect(stop.disabled).toBe(false)
     expect(stop.className).toContain("bg-[#dc2626]")
     expect(stop.className).toContain("text-white")
-    expect(stop.className).toContain("min-h-11")
+    expect(stop.className).toContain("min-h-7")
     const activeRow = renderer.container.querySelector(
       '[data-testid="community-bot-audit-preview-active"]',
     )!

--- a/src/web/src/components/community/social/bot-mark-sticker.tsx
+++ b/src/web/src/components/community/social/bot-mark-sticker.tsx
@@ -259,7 +259,7 @@ export function BotMarkSticker({
         </div>
       )}
 
-      <footer className="flex h-12 shrink-0 items-center gap-1 px-3 py-0.5 sm:h-9 sm:py-1">
+      <footer className="flex h-9 shrink-0 items-center gap-1 px-3 py-1">
         {active ? (
           <div className="min-w-0 flex-1 overflow-hidden">
             <BotAuditActiveRow latestEventAt={visibleEvents.at(-1)?.createdAt} tone="note" />
@@ -274,7 +274,7 @@ export function BotMarkSticker({
             onClick={onStop}
             disabled={stopPending}
             aria-label={stopPending ? "Stopping current agent turn" : "Stop current agent turn"}
-            className="flex min-h-11 shrink-0 items-center justify-center gap-1.5 rounded-lg bg-[#dc2626] px-2.5 text-xs font-semibold text-white shadow-[0_2px_5px_rgba(127,29,29,0.28)] transition-colors hover:bg-[#b91c1c] active:bg-[#991b1b] focus-visible:ring-2 focus-visible:ring-[#7f1d1d] focus-visible:ring-offset-1 focus-visible:outline-none disabled:cursor-wait disabled:bg-[#b91c1c] disabled:text-white/85 sm:min-h-7"
+            className="flex min-h-7 shrink-0 items-center justify-center gap-1.5 rounded-lg bg-[#dc2626] px-2.5 text-xs font-semibold text-white shadow-[0_2px_5px_rgba(127,29,29,0.28)] transition-colors hover:bg-[#b91c1c] active:bg-[#991b1b] focus-visible:ring-2 focus-visible:ring-[#7f1d1d] focus-visible:ring-offset-1 focus-visible:outline-none disabled:cursor-wait disabled:bg-[#b91c1c] disabled:text-white/85"
           >
             {stopPending
               ? <LoaderCircle className="size-3.5 animate-spin motion-reduce:animate-none" aria-hidden />

--- a/src/web/src/hooks/community/read-coordinator.test.ts
+++ b/src/web/src/hooks/community/read-coordinator.test.ts
@@ -376,6 +376,34 @@ describe("read coordinator", () => {
     expect(apiFetch).toHaveBeenCalledOnce()
   })
 
+  it.each(["snapshot", "surface"] as const)("sends a queued newer target when %s confirmation retires the active request after debounce", async (confirmation) => {
+    const queryClient = new QueryClient()
+    const lease = timelineLease(queryClient)
+    apiFetch
+      .mockReturnValueOnce(new Promise(() => {}))
+      .mockResolvedValueOnce({ changed: true, revision: 6, targetSeq: 8 })
+
+    submitTimeline(lease, 3)
+    await vi.advanceTimersByTimeAsync(READ_COORDINATOR_DEBOUNCE_MS)
+    const signal = apiFetch.mock.calls[0]?.[1]?.signal as AbortSignal
+    submitTimeline(lease, 8)
+    await vi.advanceTimersByTimeAsync(READ_COORDINATOR_DEBOUNCE_MS)
+    expect(apiFetch).toHaveBeenCalledTimes(1)
+
+    if (confirmation === "snapshot") {
+      projectReadCoordinatorSnapshot(queryClient, {
+        readStates: [{ channelId: "channel-1", lastReadSeq: 3 }],
+      })
+    } else {
+      confirmReadSurface(lease, 3)
+    }
+    expect(signal.aborted).toBe(true)
+    await vi.advanceTimersByTimeAsync(READ_COORDINATOR_DEBOUNCE_MS)
+    expect(apiFetch).toHaveBeenCalledTimes(2)
+    expect(apiFetch.mock.calls[1]?.[1]?.body).toBe(JSON.stringify({ lastReadMessageId: "message-8" }))
+    disposeReadCoordinator(queryClient)
+  })
+
   it("serializes a newer visible target behind the active request", async () => {
     const queryClient = new QueryClient()
     const lease = timelineLease(queryClient)

--- a/src/web/src/hooks/community/read-coordinator.ts
+++ b/src/web/src/hooks/community/read-coordinator.ts
@@ -560,6 +560,9 @@ class ReadCoordinator {
       state.attemptEpoch += 1
       state.inFlight.controller.abort()
       state.inFlight = null
+      if (state.accepted && state.retryTimer === null) {
+        this.schedule(state, Math.max(0, state.accepted.dueAt - Date.now()))
+      }
     }
     if (!state.accepted && state.timer !== null) {
       clearTimeout(state.timer)

--- a/src/web/src/hooks/community/use-servers.test.ts
+++ b/src/web/src/hooks/community/use-servers.test.ts
@@ -57,6 +57,7 @@ describe("useServers / serversQueryFn", () => {
           name: "Alook",
           discriminator: "0042",
           description: "Build together",
+          official: true,
           icon: null,
           ownerId: "u_1",
           role: "owner",
@@ -69,6 +70,8 @@ describe("useServers / serversQueryFn", () => {
     const { serversQueryFn } = await import("./use-servers")
     const data = await serversQueryFn()
     expect(apiFetchMock).toHaveBeenCalledWith("/api/community/servers", { signal: undefined })
+    expect(data.servers[0].official).toBe(true)
+    expect(data.servers[1].official).toBe(false)
     expect(data.servers[0].initial).toBe("A")
     expect(data.servers[0].isOwner).toBe(true)
     expect(data.servers[0].mentions).toBe(3)
@@ -591,7 +594,7 @@ describe("useServer / serverQueryFn", () => {
   })
 
   it("composes a single server detail from canonical resources", async () => {
-    const detail = { id: "srv_1", name: "Alook", description: "", icon: null, ownerId: "u_1" }
+    const detail = { id: "srv_1", name: "Alook", description: "", icon: null, ownerId: "u_1", official: true }
     apiFetchMock.mockImplementation(async (url: string) => {
       if (url === "/api/community/servers") return { servers: [{ ...detail, discriminator: "0001" }] }
       if (url.endsWith("/categories")) return { categories: [{ id: "cat_1", name: "Main", private: 0 }] }

--- a/src/web/src/hooks/community/use-servers.ts
+++ b/src/web/src/hooks/community/use-servers.ts
@@ -59,6 +59,7 @@ type RawServerRow = {
   name: string
   discriminator: string
   icon: string | null
+  official?: boolean
   role?: string
   mentions?: number
   unread?: boolean
@@ -96,6 +97,7 @@ export const serversQueryFn = async (
     mentions: s.mentions ?? 0,
     isOwner: isServerOwner(s.role),
     icon: s.icon ?? null,
+    official: s.official === true,
     ...(s.unreadSources ? { unreadSources: s.unreadSources } : {}),
     ...(s.mentionSources ? { mentionSources: s.mentionSources } : {}),
   }))
@@ -251,6 +253,7 @@ export type ServerDetail = {
   discriminator: string
   description: string
   icon: string | null
+  official?: boolean
   ownerId: string
   categories: Category[]
   /** Canonical unread ownership for participating children of forum channels. */
@@ -384,6 +387,7 @@ export const serverQueryFn = (
     discriminator: server.discriminator ?? "",
     description: server.description ?? "",
     icon: server.icon ?? null,
+    official: server.official === true,
     ownerId: server.ownerId ?? "",
     categories,
     forumUnreadState,

--- a/src/web/src/lib/community/models/navigation.ts
+++ b/src/web/src/lib/community/models/navigation.ts
@@ -17,6 +17,7 @@ export type Server = {
   unreadSources?: Array<{ channelId: string; lastUnreadSeq: number }>
   /** Exact direct-mention sources behind the numeric rail badge. */
   mentionSources?: Array<{ channelId: string; count: number; lastSeq: number }>
+  official?: boolean
   isOwner?: boolean
   icon?: string | null
 }

--- a/src/web/src/test/e2e-ui/55-message-scroll-characterization.spec.ts
+++ b/src/web/src/test/e2e-ui/55-message-scroll-characterization.spec.ts
@@ -543,6 +543,10 @@ test.describe.serial("message scroll characterization", () => {
     const proxy = await proxyCommunityWebSockets(alice.context)
     await gotoAfterUserWsAuth(alice.page, `/c/channels/${serverId}/${upwardChannelId}`)
     await expect(alice.page.getByTestId(tid.newDivider)).toBeVisible({ timeout: 30_000 })
+    await alice.page.getByTestId(tid.scrollToPresent).click()
+    await expect(alice.page.getByTestId(tid.message(upwardProfile.ids.at(-1)!)))
+      .toBeVisible({ timeout: 30_000 })
+    await expect(alice.page.getByTestId(tid.scrollToPresent)).toHaveCount(0)
     const scroller = alice.page.getByTestId(tid.messageScroller)
     await startScrollTrace(alice.page, {
       scenario: "remote-receive-and-upward-input",


### PR DESCRIPTION
Official servers now show a shared flat yellow-and-black badge on the server rail and overlapping the server-name header. The badge is 20px, includes an accessible official label, and leaves ordinary servers unchanged.

`community_server.official` is a default-false boolean backed by a 0/1 D1 column (migration 0100). Admins set it directly in the database; the member-scoped server list and client-composed server detail carry it to both placements. Existing create/update APIs cannot set official status. Reload reads DB changes; no management CRUD, new permissions or realtime events are introduced.

Validation: focused migration/query/API/materialization/component/DOM tests pass. Prior full typecheck, lint and boundary checks passed. Independent local browser QA verified DB toggles, API privilege boundaries, ordinary unread/navigation, expanded folders, and desktop/mobile light/dark; the owner selected this visual after live preview. Final scoped checks rerun after rebasing onto main. Full local monorepo test execution was stopped at the owner's focused-test direction; shared package completed 2182 tests. Required CI remains the merge gate.

Migration 0098/0099 are reserved by the concurrent billing work; this change intentionally uses 0100. Apply the migration before running code that selects the new column.

Coverage completeness now records missing-report TypeScript files as type-only only when the parser accepts every statement as an explicit type import/export, type alias, or interface. Runtime-bearing and unparseable sources still require report entries, and project denominator/threshold checks remain enforced. Focused verifier/scope tests: 47 passed; verifier Istanbul coverage: 100% lines, 98.48% statements, 93.75% branches.

The remote-receive scroll characterization now explicitly loads the latest seeded message before establishing its pinned precondition. This avoids newer-page loading racing the setup; existing exact geometry and remote-receive assertions are unchanged. The isolated targeted browser scenario passed after the four-line readiness change.

Read coordination now restores scheduling for a newer accepted target when authoritative confirmation retires an older in-flight request after the newer debounce has elapsed. It preserves the target deadline and stale-response fencing. Two deterministic regressions cover snapshot and surface confirmation;69 focused coordinator/observer/reconciliation tests pass. The original cross-device visible/unseen-tail browser scenario passes against the production build (one worker, zero retries).

Mobile bot-log Stop controls now use the existing desktop28px button and36px footer heights. Ten component tests and independent desktop/mobile fixture QA pass, including pending disabled behavior; the owner approved both screenshots. The fixture uses real component/CSS with mocked log data and does not validate backend stop execution.

The existing delete/server-back-navigation scenario also passes unchanged against this production build (8.6s). No speculative navigation patch was introduced; latest-head CI must still validate both previously failing shards.
