### PR TITLE
fix(web): stabilize server delete navigation

### DIFF
--- a/scripts/ci/e2e-shards.mjs
+++ b/scripts/ci/e2e-shards.mjs
@@ -78,6 +78,7 @@ export const SPEC_SECONDS = {
   "54-blog-multizone.spec.ts": 5.485,
   "55-message-scroll-characterization.spec.ts": 109.548,
   "56-remote-image-state-contract.spec.ts": 3.122,
+  "57-server-delete-navigation-races.spec.ts": 55,
 }
 
 function walk(directory) {

--- a/scripts/ci/e2e-shards.test.ts
+++ b/scripts/ci/e2e-shards.test.ts
@@ -80,10 +80,10 @@ describe("planE2eShards", () => {
     expect(new Set(assigned).size).toBe(specs.length)
     expect(SPEC_SECONDS["55-message-scroll-characterization.spec.ts"]).toBe(109.548)
     expect(specSeconds).toEqual([
-      156.526, 155.455, 155.858, 156.114, 153.041, 153.044, 154.015, 153.713, 154.663,
+      159.424, 161.016, 162.097, 159.838, 161.875, 161.643, 159.966, 161.68, 159.89,
     ])
     expect(predictedSeconds).toEqual([
-      231.526, 230.455, 230.858, 231.114, 228.041, 228.044, 229.015, 228.713, 229.663,
+      234.424, 236.016, 237.097, 234.838, 236.875, 236.643, 234.966, 236.68, 234.89,
     ])
     expect(first.every((shard) => (
       shard.fixed_setup_seconds === E2E_FIXED_SETUP_SECONDS

--- a/src/web/src/app/c/channels/layout.route-memory.dom.test.ts
+++ b/src/web/src/app/c/channels/layout.route-memory.dom.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   routeProtected: { current: false },
   routeToken: {},
   clearLastChannel: vi.fn(),
+  communityServerId: vi.fn(),
   useServer: vi.fn(),
   servers: { current: [] as Array<{ id: string }> },
   serverDetails: new Map<string, {
@@ -73,7 +74,7 @@ vi.mock("@/components/community/shell/shell-frame", () => ({
 }))
 vi.mock("@/lib/community/community-route", () => ({
   channelHref: (serverId: string, channelId: string) => `/c/channels/${serverId}/${channelId}`,
-  communityServerId: () => "missing-server",
+  communityServerId: (pathname: string) => mocks.communityServerId(pathname),
   serverRootHref: (serverId: string) => `/c/channels/${serverId}`,
   serverModalMarkerCleanupHref: () => null,
 }))
@@ -235,6 +236,7 @@ import ServerLayout from "./layout"
 
 describe("ServerLayout deletion routing", () => {
   beforeEach(() => {
+    window.history.replaceState({}, "", "/c/channels/missing-server/missing-channel")
     mocks.replace.mockClear()
     mocks.navigatePath.mockClear()
     mocks.cancelPendingNavigation.mockClear()
@@ -249,6 +251,10 @@ describe("ServerLayout deletion routing", () => {
     mocks.registerRoute.mockReturnValue("ordinary")
     mocks.routeProtected.current = false
     mocks.clearLastChannel.mockClear()
+    mocks.communityServerId.mockReset()
+    mocks.communityServerId.mockImplementation((pathname: string) => (
+      pathname.match(/^\/c\/channels\/([^/?#]+)/)?.[1] ?? null
+    ))
     mocks.deleteServerAction.current = null
     mocks.useServer.mockClear()
     mocks.servers.current = []
@@ -269,6 +275,16 @@ describe("ServerLayout deletion routing", () => {
       Promise.resolve(mocks.serverDetails.get(String(queryKey.at(-1))))
     ))
     mocks.runEject.mockReturnValue(false)
+  })
+
+  it("checks the current pathname before running the generic eject", () => {
+    expect(window.location.href).toContain("://")
+
+    render(createElement(ServerLayout, null, createElement("div")))
+
+    expect(mocks.communityServerId).toHaveBeenCalledWith(window.location.pathname)
+    expect(mocks.communityServerId).not.toHaveBeenCalledWith(window.location.href)
+    expect(mocks.runEject).toHaveBeenCalledOnce()
   })
 
   it("passes the authenticated leaf and target-specific revoke facts to generic eject", () => {

--- a/src/web/src/app/c/channels/layout.route-memory.dom.test.ts
+++ b/src/web/src/app/c/channels/layout.route-memory.dom.test.ts
@@ -1,14 +1,39 @@
-import { createElement } from "react"
+import { createElement, useLayoutEffect } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { render } from "@/test/react-dom-harness"
+import { act, render } from "@/test/react-dom-harness"
 
 const mocks = vi.hoisted(() => ({
   replace: vi.fn(),
+  navigatePath: vi.fn(),
   cancelPendingNavigation: vi.fn(),
+  setCurrentServerId: vi.fn(),
+  toast: vi.fn(),
+  toastApiError: vi.fn(),
   runEject: vi.fn(),
+  deleteServer: vi.fn(),
+  deleteServerAction: { current: null as null | (() => Promise<void>) },
+  claimNavigation: vi.fn(),
+  registerRoute: vi.fn(),
+  routeProtected: { current: false },
+  routeToken: {},
+  clearLastChannel: vi.fn(),
+  useServer: vi.fn(),
+  servers: { current: [] as Array<{ id: string }> },
+  serverDetails: new Map<string, {
+    categories: Array<{ channels: Array<{ id: string; pending?: boolean }> }>
+  }>(),
+  structuralSnapshot: { current: null as null | {
+    servers: Array<{ id: string; channels: Array<{ id: string }> }>
+  } },
+  lastChannels: new Map<string, string>(),
   serverListSuccess: { current: true },
   serverListFetching: { current: false },
   serverAccessRevoked: { current: false },
+  queryClient: { getQueryData: vi.fn(), fetchQuery: vi.fn() },
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => mocks.queryClient,
 }))
 
 vi.mock("next/navigation", () => ({
@@ -17,8 +42,8 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace: mocks.replace, prefetch: vi.fn() }),
   useSearchParams: () => new URLSearchParams(),
 }))
-vi.mock("sonner", () => ({ toast: vi.fn() }))
-vi.mock("@/lib/api/client", () => ({ toastApiError: vi.fn() }))
+vi.mock("sonner", () => ({ toast: mocks.toast }))
+vi.mock("@/lib/api/client", () => ({ toastApiError: mocks.toastApiError }))
 vi.mock("@/lib/perf/switch-mark", () => ({ markSwitch: vi.fn() }))
 vi.mock("@/components/ui/dialog", () => ({
   Dialog: ({ children }: { children: React.ReactNode }) => children,
@@ -28,17 +53,45 @@ vi.mock("@/components/community/channels/use-channel-tree", () => ({
   useChannelTree: () => [],
 }))
 vi.mock("@/components/community/shell/shell-frame", () => ({
-  ShellFrame: ({ children }: { children: React.ReactNode }) => createElement("shell-frame", null, children),
+  ShellFrame: ({ children, extraDialogs, ownerDeleteRouteScope }: {
+    children: React.ReactNode
+    extraDialogs?: React.ReactNode
+    ownerDeleteRouteScope?: {
+      serverId: string
+      token: object
+    }
+  }) => {
+    useLayoutEffect(() => {
+      if (!ownerDeleteRouteScope) return
+      mocks.registerRoute(
+        ownerDeleteRouteScope.serverId,
+        ownerDeleteRouteScope.token,
+      )
+    }, [ownerDeleteRouteScope])
+    return createElement("shell-frame", null, children, extraDialogs)
+  },
 }))
 vi.mock("@/lib/community/community-route", () => ({
   channelHref: (serverId: string, channelId: string) => `/c/channels/${serverId}/${channelId}`,
+  communityServerId: () => "missing-server",
   serverRootHref: (serverId: string) => `/c/channels/${serverId}`,
   serverModalMarkerCleanupHref: () => null,
 }))
 vi.mock("@/hooks/use-mobile", () => ({ useBreakpoint: () => "desktop" }))
 vi.mock("@/components/community/channels/channel-sidebar", () => ({ ChannelSidebar: () => null }))
 vi.mock("@/components/community/channels/channel-route", () => ({ ChannelRoute: () => null }))
-vi.mock("@/components/community/settings/server-settings", () => ({ ServerSettings: () => null }))
+vi.mock("@/components/community/shell/community-pending-frame", () => ({
+  CommunityPendingFrame: ({ href }: { href: string }) => createElement("div", {
+    "data-testid": "owner-delete-pending-frame",
+    "data-href": href,
+  }),
+}))
+vi.mock("@/components/community/settings/server-settings", () => ({
+  ServerSettings: ({ onDeleteServer }: { onDeleteServer: () => Promise<void> }) => {
+    mocks.deleteServerAction.current = onDeleteServer
+    return null
+  },
+}))
 vi.mock("@/components/community/image-crop-dialog", () => ({ ImageCropDialog: () => null }))
 vi.mock("@/lib/community/image-crop", () => ({ validateIconSourceFile: () => ({ ok: true }) }))
 vi.mock("@alook/shared", () => ({
@@ -49,8 +102,11 @@ vi.mock("@alook/shared", () => ({
 vi.mock("@/lib/community/profile-read", () => ({ readCommunityProfile: vi.fn() }))
 vi.mock("@/stores/community", () => {
   const state = {
-    setCurrentServerId: vi.fn(),
-    uiHandlers: { cancelPendingNavigation: mocks.cancelPendingNavigation },
+    setCurrentServerId: mocks.setCurrentServerId,
+    uiHandlers: {
+      cancelPendingNavigation: mocks.cancelPendingNavigation,
+      navigatePath: mocks.navigatePath,
+    },
   }
   return {
     useCommunityStore: { getState: () => state },
@@ -62,17 +118,23 @@ vi.mock("@/contexts/community/current-user", () => ({
   useCurrentUser: () => ({ id: "viewer-1" }),
 }))
 vi.mock("@/hooks/community/use-servers", () => ({
-  useServer: () => ({ server: undefined }),
+  serverProjectedQueryFn: () => vi.fn(),
+  useServer: (serverId: string | null) => {
+    mocks.useServer(serverId)
+    return { server: undefined }
+  },
   useServers: () => ({
-    servers: [],
+    servers: mocks.servers.current,
     isSuccess: mocks.serverListSuccess.current,
     isFetching: mocks.serverListFetching.current,
   }),
 }))
 vi.mock("@/hooks/community/use-structural-snapshot", () => ({
-  useStructuralSnapshot: () => null,
+  useStructuralSnapshot: () => mocks.structuralSnapshot.current,
   structuralHintServer: () => null,
-  hasStructuralServerTree: () => false,
+  hasStructuralServerTree: (server: { channels?: unknown[] } | null) => (
+    (server?.channels?.length ?? 0) > 0
+  ),
 }))
 vi.mock("@/hooks/community/use-server-members", () => ({
   useServerMembers: () => ({
@@ -81,10 +143,32 @@ vi.mock("@/hooks/community/use-server-members", () => ({
   }),
 }))
 vi.mock("@/lib/community/eject-server", () => ({
+  claimOwnerServerDeleteNavigation: (...args: unknown[]) => mocks.claimNavigation(...args),
   consumeVoluntaryLeave: vi.fn(),
+  createOwnerServerDeleteRouteToken: () => mocks.routeToken,
+  isOwnerServerDeleteCommittedRoute: () => true,
+  isOwnerServerDeleteRouteProtected: () => mocks.routeProtected.current,
+  pickPostEjectDestination: (
+    servers: Array<{ id: string }>,
+    deletedServerId: string,
+    destination: (serverId: string) => string,
+  ) => {
+    const survivor = servers.find((server) => server.id !== deletedServerId)
+    return survivor ? destination(survivor.id) : "/c/me"
+  },
+  registerOwnerServerDeleteRoute: (...args: unknown[]) => mocks.registerRoute(...args),
   runAuthoritativeServerEject: (args: Record<string, unknown>) => mocks.runEject(args),
 }))
-vi.mock("@/lib/community/last-channel", () => ({ clearLastChannel: vi.fn() }))
+vi.mock("@/lib/community/last-channel", () => ({
+  clearLastChannel: (...args: unknown[]) => mocks.clearLastChannel(...args),
+  getLastChannel: (serverId: string) => mocks.lastChannels.get(serverId) ?? null,
+  pickServerLandingHref: (serverId: string, channelIds: string[], last: string | null) => {
+    const channelId = last ?? channelIds[0]
+    return channelId
+      ? `/c/channels/${serverId}/${channelId}`
+      : `/c/channels/${serverId}`
+  },
+}))
 vi.mock("@/hooks/community/use-server-panels", () => ({ usePresence: vi.fn() }))
 vi.mock("@/hooks/community/use-forum-sidebar-threads", () => ({
   resolveForumSidebarRouteCandidate: () => null,
@@ -117,7 +201,27 @@ vi.mock("@/hooks/community/mutations", () => {
     useDeleteCategory: mutation,
     useReorderCategories: mutation,
     useReorderChannels: mutation,
-    useDeleteServer: mutation,
+    useDeleteServer: (callbacks: {
+      routeToken: object
+      onSuccess: (
+        args: { serverId: string },
+        result: { needsNavigation: boolean },
+      ) => void
+      onError: (error: Error, args: { serverId: string }) => void
+    }) => ({
+      mutate: (args: { serverId: string }) => {
+        mocks.routeProtected.current = true
+        mocks.deleteServer(args, {
+          onSuccess: (needsNavigation = true) => {
+            callbacks.onSuccess(args, { needsNavigation })
+          },
+          onError: (error: Error) => {
+            mocks.routeProtected.current = false
+            callbacks.onError(error, args)
+          },
+        })
+      },
+    }),
     useUpdateServer: mutation,
     useUploadServerIcon: mutation,
     useSetServerNotifLevel: mutation,
@@ -129,43 +233,273 @@ vi.mock("@/hooks/community/mutations", () => {
 
 import ServerLayout from "./layout"
 
-describe("ServerLayout cold-entry ejection context", () => {
+describe("ServerLayout deletion routing", () => {
   beforeEach(() => {
     mocks.replace.mockClear()
+    mocks.navigatePath.mockClear()
     mocks.cancelPendingNavigation.mockClear()
+    mocks.setCurrentServerId.mockClear()
+    mocks.toast.mockClear()
+    mocks.toastApiError.mockClear()
     mocks.runEject.mockReset()
+    mocks.deleteServer.mockReset()
+    mocks.claimNavigation.mockReset()
+    mocks.claimNavigation.mockReturnValue(true)
+    mocks.registerRoute.mockReset()
+    mocks.registerRoute.mockReturnValue("ordinary")
+    mocks.routeProtected.current = false
+    mocks.clearLastChannel.mockClear()
+    mocks.deleteServerAction.current = null
+    mocks.useServer.mockClear()
+    mocks.servers.current = []
+    mocks.serverDetails.clear()
+    mocks.structuralSnapshot.current = null
+    mocks.lastChannels.clear()
     mocks.serverListSuccess.current = true
     mocks.serverListFetching.current = false
     mocks.serverAccessRevoked.current = false
-    mocks.runEject.mockImplementation((args: { replace: (destination: string) => void }) => {
+    mocks.queryClient.getQueryData.mockImplementation((key: unknown[]) => {
+      if (key.length === 2 && key[1] === "servers") {
+        return { servers: mocks.servers.current }
+      }
+      return mocks.serverDetails.get(String(key.at(-1)))
+    })
+    mocks.queryClient.fetchQuery.mockReset()
+    mocks.queryClient.fetchQuery.mockImplementation(({ queryKey }: { queryKey: unknown[] }) => (
+      Promise.resolve(mocks.serverDetails.get(String(queryKey.at(-1))))
+    ))
+    mocks.runEject.mockReturnValue(false)
+  })
+
+  it("passes the authenticated leaf and target-specific revoke facts to generic eject", () => {
+    mocks.serverListSuccess.current = false
+    mocks.serverListFetching.current = true
+    mocks.serverAccessRevoked.current = true
+    mocks.runEject.mockImplementation((args: {
+      replace: (destination: string) => void
+    }) => {
       args.replace("/c/me/machines")
       return true
     })
-  })
 
-  it("passes authenticated account and exact leaf to the authoritative eject owner", () => {
     render(createElement(ServerLayout, null, createElement("div")))
 
     expect(mocks.runEject).toHaveBeenCalledWith(expect.objectContaining({
       serverId: "missing-server",
       accountId: "viewer-1",
       routeHref: "/c/channels/missing-server/missing-channel",
-    }))
-    expect(mocks.cancelPendingNavigation).toHaveBeenCalledTimes(1)
-    expect(mocks.replace).toHaveBeenCalledWith("/c/me/machines")
-  })
-
-  it("treats a target-specific access revoke as definitive while the list read is retired", () => {
-    mocks.serverListSuccess.current = false
-    mocks.serverListFetching.current = true
-    mocks.serverAccessRevoked.current = true
-
-    render(createElement(ServerLayout, null, createElement("div")))
-
-    expect(mocks.runEject).toHaveBeenCalledWith(expect.objectContaining({
-      serverId: "missing-server",
       isSuccess: true,
       isFetching: false,
     }))
+    expect(mocks.cancelPendingNavigation).toHaveBeenCalledTimes(1)
+    expect(mocks.replace).toHaveBeenCalledWith("/c/me/machines")
+    expect(mocks.registerRoute).toHaveBeenCalledWith("missing-server", mocks.routeToken)
+  })
+
+  it("suppresses optimistic/list eject and replaces directly to the survivor Channel leaf", async () => {
+    mocks.servers.current = [
+      { id: "missing-server" },
+      { id: "surviving-server" },
+    ]
+    mocks.serverDetails.set("surviving-server", {
+      categories: [{ channels: [
+        { id: "channel-default" },
+        { id: "channel-remembered" },
+      ] }],
+    })
+    mocks.lastChannels.set("surviving-server", "channel-remembered")
+    mocks.runEject.mockImplementation((args: {
+      ownerDeleteRouteProtected?: boolean
+      servers: Array<{ id: string }>
+    }) => !args.ownerDeleteRouteProtected
+      && !args.servers.some((server) => server.id === "missing-server"))
+    const rendered = render(createElement(ServerLayout, null, createElement("div")))
+
+    await act(async () => mocks.deleteServerAction.current?.())
+    const callbacks = mocks.deleteServer.mock.calls[0]![1] as {
+      onSuccess: (needsNavigation?: boolean) => void
+    }
+    mocks.servers.current = [{ id: "surviving-server" }]
+    rendered.rerender(createElement(ServerLayout, null, createElement("div")))
+    expect(mocks.runEject).toHaveBeenLastCalledWith(expect.objectContaining({
+      ownerDeleteRouteProtected: true,
+    }))
+    expect(mocks.useServer).toHaveBeenLastCalledWith(null)
+    expect(rendered.getByTestId("owner-delete-pending-frame")).toBeInTheDocument()
+    expect(mocks.replace).not.toHaveBeenCalled()
+
+    await act(async () => callbacks.onSuccess())
+    expect(mocks.claimNavigation).toHaveBeenCalledExactlyOnceWith(
+      "missing-server",
+      mocks.routeToken,
+      "/c/channels/surviving-server/channel-remembered",
+    )
+    expect(mocks.replace).toHaveBeenCalledExactlyOnceWith(
+      "/c/channels/surviving-server/channel-remembered",
+    )
+    expect(mocks.navigatePath).not.toHaveBeenCalled()
+    expect(mocks.setCurrentServerId).not.toHaveBeenCalledWith(null)
+    expect(mocks.toast).toHaveBeenCalledExactlyOnceWith("Server deleted")
+  })
+
+  it("replaces directly to /c/me when no Server survives", async () => {
+    mocks.servers.current = [{ id: "missing-server" }]
+    render(createElement(ServerLayout, null, createElement("div")))
+
+    await act(async () => mocks.deleteServerAction.current?.())
+    const callbacks = mocks.deleteServer.mock.calls[0]![1] as {
+      onSuccess: (needsNavigation?: boolean) => void
+    }
+    mocks.servers.current = []
+    await act(async () => callbacks.onSuccess())
+
+    expect(mocks.claimNavigation).toHaveBeenCalledExactlyOnceWith(
+      "missing-server",
+      mocks.routeToken,
+      "/c/me",
+    )
+    expect(mocks.replace).toHaveBeenCalledExactlyOnceWith("/c/me")
+    expect(mocks.navigatePath).not.toHaveBeenCalled()
+  })
+
+  it("resolves a survivor leaf from the structural snapshot without waiting for a fetch", async () => {
+    mocks.servers.current = [
+      { id: "missing-server" },
+      { id: "surviving-server" },
+    ]
+    mocks.structuralSnapshot.current = {
+      servers: [{
+        id: "surviving-server",
+        channels: [{ id: "channel-structural" }],
+      }],
+    }
+    render(createElement(ServerLayout, null, createElement("div")))
+
+    await act(async () => mocks.deleteServerAction.current?.())
+    const callbacks = mocks.deleteServer.mock.calls[0]![1] as {
+      onSuccess: (needsNavigation?: boolean) => void
+    }
+    mocks.servers.current = [{ id: "surviving-server" }]
+    await act(async () => callbacks.onSuccess())
+
+    expect(mocks.queryClient.fetchQuery).not.toHaveBeenCalled()
+    expect(mocks.claimNavigation).toHaveBeenCalledWith(
+      "missing-server",
+      mocks.routeToken,
+      "/c/channels/surviving-server/channel-structural",
+    )
+  })
+
+  it("keeps an already committed safe route without resolving or navigating", async () => {
+    mocks.servers.current = [
+      { id: "missing-server" },
+      { id: "surviving-server" },
+    ]
+    render(createElement(ServerLayout, null, createElement("div")))
+
+    await act(async () => mocks.deleteServerAction.current?.())
+    const callbacks = mocks.deleteServer.mock.calls[0]![1] as {
+      onSuccess: (needsNavigation?: boolean) => void
+    }
+    await act(async () => callbacks.onSuccess(false))
+
+    expect(mocks.claimNavigation).not.toHaveBeenCalled()
+    expect(mocks.replace).not.toHaveBeenCalled()
+    expect(mocks.toast).toHaveBeenCalledExactlyOnceWith("Server deleted")
+    expect(mocks.clearLastChannel).toHaveBeenCalledWith("missing-server")
+  })
+
+  it("drops a resolved target when the transaction claim loses to a safe commit", async () => {
+    mocks.servers.current = [
+      { id: "missing-server" },
+      { id: "surviving-server" },
+    ]
+    mocks.serverDetails.set("surviving-server", {
+      categories: [{ channels: [{ id: "channel-default" }] }],
+    })
+    mocks.claimNavigation.mockReturnValue(false)
+    render(createElement(ServerLayout, null, createElement("div")))
+
+    await act(async () => mocks.deleteServerAction.current?.())
+    const callbacks = mocks.deleteServer.mock.calls[0]![1] as {
+      onSuccess: (needsNavigation?: boolean) => void
+    }
+    await act(async () => callbacks.onSuccess())
+
+    expect(mocks.claimNavigation).toHaveBeenCalledOnce()
+    expect(mocks.replace).not.toHaveBeenCalled()
+  })
+
+  it("treats a deleted-Server route first committed after terminal cleanup as ordinary", () => {
+    mocks.routeProtected.current = true
+    mocks.registerRoute.mockImplementation(() => {
+      mocks.routeProtected.current = false
+      return "ordinary"
+    })
+    mocks.servers.current = [{ id: "surviving-server" }]
+    mocks.runEject.mockImplementation((args: {
+      ownerDeleteRouteProtected?: boolean
+      replace: (destination: string) => void
+    }) => {
+      if (args.ownerDeleteRouteProtected) return false
+      args.replace("/c/channels/surviving-server")
+      return true
+    })
+
+    render(createElement(ServerLayout, null, createElement("div")))
+
+    expect(mocks.registerRoute).toHaveBeenCalledWith("missing-server", mocks.routeToken)
+    expect(mocks.runEject).toHaveBeenLastCalledWith(expect.objectContaining({
+      ownerDeleteRouteProtected: false,
+    }))
+    expect(mocks.replace).toHaveBeenCalledExactlyOnceWith(
+      "/c/channels/surviving-server",
+    )
+  })
+
+  it("clears a failed delete without navigation and restores ordinary eject eligibility", async () => {
+    mocks.servers.current = [
+      { id: "missing-server" },
+      { id: "surviving-server" },
+    ]
+    mocks.runEject.mockImplementation((args: {
+      ownerDeleteRouteProtected?: boolean
+      servers: Array<{ id: string }>
+      replace: (destination: string) => void
+    }) => {
+      if (args.ownerDeleteRouteProtected
+        || args.servers.some((server) => server.id === "missing-server")) return false
+      args.replace("/c/channels/surviving-server")
+      return true
+    })
+    const rendered = render(createElement(ServerLayout, null, createElement("div")))
+
+    await act(async () => mocks.deleteServerAction.current?.())
+    const callbacks = mocks.deleteServer.mock.calls[0]![1] as {
+      onError: (error: Error) => void
+    }
+    mocks.servers.current = [{ id: "surviving-server" }]
+    rendered.rerender(createElement(ServerLayout, null, createElement("div")))
+    expect(mocks.replace).not.toHaveBeenCalled()
+
+    const error = new Error("delete failed")
+    await act(async () => callbacks.onError(error))
+    mocks.servers.current = [
+      { id: "missing-server" },
+      { id: "surviving-server" },
+    ]
+    rendered.rerender(createElement(ServerLayout, null, createElement("div")))
+    expect(mocks.replace).not.toHaveBeenCalled()
+    expect(mocks.toastApiError).toHaveBeenCalledWith(error, "Failed to delete server")
+    expect(mocks.useServer).toHaveBeenLastCalledWith("missing-server")
+
+    mocks.servers.current = [{ id: "surviving-server" }]
+    rendered.rerender(createElement(ServerLayout, null, createElement("div")))
+    expect(mocks.runEject).toHaveBeenLastCalledWith(expect.objectContaining({
+      ownerDeleteRouteProtected: false,
+    }))
+    expect(mocks.replace).toHaveBeenCalledExactlyOnceWith(
+      "/c/channels/surviving-server",
+    )
   })
 })

--- a/src/web/src/app/c/channels/layout.tsx
+++ b/src/web/src/app/c/channels/layout.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
 import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation"
+import { useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { toastApiError } from "@/lib/api/client"
 import { markSwitch } from "@/lib/perf/switch-mark"
@@ -9,12 +10,14 @@ import { Dialog, DialogContent } from "@/components/ui/dialog"
 import { ShellFrame } from "@/components/community/shell/shell-frame"
 import {
   channelHref,
+  communityServerId,
   serverModalMarkerCleanupHref,
   serverRootHref,
 } from "@/lib/community/community-route"
 import { useBreakpoint } from "@/hooks/use-mobile"
 import { ChannelSidebarScope } from "@/components/community/channels/channel-sidebar-tree-owner"
 import { ChannelRoute } from "@/components/community/channels/channel-route"
+import { CommunityPendingFrame } from "@/components/community/shell/community-pending-frame"
 import { ServerSettings } from "@/components/community/settings/server-settings"
 import { ImageCropDialog } from "@/components/community/image-crop-dialog"
 import { validateIconSourceFile } from "@/lib/community/image-crop"
@@ -27,13 +30,27 @@ import {
   useCurrentChannelMeta,
 } from "@/stores/community"
 import { useCurrentUser } from "@/contexts/community/current-user"
-import { useServer, useServers } from "@/hooks/community/use-servers"
+import {
+  useServer,
+  useServers,
+  serverProjectedQueryFn,
+  type ServerDetail,
+  type ServersResponse,
+} from "@/hooks/community/use-servers"
 import { useServerMembers } from "@/hooks/community/use-server-members"
 import {
+  claimOwnerServerDeleteNavigation,
   consumeVoluntaryLeave,
+  createOwnerServerDeleteRouteToken,
+  isOwnerServerDeleteRouteProtected,
   runAuthoritativeServerEject,
 } from "@/lib/community/eject-server"
-import { clearLastChannel } from "@/lib/community/last-channel"
+import {
+  clearLastChannel,
+  getLastChannel,
+  pickServerLandingHref,
+} from "@/lib/community/last-channel"
+import { communityKeys } from "@/lib/query-keys"
 import { usePresence } from "@/hooks/community/use-server-panels"
 import {
   resolveForumSidebarRouteCandidate,
@@ -75,10 +92,23 @@ export default function ServerLayout({ children }: { children: ReactNode }) {
   const pathname = usePathname()
   const serverId = decodeURIComponent(params.serverId)
   const routeChannelId = params.channelId ? decodeURIComponent(params.channelId) : null
+  const ownerDeleteRouteIdentity = useMemo(
+    () => ({
+      serverId,
+      token: createOwnerServerDeleteRouteToken(),
+    }),
+    [serverId],
+  )
+  const ownerDeleteRouteToken = ownerDeleteRouteIdentity.token
+  const ownerDeleteRouteProtected = isOwnerServerDeleteRouteProtected(
+    serverId,
+    ownerDeleteRouteToken,
+  )
   const hasChannel = !!routeChannelId
   const breakpoint = useBreakpoint()
 
   const router = useRouter()
+  const queryClient = useQueryClient()
   const cancelPendingNavigation = useCallback(() => {
     useCommunityStore.getState().uiHandlers.cancelPendingNavigation?.()
   }, [])
@@ -91,7 +121,7 @@ export default function ServerLayout({ children }: { children: ReactNode }) {
     () => structuralHintServer(structuralSnapshot, serverId),
     [serverId, structuralSnapshot],
   )
-  const { server: currentServer } = useServer(serverId)
+  const { server: currentServer } = useServer(ownerDeleteRouteProtected ? null : serverId)
   const structuralTreeReady = hasStructuralServerTree(structuralServer)
   const sidebarCategories = useMemo(
     () => currentServer?.categories ?? (structuralTreeReady ? structuralServer?.categoriesView : undefined) ?? [],
@@ -162,6 +192,31 @@ export default function ServerLayout({ children }: { children: ReactNode }) {
     return grouped
   }, [forumSidebar.threads])
 
+  const serversList = useServers()
+  const serverDestination = useCallback(async (id: string) => {
+    const structural = structuralSnapshot?.servers.find((server) => server.id === id)
+    const lastChannel = getLastChannel(id)
+    let detail = queryClient.getQueryData<ServerDetail>(communityKeys.server(id))
+    if (!detail && !lastChannel && !hasStructuralServerTree(structural)) {
+      try {
+        detail = await queryClient.fetchQuery({
+          queryKey: communityKeys.server(id),
+          queryFn: serverProjectedQueryFn(queryClient, id),
+          staleTime: Infinity,
+        })
+      } catch {
+        // The server landing route remains the safe fallback if its detail
+        // cannot be resolved. Its ordinary loader owns retry/error handling.
+      }
+    }
+    const channelIds = detail?.categories.flatMap((category) =>
+      category.channels
+        .filter((channel) => !channel.pending)
+        .map((channel) => channel.id),
+    ) ?? structural?.channels.map((channel) => channel.id) ?? []
+    return pickServerLandingHref(id, channelIds, lastChannel)
+  }, [queryClient, structuralSnapshot])
+
   // Mutations
   const createChannelMut = useCreateChannel()
   const renameChannelMut = useRenameChannel()
@@ -172,7 +227,31 @@ export default function ServerLayout({ children }: { children: ReactNode }) {
   const deleteCategoryMut = useDeleteCategory()
   const reorderCategoriesMut = useReorderCategories()
   const reorderChannelsMut = useReorderChannels()
-  const deleteServerMut = useDeleteServer()
+  const deleteServerMut = useDeleteServer({
+    routeToken: ownerDeleteRouteToken,
+    onSuccess: ({ serverId: deletedServerId }, { needsNavigation }) => {
+      toast("Server deleted")
+      clearLastChannel(deletedServerId)
+      if (!needsNavigation) return
+      void (async () => {
+        const servers = queryClient.getQueryData<ServersResponse>(
+          communityKeys.servers(),
+        )?.servers ?? []
+        const survivor = servers.find((server) => server.id !== deletedServerId)
+        const destination = survivor
+          ? await serverDestination(survivor.id)
+          : "/c/me"
+        if (!claimOwnerServerDeleteNavigation(
+          deletedServerId,
+          ownerDeleteRouteToken,
+          destination,
+        )) return
+        cancelPendingNavigation()
+        router.replace(destination)
+      })()
+    },
+    onError: (error) => toastApiError(error, "Failed to delete server"),
+  })
   const updateServerMut = useUpdateServer()
   const uploadServerIconMut = useUploadServerIcon()
   const setServerNotifMut = useSetServerNotifLevel()
@@ -198,10 +277,11 @@ export default function ServerLayout({ children }: { children: ReactNode }) {
   // true after a first 5xx, while a failed background refetch may retain
   // last-good data; treating either as authoritative ejects valid URLs on a
   // transient read failure. The ref prevents a re-fire during navigation.
-  const serversList = useServers()
   const ejectedRef = useRef(false)
   useEffect(() => {
     if (ejectedRef.current) return
+    if (typeof window !== "undefined"
+      && communityServerId(window.location.href) !== serverId) return
     ejectedRef.current = runAuthoritativeServerEject({
       serverId,
       servers: serversList.servers,
@@ -209,6 +289,7 @@ export default function ServerLayout({ children }: { children: ReactNode }) {
       // target advanced the access epoch and retired an in-flight list read.
       isSuccess: serverAccessRevoked || serversList.isSuccess,
       isFetching: serverAccessRevoked ? false : serversList.isFetching,
+      ownerDeleteRouteProtected: isOwnerServerDeleteRouteProtected(serverId),
       consumeVoluntaryLeave,
       clearLastChannel,
       toast,
@@ -484,15 +565,7 @@ export default function ServerLayout({ children }: { children: ReactNode }) {
           onCopyInvite={(code) => { navigator.clipboard?.writeText(`${window.location.origin}/c/invite/${code}`); toast("Invite copied") }}
           onDeleteServer={async () => {
             closeSettings()
-            deleteServerMut.mutate({ serverId }, {
-              onSuccess: () => {
-                toast("Server deleted")
-                useCommunityStore.getState().setCurrentServerId(null)
-                cancelPendingNavigation()
-                useCommunityStore.getState().uiHandlers.navigatePath?.("/c/me")
-              },
-              onError: (e) => toastApiError(e, "Failed to delete server"),
-            })
+            deleteServerMut.mutate({ serverId })
           }}
           onUploadIcon={() => {
             const input = document.createElement("input")
@@ -549,7 +622,9 @@ export default function ServerLayout({ children }: { children: ReactNode }) {
   const structuralFrameHref = routeChannelId
     ? channelHref(serverId, routeChannelId)
     : serverRootHref(serverId)
-  const content = routeChannelId
+  const content = ownerDeleteRouteProtected
+    ? <CommunityPendingFrame href={pathname} />
+    : routeChannelId
     ? (
         <ChannelRoute
           key={`${serverId}/${routeChannelId}`}
@@ -568,6 +643,7 @@ export default function ServerLayout({ children }: { children: ReactNode }) {
       extraDialogs={<>{serverSettingsDialog}{iconCropDialog}</>}
       onOpenActiveServerSettings={onSidebarOpenSettings}
       onOpenActiveServerInvite={onRailOpenActiveInvite}
+      ownerDeleteRouteScope={ownerDeleteRouteIdentity}
     >
       {content}
     </ShellFrame>

--- a/src/web/src/app/c/channels/layout.tsx
+++ b/src/web/src/app/c/channels/layout.tsx
@@ -281,7 +281,7 @@ export default function ServerLayout({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (ejectedRef.current) return
     if (typeof window !== "undefined"
-      && communityServerId(window.location.href) !== serverId) return
+      && communityServerId(window.location.pathname) !== serverId) return
     ejectedRef.current = runAuthoritativeServerEject({
       serverId,
       servers: serversList.servers,

--- a/src/web/src/app/c/community-shell.identity.dom.test.ts
+++ b/src/web/src/app/c/community-shell.identity.dom.test.ts
@@ -42,6 +42,9 @@ vi.mock("@/components/community/onboarding/community-onboarding-form", () => ({
 vi.mock("@/components/community/shell/community-ws-reconnect-overlay", () => ({
   CommunityWsReconnectBoundary: ({ children }: { children: React.ReactNode }) => children,
 }))
+vi.mock("@/components/community/shell/owner-server-delete-route-guard", () => ({
+  OwnerServerDeleteRouteGuard: () => null,
+}))
 
 import { CommunityShell } from "./community-shell"
 

--- a/src/web/src/app/c/community-shell.tsx
+++ b/src/web/src/app/c/community-shell.tsx
@@ -14,6 +14,7 @@ import { PerfTraceBootstrap } from "@/components/perf/perf-trace-bootstrap"
 import { CommunityOnboardingForm } from "@/components/community/onboarding/community-onboarding-form"
 import { CommunityWsReconnectBoundary } from "@/components/community/shell/community-ws-reconnect-overlay"
 import { useCommunityWsStore } from "@/stores/community/ws"
+import { OwnerServerDeleteRouteGuard } from "@/components/community/shell/owner-server-delete-route-guard"
 
 /**
  * Client wrapper that provides the QueryClient, CurrentUser, and the
@@ -113,6 +114,7 @@ function CommunityBootstrap({ children }: { children: ReactNode }) {
     <>
       <PerfTraceBootstrap />
       <CommunityWsReconnectBoundary>
+        <OwnerServerDeleteRouteGuard />
         <CommunityOnboardingForm />
         {children}
       </CommunityWsReconnectBoundary>

--- a/src/web/src/components/community/shell/owner-server-delete-route-guard.dom.test.tsx
+++ b/src/web/src/components/community/shell/owner-server-delete-route-guard.dom.test.tsx
@@ -1,0 +1,73 @@
+import { createElement } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render } from "@/test/react-dom-harness"
+
+const mocks = vi.hoisted(() => ({
+  pathname: "/c/channels/deleted/channel-1",
+  completed: true,
+  runEject: vi.fn(() => true),
+  replace: vi.fn(),
+  getQueryData: vi.fn(() => ({ servers: [{ id: "survivor" }] })),
+  getQueryState: vi.fn(() => ({ status: "success", fetchStatus: "idle" })),
+  subscribe: vi.fn(),
+}))
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mocks.pathname,
+  useRouter: () => ({ replace: mocks.replace }),
+}))
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({
+    getQueryData: mocks.getQueryData,
+    getQueryState: mocks.getQueryState,
+    getQueryCache: () => ({
+      subscribe: mocks.subscribe,
+      find: () => ({ queryHash: "servers" }),
+    }),
+  }),
+}))
+vi.mock("sonner", () => ({ toast: vi.fn() }))
+vi.mock("@/contexts/community/current-user", () => ({
+  useCurrentUser: () => ({ id: "viewer-1" }),
+}))
+vi.mock("@/lib/community/eject-server", () => ({
+  consumeVoluntaryLeave: vi.fn(),
+  isOwnerServerDeleteCompleted: () => mocks.completed,
+  runAuthoritativeServerEject: mocks.runEject,
+}))
+vi.mock("@/lib/community/last-channel", () => ({ clearLastChannel: vi.fn() }))
+
+import { OwnerServerDeleteRouteGuard } from "./owner-server-delete-route-guard"
+
+describe("OwnerServerDeleteRouteGuard", () => {
+  beforeEach(() => {
+    mocks.pathname = "/c/channels/deleted/channel-1"
+    mocks.completed = true
+    mocks.runEject.mockClear()
+    mocks.getQueryData.mockClear()
+    mocks.getQueryState.mockClear()
+    mocks.subscribe.mockReset()
+  })
+
+  it("rechecks a completed delete from cached server-list state without mounting a query observer", () => {
+    render(createElement(OwnerServerDeleteRouteGuard))
+
+    expect(mocks.runEject).toHaveBeenCalledWith(expect.objectContaining({
+      serverId: "deleted",
+      servers: [{ id: "survivor" }],
+      isSuccess: true,
+      isFetching: false,
+      routeHref: "/c/channels/deleted/channel-1",
+    }))
+    expect(mocks.subscribe).not.toHaveBeenCalled()
+  })
+
+  it("does not touch the server-list cache for ordinary routes", () => {
+    mocks.completed = false
+    render(createElement(OwnerServerDeleteRouteGuard))
+
+    expect(mocks.runEject).not.toHaveBeenCalled()
+    expect(mocks.getQueryData).not.toHaveBeenCalled()
+    expect(mocks.subscribe).not.toHaveBeenCalled()
+  })
+})

--- a/src/web/src/components/community/shell/owner-server-delete-route-guard.tsx
+++ b/src/web/src/components/community/shell/owner-server-delete-route-guard.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import { useEffect } from "react"
+import { usePathname, useRouter } from "next/navigation"
+import { useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { useCurrentUser } from "@/contexts/community/current-user"
+import type { ServersResponse } from "@/hooks/community/use-servers"
+import { communityServerId } from "@/lib/community/community-route"
+import {
+  consumeVoluntaryLeave,
+  isOwnerServerDeleteCompleted,
+  runAuthoritativeServerEject,
+} from "@/lib/community/eject-server"
+import { clearLastChannel } from "@/lib/community/last-channel"
+import { communityKeys } from "@/lib/query-keys"
+
+/** Rechecks cached deleted-server history entries from the persistent `/c` tree. */
+export function OwnerServerDeleteRouteGuard() {
+  const pathname = usePathname()
+  const router = useRouter()
+  const queryClient = useQueryClient()
+  const currentUser = useCurrentUser()
+
+  useEffect(() => {
+    const serverId = communityServerId(pathname)
+    if (!serverId || !isOwnerServerDeleteCompleted(serverId)) return
+
+    const eject = () => {
+      const key = communityKeys.servers()
+      const state = queryClient.getQueryState(key)
+      const servers = queryClient.getQueryData<ServersResponse>(key)?.servers ?? []
+      return runAuthoritativeServerEject({
+        serverId,
+        servers,
+        isSuccess: state?.status === "success",
+        isFetching: state?.fetchStatus === "fetching",
+        consumeVoluntaryLeave,
+        clearLastChannel,
+        toast,
+        accountId: currentUser.id,
+        routeHref: pathname,
+        replace: (destination) => router.replace(destination),
+      })
+    }
+
+    if (eject()) return
+    const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
+      if (event.query.queryHash !== queryClient.getQueryCache().find({
+        queryKey: communityKeys.servers(),
+        exact: true,
+      })?.queryHash) return
+      if (eject()) unsubscribe()
+    })
+    return unsubscribe
+  }, [currentUser.id, pathname, queryClient, router])
+
+  return null
+}

--- a/src/web/src/components/community/shell/shell-frame-types.ts
+++ b/src/web/src/components/community/shell/shell-frame-types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react"
+import type { OwnerServerDeleteRouteToken } from "@/lib/community/eject-server"
 import type { View } from "./shell-types"
 
 export type ShellFrameProps = {
@@ -10,6 +11,10 @@ export type ShellFrameProps = {
   extraDialogs?: ReactNode
   onOpenActiveServerSettings?: () => void
   onOpenActiveServerInvite?: () => void
+  ownerDeleteRouteScope?: {
+    serverId: string
+    token: OwnerServerDeleteRouteToken
+  }
 }
 
 export type ShellRouter = {

--- a/src/web/src/components/community/shell/shell-frame.dom.test.ts
+++ b/src/web/src/components/community/shell/shell-frame.dom.test.ts
@@ -4,6 +4,7 @@ import { render } from "@/test/react-dom-harness"
 import { ShellFrame } from "./shell-frame"
 
 const mocks = vi.hoisted(() => {
+  const serverCache = new Set<string>()
   const handlers = {
     previewImage: vi.fn(),
     previewAttachment: vi.fn(),
@@ -15,13 +16,21 @@ const mocks = vi.hoisted(() => {
     currentHref: { current: "/c/channels/s1" },
     pendingHref: { current: null as string | null },
     navigationPending: { current: false },
-    serverCache: new Set<string>(),
+    serverCache,
+    queryClient: {
+      getQueryData: (key: unknown[]) => serverCache.has(String(key.at(-1)))
+        ? { id: key.at(-1) }
+        : undefined,
+    },
     structuralSnapshot: { current: null as null | Record<string, unknown> },
     breakpoint: { current: "desktop" },
     onboardingState: { current: null as Record<string, unknown> | null },
     replace: vi.fn(),
     push: vi.fn(),
     registerUiHandlers: vi.fn(),
+    observeOwnerDelete: vi.fn(),
+    registerOwnerDelete: vi.fn(() => "ordinary"),
+    flushOwnerDelete: vi.fn(),
     handlers,
     rail: {
       railProps: {},
@@ -48,11 +57,14 @@ const mocks = vi.hoisted(() => {
 })
 
 vi.mock("@tanstack/react-query", () => ({
-  useQueryClient: () => ({
-    getQueryData: (key: unknown[]) => mocks.serverCache.has(String(key.at(-1)))
-      ? { id: key.at(-1) }
-      : undefined,
-  }),
+  useQueryClient: () => mocks.queryClient,
+}))
+vi.mock("@/hooks/community/community-ws/scope-eviction", () => ({
+  flushOwnerServerDeleteRouteCommit: (...args: unknown[]) => mocks.flushOwnerDelete(...args),
+}))
+vi.mock("@/lib/community/eject-server", () => ({
+  observeOwnerServerDeleteRouteCommit: (...args: unknown[]) => mocks.observeOwnerDelete(...args),
+  registerOwnerServerDeleteRoute: (...args: unknown[]) => mocks.registerOwnerDelete(...args),
 }))
 vi.mock("@/hooks/use-mobile", () => ({ useBreakpoint: () => mocks.breakpoint.current }))
 vi.mock("@/lib/community-onboarding", () => ({
@@ -136,6 +148,9 @@ describe("ShellFrame orchestration", () => {
     mocks.breakpoint.current = "desktop"
     mocks.onboardingState.current = null
     mocks.registerUiHandlers.mockClear()
+    mocks.observeOwnerDelete.mockClear()
+    mocks.registerOwnerDelete.mockClear()
+    mocks.flushOwnerDelete.mockClear()
     mocks.replace.mockClear()
     mocks.push.mockClear()
     mocks.railOptions.mockClear()
@@ -167,6 +182,28 @@ describe("ShellFrame orchestration", () => {
       frameHref: "/c/channels/s1/c2",
     }))
     expect(checkpoint().mode).toBe("committed")
+    expect(mocks.observeOwnerDelete).toHaveBeenLastCalledWith("/c/channels/s1/c2")
+    expect(mocks.flushOwnerDelete).toHaveBeenLastCalledWith(
+      mocks.queryClient,
+    )
+    expect(mocks.observeOwnerDelete.mock.invocationCallOrder.at(-1)).toBeLessThan(
+      mocks.flushOwnerDelete.mock.invocationCallOrder.at(-1) ?? 0,
+    )
+  })
+
+  it("registers the route token at the same committed-frame boundary", () => {
+    const token = {}
+    mocks.registerOwnerDelete.mockReturnValueOnce("participant")
+
+    render(createElement(ShellFrame, {
+      ...baseProps,
+      ownerDeleteRouteScope: { serverId: "s1", token },
+    }))
+
+    expect(mocks.registerOwnerDelete).toHaveBeenCalledWith("s1", token)
+    expect(mocks.registerOwnerDelete.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.observeOwnerDelete.mock.invocationCallOrder[0] ?? 0,
+    )
   })
 
   it("keeps the committed surface until exact frame evidence arrives", () => {

--- a/src/web/src/components/community/shell/shell-frame.tsx
+++ b/src/web/src/components/community/shell/shell-frame.tsx
@@ -30,6 +30,11 @@ import {
   userBarExtensionReducer,
 } from "./user-bar-extension-state"
 import { useShellDaemonUpdateController } from "./use-shell-daemon-update-controller"
+import { flushOwnerServerDeleteRouteCommit } from "@/hooks/community/community-ws/scope-eviction"
+import {
+  observeOwnerServerDeleteRouteCommit,
+  registerOwnerServerDeleteRoute,
+} from "@/lib/community/eject-server"
 
 /** Shared community shell orchestration for the server and DM layouts. */
 export function ShellFrame(props: ShellFrameProps) {
@@ -42,6 +47,7 @@ export function ShellFrame(props: ShellFrameProps) {
     extraDialogs,
     onOpenActiveServerSettings,
     onOpenActiveServerInvite,
+    ownerDeleteRouteScope,
   } = props
   const queryClient = useQueryClient()
   const currentUser = useCurrentUser()
@@ -62,7 +68,19 @@ export function ShellFrame(props: ShellFrameProps) {
     committedFrameRef.current = next
     setCommittedFrame(next)
   }, [])
-  useLayoutEffect(() => commitFrame(frameHref), [commitFrame, frameHref])
+  useLayoutEffect(() => {
+    commitFrame(frameHref)
+    if (ownerDeleteRouteScope) {
+      registerOwnerServerDeleteRoute(
+        ownerDeleteRouteScope.serverId,
+        ownerDeleteRouteScope.token,
+      )
+    }
+    observeOwnerServerDeleteRouteCommit(frameHref)
+  }, [commitFrame, frameHref, ownerDeleteRouteScope])
+  useEffect(() => {
+    flushOwnerServerDeleteRouteCommit(queryClient)
+  }, [frameHref, queryClient])
   const navigation = useCommunityNavigationController(committedFrame)
   const replacePath = navigation.replace
   const route = resolveCommunityRoute(committedFrame.pathname)

--- a/src/web/src/hooks/community/community-ws/scope-eviction.test.ts
+++ b/src/web/src/hooks/community/community-ws/scope-eviction.test.ts
@@ -1,0 +1,124 @@
+import { QueryClient } from "@tanstack/react-query"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { communityKeys } from "@/lib/query-keys"
+import {
+  beginOwnerServerDelete,
+  cancelOwnerServerDelete,
+  commitOwnerServerDelete,
+  createOwnerServerDeleteRouteToken,
+  isOwnerServerDeleteRouteProtected,
+  observeOwnerServerDeleteRouteCommit,
+} from "@/lib/community/eject-server"
+import {
+  evictServerChannelScopes,
+  flushOwnerServerDeleteAfterSuccess,
+  flushOwnerServerDeleteRouteCommit,
+} from "./scope-eviction"
+
+describe("owner-delete scope eviction", () => {
+  const deletedServerId = "srv_owner_deleted"
+  const otherServerId = "srv_other"
+
+  beforeEach(() => {
+    cancelOwnerServerDelete(deletedServerId)
+    cancelOwnerServerDelete(otherServerId)
+  })
+
+  it("merges mutation and WS eviction until one safe route commit flushes once", () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(communityKeys.server(deletedServerId), {
+      id: deletedServerId,
+      categories: [],
+    })
+    const removeQueries = vi.spyOn(queryClient, "removeQueries")
+    const token = createOwnerServerDeleteRouteToken()
+
+    beginOwnerServerDelete(deletedServerId, token)
+    expect(evictServerChannelScopes(queryClient, deletedServerId)).toBe(false)
+    expect(commitOwnerServerDelete(deletedServerId, token)).toBe(false)
+    expect(evictServerChannelScopes(queryClient, deletedServerId)).toBe(false)
+    expect(queryClient.getQueryState(communityKeys.server(deletedServerId))).toBeDefined()
+
+    expect(observeOwnerServerDeleteRouteCommit(
+      `/c/channels/${deletedServerId}/channel-1`,
+    )).toEqual([])
+    expect(flushOwnerServerDeleteRouteCommit(queryClient)).toEqual([])
+
+    expect(observeOwnerServerDeleteRouteCommit("/c/me")).toEqual([deletedServerId])
+    expect(flushOwnerServerDeleteRouteCommit(queryClient)).toEqual([deletedServerId])
+    expect(queryClient.getQueryState(communityKeys.server(deletedServerId))).toBeUndefined()
+    expect(removeQueries).toHaveBeenCalledTimes(1)
+    expect(isOwnerServerDeleteRouteProtected(deletedServerId)).toBe(false)
+    expect(isOwnerServerDeleteRouteProtected(deletedServerId, token)).toBe(true)
+
+    expect(evictServerChannelScopes(queryClient, deletedServerId)).toBe(false)
+    expect(flushOwnerServerDeleteRouteCommit(queryClient)).toEqual([])
+    expect(removeQueries).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps unrelated Servers immediate and releases a cancelled attempt", () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(communityKeys.server(deletedServerId), {
+      id: deletedServerId,
+      categories: [],
+    })
+    queryClient.setQueryData(communityKeys.server(otherServerId), {
+      id: otherServerId,
+      categories: [],
+    })
+    const token = createOwnerServerDeleteRouteToken()
+
+    beginOwnerServerDelete(deletedServerId, token)
+    expect(evictServerChannelScopes(queryClient, otherServerId)).toBe(true)
+    expect(queryClient.getQueryState(communityKeys.server(otherServerId))).toBeUndefined()
+    expect(queryClient.getQueryState(communityKeys.server(deletedServerId))).toBeDefined()
+
+    cancelOwnerServerDelete(deletedServerId, token)
+    expect(evictServerChannelScopes(queryClient, deletedServerId)).toBe(true)
+    expect(queryClient.getQueryState(communityKeys.server(deletedServerId))).toBeUndefined()
+  })
+
+  it("flushes immediately when success follows an already-safe commit", () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(communityKeys.server(deletedServerId), {
+      id: deletedServerId,
+      categories: [],
+    })
+    const removeQueries = vi.spyOn(queryClient, "removeQueries")
+    const token = createOwnerServerDeleteRouteToken()
+
+    beginOwnerServerDelete(deletedServerId, token)
+    expect(observeOwnerServerDeleteRouteCommit("/c/me")).toEqual([])
+    expect(commitOwnerServerDelete(deletedServerId, token)).toBe(true)
+    expect(flushOwnerServerDeleteAfterSuccess(queryClient, deletedServerId)).toBe(true)
+
+    expect(queryClient.getQueryState(communityKeys.server(deletedServerId))).toBeUndefined()
+    expect(removeQueries).toHaveBeenCalledTimes(1)
+    expect(flushOwnerServerDeleteAfterSuccess(queryClient, deletedServerId)).toBe(false)
+    expect(flushOwnerServerDeleteRouteCommit(queryClient)).toEqual([])
+    expect(removeQueries).toHaveBeenCalledTimes(1)
+  })
+
+  it("uses the latest committed route fact at DELETE success", () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(communityKeys.server(deletedServerId), {
+      id: deletedServerId,
+      categories: [],
+    })
+    const removeQueries = vi.spyOn(queryClient, "removeQueries")
+    const token = createOwnerServerDeleteRouteToken()
+
+    beginOwnerServerDelete(deletedServerId, token)
+    observeOwnerServerDeleteRouteCommit("/c/me")
+    observeOwnerServerDeleteRouteCommit(
+      `/c/channels/${deletedServerId}/channel-1`,
+    )
+    expect(commitOwnerServerDelete(deletedServerId, token)).toBe(false)
+    expect(flushOwnerServerDeleteAfterSuccess(queryClient, deletedServerId)).toBe(false)
+    expect(removeQueries).not.toHaveBeenCalled()
+
+    expect(observeOwnerServerDeleteRouteCommit("/c/me")).toEqual([deletedServerId])
+    expect(flushOwnerServerDeleteRouteCommit(queryClient)).toEqual([deletedServerId])
+    expect(removeQueries).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/web/src/hooks/community/community-ws/scope-eviction.ts
+++ b/src/web/src/hooks/community/community-ws/scope-eviction.ts
@@ -5,6 +5,13 @@ import { useCommunityStore } from "@/stores/community"
 import { useMessageStreamStore } from "@/stores/community/message-stream"
 import { clearTypingIndicator } from "./typing"
 import { updateStructuralSnapshot } from "@/lib/community/structural-snapshot"
+import {
+  claimOwnerServerDeleteScopeFlush,
+  completeOwnerServerDeleteScopeFlush,
+  isOwnerServerDeleteScopeFlushReady,
+  isOwnerServerDeleteScopeEvictionBlocked,
+  ownerServerDeleteScopeFlushCandidates,
+} from "@/lib/community/eject-server"
 
 type ThreadPageLike = {
   serverId?: string
@@ -101,7 +108,7 @@ export function evictScopeContent(
   }
 }
 
-export function evictServerChannelScopes(queryClient: QueryClient, serverId: string) {
+function evictServerChannelScopesNow(queryClient: QueryClient, serverId: string) {
   useCommunityWsStore.getState().revokeServerAccess(serverId)
   for (const id of collectChannelScopeIds(queryClient, serverId)) {
     evictScopeContent(queryClient, serverId, id)
@@ -122,4 +129,41 @@ export function evictServerChannelScopes(queryClient: QueryClient, serverId: str
     community.setCurrentServerId(null)
   }
   updateStructuralSnapshot(queryClient, { type: "removeServer", serverId })
+}
+
+export function evictServerChannelScopes(queryClient: QueryClient, serverId: string): boolean {
+  if (isOwnerServerDeleteScopeEvictionBlocked(serverId)) return false
+  evictServerChannelScopesNow(queryClient, serverId)
+  return true
+}
+
+function flushOwnerServerDeleteScopes(
+  queryClient: QueryClient,
+  serverIds: readonly string[],
+): string[] {
+  const flushed: string[] = []
+  for (const serverId of serverIds) {
+    if (!isOwnerServerDeleteScopeFlushReady(serverId)) continue
+    if (!claimOwnerServerDeleteScopeFlush(serverId)) continue
+    evictServerChannelScopesNow(queryClient, serverId)
+    if (!completeOwnerServerDeleteScopeFlush(serverId)) continue
+    flushed.push(serverId)
+  }
+  return flushed
+}
+
+export function flushOwnerServerDeleteAfterSuccess(
+  queryClient: QueryClient,
+  serverId: string,
+): boolean {
+  return flushOwnerServerDeleteScopes(queryClient, [serverId]).length === 1
+}
+
+export function flushOwnerServerDeleteRouteCommit(
+  queryClient: QueryClient,
+): string[] {
+  return flushOwnerServerDeleteScopes(
+    queryClient,
+    ownerServerDeleteScopeFlushCandidates(),
+  )
 }

--- a/src/web/src/hooks/community/mutations/servers.dom.test.tsx
+++ b/src/web/src/hooks/community/mutations/servers.dom.test.tsx
@@ -1,0 +1,177 @@
+import React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, renderHook, waitFor } from "@/test/react-dom-harness"
+import { communityKeys } from "@/lib/query-keys"
+import {
+  cancelOwnerServerDelete,
+  claimOwnerServerDeleteNavigation,
+  claimOwnerServerDeleteScopeFlush,
+  completeOwnerServerDeleteScopeFlush,
+  createOwnerServerDeleteRouteToken,
+  isOwnerServerDeleteRouteProtected,
+  observeOwnerServerDeleteRouteCommit,
+} from "@/lib/community/eject-server"
+import { useDeleteServer } from "./servers"
+
+const mocks = vi.hoisted(() => ({
+  api: vi.fn(),
+  evictServerChannelScopes: vi.fn(),
+  flushOwnerServerDeleteAfterSuccess: vi.fn(),
+}))
+
+vi.mock("@/lib/api/client", () => ({
+  apiFetch: mocks.api,
+  readUploadError: vi.fn(),
+}))
+
+vi.mock("@/hooks/community/community-ws/scope-eviction", () => ({
+  evictServerChannelScopes: mocks.evictServerChannelScopes,
+  flushOwnerServerDeleteAfterSuccess: mocks.flushOwnerServerDeleteAfterSuccess,
+}))
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+function setup(
+  serverId: string,
+  callbacks: Parameters<typeof useDeleteServer>[0],
+) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  client.setQueryData(communityKeys.servers(), {
+    servers: [{ id: serverId }],
+  })
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+  return {
+    client,
+    ...renderHook(
+      ({ activeCallbacks }) => useDeleteServer(activeCallbacks),
+      { initialProps: { activeCallbacks: callbacks }, wrapper },
+    ),
+  }
+}
+
+describe("useDeleteServer — unmounted caller", () => {
+  const serverIds = [
+    "srv_unmounted_success",
+    "srv_unmounted_failure",
+    "srv_rerendered_success",
+  ]
+
+  beforeEach(() => {
+    mocks.api.mockReset()
+    mocks.evictServerChannelScopes.mockReset()
+    mocks.flushOwnerServerDeleteAfterSuccess.mockReset()
+    for (const serverId of serverIds) cancelOwnerServerDelete(serverId)
+  })
+
+  afterEach(() => {
+    for (const serverId of serverIds) cancelOwnerServerDelete(serverId)
+  })
+
+  it("keeps the successful navigation handoff after the calling component unmounts", async () => {
+    const serverId = serverIds[0]
+    const request = deferred<void>()
+    const onSuccess = vi.fn()
+    const routeToken = createOwnerServerDeleteRouteToken()
+    mocks.api.mockReturnValueOnce(request.promise)
+    const view = setup(serverId, { routeToken, onSuccess })
+
+    act(() => view.result.current.mutate({ serverId }))
+    await waitFor(() => {
+      expect(mocks.api).toHaveBeenCalledOnce()
+      expect(view.client.getQueryData<{ servers: unknown[] }>(
+        communityKeys.servers(),
+      )?.servers).toEqual([])
+      expect(isOwnerServerDeleteRouteProtected(serverId)).toBe(true)
+    })
+    view.unmount()
+
+    request.resolve(undefined)
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledOnce())
+    expect(onSuccess).toHaveBeenCalledWith({ serverId }, { needsNavigation: true })
+    expect(isOwnerServerDeleteRouteProtected(serverId)).toBe(true)
+    expect(claimOwnerServerDeleteNavigation(serverId, routeToken, "/c/me")).toBe(true)
+
+    observeOwnerServerDeleteRouteCommit("/c/me")
+    expect(claimOwnerServerDeleteScopeFlush(serverId)).toBe(true)
+    expect(completeOwnerServerDeleteScopeFlush(serverId)).toBe(true)
+    expect(isOwnerServerDeleteRouteProtected(serverId)).toBe(false)
+    expect(isOwnerServerDeleteRouteProtected(serverId, routeToken)).toBe(true)
+  })
+
+  it("rolls back and clears coordination before reporting an unmounted failure", async () => {
+    const serverId = serverIds[1]
+    const request = deferred<void>()
+    const failure = new Error("delete failed")
+    const routeToken = createOwnerServerDeleteRouteToken()
+    const clientRef: { current: QueryClient | null } = { current: null }
+    const onError = vi.fn(() => {
+      expect(clientRef.current?.getQueryData<{ servers: Array<{ id: string }> }>(
+        communityKeys.servers(),
+      )?.servers).toEqual([{ id: serverId }])
+      expect(isOwnerServerDeleteRouteProtected(serverId)).toBe(false)
+    })
+    mocks.api.mockReturnValueOnce(request.promise)
+    const view = setup(serverId, { routeToken, onError })
+    clientRef.current = view.client
+
+    act(() => view.result.current.mutate({ serverId }))
+    await waitFor(() => {
+      expect(mocks.api).toHaveBeenCalledOnce()
+      expect(isOwnerServerDeleteRouteProtected(serverId)).toBe(true)
+    })
+    view.unmount()
+
+    request.reject(failure)
+    await waitFor(() => expect(onError).toHaveBeenCalledOnce())
+    expect(onError).toHaveBeenCalledWith(failure, { serverId })
+    observeOwnerServerDeleteRouteCommit("/c/me")
+    expect(claimOwnerServerDeleteScopeFlush(serverId)).toBe(false)
+    expect(isOwnerServerDeleteRouteProtected(serverId, routeToken)).toBe(false)
+  })
+
+  it("finishes with the originating token and callback after the route layout rerenders", async () => {
+    const serverId = serverIds[2]
+    const request = deferred<void>()
+    const originToken = createOwnerServerDeleteRouteToken()
+    const survivorToken = createOwnerServerDeleteRouteToken()
+    const originSuccess = vi.fn()
+    const survivorSuccess = vi.fn()
+    mocks.api.mockReturnValueOnce(request.promise)
+    const view = setup(serverId, { routeToken: originToken, onSuccess: originSuccess })
+
+    act(() => view.result.current.mutate({ serverId }))
+    await waitFor(() => expect(isOwnerServerDeleteRouteProtected(serverId)).toBe(true))
+    observeOwnerServerDeleteRouteCommit("/c/channels/survivor/channel-1")
+    view.rerender({
+      activeCallbacks: { routeToken: survivorToken, onSuccess: survivorSuccess },
+    })
+
+    request.resolve(undefined)
+    await waitFor(() => expect(originSuccess).toHaveBeenCalledOnce())
+    expect(originSuccess).toHaveBeenCalledWith({ serverId }, { needsNavigation: false })
+    expect(survivorSuccess).not.toHaveBeenCalled()
+    expect(mocks.flushOwnerServerDeleteAfterSuccess).toHaveBeenCalledWith(
+      view.client,
+      serverId,
+    )
+  })
+})

--- a/src/web/src/hooks/community/mutations/servers.test.ts
+++ b/src/web/src/hooks/community/mutations/servers.test.ts
@@ -113,7 +113,10 @@ describe("useLeaveServer — optimistic + rollback", () => {
     apiFetchMock.mockRejectedValueOnce(new Error("boom"))
     const mod = await load()
     if (operation === "leave") mod.useLeaveServer()
-    else mod.useDeleteServer()
+    else {
+      const lifecycle = await import("@/lib/community/eject-server")
+      mod.useDeleteServer({ routeToken: lifecycle.createOwnerServerDeleteRouteToken() })
+    }
     await runMutation({ serverId: "srv_1" }).catch(() => {})
     const cache = capturedQc.getQueryData<{ servers: { id: string }[] }>(communityKeys.servers())
     expect(cache?.servers).toHaveLength(1)
@@ -152,9 +155,23 @@ describe("useLeaveServer — optimistic + rollback", () => {
         categories: [],
       })
       if (operation === "leave") mod.useLeaveServer()
-      else mod.useDeleteServer()
+      else {
+        const lifecycle = await import("@/lib/community/eject-server")
+        mod.useDeleteServer({ routeToken: lifecycle.createOwnerServerDeleteRouteToken() })
+      }
 
       await runMutation({ serverId: "srv_1" })
+      if (operation === "delete") {
+        expect(useCommunityStore.getState().currentServerId).toBe("srv_1")
+        const { flushOwnerServerDeleteRouteCommit } = await import(
+          "@/hooks/community/community-ws/scope-eviction"
+        )
+        const { observeOwnerServerDeleteRouteCommit } = await import(
+          "@/lib/community/eject-server"
+        )
+        expect(observeOwnerServerDeleteRouteCommit("/c/me")).toEqual(["srv_1"])
+        expect(flushOwnerServerDeleteRouteCommit(capturedQc)).toEqual(["srv_1"])
+      }
 
       expect(useCommunityStore.getState()).toMatchObject({
         currentServerId: null,
@@ -167,8 +184,121 @@ describe("useLeaveServer — optimistic + rollback", () => {
       expect(capturedQc.getQueryData<{
         serverOrder: string[]
       }>(communityKeys.structuralSnapshot())?.serverOrder).toEqual([])
+      if (operation === "delete") {
+        const lifecycle = await import("@/lib/community/eject-server")
+        expect(lifecycle.isOwnerServerDeleteRouteProtected("srv_1")).toBe(false)
+      }
     },
   )
+})
+
+describe("useDeleteServer — navigation lifecycle", () => {
+  it("reports zero navigation and flushes once when a safe route committed before success", async () => {
+    const args = { serverId: "srv_delete_after_safe_commit" }
+    capturedQc.setQueryData(communityKeys.servers(), {
+      servers: [{ id: args.serverId }],
+    })
+    capturedQc.setQueryData(communityKeys.server(args.serverId), {
+      id: args.serverId,
+      categories: [],
+    })
+    apiFetchMock.mockResolvedValueOnce(undefined)
+    const mod = await load()
+    const lifecycle = await import("@/lib/community/eject-server")
+    const routeToken = lifecycle.createOwnerServerDeleteRouteToken()
+    const onSuccess = vi.fn()
+    mod.useDeleteServer({ routeToken, onSuccess })
+    const { flushOwnerServerDeleteRouteCommit } = await import(
+      "@/hooks/community/community-ws/scope-eviction"
+    )
+    lifecycle.cancelOwnerServerDelete(args.serverId)
+    const removeQueries = vi.spyOn(capturedQc, "removeQueries")
+    const cfg = capturedConfig as MutConfig<typeof args, unknown>
+
+    const context = await cfg.onMutate?.(args)
+    expect(lifecycle.observeOwnerServerDeleteRouteCommit("/c/me")).toEqual([])
+    expect(flushOwnerServerDeleteRouteCommit(capturedQc)).toEqual([])
+    expect(capturedQc.getQueryState(communityKeys.server(args.serverId))).toBeDefined()
+    await cfg.mutationFn?.(args)
+    cfg.onSuccess?.(undefined, args, context)
+
+    expect(capturedQc.getQueryState(communityKeys.server(args.serverId))).toBeUndefined()
+    expect(removeQueries).toHaveBeenCalledTimes(1)
+    expect(onSuccess).toHaveBeenCalledWith(args, { needsNavigation: false })
+    expect(flushOwnerServerDeleteRouteCommit(capturedQc)).toEqual([])
+    expect(removeQueries).toHaveBeenCalledTimes(1)
+    expect(lifecycle.isOwnerServerDeleteRouteProtected(args.serverId)).toBe(false)
+    expect(lifecycle.isOwnerServerDeleteRouteProtected(args.serverId, routeToken)).toBe(true)
+  })
+
+  it("requests one navigation while the deleted route remains committed", async () => {
+    const args = { serverId: "srv_delete" }
+    capturedQc.setQueryData(communityKeys.servers(), {
+      servers: [{ id: args.serverId }],
+    })
+    apiFetchMock.mockResolvedValueOnce(undefined)
+    const mod = await load()
+    const lifecycle = await import("@/lib/community/eject-server")
+    const routeToken = lifecycle.createOwnerServerDeleteRouteToken()
+    const onSuccess = vi.fn()
+    mod.useDeleteServer({ routeToken, onSuccess })
+    lifecycle.cancelOwnerServerDelete(args.serverId)
+    const cfg = capturedConfig as MutConfig<typeof args, unknown>
+
+    const context = await cfg.onMutate?.(args)
+    expect(lifecycle.isOwnerServerDeleteRouteProtected(args.serverId)).toBe(true)
+    expect(capturedQc.getQueryData<{ servers: unknown[] }>(
+      communityKeys.servers(),
+    )?.servers).toEqual([])
+    await cfg.mutationFn?.(args)
+
+    cfg.onSuccess?.(undefined, args, context)
+    expect(onSuccess).toHaveBeenCalledWith(args, { needsNavigation: true })
+    expect(lifecycle.claimOwnerServerDeleteNavigation(
+      args.serverId,
+      routeToken,
+      "/c/me",
+    )).toBe(true)
+    const { flushOwnerServerDeleteRouteCommit } = await import(
+      "@/hooks/community/community-ws/scope-eviction"
+    )
+    expect(lifecycle.observeOwnerServerDeleteRouteCommit("/c/me")).toEqual([
+      args.serverId,
+    ])
+    expect(flushOwnerServerDeleteRouteCommit(capturedQc)).toEqual([
+      args.serverId,
+    ])
+    expect(lifecycle.isOwnerServerDeleteRouteProtected(args.serverId)).toBe(false)
+    expect(lifecycle.isOwnerServerDeleteRouteProtected(args.serverId, routeToken)).toBe(true)
+  })
+
+  it("restores the Server row and clears coordination after DELETE failure", async () => {
+    const args = { serverId: "srv_delete_failed" }
+    capturedQc.setQueryData(communityKeys.servers(), {
+      servers: [{ id: args.serverId }],
+    })
+    const mod = await load()
+    const lifecycle = await import("@/lib/community/eject-server")
+    const routeToken = lifecycle.createOwnerServerDeleteRouteToken()
+    const onError = vi.fn()
+    mod.useDeleteServer({ routeToken, onError })
+    lifecycle.cancelOwnerServerDelete(args.serverId)
+    const cfg = capturedConfig as MutConfig<typeof args, unknown>
+
+    const context = await cfg.onMutate?.(args)
+    expect(lifecycle.isOwnerServerDeleteRouteProtected(args.serverId)).toBe(true)
+    const failure = new Error("failed")
+    cfg.onError?.(failure, args, context)
+
+    expect(capturedQc.getQueryData<{ servers: Array<{ id: string }> }>(
+      communityKeys.servers(),
+    )?.servers).toEqual([{ id: args.serverId }])
+    expect(onError).toHaveBeenCalledWith(failure, args)
+    expect(lifecycle.isOwnerServerDeleteRouteProtected(args.serverId)).toBe(false)
+    expect(lifecycle.isOwnerServerDeleteRouteProtected(args.serverId, routeToken)).toBe(false)
+    lifecycle.observeOwnerServerDeleteRouteCommit("/c/me")
+    expect(lifecycle.claimOwnerServerDeleteScopeFlush(args.serverId)).toBe(false)
+  })
 })
 
 describe("useUpdateServer — rollback on both caches", () => {

--- a/src/web/src/hooks/community/mutations/servers.ts
+++ b/src/web/src/hooks/community/mutations/servers.ts
@@ -10,7 +10,16 @@ import {
   type AccountUnreadScopeToken,
 } from "@/hooks/community/account-unread-projection"
 import { updateStructuralSnapshot } from "@/lib/community/structural-snapshot"
-import { evictServerChannelScopes } from "@/hooks/community/community-ws/scope-eviction"
+import {
+  evictServerChannelScopes,
+  flushOwnerServerDeleteAfterSuccess,
+} from "@/hooks/community/community-ws/scope-eviction"
+import {
+  beginOwnerServerDelete,
+  cancelOwnerServerDelete,
+  commitOwnerServerDelete,
+  type OwnerServerDeleteRouteToken,
+} from "@/lib/community/eject-server"
 
 /**
  * Server-scoped mutations. `create`/`join` invalidate the rail; `leave`/`delete`
@@ -74,6 +83,14 @@ export function useJoinServer() {
 // ── Leave / delete server ──────────────────────────────────────────────────
 
 export type LeaveServerArgs = { serverId: string }
+type DeleteServerCallbacks = {
+  routeToken: OwnerServerDeleteRouteToken
+  onSuccess?: (
+    args: LeaveServerArgs,
+    result: { needsNavigation: boolean },
+  ) => void
+  onError?: (error: Error, args: LeaveServerArgs) => void
+}
 
 export function useLeaveServer() {
   const queryClient = useQueryClient()
@@ -112,17 +129,21 @@ export function useLeaveServer() {
   })
 }
 
-export function useDeleteServer() {
+export function useDeleteServer(callbacks: DeleteServerCallbacks) {
   const queryClient = useQueryClient()
   const unreadProjection = getActiveAccountUnreadProjection(queryClient)
   return useMutation<void, Error, LeaveServerArgs, {
     snapshot: ServersResponse | undefined
     token: AccountUnreadScopeToken
+    routeToken: OwnerServerDeleteRouteToken
+    onSuccess: DeleteServerCallbacks["onSuccess"]
+    onError: DeleteServerCallbacks["onError"]
   }>({
     mutationFn: async ({ serverId }) => {
       await apiFetch(`/api/community/servers/${serverId}`, { method: "DELETE" })
     },
     onMutate: async (args) => {
+      beginOwnerServerDelete(args.serverId, callbacks.routeToken)
       const key = communityKeys.servers()
       await queryClient.cancelQueries({ queryKey: key })
       const snapshot = queryClient.getQueryData<ServersResponse>(key)
@@ -132,19 +153,29 @@ export function useDeleteServer() {
       return {
         snapshot,
         token: unreadProjection.beginScopeRetirement({ kind: "server", serverId: args.serverId }),
+        routeToken: callbacks.routeToken,
+        onSuccess: callbacks.onSuccess,
+        onError: callbacks.onError,
       }
     },
-    onError: (_err, _args, ctx) => {
+    onError: (error, args, ctx) => {
       if (ctx) unreadProjection.rollbackScopeRetirement(ctx.token)
       if (ctx?.snapshot) queryClient.setQueryData(communityKeys.servers(), ctx.snapshot)
+      cancelOwnerServerDelete(args.serverId, ctx?.routeToken ?? callbacks.routeToken)
+      const onError = ctx?.onError ?? callbacks.onError
+      onError?.(error, args)
     },
     onSuccess: (_data, args, context) => {
+      const scopeFlushReady = commitOwnerServerDelete(args.serverId, context.routeToken)
       unreadProjection.commitScopeRetirement(context.token)
-      evictServerChannelScopes(queryClient, args.serverId)
+      if (scopeFlushReady) {
+        flushOwnerServerDeleteAfterSuccess(queryClient, args.serverId)
+      }
       void queryClient.invalidateQueries({
         queryKey: communityKeys.channelRefDirectory(),
         exact: true,
       })
+      context.onSuccess?.(args, { needsNavigation: !scopeFlushReady })
     },
   })
 }

--- a/src/web/src/lib/community/community-route.test.ts
+++ b/src/web/src/lib/community/community-route.test.ts
@@ -110,6 +110,12 @@ describe("community route", () => {
     expect(communityServerId(href)).toBe(serverId)
   })
 
+  it("accepts a pathname but rejects an absolute URL at the parser boundary", () => {
+    expect(communityServerId("/c/channels/server_1/channel_1")).toBe("server_1")
+    expect(communityServerId("https://alook.local/c/channels/server_1/channel_1"))
+      .toBeNull()
+  })
+
   it("normalizes query order and keeps structural scope independent from hash", () => {
     expect(normalizeCommunityHref("/c/channels/server_1/channel_1?z=2&a=1#message"))
       .toEqual({

--- a/src/web/src/lib/community/eject-server.test.ts
+++ b/src/web/src/lib/community/eject-server.test.ts
@@ -1,16 +1,28 @@
-import { describe, it, expect, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import {
-  markVoluntaryLeave,
+  beginOwnerServerDelete,
+  cancelOwnerServerDelete,
+  claimOwnerServerDeleteNavigation,
+  claimOwnerServerDeleteScopeFlush,
+  commitOwnerServerDelete,
+  completeOwnerServerDeleteScopeFlush,
   consumeVoluntaryLeave,
-  pickPostEjectDestination,
-  runAuthoritativeServerEject,
+  createOwnerServerDeleteRouteToken,
   isDefinitiveChildMetaFailure,
+  isOwnerServerDeleteCompleted,
+  isOwnerServerDeleteRouteProtected,
+  isOwnerServerDeleteScopeEvictionBlocked,
+  markVoluntaryLeave,
+  observeOwnerServerDeleteRouteCommit,
+  pickPostEjectDestination,
+  registerOwnerServerDeleteRoute,
+  runAuthoritativeServerEject,
 } from "./eject-server"
 import type { Server } from "./models/navigation"
 import { ApiError } from "@/lib/errors"
 import {
-  commitLastCommunityRoute,
   clearCommunityColdEntryAttempts,
+  commitLastCommunityRoute,
   resolveCommunityColdEntryDestination,
 } from "./last-community-route"
 
@@ -26,6 +38,11 @@ function makeServer(id: string): Server {
   }
 }
 
+function terminalize(serverId: string): void {
+  expect(claimOwnerServerDeleteScopeFlush(serverId)).toBe(true)
+  expect(completeOwnerServerDeleteScopeFlush(serverId)).toBe(true)
+}
+
 describe("voluntary-leave marker", () => {
   it("marked id consumes as true, then false on the second read", () => {
     markVoluntaryLeave("srv_a")
@@ -36,13 +53,137 @@ describe("voluntary-leave marker", () => {
   it("unrelated ids consume as false", () => {
     markVoluntaryLeave("srv_b")
     expect(consumeVoluntaryLeave("srv_other")).toBe(false)
-    // srv_b still marked — clean it up to keep test isolation
     expect(consumeVoluntaryLeave("srv_b")).toBe(true)
   })
 })
 
+describe("owner-delete single-navigation lifecycle", () => {
+  const serverId = "srv_deleted"
+
+  beforeEach(() => {
+    cancelOwnerServerDelete(serverId)
+  })
+
+  it("claims exactly one survivor navigation while the deleted route is committed", () => {
+    const origin = createOwnerServerDeleteRouteToken()
+    beginOwnerServerDelete(serverId, origin)
+
+    expect(commitOwnerServerDelete(serverId, origin)).toBe(false)
+    expect(claimOwnerServerDeleteNavigation(
+      serverId,
+      origin,
+      "/c/channels/srv_next/channel_remembered",
+    )).toBe(true)
+    expect(claimOwnerServerDeleteNavigation(serverId, origin, "/c/me")).toBe(false)
+    expect(isOwnerServerDeleteRouteProtected(serverId, origin)).toBe(true)
+
+    expect(observeOwnerServerDeleteRouteCommit(
+      "/c/channels/srv_next/channel_remembered",
+    )).toEqual([serverId])
+    terminalize(serverId)
+    expect(isOwnerServerDeleteCompleted(serverId)).toBe(true)
+    expect(isOwnerServerDeleteRouteProtected(serverId)).toBe(false)
+    expect(isOwnerServerDeleteRouteProtected(serverId, origin)).toBe(true)
+    expect(isOwnerServerDeleteScopeEvictionBlocked(serverId)).toBe(true)
+  })
+
+  it.each([
+    "/c/channels/srv_next/channel_remembered",
+    "/c/me/friends",
+  ])("keeps an already committed safe route and issues no navigation: %s", (safeHref) => {
+    const origin = createOwnerServerDeleteRouteToken()
+    beginOwnerServerDelete(serverId, origin)
+    expect(observeOwnerServerDeleteRouteCommit(safeHref)).toEqual([])
+
+    expect(commitOwnerServerDelete(serverId, origin)).toBe(true)
+    expect(claimOwnerServerDeleteNavigation(
+      serverId,
+      origin,
+      "/c/channels/srv_next/channel_remembered",
+    )).toBe(false)
+    terminalize(serverId)
+    expect(isOwnerServerDeleteRouteProtected(serverId)).toBe(false)
+  })
+
+  it("turns a resolver result into a no-op when a safe route commits first", () => {
+    const origin = createOwnerServerDeleteRouteToken()
+    beginOwnerServerDelete(serverId, origin)
+    expect(commitOwnerServerDelete(serverId, origin)).toBe(false)
+
+    expect(observeOwnerServerDeleteRouteCommit("/c/me")).toEqual([serverId])
+    expect(claimOwnerServerDeleteNavigation(
+      serverId,
+      origin,
+      "/c/channels/srv_next/channel_default",
+    )).toBe(false)
+    terminalize(serverId)
+  })
+
+  it("lets either the claimed target or a newer user route finish cleanup", () => {
+    for (const safeHref of [
+      "/c/channels/srv_next/channel_default",
+      "/c/me/machines",
+    ]) {
+      const origin = createOwnerServerDeleteRouteToken()
+      beginOwnerServerDelete(serverId, origin)
+      expect(commitOwnerServerDelete(serverId, origin)).toBe(false)
+      expect(claimOwnerServerDeleteNavigation(
+        serverId,
+        origin,
+        "/c/channels/srv_next/channel_default",
+      )).toBe(true)
+      expect(observeOwnerServerDeleteRouteCommit(safeHref)).toEqual([serverId])
+      terminalize(serverId)
+      expect(isOwnerServerDeleteRouteProtected(serverId)).toBe(false)
+    }
+  })
+
+  it("tombstones only route instances committed before the terminal boundary", () => {
+    const origin = createOwnerServerDeleteRouteToken()
+    const preTerminal = createOwnerServerDeleteRouteToken()
+    const postTerminal = createOwnerServerDeleteRouteToken()
+    beginOwnerServerDelete(serverId, origin)
+    expect(registerOwnerServerDeleteRoute(serverId, preTerminal)).toBe("participant")
+    expect(commitOwnerServerDelete(serverId, origin)).toBe(false)
+    observeOwnerServerDeleteRouteCommit("/c/me")
+    terminalize(serverId)
+
+    expect(isOwnerServerDeleteRouteProtected(serverId, origin)).toBe(true)
+    expect(isOwnerServerDeleteRouteProtected(serverId, preTerminal)).toBe(true)
+    expect(registerOwnerServerDeleteRoute(serverId, postTerminal)).toBe("ordinary")
+    expect(isOwnerServerDeleteRouteProtected(serverId, postTerminal)).toBe(false)
+    expect(registerOwnerServerDeleteRoute(serverId, origin)).toBe("ordinary")
+    expect(isOwnerServerDeleteRouteProtected(serverId, origin)).toBe(false)
+    expect(isOwnerServerDeleteRouteProtected(serverId, preTerminal)).toBe(true)
+  })
+
+  it("classifies registration after the terminal claim as ordinary", () => {
+    const origin = createOwnerServerDeleteRouteToken()
+    const lateCommit = createOwnerServerDeleteRouteToken()
+    beginOwnerServerDelete(serverId, origin)
+    commitOwnerServerDelete(serverId, origin)
+    observeOwnerServerDeleteRouteCommit("/c/me")
+
+    expect(claimOwnerServerDeleteScopeFlush(serverId)).toBe(true)
+    expect(registerOwnerServerDeleteRoute(serverId, lateCommit)).toBe("ordinary")
+    expect(completeOwnerServerDeleteScopeFlush(serverId)).toBe(true)
+    expect(isOwnerServerDeleteRouteProtected(serverId, lateCommit)).toBe(false)
+  })
+
+  it("cancels a failed request without navigation, flush, or tombstone", () => {
+    const origin = createOwnerServerDeleteRouteToken()
+    beginOwnerServerDelete(serverId, origin)
+    cancelOwnerServerDelete(serverId, origin)
+
+    expect(claimOwnerServerDeleteNavigation(serverId, origin, "/c/me")).toBe(false)
+    expect(claimOwnerServerDeleteScopeFlush(serverId)).toBe(false)
+    expect(isOwnerServerDeleteRouteProtected(serverId, origin)).toBe(false)
+    expect(isOwnerServerDeleteScopeEvictionBlocked(serverId)).toBe(false)
+  })
+})
+
 describe("runAuthoritativeServerEject", () => {
-  const target = { id: "srv_target" } as Server
+  const target = makeServer("srv_target")
   const callbacks = () => ({
     consumeVoluntaryLeave: vi.fn(() => false),
     clearLastChannel: vi.fn(),
@@ -50,46 +191,68 @@ describe("runAuthoritativeServerEject", () => {
     replace: vi.fn(),
   })
 
-  it("keeps the URL and last-channel through first 500, then accepts a success containing the target", () => {
+  beforeEach(() => {
+    cancelOwnerServerDelete(target.id)
+  })
+
+  it("keeps the URL through failures, refetches, and snapshots containing the target", () => {
     const sideEffects = callbacks()
     expect(runAuthoritativeServerEject({
       serverId: target.id, servers: [], isSuccess: false, isFetching: false, ...sideEffects,
     })).toBe(false)
     expect(runAuthoritativeServerEject({
-      serverId: target.id, servers: [target], isSuccess: true, isFetching: false, ...sideEffects,
-    })).toBe(false)
-    expect(sideEffects.replace).not.toHaveBeenCalled()
-    expect(sideEffects.toast).not.toHaveBeenCalled()
-    expect(sideEffects.clearLastChannel).not.toHaveBeenCalled()
-  })
-
-  it("does not eject from last-good data when a refetch errors", () => {
-    const sideEffects = callbacks()
-    expect(runAuthoritativeServerEject({
       serverId: target.id, servers: [target], isSuccess: false, isFetching: false, ...sideEffects,
     })).toBe(false)
-    expect(sideEffects.replace).not.toHaveBeenCalled()
-    expect(sideEffects.toast).not.toHaveBeenCalled()
-    expect(sideEffects.clearLastChannel).not.toHaveBeenCalled()
-  })
-
-  it("does not decide absence while a successful snapshot is still fetching", () => {
-    const sideEffects = callbacks()
     expect(runAuthoritativeServerEject({
       serverId: target.id, servers: [], isSuccess: true, isFetching: true, ...sideEffects,
     })).toBe(false)
+    expect(runAuthoritativeServerEject({
+      serverId: target.id, servers: [target], isSuccess: true, isFetching: false, ...sideEffects,
+    })).toBe(false)
     expect(sideEffects.replace).not.toHaveBeenCalled()
   })
 
-  it("ejects, clears memory, and toasts only when settled success explicitly lacks the target", () => {
+  it("does not consume optimistic absence while owner delete protects the route", () => {
     const sideEffects = callbacks()
-    const remaining = { id: "srv_remaining" } as Server
     expect(runAuthoritativeServerEject({
-      serverId: target.id, servers: [remaining], isSuccess: true, isFetching: false, ...sideEffects,
+      serverId: target.id,
+      servers: [],
+      isSuccess: true,
+      isFetching: false,
+      ownerDeleteRouteProtected: true,
+      ...sideEffects,
+    })).toBe(false)
+    expect(sideEffects.replace).not.toHaveBeenCalled()
+    expect(sideEffects.toast).not.toHaveBeenCalled()
+    expect(sideEffects.clearLastChannel).not.toHaveBeenCalled()
+  })
+
+  it("ejects, clears memory, and toasts only on settled authoritative absence", () => {
+    const sideEffects = callbacks()
+    expect(runAuthoritativeServerEject({
+      serverId: target.id,
+      servers: [makeServer("srv_remaining")],
+      isSuccess: true,
+      isFetching: false,
+      ...sideEffects,
     })).toBe(true)
     expect(sideEffects.clearLastChannel).toHaveBeenCalledWith(target.id)
     expect(sideEffects.toast).toHaveBeenCalledWith("You're no longer in this server")
     expect(sideEffects.replace).toHaveBeenCalledWith("/c/channels/srv_remaining")
+  })
+
+  it("keeps voluntary leave silent", () => {
+    const sideEffects = callbacks()
+    sideEffects.consumeVoluntaryLeave.mockReturnValue(true)
+    expect(runAuthoritativeServerEject({
+      serverId: target.id,
+      servers: [],
+      isSuccess: true,
+      isFetching: false,
+      ...sideEffects,
+    })).toBe(true)
+    expect(sideEffects.replace).toHaveBeenCalledWith("/c/me")
+    expect(sideEffects.toast).not.toHaveBeenCalled()
   })
 
   it("clears a matching cold-entry route and falls back once to Machines", () => {
@@ -125,7 +288,7 @@ describe("runAuthoritativeServerEject", () => {
 })
 
 describe("isDefinitiveChildMetaFailure", () => {
-  it("keeps the existing 403/404 bounce boundary without treating 5xx as absence", () => {
+  it("keeps 403/404 definitive without treating 5xx as absence", () => {
     expect(isDefinitiveChildMetaFailure(new ApiError("forbidden", 403))).toBe(true)
     expect(isDefinitiveChildMetaFailure(new ApiError("missing", 404))).toBe(true)
     expect(isDefinitiveChildMetaFailure(new ApiError("transient", 500))).toBe(false)
@@ -134,28 +297,29 @@ describe("isDefinitiveChildMetaFailure", () => {
 })
 
 describe("pickPostEjectDestination", () => {
-  it("returns the first other server when one remains", () => {
-    const servers = [makeServer("srv_ejected"), makeServer("srv_next"), makeServer("srv_third")]
-    expect(pickPostEjectDestination(servers, "srv_ejected")).toBe(
-      "/c/channels/srv_next",
-    )
-  })
-
-  it("uses array order (railOrder is applied by the API before this call)", () => {
-    // Simulate a rail with the ejected server in the middle — the picker
-    // must still land on the first non-ejected id from left to right.
-    const servers = [makeServer("srv_first"), makeServer("srv_ejected"), makeServer("srv_third")]
+  it("uses the first surviving Server in API rail order", () => {
+    const servers = [
+      makeServer("srv_first"),
+      makeServer("srv_ejected"),
+      makeServer("srv_third"),
+    ]
     expect(pickPostEjectDestination(servers, "srv_ejected")).toBe(
       "/c/channels/srv_first",
     )
   })
 
-  it("returns /c/me when the ejected server was the only one", () => {
-    const servers = [makeServer("srv_only")]
-    expect(pickPostEjectDestination(servers, "srv_only")).toBe("/c/me")
+  it("uses the surviving Server's remembered/default Channel resolver", () => {
+    const destination = vi.fn(() => "/c/channels/srv_next/channel_default")
+    expect(pickPostEjectDestination(
+      [makeServer("srv_ejected"), makeServer("srv_next")],
+      "srv_ejected",
+      destination,
+    )).toBe("/c/channels/srv_next/channel_default")
+    expect(destination).toHaveBeenCalledExactlyOnceWith("srv_next")
   })
 
-  it("returns /c/me when the list is empty", () => {
+  it("returns /c/me when no Server survives", () => {
+    expect(pickPostEjectDestination([makeServer("srv_only")], "srv_only")).toBe("/c/me")
     expect(pickPostEjectDestination([], "srv_anything")).toBe("/c/me")
   })
 })

--- a/src/web/src/lib/community/eject-server.test.ts
+++ b/src/web/src/lib/community/eject-server.test.ts
@@ -87,6 +87,25 @@ describe("owner-delete single-navigation lifecycle", () => {
     expect(isOwnerServerDeleteScopeEvictionBlocked(serverId)).toBe(true)
   })
 
+  it("keeps duplicate begin as a participant without transferring origin ownership", () => {
+    const origin = createOwnerServerDeleteRouteToken()
+    const duplicate = createOwnerServerDeleteRouteToken()
+    beginOwnerServerDelete(serverId, origin)
+    beginOwnerServerDelete(serverId, duplicate)
+
+    expect(commitOwnerServerDelete(serverId, duplicate)).toBe(false)
+    cancelOwnerServerDelete(serverId, duplicate)
+    expect(claimOwnerServerDeleteNavigation(serverId, duplicate, "/c/me")).toBe(false)
+
+    expect(commitOwnerServerDelete(serverId, origin)).toBe(false)
+    expect(claimOwnerServerDeleteNavigation(serverId, origin, "/c/me")).toBe(true)
+    expect(observeOwnerServerDeleteRouteCommit("/c/me")).toEqual([serverId])
+    terminalize(serverId)
+
+    expect(isOwnerServerDeleteRouteProtected(serverId, origin)).toBe(true)
+    expect(isOwnerServerDeleteRouteProtected(serverId, duplicate)).toBe(true)
+  })
+
   it.each([
     "/c/channels/srv_next/channel_remembered",
     "/c/me/friends",

--- a/src/web/src/lib/community/eject-server.ts
+++ b/src/web/src/lib/community/eject-server.ts
@@ -1,5 +1,6 @@
 import type { Server } from "./models/navigation"
 import { ApiError } from "@/lib/errors"
+import { communityServerId } from "./community-route"
 import {
   COMMUNITY_COLD_ENTRY_FALLBACK,
   consumeCommunityColdEntryFailure,
@@ -16,6 +17,52 @@ import {
 // the coordination warrants. Same trick as `wsStore.hasSeenMessage`.
 const voluntaryLeaves = new Set<string>()
 
+export type OwnerServerDeleteRouteToken = object
+
+type OwnerServerDeleteRecord = {
+  serverId: string
+  request: "pending" | "resolving" | "navigating"
+  originToken: OwnerServerDeleteRouteToken
+  participantTokens: Set<OwnerServerDeleteRouteToken>
+  lastCommittedHref: string
+  targetHref: string | null
+  navigationIssued: boolean
+  scopes: "retained" | "flushing"
+}
+
+type OwnerServerDeleteState = {
+  transactions: Map<string, OwnerServerDeleteRecord>
+  tombstones: WeakMap<OwnerServerDeleteRouteToken, string>
+  flushedServerIds: Set<string>
+}
+
+type OwnerServerDeleteWindow = Window & {
+  __alookOwnerServerDeleteStateV8?: OwnerServerDeleteState
+}
+
+const ownerServerDeleteFallback: OwnerServerDeleteState = {
+  transactions: new Map(),
+  tombstones: new WeakMap(),
+  flushedServerIds: new Set(),
+}
+
+function ownerServerDeleteState(): OwnerServerDeleteState {
+  if (typeof window === "undefined") return ownerServerDeleteFallback
+  const scope = window as OwnerServerDeleteWindow
+  scope.__alookOwnerServerDeleteStateV8 ??= {
+    transactions: new Map(),
+    tombstones: new WeakMap(),
+    flushedServerIds: new Set(),
+  }
+  return scope.__alookOwnerServerDeleteStateV8
+}
+
+function ownerServerDeleteScopeFlushReady(record: OwnerServerDeleteRecord): boolean {
+  return record.request !== "pending"
+    && communityServerId(record.lastCommittedHref) !== record.serverId
+    && record.scopes === "retained"
+}
+
 export function markVoluntaryLeave(serverId: string): void {
   voluntaryLeaves.add(serverId)
 }
@@ -23,6 +70,141 @@ export function markVoluntaryLeave(serverId: string): void {
 // Returns true iff the id was marked; clears the marker either way.
 export function consumeVoluntaryLeave(serverId: string): boolean {
   return voluntaryLeaves.delete(serverId)
+}
+
+export function createOwnerServerDeleteRouteToken(): OwnerServerDeleteRouteToken {
+  return {}
+}
+
+export function registerOwnerServerDeleteRoute(
+  serverId: string,
+  token: OwnerServerDeleteRouteToken,
+): "participant" | "ordinary" {
+  const state = ownerServerDeleteState()
+  const record = state.transactions.get(serverId)
+  if (record?.scopes === "retained") {
+    record.participantTokens.add(token)
+    return "participant"
+  }
+  if (state.tombstones.get(token) === serverId) state.tombstones.delete(token)
+  return "ordinary"
+}
+
+export function beginOwnerServerDelete(
+  serverId: string,
+  originToken: OwnerServerDeleteRouteToken,
+): void {
+  const state = ownerServerDeleteState()
+  const current = state.transactions.get(serverId)
+  if (current) {
+    if (current.scopes === "retained") current.participantTokens.add(originToken)
+    return
+  }
+  state.flushedServerIds.delete(serverId)
+  state.transactions.set(serverId, {
+    serverId,
+    request: "pending",
+    originToken,
+    participantTokens: new Set([originToken]),
+    lastCommittedHref: `/c/channels/${encodeURIComponent(serverId)}`,
+    targetHref: null,
+    navigationIssued: false,
+    scopes: "retained",
+  })
+}
+
+export function commitOwnerServerDelete(
+  serverId: string,
+  originToken: OwnerServerDeleteRouteToken,
+): boolean {
+  const record = ownerServerDeleteState().transactions.get(serverId)
+  if (!record || record.originToken !== originToken || record.request !== "pending") return false
+  record.request = "resolving"
+  return ownerServerDeleteScopeFlushReady(record)
+}
+
+export function cancelOwnerServerDelete(
+  serverId: string,
+  originToken?: OwnerServerDeleteRouteToken,
+): void {
+  const state = ownerServerDeleteState()
+  const record = state.transactions.get(serverId)
+  if (record && (!originToken || record.originToken === originToken)) {
+    state.transactions.delete(serverId)
+  }
+}
+
+export function claimOwnerServerDeleteNavigation(
+  serverId: string,
+  originToken: OwnerServerDeleteRouteToken,
+  targetHref: string,
+): boolean {
+  const record = ownerServerDeleteState().transactions.get(serverId)
+  if (!record
+    || record.originToken !== originToken
+    || record.request !== "resolving"
+    || record.scopes !== "retained"
+    || record.navigationIssued
+    || communityServerId(record.lastCommittedHref) !== serverId
+    || communityServerId(targetHref) === serverId) return false
+  record.request = "navigating"
+  record.targetHref = targetHref
+  record.navigationIssued = true
+  return true
+}
+
+export function isOwnerServerDeleteRouteProtected(
+  serverId: string,
+  token?: OwnerServerDeleteRouteToken,
+): boolean {
+  const state = ownerServerDeleteState()
+  if (state.transactions.has(serverId)) return true
+  return token ? state.tombstones.get(token) === serverId : false
+}
+
+export function isOwnerServerDeleteScopeEvictionBlocked(serverId: string): boolean {
+  const state = ownerServerDeleteState()
+  return state.transactions.has(serverId) || state.flushedServerIds.has(serverId)
+}
+
+export function isOwnerServerDeleteCompleted(serverId: string): boolean {
+  return ownerServerDeleteState().flushedServerIds.has(serverId)
+}
+
+export function observeOwnerServerDeleteRouteCommit(committedHref: string): string[] {
+  const state = ownerServerDeleteState()
+  for (const record of state.transactions.values()) {
+    record.lastCommittedHref = committedHref
+  }
+  return ownerServerDeleteScopeFlushCandidates()
+}
+
+export function ownerServerDeleteScopeFlushCandidates(): string[] {
+  return [...ownerServerDeleteState().transactions]
+    .filter(([, record]) => ownerServerDeleteScopeFlushReady(record))
+    .map(([serverId]) => serverId)
+}
+
+export function isOwnerServerDeleteScopeFlushReady(serverId: string): boolean {
+  const record = ownerServerDeleteState().transactions.get(serverId)
+  return record ? ownerServerDeleteScopeFlushReady(record) : false
+}
+
+export function claimOwnerServerDeleteScopeFlush(serverId: string): boolean {
+  const record = ownerServerDeleteState().transactions.get(serverId)
+  if (!record || !ownerServerDeleteScopeFlushReady(record)) return false
+  record.scopes = "flushing"
+  return true
+}
+
+export function completeOwnerServerDeleteScopeFlush(serverId: string): boolean {
+  const state = ownerServerDeleteState()
+  const record = state.transactions.get(serverId)
+  if (!record || record.scopes !== "flushing") return false
+  for (const token of record.participantTokens) state.tombstones.set(token, serverId)
+  state.flushedServerIds.add(serverId)
+  state.transactions.delete(serverId)
+  return true
 }
 
 export function isDefinitiveChildMetaFailure(error: unknown): boolean {
@@ -35,10 +217,11 @@ export function isDefinitiveChildMetaFailure(error: unknown): boolean {
 export function pickPostEjectDestination(
   servers: readonly Server[],
   ejectedServerId: string,
+  serverDestination?: (serverId: string) => string,
 ): string {
   const remaining = servers.filter((s) => s.id !== ejectedServerId)
   if (remaining.length === 0) return "/c/me"
-  return `/c/channels/${remaining[0].id}`
+  return serverDestination?.(remaining[0].id) ?? `/c/channels/${remaining[0].id}`
 }
 
 export function runAuthoritativeServerEject(args: {
@@ -46,6 +229,7 @@ export function runAuthoritativeServerEject(args: {
   servers: readonly Server[]
   isSuccess: boolean
   isFetching: boolean
+  ownerDeleteRouteProtected?: boolean
   consumeVoluntaryLeave: (serverId: string) => boolean
   clearLastChannel: (serverId: string) => void
   toast: (message: string) => void
@@ -58,7 +242,7 @@ export function runAuthoritativeServerEject(args: {
   // retain last-good data; neither may become an existence/membership verdict.
   if (!args.isSuccess || args.isFetching) return false
   if (args.servers.some((server) => server.id === args.serverId)) return false
-
+  if (args.ownerDeleteRouteProtected) return false
   args.clearLastChannel(args.serverId)
   const voluntary = args.consumeVoluntaryLeave(args.serverId)
   if (!voluntary) args.toast("You're no longer in this server")

--- a/src/web/src/test/e2e-ui/28-community-delete-media-cleanup.spec.ts
+++ b/src/web/src/test/e2e-ui/28-community-delete-media-cleanup.spec.ts
@@ -97,7 +97,7 @@ async function status(
 }
 
 test("existing channel/server deletes converge UI, WS, pending rows, linked media, and icon reads", async ({ asUser }) => {
-  test.setTimeout(150_000)
+  test.setTimeout(210_000)
   const stamp = Date.now()
   const channelServerId = await seedServer("alice", `C1 channel ${stamp}`)
   const channelId = await seedChannel("alice", channelServerId, `delete-media-${stamp}`, "text")
@@ -121,7 +121,7 @@ test("existing channel/server deletes converge UI, WS, pending rows, linked medi
 
   await gotoAfterUserWsAuth(alice.page, `/c/channels/${channelServerId}/${channelId}`)
   await gotoAfterUserWsAuth(bob.page, `/c/channels/${channelServerId}/${channelId}`)
-  await expect(bob.page.getByTestId(tid.channelRow(channelId))).toBeVisible()
+  await expect(bob.page.getByTestId(tid.channelRow(channelId))).toBeVisible({ timeout: 30_000 })
 
   expect(await status("bob", `/api/community/channels/${channelId}`, "DELETE")).toBe(403)
   expect(await status("carol", `/api/community/channels/${channelId}`, "DELETE")).toBe(403)
@@ -165,7 +165,14 @@ test("existing channel/server deletes converge UI, WS, pending rows, linked medi
   }).click()
   expect((await serverDeleteResponse).status()).toBe(204)
 
-  await expect(alice.page).toHaveURL(/\/c\/me(?:\/friends)?$/)
+  await expect(alice.page).not.toHaveURL(new RegExp(`/c/channels/${serverId}(?:/|$)`))
+  await expect(alice.page).toHaveURL(/\/c\/channels\/[^/]+\/[^/]+$/)
+  const deleteLanding = new URL(alice.page.url()).pathname.match(
+    /^\/c\/channels\/([^/]+)\/([^/]+)$/,
+  )
+  expect(deleteLanding).not.toBeNull()
+  expect(deleteLanding?.[1]).not.toBe(serverId)
+  expect(await status("alice", `/api/community/channels/${deleteLanding?.[2]}`)).toBe(200)
   await expect(alice.page.getByTestId(tid.serverIcon(serverId))).toHaveCount(0)
   await expect(alice.page.getByTestId(tid.channelRow(serverChannelId))).toHaveCount(0)
   await expect(alice.page.getByTestId(tid.composerInput)).toHaveCount(0)
@@ -182,6 +189,7 @@ test("existing channel/server deletes converge UI, WS, pending rows, linked medi
 
   await alice.page.goBack()
   await expect(alice.page).not.toHaveURL(new RegExp(`/c/channels/${serverId}/`))
+  // Regression: a fresh Back visit must not settle on the survivor Server root.
   await expect(alice.page).toHaveURL(/\/c\/channels\/[^/]+\/[^/]+$/)
   const siblingRoute = new URL(alice.page.url()).pathname.match(/^\/c\/channels\/([^/]+)\/([^/]+)$/)
   expect(siblingRoute).not.toBeNull()
@@ -196,7 +204,9 @@ test("existing channel/server deletes converge UI, WS, pending rows, linked medi
   expect(liveServers.servers.some(({ id }) => id === serverId)).toBe(false)
   expect(await status("alice", `/api/community/channels/${siblingChannelId}`)).toBe(200)
   await expect(alice.page.getByTestId(tid.serverIcon(siblingServerId))).toBeVisible()
-  await expect(alice.page.getByTestId(tid.channelRow(siblingChannelId))).toBeVisible()
+  await expect(alice.page.getByTestId(tid.channelRow(siblingChannelId))).toBeVisible({
+    timeout: 30_000,
+  })
   await alice.page.reload()
   await expect(alice.page).toHaveURL(new RegExp(`/c/channels/${siblingServerId}/${siblingChannelId}$`))
   await expect(alice.page.getByTestId(tid.serverIcon(serverId))).toHaveCount(0)

--- a/src/web/src/test/e2e-ui/57-server-delete-navigation-races.spec.ts
+++ b/src/web/src/test/e2e-ui/57-server-delete-navigation-races.spec.ts
@@ -226,16 +226,20 @@ for (const testCase of [
 
 test("slow target RSC survives delete/list/WS convergence and lands on its remembered Channel", async ({ asUser }) => {
   const stamp = Date.now()
-  const survivor = await seedServerRoute("carol", `slow-target-${stamp}`)
+  const ensuredSurvivor = await seedServerRoute("carol", `slow-target-${stamp}`)
   const deleted = await seedServerRoute("carol", `slow-deleted-${stamp}`)
   const page = (await asUser("carol")).page
   await gotoAfterUserWsAuth(
     page,
-    `/c/channels/${survivor.serverId}/${survivor.channelId}`,
+    `/c/channels/${ensuredSurvivor.serverId}/${ensuredSurvivor.channelId}`,
   )
+  const targetServerId = (await serverIds("carol")).find((id) => id !== deleted.serverId)
+  expect(targetServerId).toBeTruthy()
+  await openServer(page, targetServerId!)
+  const targetPathname = await expectServerLeaf(page, targetServerId!)
   await expect(page.getByTestId(tid.composerInput)).toBeVisible()
   await openServer(page, deleted.serverId)
-  const targetRsc = await delayServerRsc(page, survivor.serverId)
+  const targetRsc = await delayServerRsc(page, targetServerId!)
   const response = page.waitForResponse((candidate) => (
     candidate.request().method() === "DELETE"
       && new URL(candidate.url()).pathname === `/api/community/servers/${deleted.serverId}`
@@ -247,25 +251,31 @@ test("slow target RSC survives delete/list/WS convergence and lands on its remem
   await targetRsc.intercepted
   expect(new URL(page.url()).pathname).not.toBe("/c/me")
   targetRsc.release()
-  expect(await expectServerLeaf(page, survivor.serverId)).toBe(
-    `/c/channels/${survivor.serverId}/${survivor.channelId}`,
-  )
+  expect(await expectServerLeaf(page, targetServerId!)).toBe(targetPathname)
   await expect(page.getByTestId(tid.serverIcon(deleted.serverId))).toHaveCount(0)
   await targetRsc.cleanup()
 })
 
 test("a newer user navigation wins while the delete target RSC is pending", async ({ asUser }) => {
   const stamp = Date.now()
-  const target = await seedServerRoute("dave", `queued-target-${stamp}`)
-  const userRoute = await seedServerRoute("dave", `queued-user-${stamp}`)
+  const candidateA = await seedServerRoute("dave", `queued-target-a-${stamp}`)
+  const candidateB = await seedServerRoute("dave", `queued-target-b-${stamp}`)
   const deleted = await seedServerRoute("dave", `queued-deleted-${stamp}`)
   const page = (await asUser("dave")).page
   await gotoAfterUserWsAuth(
     page,
-    `/c/channels/${target.serverId}/${target.channelId}`,
+    `/c/channels/${candidateA.serverId}/${candidateA.channelId}`,
   )
+  const targetServerId = (await serverIds("dave")).find((id) => id !== deleted.serverId)
+  expect(targetServerId).toBeTruthy()
+  const userRoute = [candidateA, candidateB].find(({ serverId }) => (
+    serverId !== targetServerId
+  ))
+  expect(userRoute).toBeTruthy()
+  await openServer(page, targetServerId!)
+  await expectServerLeaf(page, targetServerId!)
   await openServer(page, deleted.serverId)
-  const targetRsc = await delayServerRsc(page, target.serverId)
+  const targetRsc = await delayServerRsc(page, targetServerId!)
   const response = page.waitForResponse((candidate) => (
     candidate.request().method() === "DELETE"
       && new URL(candidate.url()).pathname === `/api/community/servers/${deleted.serverId}`
@@ -275,10 +285,10 @@ test("a newer user navigation wins while the delete target RSC is pending", asyn
 
   expect((await response).status()).toBe(204)
   await targetRsc.intercepted
-  await page.getByTestId(tid.serverIcon(userRoute.serverId)).click()
+  await page.getByTestId(tid.serverIcon(userRoute!.serverId)).click()
   targetRsc.release()
-  await expectServerLeaf(page, userRoute.serverId)
-  await expect(page).not.toHaveURL(new RegExp(`/c/channels/${target.serverId}(?:/|$)`), {
+  await expectServerLeaf(page, userRoute!.serverId)
+  await expect(page).not.toHaveURL(new RegExp(`/c/channels/${targetServerId}(?:/|$)`), {
     timeout: 2_000,
   })
   await targetRsc.cleanup()

--- a/src/web/src/test/e2e-ui/57-server-delete-navigation-races.spec.ts
+++ b/src/web/src/test/e2e-ui/57-server-delete-navigation-races.spec.ts
@@ -1,0 +1,347 @@
+import type { Page, WebSocket } from "@playwright/test"
+import { expect, sessionCookie, test } from "./_fixtures/community-fixture"
+import { gotoAfterUserWsAuth, openServer } from "./_fixtures/actions"
+import { seedChannel, seedServer } from "./_fixtures/seed"
+import { tid } from "./_fixtures/testids"
+import { WEB_URL } from "./_setup/paths"
+import type { UserKey } from "./_setup/users"
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+}
+
+function captureServerDeletes(page: Page) {
+  const frames: Array<{ type: string; serverId?: string }> = []
+  const sockets = new Set<WebSocket>()
+  page.on("websocket", (socket) => {
+    sockets.add(socket)
+    socket.on("framereceived", ({ payload }) => {
+      try {
+        const frame = JSON.parse(payload.toString()) as { type: string; serverId?: string }
+        if (frame.type === "community:server.delete") frames.push(frame)
+      } catch {}
+    })
+  })
+  return { frames, sockets }
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+async function serverIds(key: UserKey): Promise<string[]> {
+  const response = await fetch(`${WEB_URL}/api/community/servers`, {
+    headers: { Cookie: sessionCookie(key), Origin: WEB_URL },
+  })
+  expect(response.status).toBe(200)
+  const body = await response.json() as { servers: Array<{ id: string }> }
+  return body.servers.map((server) => server.id)
+}
+
+async function seedServerRoute(
+  key: UserKey,
+  name: string,
+): Promise<{ serverId: string; channelId: string }> {
+  const serverId = await seedServer(key, name)
+  const channelId = await seedChannel(key, serverId, `${name} channel`, "text")
+  return { serverId, channelId }
+}
+
+async function clickDeleteServer(page: Page, serverId: string): Promise<void> {
+  await page.getByTestId(tid.serverIcon(serverId)).click({ button: "right" })
+  await page.getByTestId(tid.serverSettingsOpen).click()
+  await expect(page.getByTestId(tid.settingsShell)).toBeVisible()
+  await page.getByRole("button", { name: "Delete Server", exact: true }).click()
+  await page.getByRole("dialog").getByRole("button", {
+    name: "Delete Server",
+    exact: true,
+  }).click()
+}
+
+async function delayDelete(page: Page, serverId: string) {
+  const release = deferred<void>()
+  const intercepted = deferred<void>()
+  const pattern = `**/api/community/servers/${serverId}`
+  await page.route(pattern, async (route) => {
+    if (route.request().method() !== "DELETE") {
+      await route.continue()
+      return
+    }
+    intercepted.resolve()
+    await release.promise
+    await route.continue()
+  })
+  const response = page.waitForResponse((candidate) => (
+    candidate.request().method() === "DELETE"
+      && new URL(candidate.url()).pathname === `/api/community/servers/${serverId}`
+  ))
+  await clickDeleteServer(page, serverId)
+  await intercepted.promise
+  return {
+    release: () => release.resolve(),
+    response,
+    cleanup: () => page.unroute(pattern),
+  }
+}
+
+async function delayServerRsc(page: Page, serverId: string) {
+  const release = deferred<void>()
+  const intercepted = deferred<void>()
+  const pattern = "**/c/channels/**"
+  await page.route(pattern, async (route) => {
+    const url = new URL(route.request().url())
+    const targetsServer = url.pathname === `/c/channels/${serverId}`
+      || url.pathname.startsWith(`/c/channels/${serverId}/`)
+    if (!targetsServer || !url.searchParams.has("_rsc")) {
+      await route.continue()
+      return
+    }
+    intercepted.resolve()
+    await release.promise
+    await route.continue()
+  })
+  return {
+    intercepted: intercepted.promise,
+    release: () => release.resolve(),
+    cleanup: () => page.unroute(pattern),
+  }
+}
+
+async function installHistoryRecorder(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const scope = window as typeof window & {
+      __serverDeleteHistoryWrites?: Array<{ method: "push" | "replace"; href: string | null }>
+      __serverDeleteHistoryWrapped?: boolean
+    }
+    scope.__serverDeleteHistoryWrites = []
+    if (scope.__serverDeleteHistoryWrapped) return
+    scope.__serverDeleteHistoryWrapped = true
+    const nativePush = history.pushState
+    const nativeReplace = history.replaceState
+    history.pushState = function (data, unused, url) {
+      scope.__serverDeleteHistoryWrites?.push({
+        method: "push",
+        href: url === undefined || url === null ? null : String(url),
+      })
+      return nativePush.call(this, data, unused, url)
+    }
+    history.replaceState = function (data, unused, url) {
+      scope.__serverDeleteHistoryWrites?.push({
+        method: "replace",
+        href: url === undefined || url === null ? null : String(url),
+      })
+      return nativeReplace.call(this, data, unused, url)
+    }
+  })
+}
+
+async function resetHistoryRecorder(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const scope = window as typeof window & {
+      __serverDeleteHistoryWrites?: unknown[]
+    }
+    scope.__serverDeleteHistoryWrites = []
+  })
+}
+
+async function divergentHistoryWrites(page: Page, expectedPathname: string) {
+  return page.evaluate((expected) => {
+    const scope = window as typeof window & {
+      __serverDeleteHistoryWrites?: Array<{ method: "push" | "replace"; href: string | null }>
+    }
+    return (scope.__serverDeleteHistoryWrites ?? []).filter(({ href }) => (
+      href !== null && new URL(href, location.origin).pathname !== expected
+    ))
+  }, expectedPathname)
+}
+
+async function expectServerLeaf(page: Page, serverId: string): Promise<string> {
+  await expect(page).toHaveURL(new RegExp(`/c/channels/${serverId}/[^/]+$`))
+  return new URL(page.url()).pathname
+}
+
+test.describe.configure({ mode: "serial" })
+
+test("deleting the only Server replaces once to Home", async ({ asUser }) => {
+  const route = await seedServerRoute("dave", `delete-only-${Date.now()}`)
+  const dave = await asUser("dave")
+  await gotoAfterUserWsAuth(
+    dave.page,
+    `/c/channels/${route.serverId}/${route.channelId}`,
+  )
+  await installHistoryRecorder(dave.page)
+  await resetHistoryRecorder(dave.page)
+  const response = dave.page.waitForResponse((candidate) => (
+    candidate.request().method() === "DELETE"
+      && new URL(candidate.url()).pathname === `/api/community/servers/${route.serverId}`
+  ))
+
+  await clickDeleteServer(dave.page, route.serverId)
+
+  expect((await response).status()).toBe(204)
+  await expect(dave.page).toHaveURL("/c/me")
+  await expect(dave.page.getByTestId(tid.serverIcon(route.serverId))).toHaveCount(0)
+  expect(await divergentHistoryWrites(dave.page, "/c/me")).toEqual([])
+})
+
+for (const testCase of [
+  { key: "alice" as const, name: "computed target", chooseUserRoute: (ids: string[]) => ids[0] },
+  { key: "bob" as const, name: "different safe route", chooseUserRoute: (ids: string[]) => ids[1] },
+]) {
+  test(`a committed ${testCase.name} wins before DELETE success with no later history write`, async ({ asUser }) => {
+    const stamp = Date.now()
+    const survivorA = await seedServerRoute(testCase.key, `survivor-a-${stamp}`)
+    const survivorB = await seedServerRoute(testCase.key, `survivor-b-${stamp}`)
+    const deleted = await seedServerRoute(testCase.key, `deleted-${stamp}`)
+    const page = (await asUser(testCase.key)).page
+    await gotoAfterUserWsAuth(
+      page,
+      `/c/channels/${deleted.serverId}/${deleted.channelId}`,
+    )
+    await installHistoryRecorder(page)
+    const survivors = (await serverIds(testCase.key)).filter((id) => id !== deleted.serverId)
+    expect(survivors).toContain(survivorA.serverId)
+    expect(survivors).toContain(survivorB.serverId)
+    const userServerId = testCase.chooseUserRoute(survivors)
+    expect(userServerId).toBeTruthy()
+    const deletion = await delayDelete(page, deleted.serverId)
+
+    await openServer(page, userServerId)
+    const safePathname = await expectServerLeaf(page, userServerId)
+    await resetHistoryRecorder(page)
+    deletion.release()
+
+    expect((await deletion.response).status()).toBe(204)
+    await expect(page).toHaveURL(safePathname)
+    await expect(page.getByText("Server deleted", { exact: true })).toBeVisible()
+    expect(await divergentHistoryWrites(page, safePathname)).toEqual([])
+    await deletion.cleanup()
+  })
+}
+
+test("slow target RSC survives delete/list/WS convergence and lands on its remembered Channel", async ({ asUser }) => {
+  const stamp = Date.now()
+  const survivor = await seedServerRoute("carol", `slow-target-${stamp}`)
+  const deleted = await seedServerRoute("carol", `slow-deleted-${stamp}`)
+  const page = (await asUser("carol")).page
+  await gotoAfterUserWsAuth(
+    page,
+    `/c/channels/${survivor.serverId}/${survivor.channelId}`,
+  )
+  await expect(page.getByTestId(tid.composerInput)).toBeVisible()
+  await openServer(page, deleted.serverId)
+  const targetRsc = await delayServerRsc(page, survivor.serverId)
+  const response = page.waitForResponse((candidate) => (
+    candidate.request().method() === "DELETE"
+      && new URL(candidate.url()).pathname === `/api/community/servers/${deleted.serverId}`
+  ))
+
+  await clickDeleteServer(page, deleted.serverId)
+
+  expect((await response).status()).toBe(204)
+  await targetRsc.intercepted
+  expect(new URL(page.url()).pathname).not.toBe("/c/me")
+  targetRsc.release()
+  expect(await expectServerLeaf(page, survivor.serverId)).toBe(
+    `/c/channels/${survivor.serverId}/${survivor.channelId}`,
+  )
+  await expect(page.getByTestId(tid.serverIcon(deleted.serverId))).toHaveCount(0)
+  await targetRsc.cleanup()
+})
+
+test("a newer user navigation wins while the delete target RSC is pending", async ({ asUser }) => {
+  const stamp = Date.now()
+  const target = await seedServerRoute("dave", `queued-target-${stamp}`)
+  const userRoute = await seedServerRoute("dave", `queued-user-${stamp}`)
+  const deleted = await seedServerRoute("dave", `queued-deleted-${stamp}`)
+  const page = (await asUser("dave")).page
+  await gotoAfterUserWsAuth(
+    page,
+    `/c/channels/${target.serverId}/${target.channelId}`,
+  )
+  await openServer(page, deleted.serverId)
+  const targetRsc = await delayServerRsc(page, target.serverId)
+  const response = page.waitForResponse((candidate) => (
+    candidate.request().method() === "DELETE"
+      && new URL(candidate.url()).pathname === `/api/community/servers/${deleted.serverId}`
+  ))
+
+  await clickDeleteServer(page, deleted.serverId)
+
+  expect((await response).status()).toBe(204)
+  await targetRsc.intercepted
+  await page.getByTestId(tid.serverIcon(userRoute.serverId)).click()
+  targetRsc.release()
+  await expectServerLeaf(page, userRoute.serverId)
+  await expect(page).not.toHaveURL(new RegExp(`/c/channels/${target.serverId}(?:/|$)`), {
+    timeout: 2_000,
+  })
+  await targetRsc.cleanup()
+})
+
+test("a Back visit after terminal cleanup is an ordinary missing route", async ({ asUser }) => {
+  const stamp = Date.now()
+  const survivor = await seedServerRoute("alice", `terminal-survivor-${stamp}`)
+  const deleted = await seedServerRoute("alice", `terminal-deleted-${stamp}`)
+  const page = (await asUser("alice")).page
+  await gotoAfterUserWsAuth(
+    page,
+    `/c/channels/${deleted.serverId}/${deleted.channelId}`,
+  )
+  const deletion = await delayDelete(page, deleted.serverId)
+  await openServer(page, survivor.serverId)
+  const safePathname = await expectServerLeaf(page, survivor.serverId)
+
+  deletion.release()
+  expect((await deletion.response).status()).toBe(204)
+  await expect(page).toHaveURL(safePathname)
+  await expect(page.getByText("Server deleted", { exact: true })).toBeVisible()
+  await page.goBack({ waitUntil: "commit" })
+
+  await expect(page).not.toHaveURL(new RegExp(`/c/channels/${deleted.serverId}(?:/|$)`))
+  await expect(page).toHaveURL(/\/c\/channels\/[^/]+\/[^/]+$/)
+  await deletion.cleanup()
+})
+
+test("a failed DELETE keeps the current route and emits no success frame", async ({ asUser }) => {
+  const route = await seedServerRoute("carol", `failed-delete-${Date.now()}`)
+  const page = (await asUser("carol")).page
+  const deletes = captureServerDeletes(page)
+  const pathname = `/c/channels/${route.serverId}/${route.channelId}`
+  await gotoAfterUserWsAuth(page, pathname)
+  const pattern = `**/api/community/servers/${route.serverId}`
+  await page.route(pattern, async (request) => {
+    if (request.request().method() !== "DELETE") {
+      await request.continue()
+      return
+    }
+    await request.fulfill({
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "forced delete failure" }),
+    })
+  })
+  const response = page.waitForResponse((candidate) => (
+    candidate.request().method() === "DELETE"
+      && new URL(candidate.url()).pathname === `/api/community/servers/${route.serverId}`
+  ))
+
+  await clickDeleteServer(page, route.serverId)
+
+  expect((await response).status()).toBe(500)
+  await expect(page).toHaveURL(pathname)
+  await expect(page.getByText("Server deleted", { exact: true })).toHaveCount(0)
+  await expect(page.getByTestId(tid.serverIcon(route.serverId))).toBeVisible()
+  await expect(page.getByTestId(tid.channelRow(route.channelId))).toBeVisible()
+  await expect(page.getByTestId(tid.composerInput)).toHaveCount(1)
+  await expect.poll(() => deletes.frames.filter((frame) => (
+    frame.serverId === route.serverId
+  ))).toHaveLength(0)
+  expect(await serverIds("carol")).toContain(route.serverId)
+  await page.unroute(pattern)
+})


### PR DESCRIPTION
# Why we need this PR?

Deleting the currently open Server had two navigation writers: the successful DELETE callback navigated toward Home, while optimistic/WebSocket list convergence could authoritatively replace the route with another Server. Their ordering made the immediate destination and browser history nondeterministic.

## What changed

- Coordinate an owner deletion as one exact-Server transaction with a stable committed-route fact and at most one navigation claim.
- If the user has already committed a safe route when DELETE succeeds, keep that route and issue no delete-owned navigation. Otherwise, replace once to the first surviving Server's remembered/default Channel leaf, or to `/c/me` when none survives.
- Retain only the deleted Server's query scopes until success plus a safe route commit, then flush them once and tombstone route instances committed before the terminal boundary.
- Recheck completed deletions from the persistent `/c` shell so cached Back visits follow the ordinary missing-route eject path.
- Snapshot the mutation's originating route token and callbacks so rerenders or caller unmounts cannot transfer completion ownership.
- Preserve existing kick, leave, inaccessible-route, 403/404, and failed-DELETE behavior.

## Validation

- Exact local and remote PR head: `019c170646153004168f2fe01b365e74d145df5d`, parent `738a088f57400ddab3f162963ef6470f2b7a0578`, result tree `450614dff866651f1c51ab4ea56a666958e4ad0b`, 21 changed paths relative to `dfdc9b89f905abd43f80f2ba6cd66e6398a8bc2d`.
- Correction package: SHA-256 `48b4cc377bd060e4b64b7426f404dfe66ed7a3203c6aa3d37add877ecac33494`, four paths; focused parser/layout validation passed (2 files / 62 tests).
- Codecov regression package: SHA-256 `7c879b9a02842c7b9741202097b688761a8b6a32e3b1d99278b6dfd0ee49580a`, one test path; focused lifecycle validation passed 20/20 and directly covers the former misses at `eject-server.ts:100-101` without source or policy changes.
- Full Chromium shard 5 passed 16/16 and shard 7 passed 26 with 2 expected skips; the navigation-race matrix passed 7/7. Product-test retries were disabled.
- Normal commit hooks passed: root typecheck (11 packages), lint (5 packages), full workspace tests (Web 828 files / 7,896 tests; agent-driver 786 passed / 4 skipped; CI scripts 287 tests), WebSocket and agent-driver boundary checks, and Knip.
- Hosted CI, all nine UI Playwright shards, both aggregate gates, and Codecov passed on the exact head; Codecov reports 100.00% of the diff hit.
- No diagnostic probes and no deployment changes.

## Checklist

- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas

- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [x] CI/CD
- [ ] Other
