### PR TITLE
fix(web): align skeleton and reconnect edges

### DIFF
--- a/src/web/src/app/globals.css
+++ b/src/web/src/app/globals.css
@@ -442,6 +442,7 @@ body.driver-active .community-ws-reconnect-overlay * {
   --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
   --background: oklch(1 0 0);
   --app-bg: var(--background);
+  --app-edge-fade-size: 60px;
   --foreground: oklch(0.18 0.03 230);
   --card: oklch(1 0.003 80);
   --card-foreground: oklch(0.18 0.03 230);

--- a/src/web/src/components/community/shell/community-ws-reconnect-overlay.dom.test.ts
+++ b/src/web/src/components/community/shell/community-ws-reconnect-overlay.dom.test.ts
@@ -31,6 +31,26 @@ describe("CommunityWsReconnectBoundary", () => {
     return { renderer, focus }
   }
 
+  function expectAppEdgeFade(overlay: HTMLElement) {
+    const fade = overlay.querySelector<HTMLElement>('[data-slot="app-edge-fade"]')!
+    expect(fade).toHaveAttribute("aria-hidden", "true")
+    expect(fade).toHaveClass("pointer-events-none", "absolute", "inset-0")
+    expect(fade.querySelectorAll("[data-app-edge]")).toHaveLength(2)
+    expect(fade.querySelector('[data-app-edge="top"]')).toHaveClass(
+      "top-0",
+      "h-(--app-edge-fade-size)",
+      "from-(--app-bg)",
+      "to-transparent",
+    )
+    expect(fade.querySelector('[data-app-edge="bottom"]')).toHaveClass(
+      "bottom-0",
+      "h-(--app-edge-fade-size)",
+      "from-transparent",
+      "to-(--app-bg)",
+    )
+    expect(fade.querySelectorAll("button, a, input, [tabindex]")).toHaveLength(0)
+  }
+
   it("leaves connected content interactive without rendering an overlay", () => {
     const { renderer } = render()
     const content = renderer.container.querySelector(".contents")!
@@ -57,6 +77,8 @@ describe("CommunityWsReconnectBoundary", () => {
       "z-2147483647",
       "backdrop-blur-sm",
     )
+    expect(overlay).toHaveClass("bg-background/60", "supports-backdrop-filter:bg-background/45")
+    expectAppEdgeFade(overlay)
     expect(screen.getByRole("status")).toHaveAttribute("aria-atomic", "true")
     expect(screen.getByRole("status")).toHaveAttribute("aria-live", "polite")
     expect(screen.getByRole("status")).toHaveAttribute("data-slot", "text-loader")
@@ -85,6 +107,7 @@ describe("CommunityWsReconnectBoundary", () => {
     expect(alert).toHaveAttribute("aria-atomic", "true")
     expect(alert).toHaveAttribute("aria-live", "assertive")
     expect(within(alert).getByRole("heading", { name: "Connection lost" })).toBeInTheDocument()
+    expectAppEdgeFade(screen.getByTestId(tid.wsReconnectOverlay))
     const retry = screen.getByTestId(tid.wsRetry)
     expect(retry).toHaveClass("h-11", "sm:h-10")
     fireEvent.click(retry)

--- a/src/web/src/components/community/shell/community-ws-reconnect-overlay.tsx
+++ b/src/web/src/components/community/shell/community-ws-reconnect-overlay.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, type ReactNode } from "react"
 import { AlookLoading } from "@/components/brand/alook-loading/AlookLoading"
+import { AppEdgeFade } from "@/components/ui/app-edge-fade"
 import { WifiOff } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { tid } from "@/lib/community/testids"
@@ -48,7 +49,8 @@ export function CommunityWsReconnectBoundary({ children }: { children: ReactNode
           data-ws-status={connectionStatus}
           className="community-ws-reconnect-overlay fixed inset-0 z-2147483647 grid place-items-center bg-background/60 px-4 outline-none backdrop-blur-sm supports-backdrop-filter:bg-background/45 motion-safe:animate-in motion-safe:fade-in-0 motion-safe:duration-150"
         >
-          <div className="flex w-full max-w-xs flex-col items-center text-center text-foreground">
+          <AppEdgeFade />
+          <div className="relative z-20 flex w-full max-w-xs flex-col items-center text-center text-foreground">
             {connectionStatus === "failed" ? (
               <>
                 <div

--- a/src/web/src/components/community/shell/unresolved-main-skeleton.test.ts
+++ b/src/web/src/components/community/shell/unresolved-main-skeleton.test.ts
@@ -4,16 +4,22 @@ import { describe, expect, it } from "vitest"
 import { UnresolvedMainSkeleton } from "./unresolved-main-skeleton"
 
 describe("UnresolvedMainSkeleton", () => {
-  it("fills the main area with one inert square Skeleton and respects reduced motion", () => {
+  it("keeps one muted pulse over an opaque app surface with inert edge fades", () => {
     const markup = renderToStaticMarkup(createElement(UnresolvedMainSkeleton))
 
     expect(markup.match(/data-slot="skeleton"/g)).toHaveLength(1)
     expect(markup).toContain('data-community-unresolved-main=""')
     expect(markup).toContain('aria-hidden="true"')
-    expect(markup).toContain("h-full w-full flex-1 rounded-none")
+    expect(markup).toContain("h-full w-full flex-1 overflow-hidden bg-(--app-bg)")
+    expect(markup).toContain("absolute inset-0 rounded-none")
     expect(markup).toContain("animate-pulse")
     expect(markup).toContain("motion-reduce:animate-none")
+    expect(markup.match(/data-slot="app-edge-fade"/g)).toHaveLength(1)
+    expect(markup.match(/h-\(--app-edge-fade-size\)/g)).toHaveLength(2)
+    expect(markup).toContain("from-(--app-bg) to-transparent")
+    expect(markup).toContain("from-transparent to-(--app-bg)")
+    expect(markup).toContain("pointer-events-none")
+    expect(markup).not.toContain("safe-area")
     expect(markup).not.toMatch(/rounded-(?:sm|md|lg|xl|2xl|3xl|full)(?:\s|")/)
-    expect(markup).toMatch(/^<div[^>]*><\/div>$/)
   })
 })

--- a/src/web/src/components/community/shell/unresolved-main-skeleton.tsx
+++ b/src/web/src/components/community/shell/unresolved-main-skeleton.tsx
@@ -1,11 +1,15 @@
 import { Skeleton } from "@/components/ui/skeleton"
+import { AppEdgeFade } from "@/components/ui/app-edge-fade"
 
 export function UnresolvedMainSkeleton() {
   return (
-    <Skeleton
+    <div
       aria-hidden
       data-community-unresolved-main=""
-      className="min-h-0 h-full w-full flex-1 rounded-none"
-    />
+      className="relative min-h-0 h-full w-full flex-1 overflow-hidden bg-(--app-bg)"
+    >
+      <Skeleton className="absolute inset-0 rounded-none" />
+      <AppEdgeFade />
+    </div>
   )
 }

--- a/src/web/src/components/ui/app-edge-fade.test.ts
+++ b/src/web/src/components/ui/app-edge-fade.test.ts
@@ -1,0 +1,33 @@
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { describe, expect, it } from "vitest"
+import { AppEdgeFade } from "./app-edge-fade"
+
+describe("AppEdgeFade", () => {
+  it("paints only fixed top and bottom app-background fades without interaction", () => {
+    const markup = renderToStaticMarkup(createElement(AppEdgeFade))
+
+    expect(markup).toContain('data-slot="app-edge-fade"')
+    expect(markup).toContain('aria-hidden="true"')
+    expect(markup).toContain("pointer-events-none")
+    expect(markup.match(/h-\(--app-edge-fade-size\)/g)).toHaveLength(2)
+    expect(markup).toContain("top-0")
+    expect(markup).toContain("from-(--app-bg) to-transparent")
+    expect(markup).toContain("bottom-0")
+    expect(markup).toContain("from-transparent to-(--app-bg)")
+    expect(markup).not.toContain("safe-area")
+    expect(markup).not.toContain("animate")
+    expect(markup).not.toMatch(/tabindex|button|href=/)
+  })
+
+  it("defines one fixed 60px token independent of the app safe-area tokens", () => {
+    const css = readFileSync(resolve(process.cwd(), "src/app/globals.css"), "utf8")
+    const token = css.match(/--app-edge-fade-size:\s*([^;]+);/)
+
+    expect(token?.[1]?.trim()).toBe("60px")
+    expect(token?.[1]).not.toContain("safe-area")
+    expect(css.match(/--app-edge-fade-size:/g)).toHaveLength(1)
+  })
+})

--- a/src/web/src/components/ui/app-edge-fade.test.ts
+++ b/src/web/src/components/ui/app-edge-fade.test.ts
@@ -1,7 +1,7 @@
 import { createElement } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 import { readFileSync } from "node:fs"
-import { resolve } from "node:path"
+import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vitest"
 import { AppEdgeFade } from "./app-edge-fade"
 
@@ -23,7 +23,10 @@ describe("AppEdgeFade", () => {
   })
 
   it("defines one fixed 60px token independent of the app safe-area tokens", () => {
-    const css = readFileSync(resolve(process.cwd(), "src/app/globals.css"), "utf8")
+    const css = readFileSync(
+      fileURLToPath(new URL("../../app/globals.css", import.meta.url)),
+      "utf8",
+    )
     const token = css.match(/--app-edge-fade-size:\s*([^;]+);/)
 
     expect(token?.[1]?.trim()).toBe("60px")

--- a/src/web/src/components/ui/app-edge-fade.tsx
+++ b/src/web/src/components/ui/app-edge-fade.tsx
@@ -1,0 +1,21 @@
+import { cn } from "@/lib/utils"
+
+export function AppEdgeFade({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      {...props}
+      aria-hidden="true"
+      data-slot="app-edge-fade"
+      className={cn("pointer-events-none absolute inset-0 z-10", className)}
+    >
+      <div
+        data-app-edge="top"
+        className="absolute inset-x-0 top-0 h-(--app-edge-fade-size) bg-linear-to-b from-(--app-bg) to-transparent"
+      />
+      <div
+        data-app-edge="bottom"
+        className="absolute inset-x-0 bottom-0 h-(--app-edge-fade-size) bg-linear-to-b from-transparent to-(--app-bg)"
+      />
+    </div>
+  )
+}

--- a/src/web/src/test/e2e-ui/25-community-ws-reconnect-overlay.spec.ts
+++ b/src/web/src/test/e2e-ui/25-community-ws-reconnect-overlay.spec.ts
@@ -1,4 +1,4 @@
-import type { Page, WebSocketRoute } from "@playwright/test"
+import type { Locator, Page, TestInfo, WebSocketRoute } from "@playwright/test"
 import { test, expect } from "./_fixtures/community-fixture"
 import {
   composerEditable,
@@ -8,6 +8,98 @@ import { seedChannel, seedServer } from "./_fixtures/seed"
 import { tid } from "./_fixtures/testids"
 
 const USER_WS_AUTH_CONSUMED_ATTRIBUTE = "data-e2e-user-ws-auth-consumed"
+
+type AppEdgeEvidence = {
+  token: string
+  ariaHidden: string | null
+  pointerEvents: string
+  focusableCount: number
+  appBackground: string
+  surfaceBackground: string
+  surface: { top: number; bottom: number; height: number }
+  top: { top: number; bottom: number; height: number; backgroundImage: string }
+  bottom: { top: number; bottom: number; height: number; backgroundImage: string }
+  rootOverflowX: number
+  rootOverflowY: number
+}
+
+async function appEdgeEvidence(surface: Locator): Promise<AppEdgeEvidence> {
+  return surface.evaluate((element) => {
+    const fade = element.querySelector<HTMLElement>('[data-slot="app-edge-fade"]')
+    const top = fade?.querySelector<HTMLElement>('[data-app-edge="top"]')
+    const bottom = fade?.querySelector<HTMLElement>('[data-app-edge="bottom"]')
+    if (!fade || !top || !bottom) throw new Error("missing app edge fade")
+    const probe = document.createElement("div")
+    probe.style.background = "var(--app-bg)"
+    probe.style.position = "fixed"
+    probe.style.visibility = "hidden"
+    document.body.appendChild(probe)
+    const appBackground = getComputedStyle(probe).backgroundColor
+    probe.remove()
+    const surfaceRect = element.getBoundingClientRect()
+    const topRect = top.getBoundingClientRect()
+    const bottomRect = bottom.getBoundingClientRect()
+    const root = document.documentElement
+    return {
+      token: getComputedStyle(root).getPropertyValue("--app-edge-fade-size").trim(),
+      ariaHidden: fade.getAttribute("aria-hidden"),
+      pointerEvents: getComputedStyle(fade).pointerEvents,
+      focusableCount: fade.querySelectorAll("button, a, input, select, textarea, [tabindex]").length,
+      appBackground,
+      surfaceBackground: getComputedStyle(element).backgroundColor,
+      surface: { top: surfaceRect.top, bottom: surfaceRect.bottom, height: surfaceRect.height },
+      top: {
+        top: topRect.top,
+        bottom: topRect.bottom,
+        height: topRect.height,
+        backgroundImage: getComputedStyle(top).backgroundImage,
+      },
+      bottom: {
+        top: bottomRect.top,
+        bottom: bottomRect.bottom,
+        height: bottomRect.height,
+        backgroundImage: getComputedStyle(bottom).backgroundImage,
+      },
+      rootOverflowX: root.scrollWidth - root.clientWidth,
+      rootOverflowY: root.scrollHeight - root.clientHeight,
+    }
+  })
+}
+
+function expectAppEdgeEvidence(evidence: AppEdgeEvidence) {
+  expect(evidence.token).toBe("60px")
+  expect(evidence.ariaHidden).toBe("true")
+  expect(evidence.pointerEvents).toBe("none")
+  expect(evidence.focusableCount).toBe(0)
+  expect(evidence.top.height).toBeCloseTo(60, 1)
+  expect(evidence.bottom.height).toBeCloseTo(60, 1)
+  expect(evidence.top.top).toBeCloseTo(evidence.surface.top, 1)
+  expect(evidence.top.bottom).toBeCloseTo(evidence.surface.top + 60, 1)
+  expect(evidence.bottom.top).toBeCloseTo(evidence.surface.bottom - 60, 1)
+  expect(evidence.bottom.bottom).toBeCloseTo(evidence.surface.bottom, 1)
+  expect(evidence.top.backgroundImage).toContain("linear-gradient")
+  expect(evidence.bottom.backgroundImage).toContain("linear-gradient")
+  expect(evidence.top.backgroundImage).toContain(evidence.appBackground)
+  expect(evidence.bottom.backgroundImage).toContain(evidence.appBackground)
+  expect(evidence.rootOverflowX).toBe(0)
+  expect(evidence.rootOverflowY).toBe(0)
+}
+
+async function attachEvidence(
+  testInfo: TestInfo,
+  page: Page,
+  name: string,
+  evidence: unknown,
+) {
+  await testInfo.attach(`${name}.json`, {
+    body: Buffer.from(JSON.stringify(evidence, null, 2)),
+    contentType: "application/json",
+  })
+  await testInfo.attach(`${name}.png`, {
+    body: await page.screenshot(),
+    contentType: "image/png",
+  })
+}
 
 async function installUserWsAuthConsumedBarrier(page: Page) {
   await page.addInitScript(({ attribute }) => {
@@ -80,7 +172,67 @@ test("slow auth and an initial retry never block a cold Community page", async (
   }
 })
 
-test("real WebSocket outage blocks the whole community surface and Retry restores it", async ({ asUser }, testInfo) => {
+test("app edge fade keeps the unresolved main surface native-aligned across theme, size, and motion", async ({ asUser }, testInfo) => {
+  test.setTimeout(90_000)
+  const suffix = Date.now().toString(36)
+  const serverId = await seedServer("alice", `Edge fade ${suffix}`)
+  const channelId = await seedChannel("alice", serverId, `edge-fade-${suffix}`)
+  const alice = await asUser("alice")
+
+  let releaseServerDetail!: () => void
+  const serverDetailGate = new Promise<void>((resolve) => {
+    releaseServerDetail = resolve
+  })
+  const detailPattern = new RegExp(`/api/community/servers/${serverId}/(?:categories|channels|unreads)(?:\\?|$)`)
+  await alice.page.route(detailPattern, async (route) => {
+    await serverDetailGate
+    await route.continue()
+  })
+
+  try {
+    await alice.page.setViewportSize({ width: 1280, height: 900 })
+    await gotoAfterUserWsAuth(alice.page, `/c/channels/${serverId}/${channelId}`)
+    const unresolved = alice.page.locator("[data-community-unresolved-main]").first()
+    await expect(unresolved).toBeVisible({ timeout: 10_000 })
+    const matrix = [
+      { name: "skeleton-1280-light-motion", width: 1280, height: 900, colorScheme: "light", reducedMotion: "no-preference" },
+      { name: "skeleton-390-dark-motion", width: 390, height: 844, colorScheme: "dark", reducedMotion: "no-preference" },
+      { name: "skeleton-1280-dark-reduced", width: 1280, height: 900, colorScheme: "dark", reducedMotion: "reduce" },
+      { name: "skeleton-390-light-reduced", width: 390, height: 844, colorScheme: "light", reducedMotion: "reduce" },
+    ] as const
+
+    for (const entry of matrix) {
+      await alice.page.emulateMedia({
+        colorScheme: entry.colorScheme,
+        reducedMotion: entry.reducedMotion,
+      })
+      await alice.page.setViewportSize({ width: entry.width, height: entry.height })
+      await expect.poll(() => alice.page.evaluate(() => document.documentElement.classList.contains("dark")))
+        .toBe(entry.colorScheme === "dark")
+      const edge = await appEdgeEvidence(unresolved)
+      expectAppEdgeEvidence(edge)
+      expect(edge.surfaceBackground).toBe(edge.appBackground)
+      const pulse = await unresolved.locator('[data-slot="skeleton"]').evaluate((element) => {
+        const style = getComputedStyle(element)
+        return {
+          animationDuration: style.animationDuration,
+          animationName: style.animationName,
+          backgroundColor: style.backgroundColor,
+        }
+      })
+      expect(pulse.animationName === "none").toBe(entry.reducedMotion === "reduce")
+      if (entry.reducedMotion === "no-preference") {
+        expect(pulse.animationDuration).toBe("2s")
+      }
+      expect(pulse.backgroundColor).not.toBe(edge.appBackground)
+      await attachEvidence(testInfo, alice.page, entry.name, { edge, pulse, entry })
+    }
+  } finally {
+    releaseServerDetail()
+  }
+})
+
+test("app edge fade keeps a real WebSocket outage native-aligned and Retry restores it", async ({ asUser }, testInfo) => {
   test.setTimeout(120_000)
   const serverId = await seedServer("alice", `Reconnect overlay ${Date.now()}`)
   const channelId = await seedChannel("alice", serverId, "reconnect-overlay")
@@ -115,6 +267,9 @@ test("real WebSocket outage blocks the whole community surface and Retry restore
     await expect(overlay).toHaveAttribute("data-ws-status", "reconnecting")
     await expect(overlay).toBeFocused()
     await expect(overlay.getByRole("status")).toContainText("Connecting…")
+    const reconnectingEdge = await appEdgeEvidence(overlay)
+    expectAppEdgeEvidence(reconnectingEdge)
+    expect(reconnectingEdge.surfaceBackground).not.toBe(reconnectingEdge.appBackground)
     const reconnectingEvidence = await overlay.evaluate((element) => {
       const rect = element.getBoundingClientRect()
       const content = element.previousElementSibling as HTMLElement | null
@@ -190,6 +345,10 @@ test("real WebSocket outage blocks the whole community surface and Retry restore
       path: mobileReconnectPath,
       contentType: "image/png",
     })
+    await testInfo.attach("390-dark-reconnecting-reduced-motion-edge.json", {
+      body: Buffer.from(JSON.stringify(reconnectingEdge, null, 2)),
+      contentType: "application/json",
+    })
 
     await alice.page.setViewportSize({ width: 1280, height: 900 })
     expect(await overlay.boundingBox()).toMatchObject({ x: 0, y: 0, width: 1280, height: 900 })
@@ -222,6 +381,12 @@ test("real WebSocket outage blocks the whole community surface and Retry restore
     await expect(retry).toBeVisible({ timeout: 40_000 })
     await expect(overlay).toHaveAttribute("data-ws-status", "failed")
     await expect(overlay.getByRole("alert")).toContainText("Connection lost")
+    const failedEdge = await appEdgeEvidence(overlay)
+    expectAppEdgeEvidence(failedEdge)
+    await testInfo.attach("failed-edge.json", {
+      body: Buffer.from(JSON.stringify(failedEdge, null, 2)),
+      contentType: "application/json",
+    })
     expect((await retry.boundingBox())!.height).toBeGreaterThanOrEqual(44)
 
     await alice.page.setViewportSize({ width: 1280, height: 900 })


### PR DESCRIPTION
# Why we need this PR?

The unresolved Community main-area skeleton and the Connecting / Connection lost overlay did not end in the native app background at the top and bottom of the WebView, leaving their center treatments exposed at the app boundary.

## What changed

- Add one shared, decorative `AppEdgeFade` primitive and a fixed `--app-edge-fade-size: 60px` token.
- Give `UnresolvedMainSkeleton` an opaque `--app-bg` base with top and bottom fades while preserving its single muted 2s pulse.
- Add the same edge handoff above the existing reconnect/failed scrim while preserving blur, centered content, focus/inert behavior, Retry, and WebSocket lifecycle.
- Add unit, DOM, and real-browser coverage for light/dark, desktop/mobile, normal/reduced motion, overflow, focus, and authenticated Retry recovery.

## Validation

- Fresh-worktree focused tests: 3 files / 6 tests passed.
- Changed-file ESLint: passed.
- Web typecheck: passed.
- Full repository pre-commit gate: typecheck, lint, tests, typegrep, and knip passed.
- Full Web suite within the gate: 825 files / 7,867 tests passed.
- Agent-driver suite: 48 files passed, 1 skipped / 786 tests passed, 4 skipped.
- CI-script suite: 21 files / 287 tests passed.
- Pre-Draft independent `alook-c-qa`: passed, including two fresh serial browser journeys and an evidence-preserving skeleton rerun.
- Post-Draft independent `/c` QA: 2/2 serial Playwright journeys passed with zero retries on the committed product source, covering real pending D1 queries plus outage → failed → Retry → second authenticated connection.
- Visual evidence covers light/dark at 1280x900 and 390x844, normal/reduced motion, unresolved skeleton, Connecting, failed Retry, and authenticated WebSocket recovery.
- Hosted-CI follow-up makes the CSS-token test fixture lookup independent of the process working directory; both repository-root and Web-package execution modes pass.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other
