### PR TITLE
fix(web): prevent audit preview overflow

### DIFF
--- a/src/web/src/components/community/social/profile-card-surface.dom.test.ts
+++ b/src/web/src/components/community/social/profile-card-surface.dom.test.ts
@@ -1,9 +1,11 @@
 import React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
 import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { describe, expect, it, vi } from "vitest"
-import { act, render } from "@/test/react-dom-harness"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { act, render, waitFor } from "@/test/react-dom-harness"
+import type { Profile } from "@/components/community/social/profile-types"
 
 const mockProps = vi.hoisted(() => new Map<string, Record<string, unknown>>())
 
@@ -42,9 +44,44 @@ vi.mock("@/components/avatar", () => ({
   SeededBackdrop: () => React.createElement("seeded-backdrop"),
 }))
 
+vi.mock("./bot-mark-sticker", () => ({
+  BotMarkSticker: () => React.createElement("bot-mark-sticker"),
+}))
+
 import { ProfileCard } from "./profile-card"
 
-function renderSurface(bp: "mobile" | "desktop") {
+const ownedBotIdentity: Profile["identity"] = {
+  kind: "bot",
+  ownerProfile: { id: "owner_1", handle: "Owner#0042" },
+  ownedByViewer: true,
+}
+
+function surfaceElement(
+  queryClient: QueryClient,
+  bp: "mobile" | "desktop",
+  overrides: Partial<Profile> = {},
+) {
+  return React.createElement(
+    QueryClientProvider,
+    { client: queryClient },
+    React.createElement(ProfileCard, {
+      data: {
+        name: "Ren",
+        userId: "user_1",
+        avatar: "R",
+        about: "Profile bio",
+        mutual: 0,
+        ...overrides,
+      },
+      x: 24,
+      y: 48,
+      bp,
+      onClose: vi.fn(),
+    }),
+  )
+}
+
+function renderSurface(bp: "mobile" | "desktop", overrides: Partial<Profile> = {}) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   })
@@ -60,6 +97,7 @@ function renderSurface(bp: "mobile" | "desktop") {
         avatar: "R",
         about: "Profile bio",
         mutual: 0,
+        ...overrides,
       },
       x: 24,
       y: 48,
@@ -69,6 +107,10 @@ function renderSurface(bp: "mobile" | "desktop") {
   ))
   return { renderer, onClose }
 }
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 describe("ProfileCard surface contracts", () => {
   it("reuses profile content without an overlay shell inside the User Bar extension", () => {
@@ -156,8 +198,100 @@ describe("ProfileCard surface contracts", () => {
     expect(trigger.style).toEqual({ left: 24, top: 48 })
     expect(content.side).toBe("right")
     expect(content.className).toContain("w-75")
+    expect(content.className).toContain("overflow-visible")
     expect(content.className).not.toContain("data-[side=bottom]:border-t-0")
     expect(renderer.container.querySelectorAll("sheet-root")).toHaveLength(0)
     expect(renderer.getByTestId("community-profile-card")).toBeInTheDocument()
+  })
+
+  it("clips and disables the owned desktop preview before its first measurement", () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const html = renderToStaticMarkup(surfaceElement(queryClient, "desktop", {
+      identity: ownedBotIdentity,
+    }))
+
+    expect(html).toContain("overflow-hidden")
+    expect(html).toContain('data-measurement-ready="false"')
+    expect(html).toContain('aria-hidden="true"')
+    expect(html).toContain("visibility:hidden")
+    expect(html).toContain("pointer-events:none")
+    expect(html).not.toContain('data-placement="right"')
+  })
+
+  it("requires a fresh measurement for each target and remount", async () => {
+    const readinessWrites: string[] = []
+    const setAttribute = Element.prototype.setAttribute
+    vi.spyOn(Element.prototype, "setAttribute").mockImplementation(function (name, value) {
+      if (name === "data-measurement-ready") readinessWrites.push(value)
+      setAttribute.call(this, name, value)
+    })
+    vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockImplementation(function () {
+      return this.getAttribute("data-testid") === "community-profile-card" ? 300 : 260
+    })
+    vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockImplementation(function () {
+      return this.getAttribute("data-testid") === "community-profile-card" ? 280 : 220
+    })
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function () {
+      const left = this.getAttribute("data-testid") === "community-profile-card" ? 24 : 0
+      const top = this.getAttribute("data-testid") === "community-profile-card" ? 48 : 0
+      const width = 300
+      const height = this.getAttribute("data-testid") === "community-profile-card" ? 280 : 220
+      return {
+        bottom: top + height,
+        height,
+        left,
+        right: left + width,
+        top,
+        width,
+        x: left,
+        y: top,
+        toJSON: () => ({}),
+      }
+    })
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const renderer = render(surfaceElement(queryClient, "desktop", {
+      identity: ownedBotIdentity,
+    }))
+    const dock = renderer.getByTestId("community-bot-audit-preview-dock")
+    await waitFor(() => expect(dock).toHaveAttribute("data-measurement-ready", "true"))
+    expect(readinessWrites.slice(0, 2)).toEqual(["false", "true"])
+    expect(dock).toHaveAttribute("aria-hidden", "false")
+    expect(dock).toHaveStyle({ visibility: "visible" })
+    expect(mockProps.get("popover-content")?.className).toContain("overflow-visible")
+
+    readinessWrites.length = 0
+    renderer.rerender(surfaceElement(queryClient, "desktop", {
+      userId: "user_2",
+      identity: ownedBotIdentity,
+    }))
+    await waitFor(() => expect(readinessWrites).toContain("true"))
+    expect(readinessWrites[0]).toBe("false")
+    expect(readinessWrites.indexOf("false")).toBeLessThan(readinessWrites.indexOf("true"))
+
+    renderer.rerender(surfaceElement(queryClient, "mobile", {
+      userId: "user_2",
+      identity: ownedBotIdentity,
+    }))
+    expect(renderer.queryByTestId("community-bot-audit-preview-dock")).toBeNull()
+    readinessWrites.length = 0
+    renderer.rerender(surfaceElement(queryClient, "desktop", {
+      userId: "user_2",
+      identity: ownedBotIdentity,
+    }))
+    await waitFor(() => expect(readinessWrites).toContain("true"))
+    expect(readinessWrites[0]).toBe("false")
+    expect(readinessWrites.indexOf("false")).toBeLessThan(readinessWrites.indexOf("true"))
+
+    renderer.unmount()
+    readinessWrites.length = 0
+    const remounted = render(surfaceElement(queryClient, "desktop", {
+      userId: "user_2",
+      identity: ownedBotIdentity,
+    }))
+    await waitFor(() => expect(readinessWrites).toContain("true"))
+    expect(readinessWrites[0]).toBe("false")
+    expect(readinessWrites.indexOf("false")).toBeLessThan(readinessWrites.indexOf("true"))
+    remounted.unmount()
   })
 })

--- a/src/web/src/components/community/social/profile-card.dom.test.ts
+++ b/src/web/src/components/community/social/profile-card.dom.test.ts
@@ -294,7 +294,7 @@ describe("ProfileCard contextual metadata", () => {
     const independentPreview = desktop.indexOf(`data-testid={tid.botAuditPreviewDock}`)
 
     expect(desktop).toContain(
-      `className="relative w-75 overflow-visible border-0 bg-transparent p-0 shadow-none"`,
+      'secondaryCards && !previewReady ? "overflow-hidden" : "overflow-visible"',
     )
     expect(mainCard).toBeGreaterThan(0)
     expect(independentPreview).toBeGreaterThan(0)
@@ -303,6 +303,10 @@ describe("ProfileCard contextual metadata", () => {
     expect(source).toContain('addEventListener("animationend", update)')
     expect(source).toContain("cardElement.offsetWidth")
     expect(source).toContain("previewElement.offsetWidth")
+    expect(source).toContain("measuredPosition?.measurementKey === measurementKey")
+    expect(source).toContain("data-measurement-ready={previewReady ? \"true\" : \"false\"}")
+    expect(source).toContain("visibility: previewReady ? \"visible\" : \"hidden\"")
+    expect(source).toContain("pointerEvents: previewReady ? undefined : \"none\"")
     expect(source).toContain("<BotMarkSticker")
     expect(source).toContain("onOpenActivity={() => onOpenBotAudit?.(data.userId!)}")
     expect(source).toContain("onStop={interruptAgent}")

--- a/src/web/src/components/community/social/profile-card.tsx
+++ b/src/web/src/components/community/social/profile-card.tsx
@@ -97,23 +97,32 @@ type AuditPreviewPosition = {
   height?: number
 }
 
+type MeasuredAuditPreviewPosition = AuditPreviewPosition & {
+  measurementKey: string
+}
+
 function clamp(value: number, min: number, max: number): number {
   if (min > max) return value
   return Math.min(Math.max(value, min), max)
 }
 
-function useAuditPreviewPosition(enabled: boolean, x: number, y: number) {
+function useAuditPreviewPosition(
+  enabled: boolean,
+  previewId: string | undefined,
+  x: number,
+  y: number,
+) {
   const popoverRef = useRef<HTMLDivElement | null>(null)
   const cardRef = useRef<HTMLDivElement | null>(null)
   const previewRef = useRef<HTMLDivElement | null>(null)
-  const [position, setPosition] = useState<AuditPreviewPosition>({
-    placement: "right",
-    left: "calc(100% + 0.5rem)",
-    top: 0,
-  })
+  const [measuredPosition, setMeasuredPosition] = useState<MeasuredAuditPreviewPosition | null>(null)
+  const measurementKey = enabled && previewId ? `${previewId}:${x}:${y}` : null
 
   useLayoutEffect(() => {
-    if (!enabled) return
+    if (!measurementKey) {
+      setMeasuredPosition(null)
+      return
+    }
 
     let frame = 0
     const update = () => {
@@ -153,15 +162,16 @@ function useAuditPreviewPosition(enabled: boolean, x: number, y: number) {
         margin - card.left,
         window.innerWidth - margin - preview.width - card.left,
       )
-      const next: AuditPreviewPosition = placement === "right"
-        ? { placement, left: card.width + gap, top: verticalOffset, height: card.height }
+      const next: MeasuredAuditPreviewPosition = placement === "right"
+        ? { measurementKey, placement, left: card.width + gap, top: verticalOffset, height: card.height }
         : placement === "left"
-          ? { placement, left: -preview.width - gap, top: verticalOffset, height: card.height }
+          ? { measurementKey, placement, left: -preview.width - gap, top: verticalOffset, height: card.height }
           : placement === "top"
-            ? { placement, left: horizontalOffset, top: -preview.height - gap, height: card.height }
-            : { placement, left: horizontalOffset, top: card.height + gap, height: card.height }
+            ? { measurementKey, placement, left: horizontalOffset, top: -preview.height - gap, height: card.height }
+            : { measurementKey, placement, left: horizontalOffset, top: card.height + gap, height: card.height }
 
-      setPosition((current) => current.placement === next.placement
+      setMeasuredPosition((current) => current?.measurementKey === next.measurementKey
+        && current.placement === next.placement
         && current.left === next.left
         && current.top === next.top
         && current.height === next.height
@@ -187,9 +197,17 @@ function useAuditPreviewPosition(enabled: boolean, x: number, y: number) {
       popoverElement?.removeEventListener("animationcancel", update)
       observer?.disconnect()
     }
-  }, [enabled, x, y])
+  }, [measurementKey])
 
-  return { popoverRef, cardRef, previewRef, position }
+  const ready = measurementKey !== null
+    && measuredPosition?.measurementKey === measurementKey
+  return {
+    popoverRef,
+    cardRef,
+    previewRef,
+    position: ready ? measuredPosition : null,
+    ready,
+  }
 }
 
 // Profile card — popover anchored at the click point on desktop, bottom sheet on mobile.
@@ -251,8 +269,15 @@ export function ProfileCard({ data, x, y, bp, onClose, onMessage, isSelf, onUpda
   const mutual = data.mutual ?? 0
   const botIdentity = data.identity?.kind === "bot" ? data.identity : null
   const showOwnedBotCard = Boolean(botIdentity?.ownedByViewer && data.userId)
-  const { popoverRef, cardRef, previewRef, position: previewPosition } = useAuditPreviewPosition(
+  const {
+    popoverRef,
+    cardRef,
+    previewRef,
+    position: previewPosition,
+    ready: previewReady,
+  } = useAuditPreviewPosition(
     showOwnedBotCard && !mobile && !embedded && !extension,
+    data.userId,
     x,
     y,
   )
@@ -491,17 +516,27 @@ export function ProfileCard({ data, x, y, bp, onClose, onMessage, isSelf, onUpda
         className="pointer-events-none fixed size-0"
         style={{ left: x, top: y }}
       />
-      <PopoverContent ref={popoverRef} side="right" align="start" sideOffset={8} className="relative w-75 overflow-visible border-0 bg-transparent p-0 shadow-none">
+      <PopoverContent
+        ref={popoverRef}
+        side="right"
+        align="start"
+        sideOffset={8}
+        className={`relative w-75 border-0 bg-transparent p-0 shadow-none ${secondaryCards && !previewReady ? "overflow-hidden" : "overflow-visible"}`}
+      >
         {secondaryCards && (
           <div
             ref={previewRef}
             data-testid={tid.botAuditPreviewDock}
-            data-placement={previewPosition.placement}
+            data-placement={previewPosition?.placement}
+            data-measurement-ready={previewReady ? "true" : "false"}
+            aria-hidden={!previewReady}
             className="absolute w-full"
             style={{
-              left: previewPosition.left,
-              top: previewPosition.top,
-              height: previewPosition.height,
+              left: previewPosition?.left ?? 0,
+              top: previewPosition?.top ?? 0,
+              height: previewPosition?.height,
+              visibility: previewReady ? "visible" : "hidden",
+              pointerEvents: previewReady ? undefined : "none",
             }}
           >
             {secondaryCards}

--- a/src/web/src/test/e2e-ui/30-bot-profile-audit-preview.spec.ts
+++ b/src/web/src/test/e2e-ui/30-bot-profile-audit-preview.spec.ts
@@ -3,12 +3,25 @@ import { resolve } from "path"
 import type { Locator, Page, TestInfo } from "@playwright/test"
 import { test, expect, sessionCookie } from "./_fixtures/community-fixture"
 import { composerEditable, gotoAfterUserWsAuth } from "./_fixtures/actions"
-import { seedChannel, seedJoinServer, seedServer } from "./_fixtures/seed"
+import { seedChannel, seedForumThread, seedJoinServer, seedServer } from "./_fixtures/seed"
 import { tid } from "./_fixtures/testids"
 import { MACHINE_WS_URL, REPO_ROOT, WEB_URL } from "./_setup/paths"
 
 type UserKey = "alice" | "bob"
 type Rect = { x: number; y: number; width: number; height: number }
+type PreviewFrameSample = {
+  phase: "start" | "mutation" | "frame"
+  rootOverflowX: number
+  rootOverflowY: number
+  scrollX: number
+  scrollY: number
+  ready: string | null
+  visibility: string | null
+  pointerEvents: string | null
+  rect: Rect | null
+  viewportWidth: number
+  viewportHeight: number
+}
 
 const createdBotIds: string[] = []
 const createdMachineIds: string[] = []
@@ -357,6 +370,127 @@ async function openBotProfile(page: Page, botName: string): Promise<void> {
   await expect(page.getByTestId(tid.profileCard)).toBeVisible()
 }
 
+async function installPreviewFrameProbe(page: Page): Promise<void> {
+  await page.evaluate((dockTestId) => {
+    type ProbeState = {
+      active: boolean
+      observer: MutationObserver
+      samples: PreviewFrameSample[]
+    }
+    const target = window as typeof window & { __previewFrameProbe?: ProbeState }
+    const samples: PreviewFrameSample[] = []
+    const sample = (phase: PreviewFrameSample["phase"]) => {
+      if (samples.length >= 500) return
+      const root = document.documentElement
+      const dock = document.querySelector<HTMLElement>(`[data-testid="${dockTestId}"]`)
+      const style = dock ? getComputedStyle(dock) : null
+      const bounds = dock?.getBoundingClientRect()
+      samples.push({
+        phase,
+        rootOverflowX: root.scrollWidth - root.clientWidth,
+        rootOverflowY: root.scrollHeight - root.clientHeight,
+        scrollX: window.scrollX,
+        scrollY: window.scrollY,
+        ready: dock?.getAttribute("data-measurement-ready") ?? null,
+        visibility: style?.visibility ?? null,
+        pointerEvents: style?.pointerEvents ?? null,
+        rect: bounds
+          ? { x: bounds.x, y: bounds.y, width: bounds.width, height: bounds.height }
+          : null,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+      })
+    }
+    const observer = new MutationObserver(() => sample("mutation"))
+    observer.observe(document.body, {
+      attributes: true,
+      attributeFilter: ["class", "data-measurement-ready", "style"],
+      childList: true,
+      subtree: true,
+    })
+    target.__previewFrameProbe = { active: true, observer, samples }
+    sample("start")
+    const frame = () => {
+      const state = target.__previewFrameProbe
+      if (!state?.active) return
+      sample("frame")
+      requestAnimationFrame(frame)
+    }
+    requestAnimationFrame(frame)
+  }, tid.botAuditPreviewDock)
+}
+
+async function finishPreviewFrameProbe(page: Page): Promise<PreviewFrameSample[]> {
+  return page.evaluate(async () => {
+    await new Promise<void>((resolveFrames) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => requestAnimationFrame(
+        () => resolveFrames(),
+      )))
+    })
+    const target = window as typeof window & {
+      __previewFrameProbe?: {
+        active: boolean
+        observer: MutationObserver
+        samples: PreviewFrameSample[]
+      }
+    }
+    const state = target.__previewFrameProbe
+    if (!state) throw new Error("preview frame probe was not installed")
+    state.active = false
+    state.observer.disconnect()
+    return state.samples
+  })
+}
+
+function expectPreviewFrames(samples: PreviewFrameSample[], label: string): void {
+  expect(samples.length, `${label}: captured frames`).toBeGreaterThan(1)
+  const baseline = samples[0]!
+  expect(baseline.rootOverflowX, `${label}: baseline root X overflow`).toBe(0)
+  expect(baseline.rootOverflowY, `${label}: baseline root Y overflow`).toBe(0)
+  const visible = samples.filter((sample) => sample.ready === "true"
+    && sample.visibility === "visible"
+    && sample.rect)
+  expect(visible.length, `${label}: visible positioned frames`).toBeGreaterThan(0)
+
+  for (const [index, sample] of samples.entries()) {
+    expect(sample.rootOverflowX, `${label}: frame ${index} root X overflow`).toBe(0)
+    expect(sample.rootOverflowY, `${label}: frame ${index} root Y overflow`).toBe(0)
+    expect(sample.scrollX, `${label}: frame ${index} root scrollX`).toBe(baseline.scrollX)
+    expect(sample.scrollY, `${label}: frame ${index} root scrollY`).toBe(baseline.scrollY)
+    if (sample.ready === "false") {
+      expect(sample.visibility, `${label}: frame ${index} hidden measurement`).toBe("hidden")
+      expect(sample.pointerEvents, `${label}: frame ${index} inert measurement`).toBe("none")
+    }
+    if (sample.ready !== "true" || sample.visibility !== "visible" || !sample.rect) continue
+    expect(sample.rect.x, `${label}: frame ${index} left boundary`).toBeGreaterThanOrEqual(7.5)
+    expect(sample.rect.y, `${label}: frame ${index} top boundary`).toBeGreaterThanOrEqual(7.5)
+    expect(
+      sample.rect.x + sample.rect.width,
+      `${label}: frame ${index} right boundary`,
+    ).toBeLessThanOrEqual(sample.viewportWidth - 7.5)
+    expect(
+      sample.rect.y + sample.rect.height,
+      `${label}: frame ${index} bottom boundary`,
+    ).toBeLessThanOrEqual(sample.viewportHeight - 7.5)
+  }
+}
+
+async function probeOwnedBotProfile(
+  page: Page,
+  author: Locator,
+  label: string,
+): Promise<PreviewFrameSample[]> {
+  await expect(author).toBeVisible({ timeout: 20_000 })
+  await installPreviewFrameProbe(page)
+  await author.click()
+  const dock = page.getByTestId(tid.botAuditPreviewDock)
+  await expect(dock).toHaveAttribute("data-measurement-ready", "true")
+  await expect(dock).toBeVisible()
+  const samples = await finishPreviewFrameProbe(page)
+  expectPreviewFrames(samples, label)
+  return samples
+}
+
 test("full audit log reveals a truncated row by hover and touch", async ({ asUser }, testInfo) => {
   test.setTimeout(120_000)
   const suffix = Date.now().toString(36)
@@ -433,6 +567,104 @@ test("full audit log reveals a truncated row by hover and touch", async ({ asUse
   } finally {
     machine.socket.close()
   }
+})
+
+test("owned bot profile preview stays root-bounded from its first visible frame", async ({ asUser }, testInfo) => {
+  test.setTimeout(120_000)
+  const suffix = Date.now().toString(36)
+  const serverId = await seedServer("alice", `preview-overflow-${suffix}`)
+  const channelName = `regular-${suffix}`
+  const forumName = `forum-${suffix}`
+  const channelId = await seedChannel("alice", serverId, channelName)
+  const forumId = await seedChannel("alice", serverId, forumName, "forum")
+  const forumThreadId = await seedForumThread(
+    "alice",
+    forumId,
+    `Right column ${suffix}`,
+    `Forum opener ${suffix}`,
+  )
+  await seedJoinServer("alice", "bob", serverId)
+
+  const { credential, machineId } = await pairMachine()
+  const botName = `Overflow bot ${suffix}`
+  const botId = await createBot(machineId, botName)
+  await jsonRequest("alice", `/api/community/servers/${serverId}/bots`, {
+    method: "POST",
+    body: JSON.stringify({ botId }),
+  })
+  const runnerKey = await enrollBot(credential, botId)
+  const { servers } = await jsonRequest<{
+    servers: Array<{ id: string; name: string; discriminator: string }>
+  }>("alice", "/api/community/servers")
+  const server = servers.find((candidate) => candidate.id === serverId)
+  expect(server).toBeTruthy()
+  const channelRef = `/${server!.name}#${server!.discriminator}/${channelName}`
+  const forumRef = `/${server!.name}#${server!.discriminator}/${forumName}`
+  const forumEnvelope = await jsonRequest<{
+    threads: Array<{ id: string; parentMessageId: string | null }>
+    included: { parentMessages: Array<{ id: string; seq: number }> }
+  }>(
+    "alice",
+    `/api/community/channels/${forumId}/threads?order=createdAt&limit=50&include=parentMessage`,
+  )
+  const forumThread = forumEnvelope.threads.find((thread) => thread.id === forumThreadId)
+  const forumOpener = forumEnvelope.included.parentMessages.find(
+    (message) => message.id === forumThread?.parentMessageId,
+  )
+  expect(forumOpener?.seq).toBeGreaterThan(0)
+  await sendBotMessage(runnerKey, channelRef, `Regular overflow probe ${suffix}`)
+  await sendBotMessage(
+    runnerKey,
+    `${forumRef}/#${forumOpener!.seq}`,
+    `Forum overflow probe ${suffix}`,
+  )
+
+  const regularRoute = `/c/channels/${serverId}/${channelId}`
+  const alice = await asUser("alice")
+  await alice.page.setViewportSize({ width: 1280, height: 900 })
+  await gotoAfterUserWsAuth(alice.page, regularRoute)
+  const regularFrames = await probeOwnedBotProfile(
+    alice.page,
+    alice.page.getByRole("button", { name: botName, exact: true }),
+    "regular channel",
+  )
+  await testInfo.attach("owned-agent-preview-regular-frames.json", {
+    body: Buffer.from(JSON.stringify(regularFrames, null, 2)),
+    contentType: "application/json",
+  })
+  await attachPageScreenshot(testInfo, "owned-agent-preview-regular", alice.page)
+
+  await gotoAfterUserWsAuth(alice.page, `/c/channels/${serverId}/${forumThreadId}`)
+  const split = alice.page.getByTestId(tid.threadSplit)
+  await expect(split).toHaveAttribute("data-layout", "split", { timeout: 20_000 })
+  const threadPanel = alice.page.getByTestId(tid.threadSplitPanel)
+  const forumFrames = await probeOwnedBotProfile(
+    alice.page,
+    threadPanel.getByRole("button", { name: botName, exact: true }),
+    "forum split right column",
+  )
+  await testInfo.attach("owned-agent-preview-forum-split-frames.json", {
+    body: Buffer.from(JSON.stringify(forumFrames, null, 2)),
+    contentType: "application/json",
+  })
+  await attachPageScreenshot(testInfo, "owned-agent-preview-forum-split", alice.page)
+
+  await alice.page.setViewportSize({ width: 390, height: 844 })
+  await gotoAfterUserWsAuth(alice.page, regularRoute)
+  await openBotProfile(alice.page, botName)
+  await expect(alice.page.getByRole("dialog", { name: `${botName} profile` })).toBeVisible()
+  await expect(alice.page.getByTestId(tid.botMarkSticker)).toBeVisible()
+  await expect(alice.page.getByTestId(tid.botAuditPreviewDock)).toHaveCount(0)
+  await attachPageScreenshot(testInfo, "owned-agent-preview-mobile-390", alice.page)
+
+  const bob = await asUser("bob")
+  await bob.page.setViewportSize({ width: 1280, height: 900 })
+  await gotoAfterUserWsAuth(bob.page, regularRoute)
+  await openBotProfile(bob.page, botName)
+  await expect(bob.page.getByTestId(tid.profileOwnerLink)).toBeVisible()
+  await expect(bob.page.getByTestId(tid.botMarkSticker)).toHaveCount(0)
+  await expect(bob.page.getByTestId(tid.botAuditPreviewDock)).toHaveCount(0)
+  await attachPageScreenshot(testInfo, "owned-agent-preview-non-owner", bob.page)
 })
 
 test("owner-only bot mark sticker, Stop lifecycle, owner swap, and URL-owned audit modal", async ({ asUser }, testInfo) => {


### PR DESCRIPTION
# Why we need this PR?

The desktop owned-Agent audit preview could render at its unclamped default position for one frame, briefly overflowing the document root near viewport edges.

## What changed

- Key audit-preview measurement readiness to the current Agent and anchor coordinates.
- Keep the preview clipped, hidden, and pointer-inert until the current position has been measured and clamped.
- Preserve the existing desktop placement, mobile Sheet, and owner-only behavior once ready.
- Add DOM transition coverage plus per-frame Playwright assertions for regular-channel and forum-split layouts.

## Validation

- Focused profile-card DOM tests: 27 passed.
- Changed-file ESLint: passed.
- Full repository pre-commit gate: typecheck, lint, tests, typegrep, and knip passed.
- Full Web suite within that gate: 824 files / 7,865 tests passed.
- Agent-driver suite: 48 files passed, 1 skipped / 786 tests passed, 4 skipped.
- CI-script suite: 21 files / 287 tests passed.
- Post-Draft independent Chromium QA passed at exact head `05f7c02da7c7841b374edea05e4438980f41869f`: ordinary desktop and forum split had zero root overflow/scroll across sampled visible frames; 390x844 mobile used the Sheet; non-owner rendered no preview.
- Hosted CI run `34599054606` passed every applicable job at the exact head after rerunning shard 5/9; Codecov reports every modified, coverable line covered.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other
