### PR TITLE
fix(web): align user bar extension borders

### DIFF
--- a/src/web/src/components/community/shell/user-bar-extension-slot.dom.test.tsx
+++ b/src/web/src/components/community/shell/user-bar-extension-slot.dom.test.tsx
@@ -49,10 +49,18 @@ describe("UserBarExtensionSlot", () => {
     expect(slot).toHaveAttribute("role", "dialog")
     expect(slot).toHaveAttribute("aria-modal", "false")
     expect(slot).toHaveAttribute("data-extension", "inbox")
-    expect(slot.className).toContain("rounded-t-xl")
-    expect(slot.className).toContain("shadow-(--e2)")
-    expect(slot.className).toContain("[clip-path:inset(-2rem_-2rem_0)]")
-    expect(slot.className).not.toContain("shadow-none")
+    const classes = slot.className.split(" ")
+    expect(classes).toEqual(expect.arrayContaining([
+      "rounded-t-xl",
+      "border-x",
+      "border-t",
+      "border-border/40",
+      "shadow-(--e2)",
+      "[clip-path:inset(-2rem_-2rem_0)]",
+    ]))
+    expect(classes).not.toContain("border-b")
+    expect(classes).not.toContain("border-b-0")
+    expect(classes).not.toContain("shadow-none")
     expect(slot.style.height).toContain("100dvh")
     expect(renderer.getByTestId("inbox-content")).toBeInTheDocument()
     expect(renderer.queryByTestId("profile-content")).not.toBeInTheDocument()

--- a/src/web/src/components/community/shell/user-bar-extension-slot.tsx
+++ b/src/web/src/components/community/shell/user-bar-extension-slot.tsx
@@ -95,7 +95,7 @@ export function UserBarExtensionSlot({
       data-extension={active}
       tabIndex={-1}
       className={cn(
-        "relative min-h-0 origin-bottom overflow-hidden rounded-t-xl border border-b-0 border-border bg-popover text-popover-foreground shadow-(--e2) [clip-path:inset(-2rem_-2rem_0)]",
+        "relative min-h-0 origin-bottom overflow-hidden rounded-t-xl border-x border-t border-border/40 bg-popover text-popover-foreground shadow-(--e2) [clip-path:inset(-2rem_-2rem_0)]",
         "motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:duration-150",
         active === "inbox" && "flex flex-col",
       )}

--- a/src/web/src/components/community/shell/user-bar.test.ts
+++ b/src/web/src/components/community/shell/user-bar.test.ts
@@ -20,6 +20,8 @@ describe("UserBar", () => {
     expect(html).toContain("pr-[max(0.75rem,var(--app-safe-area-right))]")
     expect(html).toContain("pb-[calc(0.75rem+var(--app-safe-area-bottom))]")
     expect(html).toContain("sm:px-3 sm:pb-3")
+    expect(html).toContain("flex h-12 items-center gap-3 border border-border/40 bg-muted px-4")
+    expect(html).not.toContain("ring-1 ring-border/40")
     expect(html).toContain('class="flex min-w-0 flex-1 items-center gap-2"')
     expect(html).toContain('data-testid="community-user-bar-name"')
     expect(html).toContain('class="truncate text-sm font-medium leading-tight"')
@@ -54,6 +56,10 @@ describe("UserBar", () => {
     expect(html).toContain("pr-[max(0.75rem,var(--app-safe-area-right))]")
     expect(html).toContain("pb-[calc(0.75rem+var(--app-safe-area-bottom))]")
     expect(html).toContain("sm:px-3 sm:pb-3")
+    expect(html).toContain(
+      "flex h-12 items-center gap-3 rounded-xl border border-border/40 bg-muted px-4",
+    )
+    expect(html).not.toContain("ring-1 ring-border/40")
     expect(html).not.toContain("<button")
     expect(html).not.toContain("<a")
   })
@@ -65,7 +71,7 @@ describe("UserBar", () => {
       inboxOpen: true,
     }))
     expect(openHtml).toContain(
-      'class="flex h-12 items-center gap-3 bg-muted px-4 ring-1 ring-border/40 rounded-b-xl"',
+      'class="flex h-12 items-center gap-3 border border-border/40 bg-muted px-4 rounded-b-xl"',
     )
 
     const closedHtml = renderToStaticMarkup(createElement(UserBar, {
@@ -74,7 +80,7 @@ describe("UserBar", () => {
       inboxOpen: false,
     }))
     expect(closedHtml).toContain(
-      'class="flex h-12 items-center gap-3 bg-muted px-4 ring-1 ring-border/40 rounded-xl"',
+      'class="flex h-12 items-center gap-3 border border-border/40 bg-muted px-4 rounded-xl"',
     )
   })
 

--- a/src/web/src/components/community/shell/user-bar.tsx
+++ b/src/web/src/components/community/shell/user-bar.tsx
@@ -98,7 +98,7 @@ export function UserBar({ breakpoint, user, onOpenProfile, onEditProfile, inbox,
         ref={inboxAnchorRef}
         data-slot="community-user-bar-base"
         className={cn(
-          "flex h-12 items-center gap-3 bg-muted px-4 ring-1 ring-border/40",
+          "flex h-12 items-center gap-3 border border-border/40 bg-muted px-4",
           (extension && extension.active !== "none") || (breakpoint === "mobile" && inboxOpen)
             ? "rounded-b-xl"
             : "rounded-xl",
@@ -136,7 +136,7 @@ export function UserBarSkeleton() {
       aria-hidden
       className="w-full min-w-0 max-w-full shrink-0 overflow-hidden pl-[max(0.75rem,var(--app-safe-area-left))] pr-[max(0.75rem,var(--app-safe-area-right))] pb-[calc(0.75rem+var(--app-safe-area-bottom))] pt-0 sm:px-3 sm:pb-3"
     >
-      <div className="flex h-12 items-center gap-3 rounded-xl bg-muted px-4 ring-1 ring-border/40">
+      <div className="flex h-12 items-center gap-3 rounded-xl border border-border/40 bg-muted px-4">
         <Skeleton className="size-7 shrink-0 rounded-full" />
         <Skeleton className="h-3.5 min-w-0 flex-1 rounded" />
         <Skeleton className="size-7 shrink-0 rounded-lg" />

--- a/src/web/src/test/e2e-ui/41-community-initial-load-module-skeletons.spec.ts
+++ b/src/web/src/test/e2e-ui/41-community-initial-load-module-skeletons.spec.ts
@@ -18,6 +18,16 @@ type ColdRootProbe = {
   machinesSeen: boolean
 }
 
+type SkeletonGeometry = {
+  wrapper: { left: number; right: number; paddingLeft: number; paddingRight: number }
+  base: { left: number; right: number; width: number; height: number }
+  expectedColor: string
+  borders: Record<"top" | "right" | "bottom" | "left", {
+    width: string
+    color: string
+  }>
+}
+
 const coldRootStorageKey = `community:lastRoute:${encodeURIComponent(userId("alice"))}`
 
 async function installColdRootProbe(page: Page, destination: string | null) {
@@ -58,6 +68,69 @@ async function expectNoMachinesDuringColdRootRestore(page: Page) {
   expect(await page.evaluate(() => (
     window as typeof window & { __communityColdRootProbe?: ColdRootProbe }
   ).__communityColdRootProbe)).toEqual({ machinesSeen: false })
+}
+
+async function userBarSkeletonGeometry(page: Page): Promise<SkeletonGeometry> {
+  return page.getByTestId(tid.initialUserBarPending).evaluate((wrapper) => {
+    const base = wrapper.firstElementChild
+    if (!(base instanceof HTMLElement)) throw new Error("missing User Bar Skeleton base")
+    const wrapperRect = wrapper.getBoundingClientRect()
+    const wrapperStyle = getComputedStyle(wrapper)
+    const baseRect = base.getBoundingClientRect()
+    const baseStyle = getComputedStyle(base)
+    const reference = document.createElement("div")
+    reference.className = "border border-border/40"
+    reference.style.position = "fixed"
+    reference.style.visibility = "hidden"
+    document.body.appendChild(reference)
+    const expectedColor = getComputedStyle(reference).borderTopColor
+    reference.remove()
+    return {
+      wrapper: {
+        left: wrapperRect.left,
+        right: wrapperRect.right,
+        paddingLeft: Number.parseFloat(wrapperStyle.paddingLeft),
+        paddingRight: Number.parseFloat(wrapperStyle.paddingRight),
+      },
+      base: {
+        left: baseRect.left,
+        right: baseRect.right,
+        width: baseRect.width,
+        height: baseRect.height,
+      },
+      expectedColor,
+      borders: {
+        top: { width: baseStyle.borderTopWidth, color: baseStyle.borderTopColor },
+        right: { width: baseStyle.borderRightWidth, color: baseStyle.borderRightColor },
+        bottom: { width: baseStyle.borderBottomWidth, color: baseStyle.borderBottomColor },
+        left: { width: baseStyle.borderLeftWidth, color: baseStyle.borderLeftColor },
+      },
+    }
+  })
+}
+
+function expectUserBarSkeletonBorderContract(geometry: SkeletonGeometry) {
+  expect(geometry.base.height).toBe(48)
+  expect(Math.abs(
+    geometry.base.left - geometry.wrapper.left - geometry.wrapper.paddingLeft,
+  )).toBeLessThanOrEqual(1)
+  expect(Math.abs(
+    geometry.wrapper.right - geometry.wrapper.paddingRight - geometry.base.right,
+  )).toBeLessThanOrEqual(1)
+  expect(geometry.base.width).toBeCloseTo(
+    geometry.wrapper.right
+      - geometry.wrapper.left
+      - geometry.wrapper.paddingLeft
+      - geometry.wrapper.paddingRight,
+    0,
+  )
+  expect(geometry.expectedColor).not.toBe("rgba(0, 0, 0, 0)")
+  for (const side of ["top", "right", "bottom", "left"] as const) {
+    expect(geometry.borders[side]).toEqual({
+      width: "1px",
+      color: geometry.expectedColor,
+    })
+  }
 }
 
 async function holdSession(page: Page) {
@@ -221,6 +294,23 @@ test.describe.serial("community initial-load module skeletons", () => {
       await page.goto(pathname, { waitUntil: "commit" })
       await expect.poll(gate.hits).toBeGreaterThan(0)
       await expectOwnedFrame(page, expected, [serverName, channelName, privateMessage])
+      if (pathname === `/c/channels/${serverId}`) {
+        await page.evaluate(() => {
+          const style = document.documentElement.style
+          style.setProperty("--app-safe-area-top", "20px")
+          style.setProperty("--app-safe-area-right", "16px")
+          style.setProperty("--app-safe-area-bottom", "34px")
+          style.setProperty("--app-safe-area-left", "18px")
+        })
+        const geometry = await userBarSkeletonGeometry(page)
+        expectUserBarSkeletonBorderContract(geometry)
+        expect(geometry.base.left).toBe(18)
+        expect(geometry.base.right).toBe(390 - 16)
+        await testInfo.attach("user-bar-skeleton-mobile-390x844", {
+          body: await page.screenshot(),
+          contentType: "image/png",
+        })
+      }
       if (pathname === "/c") {
         await testInfo.attach("community-root-neutral-390x844", {
           body: await page.screenshot(),
@@ -254,6 +344,14 @@ test.describe.serial("community initial-load module skeletons", () => {
       await page.goto(pathname, { waitUntil: "commit" })
       await expect.poll(gate.hits).toBeGreaterThan(0)
       await expectOwnedFrame(page, expected, [serverName, channelName, privateMessage])
+      if (pathname === `/c/channels/${serverId}`) {
+        const geometry = await userBarSkeletonGeometry(page)
+        expectUserBarSkeletonBorderContract(geometry)
+        await testInfo.attach("user-bar-skeleton-desktop-1280x900", {
+          body: await page.screenshot(),
+          contentType: "image/png",
+        })
+      }
       if (pathname === "/c") {
         await testInfo.attach("community-root-neutral-1280x900", {
           body: await page.screenshot(),

--- a/src/web/src/test/e2e-ui/53-mobile-inbox-surface.spec.ts
+++ b/src/web/src/test/e2e-ui/53-mobile-inbox-surface.spec.ts
@@ -14,8 +14,13 @@ import { tid } from "./_fixtures/testids"
 
 type SurfaceGeometry = {
   viewport: { width: number; height: number }
-  userBar: { top: number; surfaceBottom: number; bottom: number; left: number; right: number }
-  card: { top: number; bottom: number; left: number; right: number; height: number }
+  userBar: { top: number; surfaceBottom: number; bottom: number; left: number; right: number; width: number }
+  card: { top: number; bottom: number; left: number; right: number; width: number; height: number }
+  borders: {
+    expectedColor: string
+    card: BorderGeometry
+    userBar: BorderGeometry
+  }
   seam: {
     cardTopLeft: string
     cardTopRight: string
@@ -29,6 +34,11 @@ type SurfaceGeometry = {
   userBarOwnsCenter: boolean
   rootScrollTop: number
 }
+
+type BorderGeometry = Record<"top" | "right" | "bottom" | "left", {
+  width: string
+  color: string
+}>
 
 async function removeServerChannels(serverId: string) {
   const headers = { Cookie: sessionCookie("alice"), Origin: WEB_URL }
@@ -53,13 +63,26 @@ async function surfaceGeometry(page: Page): Promise<SurfaceGeometry> {
       "[data-slot='community-user-bar-base']",
     ) ?? null
     if (!userBar || !userBarSurface) {
-      throw new Error("missing mobile Inbox geometry")
+      throw new Error("missing User Bar Extension geometry")
     }
     const wrapperRect = userBar.getBoundingClientRect()
     const userRect = userBarSurface.getBoundingClientRect()
     const cardRect = card.getBoundingClientRect()
     const cardStyle = getComputedStyle(card)
     const userBarStyle = getComputedStyle(userBarSurface)
+    const reference = document.createElement("div")
+    reference.className = "border border-border/40"
+    reference.style.position = "fixed"
+    reference.style.visibility = "hidden"
+    document.body.appendChild(reference)
+    const expectedColor = getComputedStyle(reference).borderTopColor
+    reference.remove()
+    const borders = (style: CSSStyleDeclaration) => ({
+      top: { width: style.borderTopWidth, color: style.borderTopColor },
+      right: { width: style.borderRightWidth, color: style.borderRightColor },
+      bottom: { width: style.borderBottomWidth, color: style.borderBottomColor },
+      left: { width: style.borderLeftWidth, color: style.borderLeftColor },
+    })
     const hit = document.elementFromPoint(
       userRect.left + userRect.width / 2,
       userRect.top + userRect.height / 2,
@@ -72,13 +95,20 @@ async function surfaceGeometry(page: Page): Promise<SurfaceGeometry> {
         bottom: wrapperRect.bottom,
         left: userRect.left,
         right: userRect.right,
+        width: userRect.width,
       },
       card: {
         top: cardRect.top,
         bottom: cardRect.bottom,
         left: cardRect.left,
         right: cardRect.right,
+        width: cardRect.width,
         height: cardRect.height,
+      },
+      borders: {
+        expectedColor,
+        card: borders(cardStyle),
+        userBar: borders(userBarStyle),
       },
       seam: {
         cardTopLeft: cardStyle.borderTopLeftRadius,
@@ -98,6 +128,28 @@ async function surfaceGeometry(page: Page): Promise<SurfaceGeometry> {
   })
 }
 
+function expectJoinedBorderContract(geometry: SurfaceGeometry) {
+  expect(Math.abs(geometry.card.left - geometry.userBar.left)).toBeLessThanOrEqual(1)
+  expect(Math.abs(geometry.card.right - geometry.userBar.right)).toBeLessThanOrEqual(1)
+  expect(Math.abs(geometry.card.width - geometry.userBar.width)).toBeLessThanOrEqual(1)
+  expect(geometry.borders.expectedColor).not.toBe("rgba(0, 0, 0, 0)")
+
+  for (const side of ["top", "right", "left"] as const) {
+    expect(geometry.borders.card[side]).toEqual({
+      width: "1px",
+      color: geometry.borders.expectedColor,
+    })
+  }
+  expect(geometry.borders.card.bottom.width).toBe("0px")
+  for (const side of ["top", "right", "bottom", "left"] as const) {
+    expect(geometry.borders.userBar[side]).toEqual({
+      width: "1px",
+      color: geometry.borders.expectedColor,
+    })
+  }
+  expect(Math.abs(geometry.card.bottom - geometry.userBar.top)).toBeLessThanOrEqual(1)
+}
+
 function observeWrites(page: Page) {
   const writes: string[] = []
   const listener = (request: Request) => {
@@ -112,7 +164,7 @@ function observeWrites(page: Page) {
 test.describe.serial("mobile Inbox interactive user-bar base", () => {
   test.setTimeout(180_000)
 
-  test("keeps the mobile shell unmasked and dismisses on outside press without writes", async ({ asUser }) => {
+  test("keeps the mobile shell unmasked and dismisses on outside press without writes", async ({ asUser }, testInfo) => {
     const stamp = Date.now()
     const serverId = await seedServer("alice", `Inbox surface ${stamp}`)
     const channelId = await seedChannel("alice", serverId, `inbox-${stamp}`)
@@ -197,7 +249,7 @@ test.describe.serial("mobile Inbox interactive user-bar base", () => {
       return Math.abs(current.card.bottom - current.userBar.top)
     }).toBeLessThanOrEqual(1)
     const geometry = await surfaceGeometry(bob.page)
-    expect(Math.abs(geometry.card.bottom - geometry.userBar.top)).toBeLessThanOrEqual(1)
+    expectJoinedBorderContract(geometry)
     expect(geometry.userBar.bottom).toBe(844)
     expect(geometry.userBar.surfaceBottom).toBe(844 - 34 - 12)
     expect(geometry.userBarOwnsCenter).toBe(true)
@@ -212,6 +264,10 @@ test.describe.serial("mobile Inbox interactive user-bar base", () => {
     expect(geometry.seam.userBarBottomLeft).not.toBe("0px")
     expect(geometry.seam.userBarBottomRight).not.toBe("0px")
     expect(geometry.rootScrollTop).toBe(0)
+    await testInfo.attach("user-bar-extension-mobile-390x844", {
+      body: await bob.page.screenshot(),
+      contentType: "image/png",
+    })
 
     const outsidePoint = {
       x: Math.floor(geometry.viewport.width / 2),
@@ -301,6 +357,7 @@ test.describe.serial("mobile Inbox interactive user-bar base", () => {
       return Math.abs(current.card.bottom - current.userBar.top)
     }).toBeLessThanOrEqual(1)
     const compact = await surfaceGeometry(bob.page)
+    expectJoinedBorderContract(compact)
     expect(compact.card.top).toBeGreaterThanOrEqual(20)
     expect(compact.card.left).toBe(18)
     expect(compact.card.right).toBe(320 - 16)
@@ -363,7 +420,7 @@ test.describe.serial("mobile Inbox interactive user-bar base", () => {
     }
   })
 
-  test("preserves Marked tab, scroll, and request ownership across 639↔640", async ({ asUser }) => {
+  test("preserves Marked tab, scroll, and request ownership across 639↔640", async ({ asUser }, testInfo) => {
     const stamp = Date.now()
     const serverId = await seedServer("alice", `Inbox continuity ${stamp}`)
     const channelId = await seedChannel("alice", serverId, `continuity-${stamp}`)
@@ -464,8 +521,13 @@ test.describe.serial("mobile Inbox interactive user-bar base", () => {
     const desktopBaseBox = await bob.page.locator("[data-slot='community-user-bar-base']").boundingBox()
     expect(desktopBaseBox).not.toBeNull()
     expect(Math.abs((desktopBox?.width ?? 0) - desktopBaseBox!.width)).toBeLessThanOrEqual(1)
+    expectJoinedBorderContract(await surfaceGeometry(bob.page))
     await expect(bob.page.getByTestId(tid.inboxMobileBackdrop)).toHaveCount(0)
     await expect(bob.page.getByRole("tab", { name: "Marked" })).toHaveAttribute("aria-selected", "true")
+    await testInfo.attach("user-bar-extension-desktop-1280x900", {
+      body: await bob.page.screenshot(),
+      contentType: "image/png",
+    })
 
     expect(inboxGets).toHaveLength(getsBeforeResize)
     expect(writes.writes).toEqual([])


### PR DESCRIPTION
# Why we need this PR?
> No linked GitHub issue.

The inbox extension and user bar rendered their shared edge with different primitives and opacity, which made the joined surface seam inconsistent across live and loading states.

## What changed
- Give the extension real 1px left, right, and top borders using `border-border/40`, with no bottom border.
- Give the live user bar and Skeleton matching 1px borders on all four sides so the user bar top edge is the only seam.
- Preserve widths, 48px heights, insets, padding, safe-area behavior, radii, Composer alignment, and interaction semantics.
- Add DOM and Playwright regressions for mobile and desktop geometry, per-side widths/colors, the unique seam, Skeleton, and Composer alignment; targeted suites pass (25 focused tests and 10 targeted UI tests).
- Full typecheck, lint, unit tests, typegreps, knip, and build pass locally. The full UI suite stops at the pre-existing realtime typing-indicator readiness failure in `03-realtime-multiuser.spec.ts`; the same isolated test fails identically on clean `origin/main` at `3f52ab7ffd972bd5902af851c7ed24dc094fc849`.
- Hosted attempt 1 hit the unchanged `55-message-scroll-characterization.spec.ts` async virtualizer path (`resize-2-shrunk away`, `scrollTop` delta 22). Exact-head single/pair runs and a same-build ring↔border counterfactual showed identical User Bar/AppSurface/scroller/Composer rectangles and isolated the variance to virtual-row measurement; failed-job attempt 2 then passed all UI shards and UI E2E Gate without source or test changes.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...
