### PR TITLE
fix(web): preserve bot activity through sheet close

### DIFF
--- a/src/web/src/components/community/bots/bot-activity-modal.dom.test.ts
+++ b/src/web/src/components/community/bots/bot-activity-modal.dom.test.ts
@@ -4,7 +4,15 @@ import React from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { act, fireEvent, render } from "@/test/react-dom-harness"
 
-const { auditState, fetchNextPage, scrollNode, bottomAnchor, sheetProps } = vi.hoisted(() => ({
+const {
+  auditState,
+  auditHook,
+  profileHook,
+  fetchNextPage,
+  scrollNode,
+  bottomAnchor,
+  sheetProps,
+} = vi.hoisted(() => ({
   auditState: {
     events: [] as Array<{
       id: string
@@ -18,6 +26,8 @@ const { auditState, fetchNextPage, scrollNode, bottomAnchor, sheetProps } = vi.h
     hasNextPage: false,
     isFetchingNextPage: false,
   },
+  auditHook: vi.fn(),
+  profileHook: vi.fn(),
   fetchNextPage: vi.fn(),
   scrollNode: { scrollHeight: 600, scrollTop: 0, clientHeight: 300 },
   bottomAnchor: { scrollIntoView: vi.fn() },
@@ -43,11 +53,17 @@ vi.mock("@/components/avatar", () => ({
 }))
 
 vi.mock("@/stores/community/ws", () => ({
-  useCommunityProfile: () => ({ presence: "online" }),
+  useCommunityProfile: (botId: string | undefined) => {
+    profileHook(botId)
+    return { presence: "online" }
+  },
 }))
 
 vi.mock("@/hooks/community/use-bot-audit-log", () => ({
-  useBotAuditLog: () => ({ ...auditState, fetchNextPage }),
+  useBotAuditLog: (botId: string | null) => {
+    auditHook(botId)
+    return { ...auditState, fetchNextPage }
+  },
 }))
 
 vi.mock("./bot-activity-row", () => ({
@@ -80,16 +96,40 @@ function event(id: string, createdAt: string) {
   }
 }
 
-function renderModal(onOpenChange = vi.fn()) {
-  const renderer = render(
-    React.createElement(BotActivityModal, { bot, open: true, onOpenChange }),
-  )
-  return { renderer, onOpenChange }
+type ModalOptions = {
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+  onOpenChangeComplete?: (open: boolean) => void
 }
 
-function updateModal(renderer: ReturnType<typeof render>, onOpenChange: (open: boolean) => void) {
+function renderModal({
+  open = true,
+  onOpenChange = vi.fn(),
+  onOpenChangeComplete = vi.fn(),
+}: ModalOptions = {}) {
+  const renderer = render(
+    React.createElement(BotActivityModal, {
+      bot,
+      open,
+      onOpenChange,
+      onOpenChangeComplete,
+    }),
+  )
+  return { renderer, onOpenChange, onOpenChangeComplete }
+}
+
+function updateModal(renderer: ReturnType<typeof render>, {
+  open = true,
+  onOpenChange = vi.fn(),
+  onOpenChangeComplete = vi.fn(),
+}: ModalOptions = {}) {
   act(() => renderer.rerender(
-    React.createElement(BotActivityModal, { bot, open: true, onOpenChange }),
+    React.createElement(BotActivityModal, {
+      bot,
+      open,
+      onOpenChange,
+      onOpenChangeComplete,
+    }),
   ))
 }
 
@@ -99,6 +139,8 @@ describe("BotActivityModal CommunitySheet contract", () => {
     auditState.isLoading = false
     auditState.hasNextPage = false
     auditState.isFetchingNextPage = false
+    auditHook.mockReset()
+    profileHook.mockReset()
     fetchNextPage.mockReset()
     bottomAnchor.scrollIntoView.mockReset()
     sheetProps.current = null
@@ -151,6 +193,33 @@ describe("BotActivityModal CommunitySheet contract", () => {
     expect(source).toContain("min-h-11 rounded-md")
   })
 
+  it("keeps bot identity and the audit key through the closed ending frame", () => {
+    auditState.events = [event("kept", "2026-08-27T12:00:00.000Z")]
+    const { renderer, onOpenChange, onOpenChangeComplete } = renderModal()
+
+    updateModal(renderer, { open: false, onOpenChange, onOpenChangeComplete })
+    const sheet = sheetProps.current!
+    expect(sheet.open).toBe(false)
+    expect(sheet.title).toBe("Build Bot")
+    expect((sheet.headerLeading as React.ReactElement).props).toMatchObject({
+      name: "Build Bot",
+      seed: "bot-1",
+      size: 32,
+    })
+    const description = sheet.description as React.ReactElement<{
+      children: React.ReactElement[]
+    }>
+    expect(description.props.children[1].props.children).toBe("Live")
+    expect(profileHook).toHaveBeenLastCalledWith("bot-1")
+    expect(auditHook).toHaveBeenLastCalledWith("bot-1")
+    expect(renderer.container.querySelector('activity-row[data-event-id="kept"]'))
+      .toBeInTheDocument()
+    expect(sheet.onOpenChangeComplete).toBe(onOpenChangeComplete)
+
+    act(() => (sheet.onOpenChangeComplete as (open: boolean) => void)(false))
+    expect(onOpenChangeComplete).toHaveBeenCalledWith(false)
+  })
+
   it("keeps loading, empty, chronological day groups, and rows in the shared body", () => {
     auditState.isLoading = true
     const loading = renderModal().renderer
@@ -189,7 +258,7 @@ describe("BotActivityModal CommunitySheet contract", () => {
       event("old", "2026-08-26T12:00:00.000Z"),
     ]
     scrollNode.scrollHeight = 850
-    updateModal(renderer, onOpenChange)
+    updateModal(renderer, { onOpenChange })
     expect(scrollNode.scrollTop).toBe(370)
   })
 
@@ -204,7 +273,7 @@ describe("BotActivityModal CommunitySheet contract", () => {
       event("one", "2026-08-27T12:00:00.000Z"),
       event("two", "2026-08-27T12:01:00.000Z"),
     ]
-    updateModal(renderer, onOpenChange)
+    updateModal(renderer, { onOpenChange })
     expect(scrollNode.scrollTop).toBe(1_100)
 
     scrollNode.scrollHeight = 1_300
@@ -213,7 +282,7 @@ describe("BotActivityModal CommunitySheet contract", () => {
       ...auditState.events,
       event("three", "2026-08-27T12:02:00.000Z"),
     ]
-    updateModal(renderer, onOpenChange)
+    updateModal(renderer, { onOpenChange })
     expect(scrollNode.scrollTop).toBe(100)
   })
 })

--- a/src/web/src/components/community/bots/bot-activity-modal.tsx
+++ b/src/web/src/components/community/bots/bot-activity-modal.tsx
@@ -32,10 +32,12 @@ export function BotActivityModal({
   bot,
   open,
   onOpenChange,
+  onOpenChangeComplete,
 }: {
   bot: BotSummary | null
   open: boolean
   onOpenChange: (open: boolean) => void
+  onOpenChangeComplete: (open: boolean) => void
 }) {
   // "Live" here means the bot's daemon is currently connected (its WS
   // presence). A viewer with a broken WS wouldn't receive events either, but
@@ -49,7 +51,7 @@ export function BotActivityModal({
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useBotAuditLog(open ? bot?.id : null)
+  } = useBotAuditLog(bot?.id ?? null)
 
   // Merged stream = paginated GET (DESC) + live WS ring (arrival-ordered).
   // The two are NOT a single monotonic sequence: a live event can carry a
@@ -157,6 +159,7 @@ export function BotActivityModal({
     <CommunitySheet
       open={open}
       onOpenChange={onOpenChange}
+      onOpenChangeComplete={onOpenChangeComplete}
       title={bot?.name ?? "Bot"}
       headerLeading={(
         <AgentAvatar name={bot?.name ?? ""} avatarUrl={bot?.image ?? null} seed={bot?.id} size={32} />

--- a/src/web/src/components/community/bots/bot-list-controller.dom.test.ts
+++ b/src/web/src/components/community/bots/bot-list-controller.dom.test.ts
@@ -200,7 +200,7 @@ describe("useBotListController", () => {
     return renderer
   }
 
-  it("keeps the exact external hook order and source-owned fourteen states", () => {
+  it("keeps the exact external hook order and source-owned states", () => {
     render()
     expect(mocks.hookOrder.slice(0, 10)).toEqual([
       "router",
@@ -217,7 +217,7 @@ describe("useBotListController", () => {
     expect(mocks.hookOrder[10]).toBe("onboarding")
 
     const source = readWebSource("src/components/community/bots/bot-list-controller.ts")
-    expect(source.match(/useState(?:<[^\n]+>)?\(/g)).toHaveLength(15)
+    expect(source.match(/useState(?:<[^\n]+>)?\(/g)).toHaveLength(16)
     expect(source).not.toMatch(/useCallback\(/)
     expect(source.match(/useMemo\(/g)).toHaveLength(1)
     const orderedHooks = [
@@ -231,6 +231,7 @@ describe("useBotListController", () => {
       "const [editOpen",
       "const [activityBot",
       "const [activityOpen",
+      "const [activityGeneration",
       "const [bugReportBot",
       "const [bugReportOpen",
       "const [confirmDelete",
@@ -444,6 +445,7 @@ describe("useBotListController", () => {
     act(() => renderer.rerender(React.createElement(Probe)))
     expect(latest.activityOpen).toBe(true)
     expect(latest.activityBot?.id).toBe("b1")
+    expect(latest.activityGeneration).toBe(1)
     expect(mocks.replace).not.toHaveBeenCalled()
   })
 
@@ -469,10 +471,11 @@ describe("useBotListController", () => {
     render()
     expect(latest.activityOpen).toBe(false)
     expect(latest.activityBot).toBeNull()
+    expect(latest.activityGeneration).toBe(0)
     expect(mocks.replace).toHaveBeenCalledWith("/c/me/bots?machineId=mac1")
   })
 
-  it("pushes URL-owned activity state, preserves machineId, and closes with replace", () => {
+  it("preserves URL state and retains the closing snapshot until eligible completion", () => {
     const renderer = render()
     act(() => latest.openActivity(mocks.bots[0]!))
     expect(mocks.push).toHaveBeenCalledWith("/c/me/bots?machineId=mac1&audit=b1")
@@ -481,27 +484,125 @@ describe("useBotListController", () => {
     act(() => renderer.rerender(React.createElement(Probe)))
     expect(latest.activityOpen).toBe(true)
     expect(latest.activityBot?.id).toBe("b1")
+    const generation = latest.activityGeneration
 
     act(() => latest.onActivityOpenChange(false))
     expect(latest.activityOpen).toBe(false)
-    expect(latest.activityBot).toBeNull()
+    expect(latest.activityBot?.id).toBe("b1")
     expect(mocks.replace).toHaveBeenLastCalledWith("/c/me/bots?machineId=mac1")
+
+    act(() => latest.onActivityOpenChangeComplete(true, generation))
+    expect(latest.activityBot?.id).toBe("b1")
+    act(() => latest.onActivityOpenChangeComplete(false, generation + 1))
+    expect(latest.activityBot?.id).toBe("b1")
+    act(() => latest.onActivityOpenChangeComplete(false, generation))
+    expect(latest.activityBot).toBeNull()
+    act(() => latest.onActivityOpenChangeComplete(false, generation))
+    expect(latest.activityBot).toBeNull()
   })
 
-  it("closes on Back and reopens the same owned target on Forward", () => {
+  it("retains on Back and fences the old completion after Forward", () => {
     mocks.audit = "b1"
     const renderer = render()
     expect(latest.activityOpen).toBe(true)
+    const closingGeneration = latest.activityGeneration
 
     mocks.audit = null
     act(() => renderer.rerender(React.createElement(Probe)))
     expect(latest.activityOpen).toBe(false)
-    expect(latest.activityBot).toBeNull()
+    expect(latest.activityBot?.id).toBe("b1")
 
     mocks.audit = "b1"
     act(() => renderer.rerender(React.createElement(Probe)))
     expect(latest.activityOpen).toBe(true)
     expect(latest.activityBot?.id).toBe("b1")
+    expect(latest.activityGeneration).toBe(closingGeneration + 1)
+    const reopenedGeneration = latest.activityGeneration
+
+    act(() => latest.onActivityOpenChangeComplete(false, closingGeneration))
+    expect(latest.activityOpen).toBe(true)
+    expect(latest.activityBot?.id).toBe("b1")
+    act(() => latest.onActivityOpenChangeComplete(false, reopenedGeneration))
+    expect(latest.activityOpen).toBe(true)
+    expect(latest.activityBot?.id).toBe("b1")
+  })
+
+  it("advances generation for a same-bot reopen after explicit close", () => {
+    mocks.audit = "b1"
+    const renderer = render()
+    const closingGeneration = latest.activityGeneration
+
+    act(() => latest.onActivityOpenChange(false))
+    expect(latest.activityOpen).toBe(false)
+    expect(latest.activityBot?.id).toBe("b1")
+    mocks.audit = null
+    act(() => renderer.rerender(React.createElement(Probe)))
+
+    act(() => latest.openActivity(mocks.bots[0]!))
+    mocks.audit = "b1"
+    act(() => renderer.rerender(React.createElement(Probe)))
+    expect(latest.activityOpen).toBe(true)
+    expect(latest.activityGeneration).toBe(closingGeneration + 1)
+
+    act(() => latest.onActivityOpenChangeComplete(false, closingGeneration))
+    expect(latest.activityBot?.id).toBe("b1")
+  })
+
+  it("lets B replace a closing A and ignores A's completion", () => {
+    mocks.audit = "b1"
+    mocks.bots = [bot("b1", "mac1"), bot("b2", "mac1")]
+    const renderer = render()
+    const aGeneration = latest.activityGeneration
+
+    act(() => latest.onActivityOpenChange(false))
+    expect(latest.activityOpen).toBe(false)
+    expect(latest.activityBot?.id).toBe("b1")
+
+    act(() => latest.openActivity(mocks.bots[1]!))
+    mocks.audit = "b2"
+    act(() => renderer.rerender(React.createElement(Probe)))
+    expect(latest.activityOpen).toBe(true)
+    expect(latest.activityBot?.id).toBe("b2")
+    expect(latest.activityGeneration).toBe(aGeneration + 1)
+
+    act(() => latest.onActivityOpenChangeComplete(false, aGeneration))
+    expect(latest.activityBot?.id).toBe("b2")
+  })
+
+  it("retains a disappeared target and lets a new valid target beat its completion", () => {
+    mocks.audit = "b1"
+    mocks.bots = [bot("b1", "mac1"), bot("b2", "mac1")]
+    const renderer = render()
+    const aGeneration = latest.activityGeneration
+
+    mocks.bots = [bot("b2", "mac1")]
+    act(() => renderer.rerender(React.createElement(Probe)))
+    expect(latest.activityOpen).toBe(false)
+    expect(latest.activityBot?.id).toBe("b1")
+    expect(mocks.replace).toHaveBeenLastCalledWith("/c/me/bots?machineId=mac1")
+
+    mocks.audit = "b2"
+    act(() => renderer.rerender(React.createElement(Probe)))
+    expect(latest.activityOpen).toBe(true)
+    expect(latest.activityBot?.id).toBe("b2")
+    expect(latest.activityGeneration).toBe(aGeneration + 1)
+
+    act(() => latest.onActivityOpenChangeComplete(false, aGeneration))
+    expect(latest.activityBot?.id).toBe("b2")
+  })
+
+  it("clears a disappeared target only after its matching false completion", () => {
+    mocks.audit = "b1"
+    const renderer = render()
+    const generation = latest.activityGeneration
+
+    mocks.bots = []
+    act(() => renderer.rerender(React.createElement(Probe)))
+    expect(latest.activityOpen).toBe(false)
+    expect(latest.activityBot?.id).toBe("b1")
+
+    act(() => latest.onActivityOpenChangeComplete(false, generation))
+    expect(latest.activityBot).toBeNull()
   })
 
   it("clears a normally consumed target after exactly 2000ms", () => {

--- a/src/web/src/components/community/bots/bot-list-controller.dom.test.ts
+++ b/src/web/src/components/community/bots/bot-list-controller.dom.test.ts
@@ -40,6 +40,7 @@ const mocks = vi.hoisted(() => ({
   advance: vi.fn(),
   updateResources: vi.fn(),
   recoverMachine: vi.fn(),
+  onProbeLayout: null as null | ((controller: BotListController) => void),
   toastSuccess: vi.fn(),
   toastError: vi.fn(),
   toastApiError: vi.fn(),
@@ -135,6 +136,7 @@ function Probe() {
   const controller = useBotListController()
   React.useLayoutEffect(() => {
     latest = controller
+    mocks.onProbeLayout?.(controller)
   }, [controller])
   return React.createElement("div", {
     ref: (element: HTMLDivElement | null) => {
@@ -182,6 +184,7 @@ describe("useBotListController", () => {
     mocks.online = new Set()
     mocks.onboardingSnapshot = null
     mocks.actionState = null
+    mocks.onProbeLayout = null
     mocks.createDm.mockResolvedValue({ conversation: { id: "dm1" } })
     mocks.del.mockResolvedValue(undefined)
     mocks.resetBot.mockResolvedValue({ ok: true })
@@ -567,6 +570,25 @@ describe("useBotListController", () => {
 
     act(() => latest.onActivityOpenChangeComplete(false, aGeneration))
     expect(latest.activityBot?.id).toBe("b2")
+  })
+
+  it("keeps a new valid target when close completion races before its open effect", () => {
+    mocks.audit = "b1"
+    mocks.bots = [bot("b1", "mac1"), bot("b2", "mac1")]
+    const renderer = render()
+    const aGeneration = latest.activityGeneration
+
+    act(() => latest.onActivityOpenChange(false))
+    mocks.onProbeLayout = (controller) => {
+      if (controller.activityOpen) return
+      controller.onActivityOpenChangeComplete(false, aGeneration)
+    }
+    mocks.audit = "b2"
+    act(() => renderer.rerender(React.createElement(Probe)))
+
+    expect(latest.activityOpen).toBe(true)
+    expect(latest.activityBot?.id).toBe("b2")
+    expect(latest.activityGeneration).toBe(aGeneration + 1)
   })
 
   it("retains a disappeared target and lets a new valid target beat its completion", () => {

--- a/src/web/src/components/community/bots/bot-list-controller.ts
+++ b/src/web/src/components/community/bots/bot-list-controller.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { isPresenceOnline } from "@alook/shared"
 import { toast } from "sonner"
@@ -48,6 +48,7 @@ export function useBotListController(): BotListController {
   const [editOpen, setEditOpen] = useState(false)
   const [activityBot, setActivityBot] = useState<BotSummary | null>(null)
   const [activityOpen, setActivityOpen] = useState(false)
+  const [activityGeneration, setActivityGeneration] = useState(0)
   const [bugReportBot, setBugReportBot] = useState<Pick<BotSummary, "id" | "name"> | null>(null)
   const [bugReportOpen, setBugReportOpen] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState<BotSummary | null>(null)
@@ -190,6 +191,16 @@ export function useBotListController(): BotListController {
   const groupRefs = useRef<Record<string, HTMLDivElement | null>>({})
   const scrolledForRef = useRef<string | null>(null)
   const suppressedAuditRef = useRef<string | null>(null)
+  const activityGenerationRef = useRef(0)
+  const activityOpenRef = useRef(activityOpen)
+  const targetAuditBotIdRef = useRef(targetAuditBotId)
+  const botsRef = useRef(bots)
+  useLayoutEffect(() => {
+    activityGenerationRef.current = activityGeneration
+    activityOpenRef.current = activityOpen
+    targetAuditBotIdRef.current = targetAuditBotId
+    botsRef.current = bots
+  }, [activityGeneration, activityOpen, bots, targetAuditBotId])
   useEffect(() => {
     if (!targetMachineId || bots.length === 0) return
     setCollapsedMachines((current) => {
@@ -210,8 +221,10 @@ export function useBotListController(): BotListController {
     if (!botsResolved) return
     if (!targetAuditBotId) {
       suppressedAuditRef.current = null
-      if (activityOpen) setActivityOpen(false)
-      if (activityBot) setActivityBot(null)
+      if (activityOpen) {
+        activityOpenRef.current = false
+        setActivityOpen(false)
+      }
       return
     }
     if (suppressedAuditRef.current === targetAuditBotId) return
@@ -219,15 +232,27 @@ export function useBotListController(): BotListController {
     const targetBot = bots.find((bot) => bot.id === targetAuditBotId)
     if (!targetBot) {
       suppressedAuditRef.current = targetAuditBotId
-      if (activityOpen) setActivityOpen(false)
-      if (activityBot) setActivityBot(null)
+      if (activityOpen) {
+        activityOpenRef.current = false
+        setActivityOpen(false)
+      }
       const query = searchParams.toString()
       router.replace(removeCommunityParam(`/c/me/bots${query ? `?${query}` : ""}`, "audit"))
       return
     }
 
-    if (activityBot?.id !== targetBot.id) setActivityBot(targetBot)
-    if (!activityOpen) setActivityOpen(true)
+    suppressedAuditRef.current = null
+    const targetChanged = activityBot?.id !== targetBot.id
+    if (!activityOpen || targetChanged) {
+      const nextGeneration = activityGenerationRef.current + 1
+      activityGenerationRef.current = nextGeneration
+      setActivityGeneration(nextGeneration)
+    }
+    if (targetChanged) setActivityBot(targetBot)
+    if (!activityOpen) {
+      activityOpenRef.current = true
+      setActivityOpen(true)
+    }
   }, [activityBot, activityOpen, bots, botsResolved, router, searchParams, targetAuditBotId])
 
   const openActivity = (bot: BotSummary) => {
@@ -240,10 +265,22 @@ export function useBotListController(): BotListController {
   const onActivityOpenChange = (open: boolean) => {
     if (open) return
     if (targetAuditBotId) suppressedAuditRef.current = targetAuditBotId
+    activityOpenRef.current = false
     setActivityOpen(false)
-    setActivityBot(null)
     const query = searchParams.toString()
     router.replace(removeCommunityParam(`/c/me/bots${query ? `?${query}` : ""}`, "audit"))
+  }
+
+  const onActivityOpenChangeComplete = (open: boolean, generation: number) => {
+    if (open || generation !== activityGenerationRef.current || activityOpenRef.current) return
+    const targetId = targetAuditBotIdRef.current
+    const hasUnsuppressedValidTarget = Boolean(
+      targetId &&
+      suppressedAuditRef.current !== targetId &&
+      botsRef.current.some((bot) => bot.id === targetId),
+    )
+    if (hasUnsuppressedValidTarget) return
+    setActivityBot(null)
   }
 
   const openMachines = () => router.push("/c/me/machines")
@@ -325,8 +362,10 @@ export function useBotListController(): BotListController {
     setEditOpen,
     activityBot,
     activityOpen,
+    activityGeneration,
     openActivity,
     onActivityOpenChange,
+    onActivityOpenChangeComplete,
     bugReportBot,
     setBugReportBot,
     bugReportOpen,

--- a/src/web/src/components/community/bots/bot-list-overlays.dom.test.ts
+++ b/src/web/src/components/community/bots/bot-list-overlays.dom.test.ts
@@ -68,7 +68,9 @@ function controller(overrides: Partial<BotListController> = {}): BotListControll
     setEditOpen: noop,
     activityBot: null,
     activityOpen: false,
+    activityGeneration: 0,
     onActivityOpenChange: noop,
+    onActivityOpenChangeComplete: noop,
     openActivity: noop,
     bugReportBot: null,
     bugReportOpen: false,
@@ -131,6 +133,7 @@ describe("renderBotListOverlaySlots", () => {
     const bot = { id: "b1", name: "Blake" }
     const setEditOpen = vi.fn()
     const onActivityOpenChange = vi.fn()
+    const onActivityOpenChangeComplete = vi.fn()
     const setBugReportOpen = vi.fn()
     const state = controller({
       createOpen: true,
@@ -142,7 +145,9 @@ describe("renderBotListOverlaySlots", () => {
       setEditOpen,
       activityBot: bot as BotListController["activityBot"],
       activityOpen: true,
+      activityGeneration: 7,
       onActivityOpenChange,
+      onActivityOpenChangeComplete,
       bugReportBot: bot,
       bugReportOpen: true,
       setBugReportOpen,
@@ -156,7 +161,13 @@ describe("renderBotListOverlaySlots", () => {
       avatarSeed: "seed",
     })
     expect(slots.edit.props).toEqual({ bot, open: true, onOpenChange: setEditOpen })
-    expect(slots.activity.props).toEqual({ bot, open: true, onOpenChange: onActivityOpenChange })
+    expect(slots.activity.key).toBe("7")
+    expect(slots.activity.props).toMatchObject({
+      bot,
+      open: true,
+      onOpenChange: onActivityOpenChange,
+    })
+    expect(slots.activity.props.onOpenChangeComplete).toEqual(expect.any(Function))
     expect(slots.help.props).toEqual({
       open: true,
       onOpenChange: state.setHelpOpen,
@@ -166,9 +177,13 @@ describe("renderBotListOverlaySlots", () => {
 
     slots.edit.props.onOpenChange(false)
     slots.activity.props.onOpenChange(false)
+    slots.activity.props.onOpenChangeComplete(false)
+    slots.activity.props.onOpenChangeComplete(true)
     slots.bug?.props.onOpenChange(false)
     expect(setEditOpen).toHaveBeenCalledWith(false)
     expect(onActivityOpenChange).toHaveBeenCalledWith(false)
+    expect(onActivityOpenChangeComplete).toHaveBeenNthCalledWith(1, false, 7)
+    expect(onActivityOpenChangeComplete).toHaveBeenNthCalledWith(2, true, 7)
     expect(setBugReportOpen).toHaveBeenCalledWith(false)
     expect(state.editingBot).toBe(bot)
     expect(state.activityBot).toBe(bot)

--- a/src/web/src/components/community/bots/bot-list-overlays.tsx
+++ b/src/web/src/components/community/bots/bot-list-overlays.tsx
@@ -42,9 +42,14 @@ export function renderBotListOverlaySlots(
     ),
     activity: (
       <BotActivityModal
+        key={controller.activityGeneration}
         bot={controller.activityBot}
         open={controller.activityOpen}
         onOpenChange={controller.onActivityOpenChange}
+        onOpenChangeComplete={(open) => controller.onActivityOpenChangeComplete(
+          open,
+          controller.activityGeneration,
+        )}
       />
     ),
     bug: controller.bugReportBot ? (

--- a/src/web/src/components/community/bots/bot-list-types.ts
+++ b/src/web/src/components/community/bots/bot-list-types.ts
@@ -35,8 +35,10 @@ export type BotListController = {
   setEditOpen: Dispatch<SetStateAction<boolean>>
   activityBot: BotSummary | null
   activityOpen: boolean
+  activityGeneration: number
   openActivity: (bot: BotSummary) => void
   onActivityOpenChange: (open: boolean) => void
+  onActivityOpenChangeComplete: (open: boolean, generation: number) => void
   bugReportBot: Pick<BotSummary, "id" | "name"> | null
   setBugReportBot: Dispatch<SetStateAction<Pick<BotSummary, "id" | "name"> | null>>
   bugReportOpen: boolean

--- a/src/web/src/components/community/shell/community-sheet.dom.test.ts
+++ b/src/web/src/components/community/shell/community-sheet.dom.test.ts
@@ -72,6 +72,22 @@ describe("CommunitySheet contracts", () => {
     expect(resizeHandle).not.toHaveBeenCalled()
   })
 
+  it.each([
+    ["fixed", false],
+    ["resizable", true],
+  ])("forwards open completion unchanged for the %s sheet", (_name, resizable) => {
+    const onOpenChangeComplete = vi.fn()
+    renderSheet({ onOpenChangeComplete, resizable })
+
+    expect(sheetProps.get("sheet-root")?.onOpenChangeComplete).toBe(onOpenChangeComplete)
+  })
+
+  it("keeps open completion optional", () => {
+    renderSheet()
+
+    expect(sheetProps.get("sheet-root")?.onOpenChangeComplete).toBeUndefined()
+  })
+
   it("uses the primitive resize policy at the caller's desktop width", () => {
     const { renderer } = renderSheet({ resizable: true, desktopWidth: 672 })
     const content = sheetProps.get("sheet-content")!

--- a/src/web/src/components/community/shell/community-sheet.tsx
+++ b/src/web/src/components/community/shell/community-sheet.tsx
@@ -25,6 +25,7 @@ const COMMUNITY_SHEET_MIN_WIDTH = 320
 type CommunitySheetProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
+  onOpenChangeComplete?: (open: boolean) => void
   title: React.ReactNode
   description?: React.ReactNode
   headerLeading?: React.ReactNode
@@ -50,6 +51,7 @@ type CommunitySheetProps = {
 export function CommunitySheet({
   open,
   onOpenChange,
+  onOpenChangeComplete,
   title,
   description,
   headerLeading,
@@ -73,7 +75,12 @@ export function CommunitySheet({
   )
 
   return (
-    <Sheet open={open} onOpenChange={handleOpenChange} modal>
+    <Sheet
+      open={open}
+      onOpenChange={handleOpenChange}
+      onOpenChangeComplete={onOpenChangeComplete}
+      modal
+    >
       {resizable ? (
         <ResizableCommunitySheetContent
           title={title}


### PR DESCRIPTION
# Why we need this PR?
Bot activity details were cleared when sheet closing began, so the 300 ms ending animation could briefly show fallback identity, presence, and audit content. A delayed close completion could also clear a newer route target.

## What changed
- Preserve the selected bot and audit query key through the closing animation.
- Fence close completion by generation, desired state, and the current unsuppressed target.
- Keep old, duplicate, and `true` completions from clearing a newer target.
- Cover close controls, browser history, reopen/retarget races, and deleted targets.

## Checklist
- [x] Tests added/updated as needed
- [x] All CI checks pass
- [x] PR targets the correct branch

## Impact Areas
- [ ] Shared library (`@alook/shared`)
- [x] Web app (`@alook/web`)
- [ ] CLI (`@alook/cli`)
- [ ] Email Worker (`@alook/email-worker`)
- [ ] WebSocket DO (`@alook/ws-do`)
- [ ] CI/CD
- [ ] Other: ...
