### PR TITLE
fix(web): stabilize mobile channel list switches

### DIFF
--- a/src/web/src/app/c/channels/[serverId]/page.dom.test.ts
+++ b/src/web/src/app/c/channels/[serverId]/page.dom.test.ts
@@ -61,7 +61,7 @@ describe("ServerDefaultPage checkpoint route contract", () => {
     expect(mocks.replace).not.toHaveBeenCalled()
     expect(screen.getByRole("main", { name: "Loading server" })).toHaveAttribute("aria-busy", "true")
     expect(screen.getByRole("main", { name: "Loading server" }))
-      .toHaveAttribute("data-community-mobile-transition", "suppress")
+      .not.toHaveAttribute("data-community-mobile-transition")
     expect(rendered.container.querySelectorAll("header, button, form, textarea")).toHaveLength(0)
 
     mocks.server.current = { categories: [{ channels: [{ id: "channel_ready" }] }] }

--- a/src/web/src/app/c/channels/layout.route-memory.dom.test.ts
+++ b/src/web/src/app/c/channels/layout.route-memory.dom.test.ts
@@ -72,6 +72,7 @@ vi.mock("@/hooks/community/use-servers", () => ({
 vi.mock("@/hooks/community/use-structural-snapshot", () => ({
   useStructuralSnapshot: () => null,
   structuralHintServer: () => null,
+  hasStructuralServerTree: () => false,
 }))
 vi.mock("@/hooks/community/use-server-members", () => ({
   useServerMembers: () => ({

--- a/src/web/src/app/c/channels/layout.tsx
+++ b/src/web/src/app/c/channels/layout.tsx
@@ -6,7 +6,6 @@ import { toast } from "sonner"
 import { toastApiError } from "@/lib/api/client"
 import { markSwitch } from "@/lib/perf/switch-mark"
 import { Dialog, DialogContent } from "@/components/ui/dialog"
-import { useChannelTree } from "@/components/community/channels/use-channel-tree"
 import { ShellFrame } from "@/components/community/shell/shell-frame"
 import {
   channelHref,
@@ -14,7 +13,7 @@ import {
   serverRootHref,
 } from "@/lib/community/community-route"
 import { useBreakpoint } from "@/hooks/use-mobile"
-import { ChannelSidebar } from "@/components/community/channels/channel-sidebar"
+import { ChannelSidebarScope } from "@/components/community/channels/channel-sidebar-tree-owner"
 import { ChannelRoute } from "@/components/community/channels/channel-route"
 import { ServerSettings } from "@/components/community/settings/server-settings"
 import { ImageCropDialog } from "@/components/community/image-crop-dialog"
@@ -65,6 +64,7 @@ import {
   useRevokeInvite,
 } from "@/hooks/community/mutations"
 import {
+  hasStructuralServerTree,
   structuralHintServer,
   useStructuralSnapshot,
 } from "@/hooks/community/use-structural-snapshot"
@@ -92,11 +92,12 @@ export default function ServerLayout({ children }: { children: ReactNode }) {
     [serverId, structuralSnapshot],
   )
   const { server: currentServer } = useServer(serverId)
+  const structuralTreeReady = hasStructuralServerTree(structuralServer)
   const sidebarCategories = useMemo(
-    () => currentServer?.categories ?? structuralServer?.categoriesView ?? [],
-    [currentServer, structuralServer],
+    () => currentServer?.categories ?? (structuralTreeReady ? structuralServer?.categoriesView : undefined) ?? [],
+    [currentServer, structuralServer, structuralTreeReady],
   )
-  const sidebarHintOnly = !currentServer && !!structuralServer
+  const sidebarHintOnly = !currentServer && structuralTreeReady
   const membersHook = useServerMembers(currentServer ? serverId : null)
   const profilesByUserId = useCommunityWsStore((s) => s.profilesByUserId)
   const enrichedMembers = useMemo(
@@ -292,7 +293,8 @@ export default function ServerLayout({ children }: { children: ReactNode }) {
         : { ...channel, unread: forumSidebar.parentUnread[channel.id] },
     ),
   })), [forumSidebar.parentUnread, sidebarCategories])
-  const channelTree = useChannelTree(categories)
+  const sidebarDataReady = Boolean(currentServer) || structuralTreeReady
+  const channelTreeScopeKey = `server:${serverId}`
 
   const setActiveChannel = useCallback((id: string) => {
     // Only navigate — do NOT eagerly set the store's currentChannelId here.
@@ -387,7 +389,6 @@ export default function ServerLayout({ children }: { children: ReactNode }) {
   }, [])
 
   const channelProps = useMemo(() => ({
-    tree: channelTree,
     serverName: currentServer?.name ?? structuralServer?.name ?? "",
     serverIcon: currentServer?.icon ?? structuralServer?.icon ?? null,
     official: currentServer?.official ?? false,
@@ -418,7 +419,7 @@ export default function ServerLayout({ children }: { children: ReactNode }) {
     invitePopoverOpen,
     onInvitePopoverOpenChange: sidebarHintOnly ? undefined : setInvitePopoverOpen,
   }), [
-    channelTree, currentServer, structuralServer, sidebarHintOnly, currentChannelMeta?.parentChannelId,
+    currentServer, structuralServer, sidebarHintOnly, currentChannelMeta?.parentChannelId,
     currentChannelId, isAdmin, currentUser.id, setActiveChannel, prefetchChannel,
     forumThreadsByParent, forumSidebar.isLoading, activeForumThreadId, setActiveForumThread,
     onSidebarOpenSettings, onBlockedCreate, mutedChannels,
@@ -437,8 +438,14 @@ export default function ServerLayout({ children }: { children: ReactNode }) {
   const closeSettings = () => { setServerSettingsOpen(false); setSettingsSection("overview") }
 
   const sidebar = useCallback((opts: { noHeader?: boolean } = {}) => (
-    <ChannelSidebar {...channelProps} {...opts} />
-  ), [channelProps])
+    <ChannelSidebarScope
+      scopeKey={channelTreeScopeKey}
+      categories={sidebarDataReady ? categories : null}
+      targetServerId={serverId}
+      {...channelProps}
+      {...opts}
+    />
+  ), [categories, channelProps, channelTreeScopeKey, serverId, sidebarDataReady])
 
   const serverSettingsDialog = (
     <Dialog open={serverSettingsOpen && !!currentServer && isAdmin} onOpenChange={(o) => { if (!o) closeSettings() }}>

--- a/src/web/src/components/community/channels/channel-loading-frame.test.ts
+++ b/src/web/src/components/community/channels/channel-loading-frame.test.ts
@@ -12,7 +12,7 @@ describe("ChannelLoadingFrame", () => {
     expect(markup.match(/data-slot="skeleton"/g)).toHaveLength(1)
     expect(markup).toContain('aria-busy="true"')
     expect(markup).toContain('aria-label="Loading conversation"')
-    expect(markup).toContain('data-community-mobile-transition="suppress"')
+    expect(markup).not.toContain("data-community-mobile-transition")
     expect(markup).not.toMatch(/<(?:header|button|a|form|textarea)\b/)
     expect(markup).not.toMatch(/composer|message-list|channel-header/)
   })

--- a/src/web/src/components/community/channels/channel-loading-frame.tsx
+++ b/src/web/src/components/community/channels/channel-loading-frame.tsx
@@ -5,7 +5,6 @@ export function ChannelLoadingFrame() {
     <div
       aria-busy="true"
       aria-label="Loading conversation"
-      data-community-mobile-transition="suppress"
       className="flex min-h-0 min-w-0 flex-1 flex-col"
     >
       <UnresolvedMainSkeleton />

--- a/src/web/src/components/community/channels/channel-sidebar-tree-owner.dom.test.tsx
+++ b/src/web/src/components/community/channels/channel-sidebar-tree-owner.dom.test.tsx
@@ -1,0 +1,83 @@
+import { createElement } from "react"
+import { describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen } from "@/test/react-dom-harness"
+import type { Category } from "@/lib/community/models/navigation"
+import { tid } from "@/lib/community/testids"
+import { ChannelSidebarScope } from "./channel-sidebar-tree-owner"
+
+const targetCategories: Category[] = [{
+  id: "target-category",
+  name: "Target category",
+  channels: [
+    { id: "target-one", name: "target-one", active: true, unread: false },
+  ],
+}]
+
+function scopeProps(categories: Category[] | null, loading = false) {
+  return {
+    categories,
+    scopeKey: "server:target",
+    targetServerId: "target",
+    serverId: "target",
+    serverName: "Target",
+    activeChannel: "target-one",
+    setActiveChannel: vi.fn(),
+    isAdmin: false,
+    currentUserId: "viewer",
+    loading,
+  }
+}
+
+describe("ChannelSidebarScope", () => {
+  it("does not mount the tree owner until target data exists", () => {
+    const rendered = render(createElement(ChannelSidebarScope, scopeProps(null)))
+
+    expect(screen.getByTestId(tid.channelSidebarPending("target"))).toBeInTheDocument()
+    expect(rendered.container.querySelector("[data-community-channel-tree-scope]"))
+      .not.toBeInTheDocument()
+    expect(rendered.container.querySelector(`[data-testid="${tid.channelRow("target-one")}"]`))
+      .not.toBeInTheDocument()
+
+    rendered.rerender(createElement(ChannelSidebarScope, scopeProps(targetCategories)))
+
+    expect(screen.queryByTestId(tid.channelSidebarPending("target"))).not.toBeInTheDocument()
+    expect(rendered.container.querySelector("[data-community-channel-tree-scope]"))
+      .toHaveAttribute("data-community-channel-tree-scope", "server:target")
+    expect(screen.getByTestId(tid.channelRow("target-one"))).toBeInTheDocument()
+    expect(rendered.container.textContent).not.toContain("source-one")
+  })
+
+  it("keeps the same owner and collapsed state through inner forum loading", () => {
+    const rendered = render(createElement(ChannelSidebarScope, scopeProps(targetCategories)))
+    const owner = rendered.container.querySelector("[data-community-channel-tree-scope]")!
+
+    fireEvent.click(screen.getByText("Target category"))
+    expect(screen.queryByTestId(tid.channelRow("target-one"))).not.toBeInTheDocument()
+
+    rendered.rerender(createElement(ChannelSidebarScope, scopeProps(targetCategories, true)))
+    expect(rendered.container.querySelector("[data-community-channel-tree-scope]")).toBe(owner)
+    expect(rendered.container.querySelector('[data-slot="skeleton"]')).toBeInTheDocument()
+
+    rendered.rerender(createElement(ChannelSidebarScope, scopeProps(targetCategories, false)))
+    expect(rendered.container.querySelector("[data-community-channel-tree-scope]")).toBe(owner)
+    expect(screen.queryByTestId(tid.channelRow("target-one"))).not.toBeInTheDocument()
+  })
+
+  it("reconciles structural data to full data without replacing the scoped owner", () => {
+    const rendered = render(createElement(ChannelSidebarScope, scopeProps(targetCategories)))
+    const owner = rendered.container.querySelector("[data-community-channel-tree-scope]")!
+    const fullCategories: Category[] = [{
+      ...targetCategories[0],
+      channels: [
+        ...targetCategories[0].channels,
+        { id: "target-two", name: "target-two", active: false, unread: false },
+      ],
+    }]
+
+    rendered.rerender(createElement(ChannelSidebarScope, scopeProps(fullCategories)))
+
+    expect(rendered.container.querySelector("[data-community-channel-tree-scope]")).toBe(owner)
+    expect(screen.getByTestId(tid.channelRow("target-one"))).toBeInTheDocument()
+    expect(screen.getByTestId(tid.channelRow("target-two"))).toBeInTheDocument()
+  })
+})

--- a/src/web/src/components/community/channels/channel-sidebar-tree-owner.tsx
+++ b/src/web/src/components/community/channels/channel-sidebar-tree-owner.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import type { Category } from "@/lib/community/models/navigation"
+import {
+  ChannelSidebar,
+  ChannelSidebarSkeleton,
+  type ChannelSidebarProps,
+} from "./channel-sidebar"
+import { useChannelTree } from "./use-channel-tree"
+
+export type ChannelSidebarTreeOwnerProps = Omit<ChannelSidebarProps, "tree"> & {
+  categories: Category[]
+  scopeKey: string
+}
+
+export type ChannelSidebarScopeProps = Omit<ChannelSidebarTreeOwnerProps, "categories"> & {
+  categories: Category[] | null
+  targetServerId: string
+}
+
+/** Keeps the cold readiness gate outside the state-owning tree component. */
+export function ChannelSidebarScope({
+  categories,
+  scopeKey,
+  targetServerId,
+  ...sidebarProps
+}: ChannelSidebarScopeProps) {
+  if (!categories) {
+    return (
+      <ChannelSidebarSkeleton
+        noHeader={sidebarProps.noHeader}
+        showInviteAction={Boolean(
+          sidebarProps.serverId && sidebarProps.onInvitePopoverOpenChange,
+        )}
+        targetServerId={targetServerId}
+      />
+    )
+  }
+
+  return (
+    <ChannelSidebarTreeOwner
+      key={scopeKey}
+      categories={categories}
+      scopeKey={scopeKey}
+      {...sidebarProps}
+    />
+  )
+}
+
+/** Owns all local Channel Tree state for exactly one explicit dataset scope. */
+export function ChannelSidebarTreeOwner({
+  categories,
+  scopeKey,
+  ...sidebarProps
+}: ChannelSidebarTreeOwnerProps) {
+  const tree = useChannelTree(categories)
+
+  return (
+    <div
+      className="contents"
+      data-community-channel-tree-scope={scopeKey}
+    >
+      <ChannelSidebar {...sidebarProps} tree={tree} />
+    </div>
+  )
+}

--- a/src/web/src/components/community/channels/channel-sidebar.tsx
+++ b/src/web/src/components/community/channels/channel-sidebar.tsx
@@ -53,15 +53,7 @@ const channelSidebarCollisionDetection: CollisionDetection = (args) => {
 // useChannelTree. The category gear/right-click opens settings; "+" (or empty-space
 // right-click) creates; channels right-click to edit/delete. A private category only
 // lets admins create channels — non-admins are blocked via onBlockedCreate.
-export const ChannelSidebar = memo(function ChannelSidebar({
-  tree, serverName, official, activeChannel, setActiveChannel, prefetchChannel, noHeader, onOpenSettings,
-  isAdmin = true, currentUserId, onBlockedCreate, mutedChannels, loading,
-  onCreateChannel, onCreateCategory, onDeleteChannel, onDeleteCategory,
-  onUpdateCategory, onRenameChannel, onReorderCategories, onReorderChannels,
-  onMoveChannel, onBlockedMove,
-  serverId, invitePopoverOpen, onInvitePopoverOpenChange,
-  forumThreadsByParent = {}, activeThreadId, onSelectForumThread,
-}: {
+export type ChannelSidebarProps = {
   tree: ChannelTree
   serverName: string
   official?: boolean
@@ -92,7 +84,17 @@ export const ChannelSidebar = memo(function ChannelSidebar({
   forumThreadsByParent?: Record<string, ForumSidebarThread[]>
   activeThreadId?: string | null
   onSelectForumThread?: (parentId: string, id: string) => void
-}) {
+}
+
+export const ChannelSidebar = memo(function ChannelSidebar({
+  tree, serverName, official, activeChannel, setActiveChannel, prefetchChannel, noHeader, onOpenSettings,
+  isAdmin = true, currentUserId, onBlockedCreate, mutedChannels, loading,
+  onCreateChannel, onCreateCategory, onDeleteChannel, onDeleteCategory,
+  onUpdateCategory, onRenameChannel, onReorderCategories, onReorderChannels,
+  onMoveChannel, onBlockedMove,
+  serverId, invitePopoverOpen, onInvitePopoverOpenChange,
+  forumThreadsByParent = {}, activeThreadId, onSelectForumThread,
+}: ChannelSidebarProps) {
   const { collapsed, catOrder, order, catNames, catPrivate, catPending, toggleCat, removeChannel, renameCategory, onDragOver, onDragEnd: treeDragEnd } = tree
   // Category the dragged channel started in — captured at drag start, because
   // `onDragOver` mutates `order` mid-drag so by drop time it already reflects

--- a/src/web/src/components/community/channels/conversation-resolution-pending-frame.test.ts
+++ b/src/web/src/components/community/channels/conversation-resolution-pending-frame.test.ts
@@ -17,7 +17,7 @@ describe("ConversationResolutionPendingFrame", () => {
     expect(markup).toContain('aria-busy="true"')
     expect(markup).toContain('aria-label="Resolving conversation"')
     expect(markup).toContain('data-community-conversation-subtype="unknown"')
-    expect(markup).toContain('data-community-mobile-transition="suppress"')
+    expect(markup).not.toContain("data-community-mobile-transition")
     expect(markup).toContain('<span class="sr-only">Resolving conversation</span>')
     expect(markup).not.toMatch(/<(?:header|button|a|form|textarea)\b/)
     expect(markup).not.toMatch(/Message|Forum|Thread|composer|previous channel/i)

--- a/src/web/src/components/community/channels/conversation-resolution-pending-frame.tsx
+++ b/src/web/src/components/community/channels/conversation-resolution-pending-frame.tsx
@@ -7,7 +7,6 @@ export function ConversationResolutionPendingFrame() {
       aria-busy="true"
       aria-label="Resolving conversation"
       data-community-conversation-subtype="unknown"
-      data-community-mobile-transition="suppress"
       className="flex min-h-0 min-w-0 flex-1 flex-col"
     >
       <UnresolvedMainSkeleton />

--- a/src/web/src/components/community/channels/use-channel-tree.dom.test.ts
+++ b/src/web/src/components/community/channels/use-channel-tree.dom.test.ts
@@ -1,6 +1,6 @@
 import React from "react"
 import { act, render as rtlRender } from "@/test/react-dom-harness"
-import { describe, it, expect } from "vitest"
+import { describe, it, expect, vi } from "vitest"
 import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
 import {
@@ -23,6 +23,36 @@ type Tree = ReturnType<typeof useChannelTree>
 
 function CaptureTree({ categories, onResult }: { categories: Category[]; onResult: (tree: Tree) => void }) {
   onResult(useChannelTree(categories))
+  return null
+}
+
+let nextOwnerId = 0
+
+function ScopedCaptureTree({
+  scopeKey,
+  categories,
+  onResult,
+}: {
+  scopeKey: string
+  categories: Category[]
+  onResult: (tree: Tree, ownerId: number) => void
+}) {
+  return React.createElement(CaptureTreeOwner, {
+    key: scopeKey,
+    categories,
+    onResult,
+  })
+}
+
+function CaptureTreeOwner({
+  categories,
+  onResult,
+}: {
+  categories: Category[]
+  onResult: (tree: Tree, ownerId: number) => void
+}) {
+  const [ownerId] = React.useState(() => ++nextOwnerId)
+  onResult(useChannelTree(categories), ownerId)
   return null
 }
 
@@ -173,6 +203,112 @@ describe("useChannelTree opaque category drag callbacks", () => {
 
     expect(hook.current.order).toBe(beforeOrder)
     expect(hook.current.catOrder).toBe(beforeCatOrder)
+  })
+})
+
+describe("useChannelTree scope ownership", () => {
+  const categoriesA: Category[] = [
+    {
+      id: "cat_A",
+      name: "Alpha",
+      private: true,
+      pending: true,
+      creatorId: "owner_A",
+      channels: [ch("a1"), { ...ch("tmp_A"), pending: true }],
+    },
+    category("cat_A2", [ch("a2")]),
+  ]
+  const categoriesB: Category[] = [
+    {
+      id: "cat_B",
+      name: "Beta",
+      private: false,
+      pending: false,
+      creatorId: "owner_B",
+      channels: [ch("b1"), ch("b2")],
+    },
+  ]
+
+  it("preserves the seven state groups and callback owner under one stable key", async () => {
+    nextOwnerId = 0
+    let current!: Tree
+    let ownerId = 0
+    const onResult = (tree: Tree, id: number) => {
+      current = tree
+      ownerId = id
+    }
+    const renderer = rtlRender(React.createElement(ScopedCaptureTree, {
+      scopeKey: "server:A",
+      categories: categoriesA,
+      onResult,
+    }))
+    const initialOwnerId = ownerId
+    const initialToggle = current.toggleCat
+
+    await act(async () => current.toggleCat("cat_A"))
+    await act(async () => current.onDragOver(dragEvent("a2", "a1")))
+    const movedOrder = current.order
+
+    renderer.rerender(React.createElement(ScopedCaptureTree, {
+      scopeKey: "server:A",
+      categories: categoriesA,
+      onResult,
+    }))
+
+    expect(ownerId).toBe(initialOwnerId)
+    expect(current.collapsed).toEqual(new Set(["cat_A"]))
+    expect(current.order).toBe(movedOrder)
+    expect(current.catOrder).toEqual(["cat_A", "cat_A2"])
+    expect(current.catNames).toMatchObject({ cat_A: "Alpha", cat_A2: "cat_A2" })
+    expect(current.catPrivate.cat_A).toBe(true)
+    expect(current.catPending.cat_A).toBe(true)
+    expect(current.catCreators.cat_A).toBe("owner_A")
+    expect(current.toggleCat).toBe(initialToggle)
+  })
+
+  it("initializes the first render of a new key atomically from only that scope", async () => {
+    nextOwnerId = 0
+    const samples: Array<{ tree: Tree; ownerId: number }> = []
+    const onResult = (tree: Tree, ownerId: number) => samples.push({ tree, ownerId })
+    const renderer = rtlRender(React.createElement(ScopedCaptureTree, {
+      scopeKey: "server:A",
+      categories: categoriesA,
+      onResult,
+    }))
+
+    const current = samples.at(-1)!.tree
+    await act(async () => current.toggleCat("cat_A"))
+    await act(async () => current.onDragOver(dragEvent("a2", "a1")))
+    const ownerA = samples.at(-1)!.ownerId
+    samples.length = 0
+
+    renderer.rerender(React.createElement(ScopedCaptureTree, {
+      scopeKey: "server:B",
+      categories: categoriesB,
+      onResult,
+    }))
+
+    const firstB = samples[0]
+    expect(firstB.ownerId).not.toBe(ownerA)
+    expect(firstB.tree.collapsed).toEqual(new Set())
+    expect(firstB.tree.catOrder).toEqual(["cat_B"])
+    expect(Object.keys(firstB.tree.order)).toEqual(["cat_B"])
+    expect(firstB.tree.order.cat_B.map((channel) => channel.id)).toEqual(["b1", "b2"])
+    expect(firstB.tree.catNames).toEqual({ cat_B: "Beta" })
+    expect(firstB.tree.catPrivate).toEqual({ cat_B: false })
+    expect(firstB.tree.catPending).toEqual({ cat_B: false })
+    expect(firstB.tree.catCreators).toEqual({ cat_B: "owner_B" })
+    expect(JSON.stringify(firstB.tree)).not.toContain("tmp_A")
+
+    samples.length = 0
+    renderer.rerender(React.createElement(ScopedCaptureTree, {
+      scopeKey: "server:A",
+      categories: categoriesA,
+      onResult,
+    }))
+    expect(samples[0].ownerId).not.toBe(firstB.ownerId)
+    expect(samples[0].tree.collapsed).toEqual(new Set())
+    expect(samples[0].tree.order.cat_A.map((channel) => channel.id)).toEqual(["a1", "tmp_A"])
   })
 })
 

--- a/src/web/src/components/community/shell/community-pending-frame.dom.test.ts
+++ b/src/web/src/components/community/shell/community-pending-frame.dom.test.ts
@@ -44,11 +44,11 @@ function renderFrame(href: string, reserveBackSlot = true) {
 }
 
 describe("CommunityPendingFrame", () => {
-  it("suppresses the outer mobile transition for every route-pending frame", () => {
+  it("does not expose a route-surface transition protocol", () => {
     for (const href of ["/c/me", "/c/me/dm_1", "/c/me/machines", "/c/channels/s1", "/c/channels/s1/c1"]) {
       const rendered = renderFrame(href)
-      expect(rendered.container.querySelector('[data-community-mobile-transition="suppress"]'))
-        .toBeInTheDocument()
+      expect(rendered.container.querySelector("[data-community-mobile-transition]"))
+        .not.toBeInTheDocument()
       rendered.unmount()
     }
   })
@@ -64,7 +64,7 @@ describe("CommunityPendingFrame", () => {
     const rendered = renderFrame(href)
     expect(screen.getByLabelText(label)).toHaveAttribute("aria-busy", "true")
     expect(rendered.container.querySelector(`[data-community-main-kind="${kind}"]`))
-      .toHaveAttribute("data-community-mobile-transition", "suppress")
+      .toBeInTheDocument()
     expect(rendered.container.querySelectorAll("header, button, a, form, textarea")).toHaveLength(0)
   })
 

--- a/src/web/src/components/community/shell/community-pending-frame.tsx
+++ b/src/web/src/components/community/shell/community-pending-frame.tsx
@@ -88,7 +88,6 @@ export function CommunityPendingFrame({
     <div
       data-testid={tid.pendingMain(plan.main.kind)}
       data-community-main-kind={plan.main.kind}
-      data-community-mobile-transition="suppress"
       className="flex min-h-0 min-w-0 flex-1 flex-col"
     >
       {content}

--- a/src/web/src/components/community/shell/community-shell-layout.tsx
+++ b/src/web/src/components/community/shell/community-shell-layout.tsx
@@ -2,8 +2,6 @@
 
 import {
   useCallback,
-  useEffect,
-  useLayoutEffect,
   useRef,
   type CSSProperties,
   type ReactNode,
@@ -31,8 +29,6 @@ import { Shell } from "./shell"
 import { useHydratedClient } from "./use-hydrated-client"
 
 const SHELL_SURFACE_CLASS = "rounded-tl-xl rounded-tr-none rounded-br-none rounded-bl-none ring-0 border-l border-t border-border/40 shadow-none"
-const MOBILE_SURFACE_TRANSITION_MS = 180
-const MOBILE_TRANSITION_SUPPRESSION_SELECTOR = '[data-community-mobile-transition="suppress"]'
 const communityLayoutStorage: Pick<Storage, "getItem" | "setItem"> = {
   getItem: (key) => typeof localStorage === "undefined" ? null : localStorage.getItem(key),
   setItem: (key, value) => {
@@ -49,10 +45,6 @@ type CommunityShellLayoutProps = {
   userBar: ReactNode
   overlays?: ReactNode
   onNavigationIntent?: () => void
-  transition?: {
-    mode: string
-    targetHref: string
-  }
   busy?: boolean
   label?: string
   routeKind?: string
@@ -70,7 +62,6 @@ export function CommunityShellLayout({
   userBar,
   overlays,
   onNavigationIntent,
-  transition,
   busy,
   label,
   routeKind,
@@ -84,15 +75,7 @@ export function CommunityShellLayout({
   })
   const hydratedClient = useHydratedClient()
   const sidebarPanelRef = useRef<HTMLDivElement>(null)
-  const mainPanelRef = useRef<HTMLDivElement>(null)
   const userBarOverlayRef = useRef<HTMLDivElement>(null)
-  const previousCommittedHrefRef = useRef<string | null>(null)
-  const pendingTransitionRef = useRef<{
-    sourceHref: string | null
-    targetHref: string
-  } | null>(null)
-  const canceledTransitionTargetsRef = useRef(new Set<string>())
-  const mobileSurfaceAnimationRef = useRef<Animation | null>(null)
   const syncDesktopUserBarWidth = useCallback((size: PanelSize) => {
     const measuredSidebarWidth = sidebarPanelRef.current?.getBoundingClientRect().width
     const sidebarWidth = measuredSidebarWidth && measuredSidebarWidth > 0
@@ -114,64 +97,6 @@ export function CommunityShellLayout({
   const mainMobileActive = isMobileDetail || isInitialDetail
   const mainMobileHidden = isMobileList || (isInitial && surface === "list")
   const showUserBar = isDesktop || isMobileList || isInitial || preserveHiddenMobileModules
-  const transitionMode = transition?.mode
-  const transitionTargetHref = transition?.targetHref
-
-  useLayoutEffect(() => {
-    if (!transitionTargetHref) return
-    if (transitionMode !== "committed") {
-      mobileSurfaceAnimationRef.current?.cancel()
-      mobileSurfaceAnimationRef.current = null
-      const pendingTransition = pendingTransitionRef.current
-      if (pendingTransition && pendingTransition.targetHref !== transitionTargetHref) {
-        canceledTransitionTargetsRef.current.add(pendingTransition.targetHref)
-      }
-      canceledTransitionTargetsRef.current.delete(transitionTargetHref)
-      pendingTransitionRef.current = {
-        sourceHref: previousCommittedHrefRef.current,
-        targetHref: transitionTargetHref,
-      }
-      return
-    }
-    const previousHref = previousCommittedHrefRef.current
-    const pendingTransition = pendingTransitionRef.current
-    pendingTransitionRef.current = null
-    if (pendingTransition && pendingTransition.targetHref !== transitionTargetHref) {
-      canceledTransitionTargetsRef.current.add(pendingTransition.targetHref)
-    }
-    previousCommittedHrefRef.current = transitionTargetHref
-    if (canceledTransitionTargetsRef.current.delete(transitionTargetHref)) {
-      mobileSurfaceAnimationRef.current?.cancel()
-      mobileSurfaceAnimationRef.current = null
-      return
-    }
-    if (
-      breakpoint !== "mobile"
-      || !previousHref
-      || previousHref === transitionTargetHref
-      || globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches
-    ) return
-
-    const element = surface === "list" ? sidebarPanelRef.current : mainPanelRef.current
-    if (!element?.animate) return
-    if (element.querySelector?.(MOBILE_TRANSITION_SUPPRESSION_SELECTOR)) {
-      mobileSurfaceAnimationRef.current?.cancel()
-      mobileSurfaceAnimationRef.current = null
-      return
-    }
-    mobileSurfaceAnimationRef.current?.cancel()
-    mobileSurfaceAnimationRef.current = element.animate([
-      {
-        opacity: 0.92,
-        transform: `translate3d(${surface === "list" ? -8 : 8}px, 0, 0)`,
-      },
-      { opacity: 1, transform: "translate3d(0, 0, 0)" },
-    ], {
-      duration: MOBILE_SURFACE_TRANSITION_MS,
-      easing: "cubic-bezier(0.22, 1, 0.36, 1)",
-    })
-  }, [breakpoint, surface, transitionMode, transitionTargetHref])
-  useEffect(() => () => mobileSurfaceAnimationRef.current?.cancel(), [])
 
   const sidebarPercentage = hydratedClient
     ? defaultLayout?.sidebar ?? COMMUNITY_SIDEBAR_DEFAULT_PERCENTAGE
@@ -264,7 +189,6 @@ export function CommunityShellLayout({
               className="flex min-w-0 flex-col bg-background"
             >
               <div
-                ref={mainPanelRef}
                 data-community-mobile-surface={isMobileDetail ? "detail" : undefined}
                 className="flex min-h-0 flex-1 flex-col"
               >

--- a/src/web/src/components/community/shell/server-landing-pending-frame.tsx
+++ b/src/web/src/components/community/shell/server-landing-pending-frame.tsx
@@ -5,7 +5,6 @@ export function ServerLandingPendingFrame() {
     <main
       aria-busy="true"
       aria-label="Loading server"
-      data-community-mobile-transition="suppress"
       className="flex min-h-0 min-w-0 flex-1 flex-col"
     >
       <UnresolvedMainSkeleton />

--- a/src/web/src/components/community/shell/server-rail.pending.dom.test.ts
+++ b/src/web/src/components/community/shell/server-rail.pending.dom.test.ts
@@ -219,6 +219,56 @@ describe("ServerRail one-in-flight structural guard", () => {
     expect(homeIndicator()).not.toHaveClass("group-hover:h-5", "group-focus-within:h-5")
   })
 
+  it.each(["top-level", "folder"] as const)(
+    "keeps a retained %s Server activation on the latest settled navigation semantics",
+    async (placement) => {
+      const activationHrefs: string[] = []
+      const navigationAt = (publishedHref: string) => vi.fn((id: string) => {
+        const href = `/c/channels/${id}`
+        if (href === publishedHref) return
+        activationHrefs.push(href)
+      })
+      const activationServers = servers.slice(0, 2)
+      const activationFolders = placement === "folder" ? [{
+        id: "activation-folder",
+        name: "Activation folder",
+        position: 0,
+        servers: [{ id: "a" }],
+      }] : []
+      const element = (
+        activeServerId: string,
+        onServerNavigate: (id: string) => void,
+      ) => createElement(ServerRail, {
+        servers: activationServers,
+        folders: activationFolders,
+        activeServerId,
+        view: "server",
+        onHome: vi.fn(),
+        onServerNavigate,
+      })
+      const renderer = render(element("a", navigationAt("/c/channels/a")))
+      if (placement === "folder") {
+        await act(async () => (latestFolderProps("activation-folder").onToggle as () => void)())
+      }
+
+      const projectedNavigation = navigationAt("/c/channels/a")
+      renderer.rerender(element("b", projectedNavigation))
+      const retainedActivation = latestSortableProps("a").onClick as () => void
+
+      const settledNavigation = navigationAt("/c/channels/b")
+      renderer.rerender(element("b", settledNavigation))
+      await act(async () => {
+        retainedActivation() // trusted click
+        retainedActivation() // native Enter button activation
+      })
+
+      expect(projectedNavigation).not.toHaveBeenCalled()
+      expect(settledNavigation).toHaveBeenNthCalledWith(1, "a")
+      expect(settledNavigation).toHaveBeenNthCalledWith(2, "a")
+      expect(activationHrefs).toEqual(["/c/channels/a", "/c/channels/a"])
+    },
+  )
+
   it.each([
     ["empty", 0],
     ["one", 1],

--- a/src/web/src/components/community/shell/server-rail.tsx
+++ b/src/web/src/components/community/shell/server-rail.tsx
@@ -169,6 +169,7 @@ export const ServerRail = memo(function ServerRail({
   const scrollRef = useRef<HTMLDivElement>(null)
   const dragSnapshotRef = useRef<RailState | null>(null)
   const stateRef = useRef(state)
+  const serverActivationRef = useRef({ onServer, onServerNavigate })
   const mutationPendingRef = useRef(false)
   const collapsedPendingFolderIdsRef = useRef(new Set<string>())
   const railMutation = useServerRailCommit()
@@ -227,6 +228,10 @@ export const ServerRail = memo(function ServerRail({
     setStateDataIdentity(railDataIdentity)
   }, [folders, railDataIdentity, serverIds])
 
+  useLayoutEffect(() => {
+    serverActivationRef.current = { onServer, onServerNavigate }
+  }, [onServer, onServerNavigate])
+
   useEffect(() => {
     sessionStorage.setItem("rail-open-folders", JSON.stringify(state.expanded))
   }, [state.expanded])
@@ -237,11 +242,14 @@ export const ServerRail = memo(function ServerRail({
   const [localActiveId, setLocalActiveId] = useState(activeFromProps)
   const activeId = activeFromProps || localActiveId
   useEffect(() => { if (activeFromProps) setLocalActiveId(activeFromProps) }, [activeFromProps])
-  const pickServer = (id: string) => {
+  // SortableServer deliberately ignores callback identity to keep rail-wide
+  // presence/roster ticks cheap. Keep the dispatcher stable while reading the
+  // latest committed navigation semantics through a layout-synchronized ref.
+  const pickServer = useCallback((id: string) => {
     setLocalActiveId(id)
-    onServer?.()
-    onServerNavigate?.(id)
-  }
+    serverActivationRef.current.onServer?.()
+    serverActivationRef.current.onServerNavigate?.(id)
+  }, [])
 
   const serverById = useMemo(() => new Map(servers.map((server) => [server.id, server])), [servers])
   const serverNames = useMemo(

--- a/src/web/src/components/community/shell/shell-frame-view.dom.test.ts
+++ b/src/web/src/components/community/shell/shell-frame-view.dom.test.ts
@@ -1,4 +1,4 @@
-import { createElement, useEffect, useState, type ReactNode } from "react"
+import { createElement, useState, type ReactNode } from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { act, render } from "@/test/react-dom-harness"
 import { ShellFrameView } from "./shell-frame-view"
@@ -68,7 +68,6 @@ vi.mock("./community-pending-frame", () => ({
     mocks.pendingProps(props)
     return createElement("div", {
       "data-channel-loading-frame": "",
-      "data-community-mobile-transition": "suppress",
     })
   },
 }))
@@ -428,21 +427,13 @@ describe("ShellFrameView", () => {
     expect(detailMotion.className).toContain("flex")
   })
 
-  it("starts both committed mobile switch directions before passive effects and skips reduced motion", async () => {
-    const cancel = vi.fn()
-    const effectOrder: string[] = []
-    const animate = vi.fn(() => {
-      effectOrder.push("animate")
-      return { cancel }
-    })
+  it.each([false, true])("keeps every mobile route commit stationary when reduced motion is %s", async (reducedMotion) => {
+    const animate = vi.fn(() => ({ cancel: vi.fn() }))
     Object.defineProperty(HTMLElement.prototype, "animate", {
       configurable: true,
       value: animate,
     })
-    function PassiveFrameProbe({ href }: { href: string }) {
-      useEffect(() => { effectOrder.push(`passive:${href}`) }, [href])
-      return createElement("main-content")
-    }
+    vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: reducedMotion })))
     let sidebarMounts = 0
     function StatefulSidebar() {
       const [identity] = useState(() => ++sidebarMounts)
@@ -465,7 +456,7 @@ describe("ShellFrameView", () => {
     const renderer = render(createElement(
       ShellFrameView,
       { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c1", "detail") },
-      createElement(PassiveFrameProbe, { href: "/c/channels/s1/c1" }),
+      createElement("main-content", { "data-href": "/c/channels/s1/c1" }),
     ))
     expect(animate).not.toHaveBeenCalled()
     const sidebarPanel = renderer.container.querySelector<HTMLElement>('[data-testid="sidebar"]')!
@@ -476,22 +467,13 @@ describe("ShellFrameView", () => {
     const dndOwner = renderer.container.querySelector<HTMLElement>('[data-testid="sidebar-dnd-owner"]')!
     sidebarScroll.scrollTop = 37
     dndOwner.dataset.owner = "stable"
-    effectOrder.length = 0
 
     renderer.rerender(createElement(
       ShellFrameView,
       { ...common, checkpoint: committedCheckpoint("/c/channels/s1", "list") },
-      createElement(PassiveFrameProbe, { href: "/c/channels/s1" }),
+      createElement("main-content", { "data-href": "/c/channels/s1" }),
     ))
-    expect(animate).toHaveBeenCalledOnce()
-    expect(animate).toHaveBeenLastCalledWith([
-      { opacity: 0.92, transform: "translate3d(-8px, 0, 0)" },
-      { opacity: 1, transform: "translate3d(0, 0, 0)" },
-    ], {
-      duration: 180,
-      easing: "cubic-bezier(0.22, 1, 0.36, 1)",
-    })
-    expect(effectOrder).toEqual(["animate", "passive:/c/channels/s1"])
+    expect(animate).not.toHaveBeenCalled()
     expect(renderer.container.querySelector('[data-testid="sidebar"]')).toBe(sidebarPanel)
     expect(renderer.container.querySelector('[data-testid="main"]')).toBe(mainPanel)
     expect(renderer.container.querySelector('[data-testid="community-channel-sidebar-scroll"]'))
@@ -499,77 +481,6 @@ describe("ShellFrameView", () => {
     expect(renderer.container.querySelector('[data-testid="sidebar-dnd-owner"]')).toBe(dndOwner)
     expect(sidebarScroll.scrollTop).toBe(37)
     expect(dndOwner.dataset.owner).toBe("stable")
-
-    effectOrder.length = 0
-    renderer.rerender(createElement(
-      ShellFrameView,
-      { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c2", "detail") },
-      createElement(PassiveFrameProbe, { href: "/c/channels/s1/c2" }),
-    ))
-    expect(animate).toHaveBeenCalledTimes(2)
-    expect(animate).toHaveBeenLastCalledWith([
-      { opacity: 0.92, transform: "translate3d(8px, 0, 0)" },
-      { opacity: 1, transform: "translate3d(0, 0, 0)" },
-    ], {
-      duration: 180,
-      easing: "cubic-bezier(0.22, 1, 0.36, 1)",
-    })
-    expect(effectOrder).toEqual(["animate", "passive:/c/channels/s1/c2"])
-    expect(renderer.container.querySelector('[data-testid="sidebar"]')).toBe(sidebarPanel)
-    expect(renderer.container.querySelector('[data-testid="main"]')).toBe(mainPanel)
-    expect(renderer.container.querySelector('[data-testid="community-channel-sidebar-scroll"]'))
-      .toBe(sidebarScroll)
-    expect(renderer.container.querySelector('[data-testid="sidebar-dnd-owner"]')).toBe(dndOwner)
-    expect(sidebarScroll.scrollTop).toBe(37)
-    expect(dndOwner.dataset.owner).toBe("stable")
-    expect(sidebarMounts).toBe(1)
-
-    effectOrder.length = 0
-    renderer.rerender(createElement(
-      ShellFrameView,
-      { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c3", "detail") },
-      createElement(PassiveFrameProbe, { href: "/c/channels/s1/c3" }),
-    ))
-    expect(animate).toHaveBeenCalledTimes(3)
-    expect(animate).toHaveBeenLastCalledWith([
-      { opacity: 0.92, transform: "translate3d(8px, 0, 0)" },
-      { opacity: 1, transform: "translate3d(0, 0, 0)" },
-    ], {
-      duration: 180,
-      easing: "cubic-bezier(0.22, 1, 0.36, 1)",
-    })
-    expect(effectOrder).toEqual(["animate", "passive:/c/channels/s1/c3"])
-
-    vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: true })))
-    renderer.rerender(createElement(
-      ShellFrameView,
-      { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c4", "detail") },
-      createElement(PassiveFrameProbe, { href: "/c/channels/s1/c4" }),
-    ))
-    expect(animate).toHaveBeenCalledTimes(3)
-  })
-
-  it("animates successful pending commits and consumes canceled stale targets", async () => {
-    const cancel = vi.fn()
-    const animate = vi.fn(() => ({ cancel }))
-    Object.defineProperty(HTMLElement.prototype, "animate", {
-      configurable: true,
-      value: animate,
-    })
-    const common = {
-      ...extensionProps,
-      breakpoint: "mobile" as const,
-      sidebar: () => createElement("sidebar-content"),
-      cancelPendingNavigation: vi.fn(),
-      rail,
-      profile,
-      inbox,
-    }
-    const renderer = render(createElement(
-      ShellFrameView,
-      { ...common, checkpoint: committedCheckpoint("/c/channels/s1", "list") },
-      createElement("main-content"),
-    ))
 
     renderer.rerender(createElement(
       ShellFrameView,
@@ -587,54 +498,15 @@ describe("ShellFrameView", () => {
       createElement("main-content"),
     ))
     expect(animate).not.toHaveBeenCalled()
-    expect(renderer.container.querySelector('[data-community-mobile-transition="suppress"]'))
-      .not.toBeNull()
+    expect(renderer.container.querySelector("[data-channel-loading-frame]")).not.toBeNull()
+    expect(renderer.container.querySelector("[data-community-mobile-transition]")).toBeNull()
 
     renderer.rerender(createElement(
       ShellFrameView,
       { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c2", "detail") },
-      createElement("main-content"),
+      createElement("main-content", { "data-href": "/c/channels/s1/c2" }),
     ))
-    expect(animate).toHaveBeenCalledOnce()
-    expect(animate).toHaveBeenLastCalledWith([
-      { opacity: 0.92, transform: "translate3d(8px, 0, 0)" },
-      { opacity: 1, transform: "translate3d(0, 0, 0)" },
-    ], {
-      duration: 180,
-      easing: "cubic-bezier(0.22, 1, 0.36, 1)",
-    })
-
-    renderer.rerender(createElement(
-      ShellFrameView,
-      {
-        ...common,
-        checkpoint: {
-          mode: "same-scope-leaf",
-          surface: "list",
-          targetHref: "/c/channels/s1",
-          rail: { kind: "keep" },
-          sidebar: { kind: "keep" },
-          main: { kind: "keep" },
-        },
-      },
-      createElement("main-content"),
-    ))
-    expect(animate).toHaveBeenCalledOnce()
-
-    renderer.rerender(createElement(
-      ShellFrameView,
-      { ...common, checkpoint: committedCheckpoint("/c/channels/s1", "list") },
-      createElement("main-content"),
-    ))
-    expect(animate).toHaveBeenCalledTimes(2)
-    expect(animate).toHaveBeenLastCalledWith([
-      { opacity: 0.92, transform: "translate3d(-8px, 0, 0)" },
-      { opacity: 1, transform: "translate3d(0, 0, 0)" },
-    ], {
-      duration: 180,
-      easing: "cubic-bezier(0.22, 1, 0.36, 1)",
-    })
-
+    expect(animate).not.toHaveBeenCalled()
     renderer.rerender(createElement(
       ShellFrameView,
       {
@@ -650,57 +522,6 @@ describe("ShellFrameView", () => {
       },
       createElement("main-content"),
     ))
-    expect(animate).toHaveBeenCalledTimes(2)
-
-    renderer.rerender(createElement(
-      ShellFrameView,
-      { ...common, checkpoint: committedCheckpoint("/c/channels/s1", "list") },
-      createElement("main-content"),
-    ))
-    expect(animate).toHaveBeenCalledTimes(2)
-
-    renderer.rerender(createElement(
-      ShellFrameView,
-      { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c3", "detail") },
-      createElement("main-content"),
-    ))
-    expect(animate).toHaveBeenCalledTimes(2)
-
-    renderer.rerender(createElement(
-      ShellFrameView,
-      { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c3", "detail") },
-      createElement("main-content"),
-    ))
-    expect(animate).toHaveBeenCalledTimes(2)
-  })
-
-  it("consumes a committed mobile target whose content suppresses entry motion", async () => {
-    const cancel = vi.fn()
-    const animate = vi.fn(() => ({ cancel }))
-    Object.defineProperty(HTMLElement.prototype, "animate", {
-      configurable: true,
-      value: animate,
-    })
-    const common = {
-      ...extensionProps,
-      breakpoint: "mobile" as const,
-      sidebar: () => createElement("sidebar-content"),
-      cancelPendingNavigation: vi.fn(),
-      rail,
-      profile,
-      inbox,
-    }
-    const renderer = render(createElement(
-      ShellFrameView,
-      { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c1", "detail") },
-      createElement("main-content"),
-    ))
-
-    renderer.rerender(createElement(
-      ShellFrameView,
-      { ...common, checkpoint: committedCheckpoint("/c/channels/s1/c2", "detail") },
-      createElement("main-content", { "data-community-mobile-transition": "suppress" }),
-    ))
     expect(animate).not.toHaveBeenCalled()
 
     renderer.rerender(createElement(
@@ -709,6 +530,14 @@ describe("ShellFrameView", () => {
       createElement("main-content"),
     ))
     expect(animate).not.toHaveBeenCalled()
+    expect(renderer.container.querySelector('[data-testid="sidebar"]')).toBe(sidebarPanel)
+    expect(renderer.container.querySelector('[data-testid="main"]')).toBe(mainPanel)
+    expect(renderer.container.querySelector('[data-testid="community-channel-sidebar-scroll"]'))
+      .toBe(sidebarScroll)
+    expect(renderer.container.querySelector('[data-testid="sidebar-dnd-owner"]')).toBe(dndOwner)
+    expect(sidebarScroll.scrollTop).toBe(37)
+    expect(dndOwner.dataset.owner).toBe("stable")
+    expect(sidebarMounts).toBe(1)
   })
 
   it("preserves child component identity across the 639 to 640 breakpoint", async () => {

--- a/src/web/src/components/community/shell/shell-frame-view.tsx
+++ b/src/web/src/components/community/shell/shell-frame-view.tsx
@@ -88,7 +88,6 @@ export function ShellFrameView({
       breakpoint={breakpoint}
       surface={surface}
       onNavigationIntent={cancelPendingNavigation}
-      transition={{ mode: checkpoint.mode, targetHref: checkpoint.targetHref }}
       rail={<ServerRail {...rail.railProps} bottomInset={60} />}
       sidebar={checkpoint.sidebar.kind === "server-skeleton"
           ? <ChannelSidebarSkeleton targetServerId={checkpoint.sidebar.serverId} />

--- a/src/web/src/components/community/shell/shell-frame.dom.test.ts
+++ b/src/web/src/components/community/shell/shell-frame.dom.test.ts
@@ -83,6 +83,12 @@ vi.mock("@/contexts/community/current-user", () => ({
 }))
 vi.mock("@/hooks/community/use-structural-snapshot", () => ({
   useStructuralSnapshot: () => mocks.structuralSnapshot.current,
+  hasStructuralServerTree: (server: {
+    categories: unknown[]
+    channels: unknown[]
+  } | null | undefined) => Boolean(
+    server && (server.categories.length > 0 || server.channels.length > 0),
+  ),
 }))
 vi.mock("./use-shell-rail-controller", () => ({
   useShellRailController: (options: unknown) => {

--- a/src/web/src/components/community/shell/shell-frame.tsx
+++ b/src/web/src/components/community/shell/shell-frame.tsx
@@ -21,7 +21,10 @@ import { useShellProfileController } from "./use-shell-profile-controller"
 import { useShellInboxController } from "./use-shell-inbox-controller"
 import { useCommunityNavigationController } from "./use-community-navigation-controller"
 import type { ShellFrameProps } from "./shell-frame-types"
-import { useStructuralSnapshot } from "@/hooks/community/use-structural-snapshot"
+import {
+  hasStructuralServerTree,
+  useStructuralSnapshot,
+} from "@/hooks/community/use-structural-snapshot"
 import {
   initialUserBarExtensionState,
   userBarExtensionReducer,
@@ -75,8 +78,7 @@ export function ShellFrame(props: ShellFrameProps) {
       // `replaceServers` can seed a rail-only identity with an empty tree.
       // Only a snapshot containing actual tree structure can replace the
       // target-scoped cold checkpoint.
-      || Boolean(structuralTarget
-        && (structuralTarget.categories.length > 0 || structuralTarget.channels.length > 0))
+      || hasStructuralServerTree(structuralTarget)
     : target?.scope.kind === "me"
       ? queryClient.getQueryData(communityKeys.dms()) !== undefined
       : false

--- a/src/web/src/components/community/shell/sortable-server.focus.dom.test.ts
+++ b/src/web/src/components/community/shell/sortable-server.focus.dom.test.ts
@@ -2,7 +2,7 @@ import { createElement, Fragment, type ReactNode } from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { SortableServer } from "./sortable-server"
 import { tid } from "@/lib/community/testids"
-import { act, fireEvent, render } from "@/test/react-dom-harness"
+import { act, fireEvent, render, setupUser } from "@/test/react-dom-harness"
 
 vi.mock("@/components/ui/context-menu", () => ({
   ContextMenu: ({ children }: { children: ReactNode }) => createElement(Fragment, null, children),
@@ -122,6 +122,18 @@ describe("SortableServer stable menu trigger", () => {
 
     expect(active.button()).toHaveClass("cursor-default")
     expect(inactive.button()).toHaveClass("cursor-pointer")
+  })
+
+  it("dispatches both pointer click and Enter through the inactive Server action", async () => {
+    const onClick = vi.fn()
+    const result = renderServer(false, 0, false, { onClick })
+    const user = setupUser()
+
+    await user.click(result.button())
+    result.button().focus()
+    await user.keyboard("{Enter}")
+
+    expect(onClick).toHaveBeenCalledTimes(2)
   })
 
   it("stacks the numeric mention badge above the icon without changing its presentation", () => {

--- a/src/web/src/components/home/landing-shell-motion.render.test.ts
+++ b/src/web/src/components/home/landing-shell-motion.render.test.ts
@@ -1,7 +1,11 @@
 import { createElement } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 import { describe, expect, it, vi } from "vitest"
-import { LandingMobileChatMotion, LandingShellMotion } from "./landing-shell-motion"
+import {
+  LandingMobileChatMotion,
+  LandingShellMotion,
+  landingChannelTreeScopeKey,
+} from "./landing-shell-motion"
 import { SCENE_MAX_BEAT, type LandingScene } from "./landing-shell-motion-timeline"
 
 vi.mock("./landing-shell-motion.module.css", () => ({
@@ -25,6 +29,36 @@ function channelHeader(markup: string) {
 }
 
 describe("landing community preview rendering", () => {
+  it("uses explicit identities for every Channel Tree fixture dataset", () => {
+    expect(landingChannelTreeScopeKey({ scene: "server", room: null, overviewDetails: false }))
+      .toBe("landing:root:default")
+    expect(landingChannelTreeScopeKey({ scene: "server", room: null, overviewDetails: true }))
+      .toBe("landing:root:overview-work")
+    expect(landingChannelTreeScopeKey({ scene: "spaces", room: "life", overviewDetails: false }))
+      .toBe("landing:space:life")
+    expect(landingChannelTreeScopeKey({ scene: "continuity", room: "life", overviewDetails: false }))
+      .toBe("landing:continuity:life")
+  })
+
+  it.each([
+    ["server", 0, false, "landing:root:default", "general"],
+    ["server", 0, true, "landing:root:overview-work", "work-general"],
+    ["spaces", SCENE_MAX_BEAT.spaces, false, "landing:space:play", "play-lobby"],
+    ["continuity", SCENE_MAX_BEAT.continuity, false, "landing:continuity:life", "continuity-family"],
+  ] as const)(
+    "renders the first %s dataset frame from %s without rows from another scope",
+    (scene, beat, overviewDetails, scopeKey, rowId) => {
+      const markup = renderToStaticMarkup(createElement(LandingShellMotion, {
+        scene,
+        beat,
+        overviewDetails,
+      }))
+
+      expect(markup).toContain(`data-community-channel-tree-scope="${scopeKey}"`)
+      expect(markup).toContain(`data-testid="community-channel-row-${rowId}"`)
+    },
+  )
+
   it.each(ALL_SCENES)("renders the final %s scene without unresolved fixture identities", (scene) => {
     const markup = renderToStaticMarkup(createElement(LandingShellMotion, {
       scene,

--- a/src/web/src/components/home/landing-shell-motion.tsx
+++ b/src/web/src/components/home/landing-shell-motion.tsx
@@ -31,7 +31,7 @@ import { AppSurface } from "@/components/ui/app-surface"
 import { SheetBody, SheetFooter, SheetHeader } from "@/components/ui/sheet"
 import { Shell } from "@/components/community/shell/shell"
 import { ServerRail } from "@/components/community/shell/server-rail"
-import { ChannelSidebar } from "@/components/community/channels/channel-sidebar"
+import { ChannelSidebarTreeOwner } from "@/components/community/channels/channel-sidebar-tree-owner"
 import { DmSidebar } from "@/components/community/channels/dm-sidebar"
 import { DmHeader } from "@/components/community/channels/dm-header"
 import { ChannelHeader } from "@/components/community/channels/channel-header"
@@ -45,7 +45,6 @@ import { ConnectTile } from "@/components/community/onboarding-tiles/connect-til
 import { BotFormFields } from "@/components/community/bots/bot-form-fields"
 import { BotRuntimeFields } from "@/components/community/bots/bot-runtime-fields"
 import { UserBar } from "@/components/community/shell/user-bar"
-import { useChannelTree } from "@/components/community/channels/use-channel-tree"
 import type { Category, Server } from "@/lib/community/models/navigation"
 import type { CommunityProfile, DM } from "@/lib/community/models/people"
 import type { RenderMsg } from "@/lib/community/models/message"
@@ -849,6 +848,11 @@ function PrototypeShell({
     scene === "identity" ||
     continuityRoom !== null
   const room = scene === "spaces" || scene === "identity" ? snapshot.room : continuityRoom
+  const channelTreeScopeKey = landingChannelTreeScopeKey({
+    scene,
+    room,
+    overviewDetails,
+  })
   const servers = overviewDetails && scene === "server"
     ? OVERVIEW_SERVERS
     : scene === "continuity"
@@ -873,6 +877,7 @@ function PrototypeShell({
               {serverView ? (
                 <PrototypeChannelSidebar
                   room={room}
+                  treeScopeKey={channelTreeScopeKey}
                   channels={scene === "continuity" ? CONTINUITY_CHANNELS : SPACE_CHANNELS}
                   rootChannels={overviewDetails && scene === "server" ? SPACE_CHANNELS.work : CHANNELS}
                 />
@@ -906,6 +911,25 @@ function PrototypeShell({
       </div>
     </Shell>
   )
+}
+
+export function landingChannelTreeScopeKey({
+  scene,
+  room,
+  overviewDetails,
+}: {
+  scene: LandingScene
+  room: LandingRoom | null
+  overviewDetails: boolean
+}) {
+  if (room) {
+    return scene === "continuity"
+      ? `landing:continuity:${room}`
+      : `landing:space:${room}`
+  }
+  return overviewDetails && scene === "server"
+    ? "landing:root:overview-work"
+    : "landing:root:default"
 }
 
 function PrototypeUserBar({
@@ -1016,15 +1040,16 @@ function PrototypeServerRail({
 
 function PrototypeChannelSidebar({
   room,
+  treeScopeKey,
   channels = SPACE_CHANNELS,
   rootChannels = CHANNELS,
 }: {
   room: LandingRoom | null
+  treeScopeKey: string
   channels?: Record<LandingRoom, Category[]>
   rootChannels?: Category[]
 }) {
   const categories = room ? channels[room] : rootChannels
-  const tree = useChannelTree(categories)
   const serverName = room
     ? SPACE_SERVERS.find((server) => server.id === room)?.name ?? ""
     : "Gus"
@@ -1053,8 +1078,10 @@ function PrototypeChannelSidebar({
 
   return (
     <div ref={sidebarRef} className="relative flex min-h-0 flex-1 flex-col">
-      <ChannelSidebar
-        tree={tree}
+      <ChannelSidebarTreeOwner
+        key={treeScopeKey}
+        scopeKey={treeScopeKey}
+        categories={categories}
         serverName={serverName}
         activeChannel={activeChannel}
         setActiveChannel={() => {}}

--- a/src/web/src/hooks/community/use-structural-snapshot.test.ts
+++ b/src/web/src/hooks/community/use-structural-snapshot.test.ts
@@ -5,6 +5,7 @@ import type { ServerDetail, ServersResponse } from "./use-servers"
 import type { FoldersResponse } from "./use-folders"
 import { useCommunityWsStore } from "@/stores/community/ws"
 import {
+  hasStructuralServerTree,
   installStructuralSnapshotProjection,
   structuralHintServer,
 } from "./use-structural-snapshot"
@@ -357,6 +358,15 @@ describe("installStructuralSnapshotProjection", () => {
       id: "server-1",
       categoriesView: [],
     })
+    expect(hasStructuralServerTree(snapshot.servers[0])).toBe(false)
+    expect(hasStructuralServerTree({
+      ...snapshot.servers[0],
+      categories: [{ id: "category-1", name: "General", private: false }],
+    })).toBe(true)
+    expect(hasStructuralServerTree({
+      ...snapshot.servers[0],
+      channels: [{ id: "channel-1", name: "chat", type: "text" as const, categoryId: null }],
+    })).toBe(true)
     expect(structuralHintServer(snapshot, "missing")).toBeNull()
     expect(structuralHintServer(null, "server-1")).toBeNull()
   })

--- a/src/web/src/hooks/community/use-structural-snapshot.ts
+++ b/src/web/src/hooks/community/use-structural-snapshot.ts
@@ -191,3 +191,10 @@ export function structuralHintServer(
   const server = snapshot?.servers.find((candidate) => candidate.id === serverId)
   return server ? { ...server, categoriesView: structuralServerToCategories(server) } : null
 }
+
+/** A rail-only Server identity is not enough to initialize a Channel Tree. */
+export function hasStructuralServerTree(
+  server: Pick<StructuralServerV1, "categories" | "channels"> | null | undefined,
+): boolean {
+  return Boolean(server && (server.categories.length > 0 || server.channels.length > 0))
+}

--- a/src/web/src/test/e2e-ui/36-server-switch-pending-checkpoint.spec.ts
+++ b/src/web/src/test/e2e-ui/36-server-switch-pending-checkpoint.spec.ts
@@ -8,6 +8,92 @@ type HeldServer = {
   release: () => Promise<void>
 }
 
+type SidebarFrame = {
+  pathname: string
+  ownerId: number | null
+  scope: string | null
+  pendingServer: string | null
+  skeleton: boolean
+  rows: string[]
+  transform: string | null
+  opacity: string | null
+}
+
+async function installSidebarFrameProbe(page: Page) {
+  const channelRowPrefix = tid.channelRow("")
+  await page.addInitScript(({ channelRowPrefix }) => {
+    const state = window as typeof window & { __communitySidebarFrames?: SidebarFrame[] }
+    state.__communitySidebarFrames = []
+    const ownerIds = new WeakMap<Element, number>()
+    let nextOwnerId = 0
+    const sample = () => {
+      const surface = document.querySelector<HTMLElement>('[data-community-mobile-surface="list"]')
+      const sidebar = surface ?? document.querySelector<HTMLElement>("#sidebar")
+      const owner = sidebar?.querySelector<HTMLElement>("[data-community-channel-tree-scope]") ?? null
+      let ownerId: number | null = null
+      if (owner) {
+        ownerId = ownerIds.get(owner) ?? ++nextOwnerId
+        ownerIds.set(owner, ownerId)
+      }
+      const rows = Array.from(sidebar?.querySelectorAll<HTMLElement>(
+        `[data-testid^="${channelRowPrefix}"]`,
+      ) ?? []).filter((row) => {
+        const style = getComputedStyle(row)
+        return style.display !== "none" && row.getClientRects().length > 0
+      }).map((row) => row.dataset.testid!.replace(channelRowPrefix, ""))
+      const surfaceStyle = surface ? getComputedStyle(surface) : null
+      state.__communitySidebarFrames!.push({
+        pathname: location.pathname,
+        ownerId,
+        scope: owner?.dataset.communityChannelTreeScope ?? null,
+        pendingServer: sidebar?.querySelector<HTMLElement>("[data-pending-server-id]")
+          ?.dataset.pendingServerId ?? null,
+        skeleton: sidebar?.querySelector('[data-slot="skeleton"]') !== null,
+        rows,
+        transform: surfaceStyle?.transform ?? null,
+        opacity: surfaceStyle?.opacity ?? null,
+      })
+      requestAnimationFrame(sample)
+    }
+    requestAnimationFrame(sample)
+  }, { channelRowPrefix })
+}
+
+async function clearSidebarFrames(page: Page) {
+  await page.evaluate(() => {
+    ;(window as typeof window & { __communitySidebarFrames?: SidebarFrame[] })
+      .__communitySidebarFrames = []
+  })
+}
+
+async function sidebarFrames(page: Page): Promise<SidebarFrame[]> {
+  return page.evaluate(() => (
+    window as typeof window & { __communitySidebarFrames?: SidebarFrame[] }
+  ).__communitySidebarFrames ?? [])
+}
+
+function expectAtomicTargetFrames(
+  frames: SidebarFrame[],
+  scope: string,
+  targetRow: string,
+  forbiddenRows: string[],
+) {
+  const target = frames.filter((frame) => frame.scope === scope)
+  expect(target.length).toBeGreaterThan(0)
+  expect(new Set(target.map((frame) => frame.ownerId)).size).toBe(1)
+  const committed = target.filter((frame) => !frame.skeleton)
+  expect(committed.length).toBeGreaterThan(0)
+  expect(committed[0].rows).toContain(targetRow)
+  for (const frame of committed) {
+    expect(frame.rows).toContain(targetRow)
+    expect(frame.rows.some((row) => forbiddenRows.includes(row))).toBe(false)
+    if (frame.transform !== null) {
+      expect(["none", "matrix(1, 0, 0, 1, 0, 0)"]).toContain(frame.transform)
+      expect(frame.opacity).toBe("1")
+    }
+  }
+}
+
 async function holdServerTransition(
   page: Page,
   serverId: string,
@@ -57,13 +143,18 @@ async function clickServer(page: Page, serverId: string): Promise<void> {
   await icon.click({ noWaitAfter: true })
 }
 
+async function expectDesktopServerDetail(page: Page, serverId: string): Promise<void> {
+  const prefix = `/c/channels/${serverId}/`
+  await expect.poll(() => new URL(page.url()).pathname.startsWith(prefix)).toBe(true)
+}
+
 async function expectActiveServer(page: Page, activeId: string, inactiveId: string): Promise<void> {
   await expect(page.getByTestId(tid.serverIcon(activeId))).toHaveClass(/cursor-default/)
   await expect(page.getByTestId(tid.serverIcon(inactiveId))).toHaveClass(/cursor-pointer/)
 }
 
 test("server switching exposes one target-scoped cold checkpoint and skips it when warm", async ({ asUser }) => {
-  test.setTimeout(120_000)
+  test.setTimeout(180_000)
   const stamp = Date.now()
   const serverA = await seedServer("alice", `Checkpoint A ${stamp}`)
   const serverB = await seedServer("alice", `Checkpoint B ${stamp}`)
@@ -81,11 +172,12 @@ test("server switching exposes one target-scoped cold checkpoint and skips it wh
   const channelB = await seedChannel("alice", serverB, channelBName)
   const channelC = await seedChannel("alice", serverC, channelCName)
   const channelD = await seedChannel("alice", serverD, channelDName)
-  await seedChannel("alice", serverE, `checkpoint-e-${stamp}`)
-  await seedChannel("alice", serverF, `checkpoint-f-${stamp}`)
+  const channelE = await seedChannel("alice", serverE, `checkpoint-e-${stamp}`)
+  const channelF = await seedChannel("alice", serverF, `checkpoint-f-${stamp}`)
 
   const { page } = await asUser("alice")
   await page.setViewportSize({ width: 1280, height: 900 })
+  await installSidebarFrameProbe(page)
   await page.goto(`/c/channels/${serverA}/${channelA}`)
   await expect(page.getByRole("heading", { name: channelAName })).toBeVisible({ timeout: 30_000 })
 
@@ -115,33 +207,36 @@ test("server switching exposes one target-scoped cold checkpoint and skips it wh
   const coldE = await holdServerTransition(page, serverE)
   const coldF = await holdServerTransition(page, serverF)
 
-  // Warm B through the exact Server-root RSC contract before the click.
-  const rootPrefetch = page.waitForResponse((response) => {
-    const url = new URL(response.url())
-    return url.pathname === `/c/channels/${serverB}`
-      && url.searchParams.has("_rsc")
-      && response.status() === 200
-  })
-  const serverBIcon = await activateServerIcon(page, serverB)
-  const prefetchResponse = await rootPrefetch
-  await prefetchResponse.finished()
-  await serverBIcon.click({ noWaitAfter: true })
+  // Visit B once so both its route and live detail query are deterministically
+  // memory-warm, then return to A before sampling the warm switch.
+  await clickServer(page, serverB)
+  await expect(page.getByTestId(tid.channelRow(channelB))).toBeVisible({ timeout: 30_000 })
+  await clickServer(page, serverA)
+  await expect(page.getByRole("heading", { name: channelAName })).toBeVisible({ timeout: 30_000 })
+
+  await clearSidebarFrames(page)
+  await clickServer(page, serverB)
   await expect(page.getByTestId(tid.channelSidebarPending(serverB))).toHaveCount(0)
   await expect(page.getByTestId(tid.pendingMain("server-landing"))).toHaveCount(0)
-  await expect.poll(() => new URL(page.url()).pathname.startsWith(`/c/channels/${serverB}`))
-    .toBe(true)
+  await expectDesktopServerDetail(page, serverB)
   await expect(page.locator("#sidebar").getByRole("button", { name: serverBName, exact: true }))
     .toBeVisible({ timeout: 30_000 })
   await expect(page.getByTestId(tid.channelRow(channelB))).toBeVisible({ timeout: 30_000 })
+  expectAtomicTargetFrames(
+    await sidebarFrames(page),
+    `server:${serverB}`,
+    channelB,
+    [channelA],
+  )
 
   await clickServer(page, serverA)
-  await expect.poll(() => new URL(page.url()).pathname.startsWith(`/c/channels/${serverA}`))
-    .toBe(true)
+  await expectDesktopServerDetail(page, serverA)
   await expect(page.locator("#sidebar").getByRole("button", { name: serverAName, exact: true }))
     .toBeVisible({ timeout: 30_000 })
   await expect(page.getByRole("heading", { name: channelAName })).toBeVisible({ timeout: 30_000 })
   await expectActiveServer(page, serverA, serverB)
 
+  await clearSidebarFrames(page)
   await clickServer(page, serverC)
   await expect.poll(coldC.heldNavigation).toBeGreaterThan(0)
   await expect(page.getByTestId(tid.channelSidebarPending(serverC))).toBeVisible()
@@ -150,18 +245,46 @@ test("server switching exposes one target-scoped cold checkpoint and skips it wh
   await expectActiveServer(page, serverC, serverA)
   expect(mutations).toEqual([])
   await coldC.release()
-  await expect.poll(() => new URL(page.url()).pathname.startsWith(`/c/channels/${serverC}`))
-    .toBe(true)
+  await expectDesktopServerDetail(page, serverC)
   await expect(page.getByTestId(tid.channelSidebarPending(serverC))).toHaveCount(0)
   await expect(page.getByTestId(tid.channelRow(channelC))).toBeVisible({ timeout: 30_000 })
+  const coldFrames = await sidebarFrames(page)
+  const coldPendingFrames = coldFrames.filter((frame) => frame.pendingServer === serverC)
+  expect(coldPendingFrames.length).toBeGreaterThan(0)
+  expect(coldPendingFrames.every((frame) => frame.ownerId === null && frame.rows.length === 0))
+    .toBe(true)
+  expectAtomicTargetFrames(coldFrames, `server:${serverC}`, channelC, [channelA])
 
   await clickServer(page, serverA)
-  await expect.poll(() => new URL(page.url()).pathname.startsWith(`/c/channels/${serverA}`))
-    .toBe(true)
+  await expectDesktopServerDetail(page, serverA)
   await expect(page.locator("#sidebar").getByRole("button", { name: serverAName, exact: true }))
     .toBeVisible({ timeout: 30_000 })
   await expect(page.getByRole("heading", { name: channelAName })).toBeVisible({ timeout: 30_000 })
   await expectActiveServer(page, serverA, serverC)
+
+  // A reload restores the persisted structural snapshot but not the live
+  // server-detail query. Hold C's fresh reads so its first non-skeleton frame
+  // must come from the structural target tree, then reconcile in the same owner.
+  await page.waitForTimeout(1_000)
+  await page.reload()
+  await expect(page.getByRole("heading", { name: channelAName })).toBeVisible({ timeout: 30_000 })
+  const structuralC = await holdServerTransition(page, serverC)
+  await clearSidebarFrames(page)
+  await clickServer(page, serverC)
+  await expect.poll(structuralC.heldNavigation).toBeGreaterThan(0)
+  await structuralC.release()
+  await expectDesktopServerDetail(page, serverC)
+  await expect(page.getByTestId(tid.channelRow(channelC))).toBeVisible({ timeout: 30_000 })
+  expectAtomicTargetFrames(
+    await sidebarFrames(page),
+    `server:${serverC}`,
+    channelC,
+    [channelA, channelB],
+  )
+
+  await clickServer(page, serverA)
+  await expectDesktopServerDetail(page, serverA)
+  await expect(page.getByRole("heading", { name: channelAName })).toBeVisible({ timeout: 30_000 })
 
   await page.setViewportSize({ width: 390, height: 844 })
   await page.getByRole("banner").getByRole("button", { name: "Back" }).click()
@@ -169,6 +292,7 @@ test("server switching exposes one target-scoped cold checkpoint and skips it wh
     .toBe(true)
   await expect(page.getByTestId(tid.serverIcon(serverD))).toBeVisible()
 
+  await clearSidebarFrames(page)
   await clickServer(page, serverD)
   await expect.poll(coldD.heldNavigation).toBeGreaterThan(0)
   const mobileCheckpoint = page.getByTestId(tid.channelSidebarPending(serverD))
@@ -183,9 +307,18 @@ test("server switching exposes one target-scoped cold checkpoint and skips it wh
   await expect.poll(() => new URL(page.url()).pathname.startsWith(`/c/channels/${serverD}`))
     .toBe(true)
   await expect(page.getByTestId(tid.channelRow(channelD))).toBeVisible({ timeout: 30_000 })
+  const mobileColdFrames = await sidebarFrames(page)
+  expectAtomicTargetFrames(
+    mobileColdFrames,
+    `server:${serverD}`,
+    channelD,
+    [channelA, channelB, channelC],
+  )
 
   await page.setViewportSize({ width: 1280, height: 900 })
+  await expectDesktopServerDetail(page, serverD)
   await expect(page.getByTestId(tid.serverIcon(serverE))).toBeVisible()
+  await clearSidebarFrames(page)
   await clickServer(page, serverE)
   // Dispatch the superseding click directly against the current stable
   // button so this remains one immediate E→F intent window; awaiting F's
@@ -199,6 +332,14 @@ test("server switching exposes one target-scoped cold checkpoint and skips it wh
   await expect(page.getByTestId(tid.channelSidebarPending(serverF))).toBeVisible()
   await expectActiveServer(page, serverF, serverD)
   await coldF.release()
-  await expect.poll(() => new URL(page.url()).pathname.startsWith(`/c/channels/${serverF}`))
-    .toBe(true)
+  await expectDesktopServerDetail(page, serverF)
+  await expect(page.getByTestId(tid.channelRow(channelF))).toBeVisible({ timeout: 30_000 })
+  const supersededFrames = await sidebarFrames(page)
+  expect(supersededFrames.some((frame) => frame.scope === `server:${serverE}`)).toBe(false)
+  expectAtomicTargetFrames(
+    supersededFrames,
+    `server:${serverF}`,
+    channelF,
+    [channelA, channelB, channelC, channelD, channelE],
+  )
 })

--- a/src/web/src/test/e2e-ui/38-community-navigation-checkpoint-matrix.spec.ts
+++ b/src/web/src/test/e2e-ui/38-community-navigation-checkpoint-matrix.spec.ts
@@ -30,36 +30,68 @@ function channelHeader(page: Page, name: string) {
 
 type SurfaceAnimationRecord = {
   surface: string | null
-  opacity: number
+}
+
+type SurfaceFrameRecord = {
+  pathname: string
+  surface: string | null
   transform: string
-  suppressed: boolean
+  opacity: string
+  rows: string[]
+  pendingMain: string | null
+  treeScope: string | null
 }
 
 async function installSurfaceAnimationProbe(page: Page) {
-  await page.addInitScript(() => {
+  const channelRowPrefix = tid.channelRow("")
+  await page.addInitScript(({ channelRowPrefix }) => {
     const state = window as typeof window & {
       __communitySurfaceAnimations?: Array<{
         surface: string | null
-        opacity: number
-        transform: string
-        suppressed: boolean
       }>
+      __communitySurfaceFrames?: SurfaceFrameRecord[]
+      __communitySurfaceFrameStop?: () => void
     }
     state.__communitySurfaceAnimations = []
+    state.__communitySurfaceFrames = []
     const nativeAnimate = Element.prototype.animate
     Element.prototype.animate = function (keyframes, options) {
-      if (this.hasAttribute("data-community-mobile-surface") && Array.isArray(keyframes)) {
-        const first = keyframes[0]
+      if (this.hasAttribute("data-community-mobile-surface")) {
         state.__communitySurfaceAnimations!.push({
           surface: this.getAttribute("data-community-mobile-surface"),
-          opacity: Number(first?.opacity),
-          transform: String(first?.transform),
-          suppressed: this.querySelector('[data-community-mobile-transition="suppress"]') !== null,
         })
       }
       return nativeAnimate.call(this, keyframes, options)
     }
-  })
+
+    let raf = 0
+    const sample = () => {
+      for (const surface of document.querySelectorAll<HTMLElement>("[data-community-mobile-surface]")) {
+        const style = getComputedStyle(surface)
+        if (style.display === "none" || surface.getClientRects().length === 0) continue
+        const rows = Array.from(surface.querySelectorAll<HTMLElement>(
+          `[data-testid^="${channelRowPrefix}"]`,
+        )).filter((row) => {
+          const rowStyle = getComputedStyle(row)
+          return rowStyle.display !== "none" && row.getClientRects().length > 0
+        }).map((row) => row.dataset.testid!.replace(channelRowPrefix, ""))
+        state.__communitySurfaceFrames!.push({
+          pathname: location.pathname,
+          surface: surface.getAttribute("data-community-mobile-surface"),
+          transform: style.transform,
+          opacity: style.opacity,
+          rows,
+          pendingMain: surface.querySelector<HTMLElement>("[data-community-main-kind]")
+            ?.dataset.communityMainKind ?? null,
+          treeScope: surface.querySelector<HTMLElement>("[data-community-channel-tree-scope]")
+            ?.dataset.communityChannelTreeScope ?? null,
+        })
+      }
+      raf = requestAnimationFrame(sample)
+    }
+    raf = requestAnimationFrame(sample)
+    state.__communitySurfaceFrameStop = () => cancelAnimationFrame(raf)
+  }, { channelRowPrefix })
 }
 
 async function surfaceAnimations(page: Page): Promise<SurfaceAnimationRecord[]> {
@@ -70,10 +102,27 @@ async function surfaceAnimations(page: Page): Promise<SurfaceAnimationRecord[]> 
 
 async function clearSurfaceAnimations(page: Page): Promise<void> {
   await page.evaluate(() => {
-    ;(window as typeof window & {
+    const state = window as typeof window & {
       __communitySurfaceAnimations?: SurfaceAnimationRecord[]
-    }).__communitySurfaceAnimations = []
+      __communitySurfaceFrames?: SurfaceFrameRecord[]
+    }
+    state.__communitySurfaceAnimations = []
+    state.__communitySurfaceFrames = []
   })
+}
+
+async function surfaceFrames(page: Page): Promise<SurfaceFrameRecord[]> {
+  return page.evaluate(() => (
+    window as typeof window & { __communitySurfaceFrames?: SurfaceFrameRecord[] }
+  ).__communitySurfaceFrames ?? [])
+}
+
+function expectStationaryFrames(frames: SurfaceFrameRecord[]) {
+  expect(frames.length).toBeGreaterThan(0)
+  for (const frame of frames) {
+    expect(["none", "matrix(1, 0, 0, 1, 0, 0)"]).toContain(frame.transform)
+    expect(frame.opacity).toBe("1")
+  }
 }
 
 test("community checkpoint shows target pending for detail and keeps list surfaces stable", async ({ asUser }) => {
@@ -144,7 +193,7 @@ test("community checkpoint shows target pending for detail and keeps list surfac
   expect(mutations).toEqual([])
 })
 
-test("mobile pending commits animate once while sidebar identity survives route changes", async ({ asUser }) => {
+test("mobile route commits stay stationary while sidebar identity survives same-server history", async ({ asUser }) => {
   test.setTimeout(120_000)
   const stamp = Date.now()
   const serverId = await seedServer("alice", `Mobile frame ${stamp}`)
@@ -172,12 +221,8 @@ test("mobile pending commits animate once while sidebar identity survives route 
   await expect.poll(() => new URL(page.url()).pathname)
     .toBe(`/c/channels/${serverId}/${fastChannel}`)
   await expect(page.getByTestId(tid.composerInput)).toBeVisible()
-  expect(await surfaceAnimations(page)).toEqual([{
-    surface: "detail",
-    opacity: 0.92,
-    transform: "translate3d(8px, 0, 0)",
-    suppressed: false,
-  }])
+  expect(await surfaceAnimations(page)).toEqual([])
+  expectStationaryFrames(await surfaceFrames(page))
   expect(await sidebarScroll.evaluate((element) => (
     element as typeof element & { __e2eIdentity?: string }
   ).__e2eIdentity)).toBe("stable")
@@ -188,20 +233,8 @@ test("mobile pending commits animate once while sidebar identity survives route 
   await page.getByRole("banner").getByRole("button", { name: "Back" }).click()
   await expect.poll(() => new URL(page.url()).pathname).toBe(`/c/channels/${serverId}`)
   await expect(fastRow).toBeVisible()
-  expect(await surfaceAnimations(page)).toEqual([
-    {
-      surface: "detail",
-      opacity: 0.92,
-      transform: "translate3d(8px, 0, 0)",
-      suppressed: false,
-    },
-    {
-      surface: "list",
-      opacity: 0.92,
-      transform: "translate3d(-8px, 0, 0)",
-      suppressed: false,
-    },
-  ])
+  expect(await surfaceAnimations(page)).toEqual([])
+  expectStationaryFrames(await surfaceFrames(page))
   expect(await sidebarScroll.evaluate((element) => (
     element as typeof element & { __e2eIdentity?: string }
   ).__e2eIdentity)).toBe("stable")
@@ -216,16 +249,35 @@ test("mobile pending commits animate once while sidebar identity survives route 
   const pendingPath = `/c/channels/${serverId}/${pendingChannel}`
   await expect.poll(() => new URL(page.url()).pathname).toBe(pendingPath)
   await expect(page.getByTestId(tid.composerInput)).toBeVisible({ timeout: 30_000 })
-  expect(await surfaceAnimations(page)).toEqual([{
-    surface: "detail",
-    opacity: 0.92,
-    transform: "translate3d(8px, 0, 0)",
-    suppressed: false,
-  }])
+  expect(await surfaceAnimations(page)).toEqual([])
+  expectStationaryFrames(await surfaceFrames(page))
   expect(await sidebarScroll.evaluate((element) => (
     element as typeof element & { __e2eIdentity?: string }
   ).__e2eIdentity)).toBe("stable")
   expect(await fastRow.evaluate((element) => (
     element as typeof element & { __e2eDndOwner?: string }
   ).__e2eDndOwner)).toBe("stable")
+
+  await page.goBack()
+  await expect.poll(() => new URL(page.url()).pathname).toBe(`/c/channels/${serverId}`)
+  await expect(fastRow).toBeVisible()
+  await page.goForward()
+  await expect.poll(() => new URL(page.url()).pathname).toBe(pendingPath)
+  await expect(page.getByTestId(tid.composerInput)).toBeVisible()
+  expect(await surfaceAnimations(page)).toEqual([])
+  expectStationaryFrames(await surfaceFrames(page))
+
+  await page.goBack()
+  await expect(fastRow).toBeVisible()
+  await page.getByTestId(tid.homeButton).click()
+  await expect.poll(() => new URL(page.url()).pathname).toBe("/c/me")
+  await page.getByTestId(tid.serverIcon(serverId)).click()
+  await expect.poll(() => new URL(page.url()).pathname).toBe(`/c/channels/${serverId}`)
+  await expect(fastRow).toBeVisible()
+  expect(await surfaceAnimations(page)).toEqual([])
+  const finalFrames = await surfaceFrames(page)
+  expectStationaryFrames(finalFrames)
+  const targetFrames = finalFrames.filter((frame) => frame.rows.includes(fastChannel))
+  expect(targetFrames.length).toBeGreaterThan(0)
+  expect(targetFrames.every((frame) => frame.treeScope === `server:${serverId}`)).toBe(true)
 })


### PR DESCRIPTION
# Why we need this PR?

Mobile Server switches could briefly render the source Server's Channel Tree and route-level translate/opacity motion. The visual leak came from reusing one local-state owner across Server datasets while shell route surfaces also ran a separate WAAPI transition. A retained memoized Server item could additionally dispatch stale navigation semantics after an A→B→A switch.

## What changed

- Remove route-surface WAAPI and the pending-frame suppression-marker protocol while preserving component-owned interaction motion.
- Gate the real Channel Tree owner until target structural/full data exists and key it by decoded Server ID, preventing row, collapsed, optimistic-order, and drag state from leaking across Servers.
- Preserve the same owner through same-Server navigation, forum loading, and structural-to-full reconciliation.
- Give landing-preview datasets explicit scope keys.
- Keep the Server activation dispatcher stable for the rail memo boundary while reading the latest committed navigation callbacks through a layout-synchronized ref.
- Add DOM/unit and Playwright frame-probe coverage for trusted click and native Enter, cold/warm/structural switches, cancellation, history, DM↔Server navigation, and normal/reduced motion.

Verification:

- Final independent focused set: 4 files / 36 tests passed.
- Normal commit hook passed without bypass: 806 web files / 7,531 tests; agent driver 48 files passed + 1 skipped and 786 tests passed + 4 skipped; changed coverage, typecheck, lint, typegrep, production-boundary, and knip gates passed.
- Exact-head browser matrix passed at 390×844 and 1280×900, including trusted click, native Enter, memory-warm, structural-warm, rapid A→B→C supersession, reduced motion, retained scroll/geometry, and DnD cancellation. Route WAAPI remained zero.
- Hosted rollup: 24 checks total, 20 passed, 4 expected skips, 0 other; Codecov patch passed.
- Production grep invariants and `git diff --check` passed.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...
