### PR TITLE
fix(web): keep invite Copy stable while friends load

### DIFF
--- a/src/web/src/components/community/social/invite-dialog.tsx
+++ b/src/web/src/components/community/social/invite-dialog.tsx
@@ -264,7 +264,7 @@ export function InviteDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="flex max-h-[80vh] w-full flex-col gap-0 p-0 sm:max-w-md">
+      <DialogContent className="flex h-96 max-h-[80vh] w-full flex-col gap-0 p-0 sm:max-w-md">
         <PeoplePickerHeader title={`Invite friends to ${serverName}`} />
 
         <div className="px-4 pt-3">

--- a/src/web/src/test/e2e-ui/33-picker-async-layout.spec.ts
+++ b/src/web/src/test/e2e-ui/33-picker-async-layout.spec.ts
@@ -129,13 +129,30 @@ test.describe.serial("invite and participant picker async states", () => {
     const dialog = page.getByRole("dialog")
     await expect(dialog.locator('[data-slot="invite-friends-loading"]')).toBeVisible()
     await expect(dialog.getByText(/No friends to invite|No matches/)).toHaveCount(0)
+    const copy = dialog.getByRole("button", { name: "Copy", exact: true })
+    await expect(copy).toBeEnabled({ timeout: 20_000 })
+    await page.context().grantPermissions(["clipboard-read", "clipboard-write"])
+    await page.evaluate(() => navigator.clipboard.writeText("invite-copy-not-yet"))
+    const inviteUrl = await dialog.locator("input[readonly]").inputValue()
+    await copy.hover()
+    const copyBeforeLoad = await copy.boundingBox()
+    expect(copyBeforeLoad).not.toBeNull()
+    await page.mouse.move(
+      copyBeforeLoad!.x + copyBeforeLoad!.width / 2,
+      copyBeforeLoad!.y + copyBeforeLoad!.height / 2,
+    )
+    await page.mouse.down()
     acceptedGate.resolve()
     await expect(dialog.getByRole("button", { name: "Invite" }).first()).toBeVisible({ timeout: 20_000 })
+    await page.mouse.up()
+    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(inviteUrl)
+    expect((await copy.boundingBox())!.y).toBe(copyBeforeLoad!.y)
     await expectTitleClearOfClose(dialog, 1280)
 
     const beforeSearch = { acceptedGets, memberGets }
     await dialog.getByPlaceholder("Search for friends").fill("no-user-matches-this-query")
     await expect(dialog.getByText("No matches.", { exact: true })).toBeVisible()
+    expect((await copy.boundingBox())!.y).toBe(copyBeforeLoad!.y)
     expect({ acceptedGets, memberGets }).toEqual(beforeSearch)
     await dialog.getByPlaceholder("Search for friends").fill("")
     await expect(dialog.getByRole("button", { name: "Invite" }).first()).toBeVisible()
@@ -187,6 +204,7 @@ test.describe.serial("invite and participant picker async states", () => {
     await page.getByRole("button", { name: "Invite to server" }).click()
     const dialog = page.getByRole("dialog")
     await expect(dialog.getByText("Couldn't load friends.", { exact: true })).toBeVisible({ timeout: 20_000 })
+    const copyBeforeRetry = await dialog.getByRole("button", { name: "Copy", exact: true }).boundingBox()
     const failedChainGets = acceptedGets
     expect(failedChainGets).toBeGreaterThanOrEqual(2)
     fail = false
@@ -194,6 +212,7 @@ test.describe.serial("invite and participant picker async states", () => {
     await expect(dialog.getByText("No friends to invite — everyone you know is already here.", { exact: true }))
       .toBeVisible({ timeout: 20_000 })
     expect(acceptedGets).toBeGreaterThan(failedChainGets)
+    expect(await dialog.getByRole("button", { name: "Copy", exact: true }).boundingBox()).toEqual(copyBeforeRetry)
     await expectTitleClearOfClose(dialog, 390)
   })
 

--- a/src/web/src/test/e2e-ui/33-picker-async-layout.spec.ts
+++ b/src/web/src/test/e2e-ui/33-picker-async-layout.spec.ts
@@ -146,7 +146,7 @@ test.describe.serial("invite and participant picker async states", () => {
     await expect(dialog.getByRole("button", { name: "Invite" }).first()).toBeVisible({ timeout: 20_000 })
     await page.mouse.up()
     await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(inviteUrl)
-    expect((await copy.boundingBox())!.y).toBe(copyBeforeLoad!.y)
+    await expect.poll(async () => (await copy.boundingBox())!.y).toBe(copyBeforeLoad!.y)
     await expectTitleClearOfClose(dialog, 1280)
 
     const beforeSearch = { acceptedGets, memberGets }


### PR DESCRIPTION
## Why we need this PR?
The enabled invite Copy button moves when friends finish loading. If that happens between pointer-down and pointer-up, the first click misses and a second click is needed. A real-component reproduction measured a 62px shift.

## What changed
Give the dialog a stable 24rem height capped at 80vh, keeping the friend list scrollable. Extend the browser regression to verify first-click clipboard content across loading completion, plus stable Copy placement during search and mobile error recovery.

## Validation
Validated at `8c12ab6adefadadb0e857e98628949bb9691eb74`:
- Independent real `/c` QA: release after the delayed friends response copies the exact D1-backed invite URL. Copy leaves invite rows unchanged; Enter also succeeds.
- Component checks pass in Chromium and WebKit; independent desktop, 390×667 and 390×400 checks cover loading, empty, error, search and scrolling.
- All CI checks, 9/9 UI shards and final UI Gate pass. [Codecov Report](https://github.com/alookai/alook/pull/772#issuecomment-5635812134) confirms all modified coverable lines are covered.

This fixes a demonstrated failure path; it does not claim to reproduce every reporter environment. Mobile checks use simulated viewports, not a physical device keyboard.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [x] Web app (`@alook/web`)
